### PR TITLE
feat(hwregd): Phase 1 iter 1 — hardware registry tree

### DIFF
--- a/src/hwregd/Makefile
+++ b/src/hwregd/Makefile
@@ -13,7 +13,10 @@
 
 PROG=		hwregd
 MAN=
-SRCS=		hwregd.c
+# hwreg_registry.c — Phase 1 hardware registry tree (newbus snapshot
+# via hw.bus.* sysctls + devctl-event maintenance). libc-only, no
+# extra LDADD.
+SRCS=		hwregd.c hwreg_registry.c
 
 WARNS?=		6
 NO_MAN=		yes

--- a/src/hwregd/hwreg_registry.c
+++ b/src/hwregd/hwreg_registry.c
@@ -1,0 +1,366 @@
+/*
+ * hwreg_registry.c — hwregd hardware registry tree (Phase 1 iter 1).
+ *
+ * Builds and maintains the hw_node tree described in hwreg_registry.h.
+ * The boot snapshot comes from the kernel newbus tree via the hw.bus.*
+ * sysctls (hw.bus.info for the ABI version, hw.bus.devices.<N> for one
+ * struct u_device per device) — the same data libdevinfo reads, but
+ * read directly so hwregd needs no FreeBSD-devmatch dependency. After
+ * the snapshot, /dev/devctl attach/detach events keep the tree current.
+ */
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/bus.h>
+#include <sys/sysctl.h>
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hwreg_registry.h"
+
+/*
+ * The registry is a singly-linked list kept in enumeration order
+ * (head .. tail). iter 1 is single-threaded — only hwregd's devctl
+ * thread touches it — so there is no lock; iter 2's Mach-RPC reader
+ * thread adds one.
+ */
+static struct hw_node *registry_head;
+static struct hw_node *registry_tail;
+static uint64_t		next_id = 1;	/* 0 is reserved for "no node" */
+static int		node_count;
+
+const char *
+hw_state_name(enum hw_node_state s)
+{
+	switch (s) {
+	case HW_PROBED:		return "PROBED";
+	case HW_ATTACHED:	return "ATTACHED";
+	case HW_DETACHED:	return "DETACHED";
+	case HW_FAILED:		return "FAILED";
+	}
+	return "?";
+}
+
+int
+hwreg_count(void)
+{
+	return node_count;
+}
+
+struct hw_node *
+hwreg_find_by_name(const char *name)
+{
+	struct hw_node *n;
+
+	if (name == NULL || name[0] == '\0')
+		return NULL;
+	for (n = registry_head; n != NULL; n = n->next)
+		if (strcmp(n->name, name) == 0)
+			return n;
+	return NULL;
+}
+
+struct hw_node *
+hwreg_get(uint64_t id)
+{
+	struct hw_node *n;
+
+	if (id == 0)
+		return NULL;
+	for (n = registry_head; n != NULL; n = n->next)
+		if (n->id == id)
+			return n;
+	return NULL;
+}
+
+void
+hwreg_foreach(void (*fn)(const struct hw_node *n, void *arg), void *arg)
+{
+	struct hw_node *n;
+
+	for (n = registry_head; n != NULL; n = n->next)
+		fn(n, arg);
+}
+
+/* Append a freshly-allocated node for `name`; returns NULL on OOM. */
+static struct hw_node *
+node_new(const char *name, uint64_t parent_id)
+{
+	struct hw_node *n = calloc(1, sizeof(*n));
+
+	if (n == NULL)
+		return NULL;
+	n->id = next_id++;
+	n->parent_id = parent_id;
+	strlcpy(n->name, name, sizeof(n->name));
+	n->state = HW_PROBED;
+	if (registry_tail == NULL)
+		registry_head = n;
+	else
+		registry_tail->next = n;
+	registry_tail = n;
+	node_count++;
+	return n;
+}
+
+/*
+ * Coarse device class, IORegistry-style. Cheap heuristic off the
+ * parent bus / device name; iter 2 refines it from PCI/USB enrichment.
+ */
+static void
+classify(struct hw_node *n)
+{
+	const struct hw_node *p = hwreg_get(n->parent_id);
+	const char *pn = (p != NULL) ? p->name : "";
+
+	if (strncmp(pn, "pci", 3) == 0)
+		strlcpy(n->classname, "PCIDevice", sizeof(n->classname));
+	else if (strncmp(pn, "usbus", 5) == 0 || strncmp(pn, "uhub", 4) == 0)
+		strlcpy(n->classname, "USBDevice", sizeof(n->classname));
+	else if (strncmp(n->name, "cpu", 3) == 0)
+		strlcpy(n->classname, "CPU", sizeof(n->classname));
+	else if (strncmp(n->name, "acpi", 4) == 0)
+		strlcpy(n->classname, "ACPIDevice", sizeof(n->classname));
+	else
+		strlcpy(n->classname, "Device", sizeof(n->classname));
+}
+
+/*
+ * Fill n->path = parent->path + "/" + name. Recurses parent-first so
+ * the result is correct regardless of enumeration order, memoised by
+ * the "already has a path" check; the device tree is acyclic so the
+ * recursion terminates.
+ */
+static void
+ensure_path(struct hw_node *n)
+{
+	struct hw_node *p;
+
+	if (n->path[0] != '\0')
+		return;
+	p = hwreg_get(n->parent_id);
+	if (p != NULL) {
+		ensure_path(p);
+		(void)snprintf(n->path, sizeof(n->path), "%s/%s",
+		    p->path, n->name);
+	} else {
+		(void)snprintf(n->path, sizeof(n->path), "/%s", n->name);
+	}
+}
+
+/* Transient parent-handle map, used only while building the snapshot. */
+struct devent {
+	uintptr_t	handle;
+	uintptr_t	parent;
+	struct hw_node *node;
+};
+
+/*
+ * Return the field `*pp` points at and advance `*pp` past its NUL.
+ * dv_fields holds five NUL-terminated strings packed back to back;
+ * the caller forces a NUL at the buffer end so a malformed reply
+ * still yields valid C strings and `*pp` can never pass `end`.
+ */
+static const char *
+next_field(const char **pp, const char *end)
+{
+	const char *s = *pp;
+	const char *q = s;
+
+	while (q < end && *q != '\0')
+		q++;
+	*pp = (q < end) ? q + 1 : end;
+	return s;
+}
+
+/* Free every node and reset the registry to empty — used between
+ * snapshot retries when the kernel generation count moves. */
+static void
+registry_reset(void)
+{
+	struct hw_node *n = registry_head, *nx;
+
+	while (n != NULL) {
+		nx = n->next;
+		free(n);
+		n = nx;
+	}
+	registry_head = NULL;
+	registry_tail = NULL;
+	node_count = 0;
+	next_id = 1;
+}
+
+/*
+ * One attempt at building the registry from the newbus sysctls.
+ * Returns the node count, or -1 with errno set; errno == EINVAL means
+ * the kernel device generation moved mid-scan — the caller resets and
+ * retries (the same contract libdevinfo's devinfo_init() works to).
+ */
+static int
+snapshot_attempt(void)
+{
+	struct u_businfo ubus;
+	struct devent *ents = NULL;
+	size_t len, nents = 0, cap = 0, i, j;
+	int mib[CTL_MAXNAME];
+	size_t miblen = nitems(mib);
+	int generation, idx;
+	struct hw_node *n;
+
+	/* hw.bus.info — validate the newbus userland ABI and get the
+	 * generation count that tags every hw.bus.devices query. */
+	len = sizeof(ubus);
+	if (sysctlbyname("hw.bus.info", &ubus, &len, NULL, 0) != 0)
+		return -1;
+	if (len != sizeof(ubus) || ubus.ub_version != BUS_USER_VERSION) {
+		errno = ENOTSUP;
+		return -1;
+	}
+	generation = ubus.ub_generation;
+
+	if (sysctlnametomib("hw.bus.devices", mib, &miblen) != 0)
+		return -1;
+
+	/*
+	 * Pass A: one struct u_device per index — create a node, stash
+	 * its handle + parent handle for the linkage pass. The device
+	 * OID is hw.bus.devices + <generation> + <index>; a stale
+	 * generation makes the kernel return EINVAL.
+	 */
+	for (idx = 0; ; idx++) {
+		struct u_device ud;
+		const char *p, *pend;
+		const char *f_name, *f_desc, *f_drv, *f_pnp, *f_loc;
+
+		mib[miblen] = generation;
+		mib[miblen + 1] = idx;
+		len = sizeof(ud);
+		if (sysctl(mib, (u_int)(miblen + 2), &ud, &len, NULL, 0) != 0) {
+			if (errno == ENOENT)
+				break;		/* past the last device */
+			free(ents);
+			return -1;		/* EINVAL bubbles up as a retry */
+		}
+		if (len != sizeof(ud)) {
+			free(ents);
+			errno = EINVAL;
+			return -1;
+		}
+		ud.dv_fields[sizeof(ud.dv_fields) - 1] = '\0';
+		p = ud.dv_fields;
+		pend = ud.dv_fields + sizeof(ud.dv_fields);
+		f_name = next_field(&p, pend);
+		f_desc = next_field(&p, pend);
+		f_drv  = next_field(&p, pend);
+		f_pnp  = next_field(&p, pend);
+		f_loc  = next_field(&p, pend);
+
+		n = node_new(f_name, 0);
+		if (n == NULL) {
+			free(ents);
+			errno = ENOMEM;
+			return -1;
+		}
+		strlcpy(n->desc, f_desc, sizeof(n->desc));
+		strlcpy(n->driver, f_drv, sizeof(n->driver));
+		strlcpy(n->pnpinfo, f_pnp, sizeof(n->pnpinfo));
+		strlcpy(n->location, f_loc, sizeof(n->location));
+		n->state = (ud.dv_state >= DS_ATTACHED) ? HW_ATTACHED : HW_PROBED;
+
+		if (nents == cap) {
+			size_t ncap = (cap == 0) ? 128 : cap * 2;
+			struct devent *ne = realloc(ents, ncap * sizeof(*ne));
+
+			if (ne == NULL) {
+				free(ents);
+				errno = ENOMEM;
+				return -1;
+			}
+			ents = ne;
+			cap = ncap;
+		}
+		ents[nents].handle = ud.dv_handle;
+		ents[nents].parent = ud.dv_parent;
+		ents[nents].node = n;
+		nents++;
+	}
+
+	/* Pass B: resolve each device's parent handle to a registry id. */
+	for (i = 0; i < nents; i++) {
+		if (ents[i].parent == 0)
+			continue;		/* root of the forest */
+		for (j = 0; j < nents; j++) {
+			if (j != i && ents[j].handle == ents[i].parent) {
+				ents[i].node->parent_id = ents[j].node->id;
+				break;
+			}
+		}
+	}
+	free(ents);
+
+	/* Parents are linked now — derive class + path for every node. */
+	for (n = registry_head; n != NULL; n = n->next) {
+		classify(n);
+		ensure_path(n);
+	}
+	return (int)nents;
+}
+
+int
+hwreg_build_snapshot(void)
+{
+	int retries, r;
+
+	/*
+	 * Retry if the kernel device generation count moves mid-scan
+	 * (snapshot_attempt() returns -1/EINVAL) — the registry built so
+	 * far is stale, so discard it and rescan from a fresh generation.
+	 */
+	for (retries = 0; retries < 8; retries++) {
+		r = snapshot_attempt();
+		if (r >= 0)
+			return r;
+		if (errno != EINVAL)
+			return -1;
+		registry_reset();
+	}
+	errno = EAGAIN;
+	return -1;
+}
+
+void
+hwreg_note_attach(const char *name, const char *parent, const char *location)
+{
+	struct hw_node *n;
+
+	if (name == NULL || name[0] == '\0')
+		return;
+	n = hwreg_find_by_name(name);
+	if (n == NULL) {
+		/* Hot-plugged device that was not in the boot snapshot. */
+		struct hw_node *p = hwreg_find_by_name(parent);
+
+		n = node_new(name, (p != NULL) ? p->id : 0);
+		if (n == NULL)
+			return;
+		classify(n);
+		ensure_path(n);
+	}
+	n->state = HW_ATTACHED;
+	if (location != NULL && location[0] != '\0')
+		strlcpy(n->location, location, sizeof(n->location));
+}
+
+void
+hwreg_note_detach(const char *name)
+{
+	struct hw_node *n = hwreg_find_by_name(name);
+
+	if (n != NULL)
+		n->state = HW_DETACHED;
+}

