### PR TITLE
Make NextBSD build in 2019

### DIFF
--- a/Makefile.libcompat
+++ b/Makefile.libcompat
@@ -93,6 +93,7 @@ LIBCOMPATWMAKEENV+= MAKEOBJDIRPREFIX=${LIBCOMPAT_OBJTREE} \
 		INSTALL="sh ${.CURDIR}/tools/install.sh" \
 		PATH=${TMPPATH} \
 		LIBDIR=/usr/lib${libcompat} \
+		MACHINE_INCLUDES="${LIBCOMPATTMP}/include" \
 		SHLIBDIR=/usr/lib${libcompat} \
 		DTRACE="${LIB$COMPATDTRACE:U${DTRACE}}"
 .if ${MK_META_MODE} != "no"

--- a/etc/rc.d/Makefile
+++ b/etc/rc.d/Makefile
@@ -280,12 +280,6 @@ RCMDSPACKAGE=	rcmds
 FILES+=		routed
 .endif
 
-.if ${MK_SENDMAIL} != "no"
-FILESGROUPS+=	SMRCD
-SMRCD=		sendmail
-SMRCDPACKAGE=	sendmail
-.endif
-
 .if ${MK_TIMED} != "no"
 FILES+=		timed
 .endif

--- a/usr.bin/Makefile
+++ b/usr.bin/Makefile
@@ -294,7 +294,7 @@ SUBDIR.${MK_TOOLCHAIN}+=	unifdef
 SUBDIR.${MK_TOOLCHAIN}+=	size
 SUBDIR.${MK_TOOLCHAIN}+=	strings
 .if ${MACHINE_ARCH} != "aarch64" # ARM64TODO xlint does not build
-SUBDIR.${MK_TOOLCHAIN}+=	xlint
+#SUBDIR.${MK_TOOLCHAIN}+=	xlint
 .endif
 SUBDIR.${MK_TOOLCHAIN}+=	xstr
 SUBDIR.${MK_TOOLCHAIN}+=	yacc

--- a/usr.bin/migcom/Makefile
+++ b/usr.bin/migcom/Makefile
@@ -29,18 +29,18 @@ SRCS= ident.c error.c global.c header.c \
 	statement.c string.c type.c user.c utils.c
 
 
-CFLAGS+= -I${.CURDIR} -I${.CURDIR}/shims -I${.CURDIR}/../../include
+CFLAGS+= -I${.CURDIR} -I${.CURDIR}/shims -I${.CURDIR}/../../include -Iinclude
 CFLAGS+= -I${.CURDIR}/../../sys 
 CFLAGS+= -DYY_NO_UNPUT
 
 .if ${TARGET} == "amd64" || ${TARGET} == "i386"
-include/x86: ${.CURDIR}/Makefile
+include/machine: ${.CURDIR}/Makefile
 	mkdir -p include
-	ln -sf ${.CURDIR}/../../sys/x86/include include/x86
+	ln -sf ${.CURDIR}/../../sys/x86/include include/machine
 .endif
 
 .if ${TARGET} == "amd64" || ${TARGET} == "i386"
-ident.c: include/x86 
+ident.c: include/machine
 .else
 ident.c: 
 .endif
@@ -51,7 +51,7 @@ ident.c:
 
 CLEANFILES+= ident.c *.o *~ *.gz cscope.* 
 .if ${TARGET} == "amd64" || ${TARGET} == "i386"
-CLEANFILES+= include/x86
+CLEANFILES+= include/machine
 .endif
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
With those few quick and dirty changes I have managed to compile NextBSD-CURRENT on FreeBSD 12.0-RELEASE-p10 using the usual buildworld/buildkernel process. I have also created ISO images that run under Xen:

![nextbsd-running](https://user-images.githubusercontent.com/248374/66474071-dae2d600-ea90-11e9-96f2-acd3e0b7024d.png)

Xen configuration file to install:

````
builder = "hvm"
name = "guest5"
disk = [
        '/dev/zvol/zroot/builder5,raw,xvda,w'
#       '/home/saper/dist/nextbsd-disc1.iso,raw,xvdc:cdrom,r'
]
boot = "c"
bios = "ovmf"
usbdevice = 'tablet'
#nographics = 1
#serial = [ "/dev/nmdm0A" ]
vnc = 1
#vnclisten = '0.0.0.0'
vif = ['bridge=bridge0,mac=00:02:04:15:fd:e9','bridge=bridge1,mac=00:02:04:15:fd:f0']
memory=1024
vcpus=2
vga = "stdvga"
videoram = 16
xen_platform_pci=1
````