### PR TITLE
fix(hwregd): HWREG-PUBSUB round-trip — size hwregtest rcv buf for the trailer

### DIFF
--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -445,6 +445,6 @@ if [ ! -x "$hwregtest" ]; then
     echo "HWREG-PUBSUB-FAIL: $hwregtest missing"
     exit 1
 fi
-"$hwregtest" || true	# round-trip not yet working — non-fatal, see boot-test.sh
+"$hwregtest" || true	# marker (HWREG-PUBSUB-OK/FAIL) gates in boot-test.sh
 
 exit 0

--- a/src/hwregd/hwregtest.c
+++ b/src/hwregd/hwregtest.c
@@ -29,7 +29,16 @@ main(void)
 	kern_return_t kr;
 	mach_msg_return_t mr;
 	mach_msg_header_t req;
-	struct hwreg_event_msg ev;
+	/*
+	 * Receive buffer for the ack EVENT. A Mach receive needs room for
+	 * the message *and* the trailer the kernel appends after it; a
+	 * buffer sized at exactly sizeof(struct hwreg_event_msg) gets
+	 * MACH_RCV_TOO_LARGE (0x10004004). Pad with a max trailer.
+	 */
+	struct {
+		struct hwreg_event_msg	ev;
+		mach_msg_max_trailer_t	trailer;
+	} rcv;
 
 	kr = bootstrap_look_up(bootstrap_port, "org.freebsd.hwregd", &svc);
 	if (kr != KERN_SUCCESS) {
@@ -74,20 +83,20 @@ main(void)
 	}
 
 	/* Receive the subscription-ack EVENT hwregd sends back. */
-	memset(&ev, 0, sizeof(ev));
-	mr = mach_msg(&ev.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0,
-	    sizeof(ev), notify, 5000, MACH_PORT_NULL);
+	memset(&rcv, 0, sizeof(rcv));
+	mr = mach_msg(&rcv.ev.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0,
+	    sizeof(rcv), notify, 5000, MACH_PORT_NULL);
 	if (mr != MACH_MSG_SUCCESS) {
 		printf("HWREG-PUBSUB-FAIL: ack receive: 0x%x\n", (unsigned)mr);
 		return 1;
 	}
-	if (ev.hdr.msgh_id != HWREG_MSG_EVENT) {
+	if (rcv.ev.hdr.msgh_id != HWREG_MSG_EVENT) {
 		printf("HWREG-PUBSUB-FAIL: unexpected msg id=%d\n",
-		    ev.hdr.msgh_id);
+		    rcv.ev.hdr.msgh_id);
 		return 1;
 	}
-	ev.text[sizeof(ev.text) - 1] = '\0';
+	rcv.ev.text[sizeof(rcv.ev.text) - 1] = '\0';
 	printf("HWREG-PUBSUB-OK: event kind=%c text=[%s]\n",
-	    ev.kind ? ev.kind : '?', ev.text);
+	    rcv.ev.kind ? rcv.ev.kind : '?', rcv.ev.text);
 	return 0;
 }

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -375,9 +375,8 @@ expect {
         exit 1
     }
     "HWREG-PUBSUB-FAIL" {
-        puts "\nKNOWN ISSUE: hwregd Mach pub/sub round-trip fails — the\
- client-side bootstrap_look_up/mach_msg path returns MACH_SEND_INVALID_DEST\
- (port-level Mach-IPC bug, under investigation; not gating CI)"
+        puts "\nFAIL: hwregd Mach pub/sub round-trip failed"
+        exit 1
     }
     "HWREG-PUBSUB-OK" { puts "\nOK: hwregd Mach pub/sub works" }
 }


### PR DESCRIPTION
## Summary

Fixes the HWREG-PUBSUB blocker (Phase K). The hwregd Mach pub/sub round-trip failed at the **client** side.

The reported "iter-3b-ii hwregd segfaults on startup" was a phantom: `/usr/sbin/hwregd` on the test box was a **0-byte/truncated file** from a botched (un-synced) install — the kernel ELF loader choked on the corrupt binary, not hwregd code. Rebuilt byte-identical, hwregd comes up clean as the launchd job and checks `org.freebsd.hwregd` in fine.

The real failure: `hwregtest`'s ack-EVENT receive returned **`MACH_RCV_TOO_LARGE` (`0x10004004`)**. It sized its receive buffer at exactly `sizeof(struct hwreg_event_msg)` (504 B), leaving no room for the trailer the kernel appends on receive, so hwregd's 504-byte EVENT + trailer overflowed it and the message was destroyed undelivered.

## Changes

- **`src/hwregd/hwregtest.c`** — receive into a struct that pads the message with a `mach_msg_max_trailer_t`, and pass `sizeof()` that. `hwregd.c` itself is unchanged — its EVENT send was always correct.
- **`tests/boot-test.sh`** — re-gate the CI marker: `exit 1` on `HWREG-PUBSUB-FAIL` (it had been demoted to a non-fatal "KNOWN ISSUE" that mis-blamed a `MACH_SEND_INVALID_DEST` bug).
- **`run.sh`** — refresh a stale comment.

## Test plan

Verified on the bsd01 test VM (FreeBSD 15.0, launchd PID 1):

- hwregd comes up clean as the launchd job (PPID 1), checks in `org.freebsd.hwregd`, stays up with no crash/core.
- `hwregtest` prints `HWREG-PUBSUB-OK: event kind=A text=[subscribed to org.freebsd.hwregd]` — repeated round-trips, all pass.

## Follow-ups (not in this PR)

- hwregd never prunes dead subscriber ports from `subscribers[]`; `publish_event` keeps failing to send to exited clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)