--- a/src/hwregd/hwreg_registry.h
+++ b/src/hwregd/hwreg_registry.h
@@ -1,0 +1,83 @@
+/*
+ * hwreg_registry.h — hwregd's hardware registry tree (Phase 1 iter 1).
+ *
+ * A tree of hw_node records, one per newbus device, modelled on
+ * macOS's IORegistry (plan §3.2). Built at startup from a snapshot of
+ * the kernel's newbus tree (the hw.bus.* sysctls — the same data
+ * libdevinfo exposes; hwregd reads the sysctls directly so it carries
+ * no dependency on the FreeBSD-devmatch package, which the image
+ * deliberately drops) and kept current by /dev/devctl attach/detach
+ * events.
+ *
+ * iter 1 is the data model + the tree itself: no Mach-RPC query API
+ * yet (that is iter 2, which also adds the typed xpc property bag and
+ * the lock the RPC thread needs). The registry is therefore touched
+ * only by hwregd's main/devctl thread in iter 1 and needs no locking.
+ *
+ * Plan: https://pkgdemon.github.io/freebsd-hardware-registry-iokit-plan.html
+ */
+
+#ifndef HWREG_REGISTRY_H
+#define HWREG_REGISTRY_H
+
+#include <stdint.h>
+
+/* Attachment state of a registry node (plan §3.2). */
+enum hw_node_state {
+	HW_PROBED = 0,	/* enumerated; driver not (yet) attached */
+	HW_ATTACHED,	/* driver attached and live */
+	HW_DETACHED,	/* device departed; node lingers for open handles */
+	HW_FAILED,	/* driver probe/load failed */
+};
+
+/*
+ * One node of the hardware registry — a newbus device. iter 1 captures
+ * the identity and the raw strings the kernel hands us; iter 2 adds the
+ * typed xpc property bag the Mach-RPC layer serialises.
+ */
+struct hw_node {
+	uint64_t		id;		/* registry-unique, monotonic; 0 = invalid */
+	uint64_t		parent_id;	/* 0 = root of the forest */
+	char			name[32];	/* newbus name: "em0", "pci0", "cpu0" */
+	char			classname[32];	/* coarse class: "PCIDevice", "USBDevice", ... */
+	char			driver[32];	/* attached driver, or "" */
+	char			desc[128];	/* human-readable description */
+	char			pnpinfo[256];	/* bus plug-and-play string */
+	char			location[128];	/* bus location string */
+	char			path[256];	/* "/nexus0/.../em0" */
+	enum hw_node_state	state;
+	uint32_t		refcnt;		/* iter 4 stale-handle detection */
+	struct hw_node		*next;		/* registry-internal list link */
+};
+
+/*
+ * Build the initial registry from a snapshot of the kernel newbus tree.
+ * Returns the number of device nodes created, or -1 on failure (errno
+ * set). Call once at startup.
+ */
+int		hwreg_build_snapshot(void);
+
+/* Number of nodes currently in the registry. */
+int		hwreg_count(void);
+
+/* Look a node up by newbus name / by id; NULL if absent. */
+struct hw_node *hwreg_find_by_name(const char *name);
+struct hw_node *hwreg_get(uint64_t id);
+
+/*
+ * Fold a /dev/devctl attach (`+`) or detach (`-`) event into the tree.
+ * An attach for an unknown device adds a node (hot-plug); a detach
+ * marks the node HW_DETACHED but leaves it in the tree.
+ */
+void		hwreg_note_attach(const char *name, const char *parent,
+		    const char *location);
+void		hwreg_note_detach(const char *name);
+
+/* Visit every node in registry order. */
+void		hwreg_foreach(void (*fn)(const struct hw_node *n, void *arg),
+		    void *arg);
+
+/* Human-readable name for a node state. */
+const char     *hw_state_name(enum hw_node_state s);
+
+#endif /* HWREG_REGISTRY_H */

--- a/src/hwregd/hwregd.c
+++ b/src/hwregd/hwregd.c
@@ -77,6 +77,8 @@
 #include <mach/mach.h>
 #include <servers/bootstrap.h>
 
+#include "hwreg_registry.h"
+
 #define DEVCTL_PATH		"/dev/devctl"
 #define READ_BUF_SIZE		(64 * 1024)
 #define EVENT_LINE_MAX		1024
@@ -799,6 +801,12 @@ handle_attach_detach(char *line, const char *kind)
 		xlog("%s", text);
 		publish_event(line[0], text);
 	}
+
+	/* Fold the event into the registry tree (Phase 1). */
+	if (line[0] == '+')
+		hwreg_note_attach(dev, parent, loc);
+	else
+		hwreg_note_detach(dev);
 }
 
 /* --- devctl event loop -------------------------------------------- */
@@ -940,13 +948,24 @@ mach_service_thread(void *arg)
 	return NULL;
 }
 
+/* hwreg_foreach() callback — log one registry node. */
+static void
+log_hw_node(const struct hw_node *n, void *arg)
+{
+	(void)arg;
+	xlog("hwreg: [%2ju<-%2ju] %-16s %-10s %-8s drv=%-8s %s",
+	    (uintmax_t)n->id, (uintmax_t)n->parent_id, n->name,
+	    n->classname, hw_state_name(n->state),
+	    n->driver[0] ? n->driver : "-", n->path);
+}
+
 int
 main(int argc, char **argv)
 {
 	(void)argc;
 	(void)argv;
 
-	xlog("starting (Phase 0 iter 3b-ii: Mach pub/sub bus)");
+	xlog("starting (Phase 1 iter 1: hardware registry tree)");
 
 	/* Clean shutdown on SIGTERM / SIGINT (launchd sends SIGTERM). */
 	{
@@ -957,6 +976,24 @@ main(int argc, char **argv)
 	}
 
 	read_linker_hints();
+
+	/*
+	 * Phase 1 iter 1 — build the hardware registry from a snapshot of
+	 * the kernel newbus tree. /dev/devctl attach/detach events keep it
+	 * current from here on (see handle_attach_detach).
+	 */
+	{
+		int nnodes = hwreg_build_snapshot();
+
+		if (nnodes < 0)
+			xlog("hwreg: registry snapshot failed: %s",
+			    strerror(errno));
+		else {
+			xlog("hwreg: registry built — %d device nodes",
+			    nnodes);
+			hwreg_foreach(log_hw_node, NULL);
+		}
+	}
 
 	int fd = open_devctl();
 	if (fd < 0)


### PR DESCRIPTION
## Summary

First iteration of hwregd **Phase 1** — the structured hardware registry that the IOKit-shaped Mach-RPC API will sit on (plan §3.2). Phase 0 gave hwregd a flat device-event bus; this adds the *tree*.

`hwreg_registry.c` maintains a tree of `hw_node` records, one per newbus device:

- **Boot snapshot** of the kernel newbus tree, read straight from the `hw.bus.*` sysctls — `hw.bus.info` for the ABI version + generation count, `hw.bus.devices.<gen>.<idx>` for each `struct u_device`. hwregd reads the sysctls directly rather than linking **libdevinfo**: that library ships in `FreeBSD-devmatch`, a package `pkglist-base.txt` deliberately drops (hwregd *replaces* devd/devmatch). The generation-change retry mirrors libdevinfo's own `devinfo_init()`.
- **Live maintenance** — `/dev/devctl` attach/detach events fold into the tree via `hwreg_note_attach()` / `hwreg_note_detach()`: a hot-plugged device not in the boot snapshot is added; a detached one is marked `HW_DETACHED` but kept.
- Each node carries `id`/`parent_id`, newbus name, a coarse IORegistry-style class, driver, pnpinfo/location/desc, a built `/path`, and an attachment state.

No Mach-RPC query API yet — that's **iter 2**, which also adds the typed `xpc` property bag and the lock the RPC reader thread needs. In iter 1 the registry is touched only by hwregd's devctl thread, so it needs no locking.

No new dependency: the registry is libc-only (sysctl). `SRCS` grows by one file.

## Test plan

Verified on the bsd01 test VM (FreeBSD 15.0, launchd PID 1):

- hwregd builds the registry at boot — **62 device nodes**, parent linkage correct (`cpu0`/`cpu1` under `acpi0`, `acpi0` under `nexus0` under `root0`), paths built (`/root0/nexus0/acpi0/cpu0`), states (`ATTACHED`/`PROBED`) and coarse classes (`CPU`, `ACPIDevice`, `PCIDevice`) populated.
- The `HWREG-PUBSUB` pub/sub round-trip is unaffected — `HWREG-PUBSUB-OK`.
- hwregd stable; clean build at `WARNS=6 -Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)