### PR TITLE
feat(hwregd): Phase 1 iter 2a — Mach-RPC registry query API

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -895,9 +895,25 @@ echo "==> launchctl built + ldd verified"
 #
 echo "==> building hwregd (src/hwregd)"
 mkdir -p "$WORK/rootfs/usr/sbin"
+# Phase 1 iter 2a — generate the hwreg.defs MIG stubs (hwreg_server()
+# demux for hwregd, hwregUser.c for the hwregquery test client). Same
+# mig.sh + migcom path as the launchd MIG step above.
+HWREG_MIG="$WORK/hwreg-mig"
+mkdir -p "$HWREG_MIG"
+( cd "$HWREG_MIG" && \
+  MIGCC=/usr/bin/cc MIGCOM="$WORK/rootfs/usr/libexec/migcom" \
+  /bin/sh "$ROOT/src/bootstrap_cmds/migcom.tproj/mig.sh" \
+    -I"$ROOT/src/libmach/include" \
+    -header hwreg.h -user hwregUser.c \
+    -server hwregServer.c -sheader hwregServer.h \
+    "$ROOT/src/hwregd/hwreg.defs" ) \
+  || { echo "FAIL: mig could not process hwreg.defs"; exit 1; }
+test -s "$HWREG_MIG/hwregServer.c" \
+    || { echo "FAIL: mig produced no hwregServer.c"; exit 1; }
 make -C "$ROOT/src/hwregd" \
     DESTDIR="$WORK/rootfs" \
     SYSROOT="$WORK/rootfs" \
+    MIGOUT="$HWREG_MIG" \
     all install
 ls -lh "$WORK/rootfs/usr/sbin/hwregd"
 test -x "$WORK/rootfs/usr/sbin/hwregd" \
@@ -916,6 +932,19 @@ cc -I"$WORK/rootfs/usr/include" \
    -llaunch -lsystem_kernel
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hwregtest" \
     || { echo "FAIL: hwregtest not built"; exit 1; }
+
+# hwregquery — iter 2a test client for hwregd's Mach-RPC query API.
+# Links the MIG user stub hwregUser.c; run.sh walks the registry tree
+# with it and checks for the HWREG-RPC-OK marker.
+echo "==> building hwregquery"
+cc -I"$HWREG_MIG" -I"$ROOT/src/hwregd" -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hwregquery" \
+   "$ROOT/src/hwregd/hwregquery.c" "$HWREG_MIG/hwregUser.c" \
+   -llaunch -lsystem_kernel
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hwregquery" \
+    || { echo "FAIL: hwregquery not built"; exit 1; }
 
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -447,4 +447,13 @@ if [ ! -x "$hwregtest" ]; then
 fi
 "$hwregtest" || true	# marker (HWREG-PUBSUB-OK/FAIL) gates in boot-test.sh
 
+# HWREG-RPC — hwregd Mach-RPC query API: walk the registry tree via
+# the MIG hwreg.defs routines (get_root / get_children / get_node).
+hwregquery=/usr/tests/freebsd-launchd-mach/hwregquery
+if [ ! -x "$hwregquery" ]; then
+    echo "HWREG-RPC-FAIL: $hwregquery missing"
+    exit 1
+fi
+"$hwregquery" || true	# marker (HWREG-RPC-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/hwregd/Makefile
+++ b/src/hwregd/Makefile
@@ -18,6 +18,24 @@ MAN=
 # extra LDADD.
 SRCS=		hwregd.c hwreg_registry.c
 
+# hwregServer.c — MIG-generated server stub for hwreg.defs (Phase 1
+# iter 2a Mach-RPC query API). build.sh runs mig and passes MIGOUT=;
+# a bare standalone build without it fails at the generated #include,
+# the same way liblaunch does. -w on the generated TU: MIG output is
+# not WARNS-clean and must not gate the build.
+MIGOUT?=
+.if !empty(MIGOUT)
+.PATH:			${MIGOUT}
+SRCS+=			hwregServer.c
+CFLAGS+=		-I${MIGOUT}
+CFLAGS+=		-I${.CURDIR}	# generated stubs #include "hwreg_mig_types.h"
+CFLAGS.hwregServer.c+=	-w
+# The MIG stubs pull <mach/notify.h>, which redefines the MACH_NOTIFY_*
+# macros <mach/message.h> also defines (identical values, whitespace
+# differs) — a benign clash in the vendored mach headers.
+CFLAGS+=		-Wno-macro-redefined
+.endif
+
 WARNS?=		6
 NO_MAN=		yes
 

--- a/src/hwregd/hwreg.defs
+++ b/src/hwregd/hwreg.defs
@@ -1,0 +1,73 @@
+/*
+ * hwreg.defs — Mach-RPC interface to hwregd's hardware registry
+ * (Phase 1 iter 2a: the tree-walk query API).
+ *
+ * MIG-generated. The server demux hwreg_server() runs inside hwregd's
+ * mach_service_thread receive loop, alongside the hand-rolled pub/sub
+ * SUBSCRIBE message (whose msgh_id sits well outside this subsystem's
+ * routine range, so the loop can tell them apart).
+ *
+ * iter 2a is the no-xpc subset — walk the tree and read each node's
+ * scalar identity fields. iter 2b adds hwreg_get_properties /
+ * hwreg_lookup with the typed xpc property bag.
+ *
+ * Plan: https://pkgdemon.github.io/freebsd-hardware-registry-iokit-plan.html
+ */
+
+#include <mach/std_types.defs>
+#include <mach/mach_types.defs>
+
+subsystem hwreg 30000;
+
+import <sys/types.h>;
+
+/*
+ * MIG needs arrays and strings declared as named types — they cannot
+ * appear inline in a routine's parameter list — and it does not emit
+ * a C typedef for a `type`, so hwreg_mig_types.h supplies them and is
+ * imported into the generated stubs. Bounds mirror the hw_node fields
+ * in hwreg_registry.h.
+ */
+import "hwreg_mig_types.h";
+
+type hwreg_id_array_t	= array[*:128] of uint64_t;
+type hwreg_name_t	= c_string[32];
+type hwreg_path_t	= c_string[256];
+
+/*
+ * hwreg_get_root — registry id of the tree root (the newbus root
+ * device, normally "root0"). 0 if the registry is empty.
+ */
+routine hwreg_get_root(
+	server		: mach_port_t;
+	out root_id	: uint64_t
+);
+
+/*
+ * hwreg_get_children — registry ids of node `id`'s direct children.
+ * Returns KERN_INVALID_ARGUMENT for an unknown id. The reply array is
+ * capped at its bound; a node with a larger fan-out is truncated
+ * (acceptable for the tree walk — iter 2b's lookup API is the route
+ * to a specific deep node).
+ */
+routine hwreg_get_children(
+	server		: mach_port_t;
+	id		: uint64_t;
+	out children	: hwreg_id_array_t
+);
+
+/*
+ * hwreg_get_node — the scalar identity fields of node `id`.
+ * KERN_INVALID_ARGUMENT for an unknown id. node_state is the
+ * hw_node_state enum; the typed property bag is iter 2b.
+ */
+routine hwreg_get_node(
+	server		: mach_port_t;
+	id		: uint64_t;
+	out parent_id	: uint64_t;
+	out node_state	: int;
+	out name	: hwreg_name_t;
+	out classname	: hwreg_name_t;
+	out driver	: hwreg_name_t;
+	out path	: hwreg_path_t
+);

--- a/src/hwregd/hwreg_mig_types.h
+++ b/src/hwregd/hwreg_mig_types.h
@@ -1,0 +1,21 @@
+/*
+ * hwreg_mig_types.h — C typedefs for the named MIG types in hwreg.defs.
+ *
+ * MIG records the wire layout of a `type` declaration but does not
+ * emit a C typedef for it: the generated stubs use the type name as-is
+ * and expect an imported header to define it. hwreg.defs imports this
+ * header so both the generated server (hwregServer.{c,h}) and user
+ * (hwregUser.c / hwreg.h) sides see the types. The bounds must match
+ * the array/string sizes in hwreg.defs (and the hw_node fields in
+ * hwreg_registry.h).
+ */
+#ifndef HWREG_MIG_TYPES_H
+#define HWREG_MIG_TYPES_H
+
+#include <stdint.h>
+
+typedef uint64_t	hwreg_id_array_t[128];	/* array[*:128] of uint64_t */
+typedef char		hwreg_name_t[32];	/* c_string[32]  */
+typedef char		hwreg_path_t[256];	/* c_string[256] */
+
+#endif /* HWREG_MIG_TYPES_H */

--- a/src/hwregd/hwreg_registry.c
+++ b/src/hwregd/hwreg_registry.c
@@ -1,12 +1,18 @@
 /*
- * hwreg_registry.c — hwregd hardware registry tree (Phase 1 iter 1).
+ * hwreg_registry.c — hwregd hardware registry tree (Phase 1).
  *
  * Builds and maintains the hw_node tree described in hwreg_registry.h.
  * The boot snapshot comes from the kernel newbus tree via the hw.bus.*
- * sysctls (hw.bus.info for the ABI version, hw.bus.devices.<N> for one
- * struct u_device per device) — the same data libdevinfo reads, but
- * read directly so hwregd needs no FreeBSD-devmatch dependency. After
- * the snapshot, /dev/devctl attach/detach events keep the tree current.
+ * sysctls (hw.bus.info for the ABI version, hw.bus.devices.<gen>.<idx>
+ * for one struct u_device per device) — the same data libdevinfo
+ * reads, but read directly so hwregd needs no FreeBSD-devmatch
+ * dependency. After the snapshot, /dev/devctl attach/detach events
+ * keep the tree current.
+ *
+ * Concurrency (iter 2a): the devctl thread mutates the tree while the
+ * Mach-RPC thread reads it, so the registry is guarded by reg_lock.
+ * Every public (hwreg_*) function locks; the static helpers below run
+ * with the lock already held by their caller.
  */
 
 #include <sys/types.h>
@@ -15,6 +21,7 @@
 #include <sys/sysctl.h>
 
 #include <errno.h>
+#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,14 +31,13 @@
 
 /*
  * The registry is a singly-linked list kept in enumeration order
- * (head .. tail). iter 1 is single-threaded — only hwregd's devctl
- * thread touches it — so there is no lock; iter 2's Mach-RPC reader
- * thread adds one.
+ * (head .. tail), guarded by reg_lock.
  */
 static struct hw_node *registry_head;
 static struct hw_node *registry_tail;
 static uint64_t		next_id = 1;	/* 0 is reserved for "no node" */
 static int		node_count;
+static pthread_mutex_t	reg_lock = PTHREAD_MUTEX_INITIALIZER;
 
 const char *
 hw_state_name(enum hw_node_state s)
@@ -45,27 +51,10 @@ hw_state_name(enum hw_node_state s)
 	return "?";
 }
 
-int
-hwreg_count(void)
-{
-	return node_count;
-}
+/* --- internal helpers — caller must hold reg_lock --------------- */
 
-struct hw_node *
-hwreg_find_by_name(const char *name)
-{
-	struct hw_node *n;
-
-	if (name == NULL || name[0] == '\0')
-		return NULL;
-	for (n = registry_head; n != NULL; n = n->next)
-		if (strcmp(n->name, name) == 0)
-			return n;
-	return NULL;
-}
-
-struct hw_node *
-hwreg_get(uint64_t id)
+static struct hw_node *
+find_by_id(uint64_t id)
 {
 	struct hw_node *n;
 
@@ -77,13 +66,17 @@ hwreg_get(uint64_t id)
 	return NULL;
 }
 
-void
-hwreg_foreach(void (*fn)(const struct hw_node *n, void *arg), void *arg)
+static struct hw_node *
+find_by_name(const char *name)
 {
 	struct hw_node *n;
 
+	if (name == NULL || name[0] == '\0')
+		return NULL;
 	for (n = registry_head; n != NULL; n = n->next)
-		fn(n, arg);
+		if (strcmp(n->name, name) == 0)
+			return n;
+	return NULL;
 }
 
 /* Append a freshly-allocated node for `name`; returns NULL on OOM. */
@@ -109,12 +102,12 @@ node_new(const char *name, uint64_t parent_id)
 
 /*
  * Coarse device class, IORegistry-style. Cheap heuristic off the
- * parent bus / device name; iter 2 refines it from PCI/USB enrichment.
+ * parent bus / device name; iter 2b refines it from PCI/USB enrichment.
  */
 static void
 classify(struct hw_node *n)
 {
-	const struct hw_node *p = hwreg_get(n->parent_id);
+	const struct hw_node *p = find_by_id(n->parent_id);
 	const char *pn = (p != NULL) ? p->name : "";
 
 	if (strncmp(pn, "pci", 3) == 0)
@@ -142,7 +135,7 @@ ensure_path(struct hw_node *n)
 
 	if (n->path[0] != '\0')
 		return;
-	p = hwreg_get(n->parent_id);
+	p = find_by_id(n->parent_id);
 	if (p != NULL) {
 		ensure_path(p);
 		(void)snprintf(n->path, sizeof(n->path), "%s/%s",
@@ -150,6 +143,24 @@ ensure_path(struct hw_node *n)
 	} else {
 		(void)snprintf(n->path, sizeof(n->path), "/%s", n->name);
 	}
+}
+
+/* Free every node and reset the registry to empty — used between
+ * snapshot retries when the kernel generation count moves. */
+static void
+registry_reset(void)
+{
+	struct hw_node *n = registry_head, *nx;
+
+	while (n != NULL) {
+		nx = n->next;
+		free(n);
+		n = nx;
+	}
+	registry_head = NULL;
+	registry_tail = NULL;
+	node_count = 0;
+	next_id = 1;
 }
 
 /* Transient parent-handle map, used only while building the snapshot. */
@@ -175,24 +186,6 @@ next_field(const char **pp, const char *end)
 		q++;
 	*pp = (q < end) ? q + 1 : end;
 	return s;
-}
-
-/* Free every node and reset the registry to empty — used between
- * snapshot retries when the kernel generation count moves. */
-static void
-registry_reset(void)
-{
-	struct hw_node *n = registry_head, *nx;
-
-	while (n != NULL) {
-		nx = n->next;
-		free(n);
-		n = nx;
-	}
-	registry_head = NULL;
-	registry_tail = NULL;
-	node_count = 0;
-	next_id = 1;
 }
 
 /*
@@ -311,6 +304,8 @@ snapshot_attempt(void)
 	return (int)nents;
 }
 
+/* --- public API — each locks reg_lock --------------------------- */
+
 int
 hwreg_build_snapshot(void)
 {
@@ -321,16 +316,43 @@ hwreg_build_snapshot(void)
 	 * (snapshot_attempt() returns -1/EINVAL) — the registry built so
 	 * far is stale, so discard it and rescan from a fresh generation.
 	 */
+	pthread_mutex_lock(&reg_lock);
 	for (retries = 0; retries < 8; retries++) {
 		r = snapshot_attempt();
 		if (r >= 0)
-			return r;
+			goto out;		/* success */
 		if (errno != EINVAL)
-			return -1;
-		registry_reset();
+			goto out;		/* hard failure, errno set */
+		registry_reset();		/* generation moved — retry */
 	}
-	errno = EAGAIN;
-	return -1;
+	errno = EAGAIN;				/* gave up after 8 tries */
+	r = -1;
+out:
+	pthread_mutex_unlock(&reg_lock);
+	return r;
+}
+
+int
+hwreg_count(void)
+{
+	int n;
+
+	pthread_mutex_lock(&reg_lock);
+	n = node_count;
+	pthread_mutex_unlock(&reg_lock);
+	return n;
+}
+
+void
+hwreg_foreach(void (*fn)(const struct hw_node *n, void *arg), void *arg)
+{
+	struct hw_node *n;
+
+	/* Callback runs under the lock — fn must not re-enter hwreg_*. */
+	pthread_mutex_lock(&reg_lock);
+	for (n = registry_head; n != NULL; n = n->next)
+		fn(n, arg);
+	pthread_mutex_unlock(&reg_lock);
 }
 
 void
@@ -340,27 +362,87 @@ hwreg_note_attach(const char *name, const char *parent, const char *location)
 
 	if (name == NULL || name[0] == '\0')
 		return;
-	n = hwreg_find_by_name(name);
+	pthread_mutex_lock(&reg_lock);
+	n = find_by_name(name);
 	if (n == NULL) {
 		/* Hot-plugged device that was not in the boot snapshot. */
-		struct hw_node *p = hwreg_find_by_name(parent);
+		struct hw_node *p = find_by_name(parent);
 
 		n = node_new(name, (p != NULL) ? p->id : 0);
-		if (n == NULL)
-			return;
-		classify(n);
-		ensure_path(n);
+		if (n != NULL) {
+			classify(n);
+			ensure_path(n);
+		}
 	}
-	n->state = HW_ATTACHED;
-	if (location != NULL && location[0] != '\0')
-		strlcpy(n->location, location, sizeof(n->location));
+	if (n != NULL) {
+		n->state = HW_ATTACHED;
+		if (location != NULL && location[0] != '\0')
+			strlcpy(n->location, location, sizeof(n->location));
+	}
+	pthread_mutex_unlock(&reg_lock);
 }
 
 void
 hwreg_note_detach(const char *name)
 {
-	struct hw_node *n = hwreg_find_by_name(name);
+	struct hw_node *n;
 
+	pthread_mutex_lock(&reg_lock);
+	n = find_by_name(name);
 	if (n != NULL)
 		n->state = HW_DETACHED;
+	pthread_mutex_unlock(&reg_lock);
+}
+
+uint64_t
+hwreg_root_id(void)
+{
+	struct hw_node *n;
+	uint64_t id = 0;
+
+	pthread_mutex_lock(&reg_lock);
+	for (n = registry_head; n != NULL; n = n->next)
+		if (n->parent_id == 0) {
+			id = n->id;
+			break;
+		}
+	pthread_mutex_unlock(&reg_lock);
+	return id;
+}
+
+int
+hwreg_children(uint64_t parent_id, uint64_t *ids, int max)
+{
+	struct hw_node *n;
+	int count = 0;
+
+	pthread_mutex_lock(&reg_lock);
+	if (find_by_id(parent_id) == NULL) {
+		pthread_mutex_unlock(&reg_lock);
+		return -1;			/* unknown parent id */
+	}
+	for (n = registry_head; n != NULL; n = n->next) {
+		if (n->parent_id == parent_id) {
+			if (count < max)
+				ids[count] = n->id;
+			count++;
+		}
+	}
+	pthread_mutex_unlock(&reg_lock);
+	return (count > max) ? max : count;
+}
+
+int
+hwreg_copy(uint64_t id, struct hw_node *dst)
+{
+	struct hw_node *n;
+	int found;
+
+	pthread_mutex_lock(&reg_lock);
+	n = find_by_id(id);
+	if (n != NULL)
+		*dst = *n;		/* struct copy; dst->next is meaningless */
+	found = (n != NULL);
+	pthread_mutex_unlock(&reg_lock);
+	return found;
 }

--- a/src/hwregd/hwreg_registry.h
+++ b/src/hwregd/hwreg_registry.h
@@ -1,5 +1,5 @@
 /*
- * hwreg_registry.h — hwregd's hardware registry tree (Phase 1 iter 1).
+ * hwreg_registry.h — hwregd's hardware registry tree (Phase 1).
  *
  * A tree of hw_node records, one per newbus device, modelled on
  * macOS's IORegistry (plan §3.2). Built at startup from a snapshot of
@@ -9,10 +9,11 @@
  * deliberately drops) and kept current by /dev/devctl attach/detach
  * events.
  *
- * iter 1 is the data model + the tree itself: no Mach-RPC query API
- * yet (that is iter 2, which also adds the typed xpc property bag and
- * the lock the RPC thread needs). The registry is therefore touched
- * only by hwregd's main/devctl thread in iter 1 and needs no locking.
+ * iter 1 was the data model + the tree. iter 2a adds the read-side
+ * query helpers the Mach-RPC layer (hwreg.defs) calls — and, with the
+ * RPC running on hwregd's mach_service_thread while devctl events
+ * mutate the tree on the main thread, the registry is now mutex-
+ * guarded: every public function below locks internally.
  *
  * Plan: https://pkgdemon.github.io/freebsd-hardware-registry-iokit-plan.html
  */
@@ -31,9 +32,9 @@ enum hw_node_state {
 };
 
 /*
- * One node of the hardware registry — a newbus device. iter 1 captures
- * the identity and the raw strings the kernel hands us; iter 2 adds the
- * typed xpc property bag the Mach-RPC layer serialises.
+ * One node of the hardware registry — a newbus device. iter 1/2a
+ * capture the identity and the raw strings the kernel hands us; iter
+ * 2b adds the typed xpc property bag the Mach-RPC layer serialises.
  */
 struct hw_node {
 	uint64_t		id;		/* registry-unique, monotonic; 0 = invalid */
@@ -51,18 +52,14 @@ struct hw_node {
 };
 
 /*
- * Build the initial registry from a snapshot of the kernel newbus tree.
- * Returns the number of device nodes created, or -1 on failure (errno
- * set). Call once at startup.
+ * Build the initial registry from a snapshot of the kernel newbus
+ * tree. Returns the number of device nodes created, or -1 on failure
+ * (errno set). Call once at startup.
  */
 int		hwreg_build_snapshot(void);
 
 /* Number of nodes currently in the registry. */
 int		hwreg_count(void);
-
-/* Look a node up by newbus name / by id; NULL if absent. */
-struct hw_node *hwreg_find_by_name(const char *name);
-struct hw_node *hwreg_get(uint64_t id);
 
 /*
  * Fold a /dev/devctl attach (`+`) or detach (`-`) event into the tree.
@@ -73,9 +70,27 @@ void		hwreg_note_attach(const char *name, const char *parent,
 		    const char *location);
 void		hwreg_note_detach(const char *name);
 
-/* Visit every node in registry order. */
+/* Visit every node in registry order (callback runs under the lock). */
 void		hwreg_foreach(void (*fn)(const struct hw_node *n, void *arg),
 		    void *arg);
+
+/* --- read-side query API, for the Mach-RPC layer (hwreg.defs) ----- */
+
+/* Registry id of the tree root (first parent-less node); 0 if empty. */
+uint64_t	hwreg_root_id(void);
+
+/*
+ * Registry ids of `parent_id`'s direct children, written into ids[0..]
+ * (at most `max`). Returns the child count (capped at `max`), or -1 if
+ * no node has id == parent_id.
+ */
+int		hwreg_children(uint64_t parent_id, uint64_t *ids, int max);
+
+/*
+ * Copy node `id` into *dst. Returns 1 if found (dst filled), 0 if not.
+ * dst->next is meaningless in the copy.
+ */
+int		hwreg_copy(uint64_t id, struct hw_node *dst);
 
 /* Human-readable name for a node state. */
 const char     *hw_state_name(enum hw_node_state s);

--- a/src/hwregd/hwregd.c
+++ b/src/hwregd/hwregd.c
@@ -78,6 +78,7 @@
 #include <servers/bootstrap.h>
 
 #include "hwreg_registry.h"
+#include "hwregServer.h"		/* MIG: hwreg_server() demux + routine protos */
 
 #define DEVCTL_PATH		"/dev/devctl"
 #define READ_BUF_SIZE		(64 * 1024)
@@ -101,6 +102,16 @@
  */
 #define HWREG_MSG_SUBSCRIBE	0x48575201	/* client  -> hwregd */
 #define HWREG_MSG_EVENT		0x48575202	/* hwregd   -> subscriber */
+
+/*
+ * Mach-RPC query API (iter 2a) — MIG subsystem 30000, demuxed by
+ * hwreg_server() in the same receive loop. HWREG_RPC_BUFSZ sizes the
+ * request + reply buffers (the largest message is hwreg_get_children's
+ * id-array reply). HWREG_RPC_MAX_CHILDREN must match the array bound
+ * `array[*:128]` in hwreg.defs.
+ */
+#define HWREG_RPC_BUFSZ		4096
+#define HWREG_RPC_MAX_CHILDREN	128
 
 /* The event message hwregd pushes to each subscriber. */
 struct hwreg_event_msg {
@@ -870,16 +881,63 @@ drain_devctl(int fd, char *buf, size_t bufsz)
 	return n;
 }
 
+/* --- Mach-RPC query routines (MIG hwreg subsystem) ---------------- */
+
 /*
- * Mach service thread (iter 3b-i skeleton). Checks the
- * org.freebsd.hwregd service in with launchd and runs a raw mach_msg
- * receive loop. It is a SECOND thread on purpose — if Mach IPC
- * stalls, the devctl loop on the main thread keeps running. A raw
- * mach_msg loop, not a libdispatch DISPATCH_SOURCE_TYPE_MACH_RECV
- * source: dispatch sources deadlock in this port (task #41). The
- * 500ms receive timeout lets the loop re-check got_term for a clean
- * shutdown. iter 3b-ii adds the subscribe/publish protocol; for now
- * any received message is just logged.
+ * Server-side implementations of the hwreg.defs routines; MIG's
+ * hwreg_server() demux calls these. Each bridges the RPC to the
+ * registry's internally-locked query helpers.
+ */
+kern_return_t
+hwreg_get_root(mach_port_t server, uint64_t *root_id)
+{
+	(void)server;
+	*root_id = hwreg_root_id();
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+hwreg_get_children(mach_port_t server, uint64_t id,
+    hwreg_id_array_t children, mach_msg_type_number_t *childrenCnt)
+{
+	int n = hwreg_children(id, children, HWREG_RPC_MAX_CHILDREN);
+
+	(void)server;
+	if (n < 0)
+		return KERN_INVALID_ARGUMENT;	/* unknown id */
+	*childrenCnt = (mach_msg_type_number_t)n;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+hwreg_get_node(mach_port_t server, uint64_t id, uint64_t *parent_id,
+    int *node_state, hwreg_name_t name, hwreg_name_t classname,
+    hwreg_name_t driver, hwreg_path_t path)
+{
+	struct hw_node n;
+
+	(void)server;
+	if (!hwreg_copy(id, &n))
+		return KERN_INVALID_ARGUMENT;	/* unknown id */
+	*parent_id = n.parent_id;
+	*node_state = (int)n.state;
+	strlcpy(name, n.name, sizeof(n.name));
+	strlcpy(classname, n.classname, sizeof(n.classname));
+	strlcpy(driver, n.driver, sizeof(n.driver));
+	strlcpy(path, n.path, sizeof(n.path));
+	return KERN_SUCCESS;
+}
+
+/*
+ * Mach service thread. Checks the org.freebsd.hwregd service in with
+ * launchd and runs a raw mach_msg receive loop. It is a SECOND thread
+ * on purpose — if Mach IPC stalls, the devctl loop on the main thread
+ * keeps running. A raw mach_msg loop, not a libdispatch
+ * DISPATCH_SOURCE_TYPE_MACH_RECV source: dispatch sources deadlock in
+ * this port (task #41). The 500ms receive timeout lets the loop
+ * re-check got_term for a clean shutdown. Each message is dispatched
+ * either to the pub/sub registry (a SUBSCRIBE) or to the MIG query
+ * demux hwreg_server() (a hwreg.defs RPC).
  */
 static void *
 mach_service_thread(void *arg)
@@ -899,24 +957,25 @@ mach_service_thread(void *arg)
 	    HWREGD_SERVICE_NAME, (unsigned)sp);
 
 	while (!got_term) {
-		struct {
+		union {
 			mach_msg_header_t hdr;
-			uint8_t body[512];
-		} msg;
+			char buf[HWREG_RPC_BUFSZ];
+		} req, rep;
 		mach_msg_return_t mr;
 
-		memset(&msg, 0, sizeof(msg));
-		mr = mach_msg(&msg.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT,
-		    0, sizeof(msg), sp, 500, MACH_PORT_NULL);
+		memset(&req, 0, sizeof(req));
+		mr = mach_msg(&req.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT,
+		    0, sizeof(req), sp, 500, MACH_PORT_NULL);
 		if (mr == MACH_RCV_TIMED_OUT)
 			continue;
 		if (mr != MACH_MSG_SUCCESS) {
-			xlog("Mach receive failed: 0x%x — Mach pub/sub off",
+			xlog("Mach receive failed: 0x%x — Mach service off",
 			    (unsigned)mr);
 			break;
 		}
-		if (msg.hdr.msgh_id == HWREG_MSG_SUBSCRIBE) {
-			mach_port_t client = msg.hdr.msgh_remote_port;
+
+		if (req.hdr.msgh_id == HWREG_MSG_SUBSCRIBE) {
+			mach_port_t client = req.hdr.msgh_remote_port;
 			int total = -1;
 
 			pthread_mutex_lock(&subscribers_lock);
@@ -935,14 +994,31 @@ mach_service_thread(void *arg)
 				/*
 				 * Ack so the client confirms the round-trip.
 				 * If the client already vanished the next
-				 * publish_event() prunes it — no need to act
-				 * on the result here.
+				 * publish_event() prunes it.
 				 */
 				(void)send_event_to(client, 'A',
 				    "subscribed to " HWREGD_SERVICE_NAME);
 			}
-		} else {
-			xlog("Mach: ignoring message id=%d", msg.hdr.msgh_id);
+			continue;
+		}
+
+		/*
+		 * Anything else goes to the MIG query demux: it writes the
+		 * routine's reply (or a MIG error) into `rep`. A false
+		 * return is a msgh_id this subsystem doesn't recognise.
+		 */
+		memset(&rep, 0, sizeof(rep));
+		if (!hwreg_server(&req.hdr, &rep.hdr)) {
+			xlog("Mach: ignoring message id=%d", req.hdr.msgh_id);
+			continue;
+		}
+		if (rep.hdr.msgh_remote_port != MACH_PORT_NULL) {
+			mr = mach_msg(&rep.hdr, MACH_SEND_MSG | MACH_SEND_TIMEOUT,
+			    rep.hdr.msgh_size, 0, MACH_PORT_NULL, 200,
+			    MACH_PORT_NULL);
+			if (mr != MACH_MSG_SUCCESS)
+				xlog("Mach: RPC reply send failed: 0x%x",
+				    (unsigned)mr);
 		}
 	}
 	return NULL;

--- a/src/hwregd/hwregquery.c
+++ b/src/hwregd/hwregquery.c
@@ -1,0 +1,92 @@
+/*
+ * hwregquery — iter 2a test client for hwregd's Mach-RPC query API.
+ *
+ * Looks up the org.freebsd.hwregd Mach service, then uses the MIG
+ * hwreg.defs routines (hwreg_get_root / hwreg_get_children /
+ * hwreg_get_node) to walk the hardware registry tree. Prints
+ * HWREG-RPC-OK on success — the CI boot test (run.sh / boot-test.sh)
+ * matches that marker. Built against the MIG user stub hwregUser.c.
+ */
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <stdio.h>
+
+#include "hwreg.h"		/* MIG user-side routine prototypes + types */
+
+#define MAXKIDS	128		/* matches array[*:128] in hwreg.defs */
+
+static int	walked;		/* nodes successfully visited */
+static int	failed;		/* set on the first RPC error */
+
+/* Depth-first walk of the registry subtree rooted at `id`. */
+static void
+walk(mach_port_t svc, uint64_t id, int depth)
+{
+	uint64_t parent_id;
+	int node_state;
+	char name[32], classname[32], driver[32], path[256];
+	uint64_t kids[MAXKIDS];
+	mach_msg_type_number_t nkids = MAXKIDS;
+	kern_return_t kr;
+	unsigned int i;
+
+	kr = hwreg_get_node(svc, id, &parent_id, &node_state,
+	    name, classname, driver, path);
+	if (kr != KERN_SUCCESS) {
+		printf("  hwreg_get_node(%llu) failed: 0x%x\n",
+		    (unsigned long long)id, (unsigned)kr);
+		failed = 1;
+		return;
+	}
+	walked++;
+	/* Print only the top few levels — keep the CI log readable. */
+	if (depth < 3)
+		printf("  %*s[%llu] %s (%s)\n", depth * 2, "",
+		    (unsigned long long)id, name, classname);
+
+	kr = hwreg_get_children(svc, id, kids, &nkids);
+	if (kr != KERN_SUCCESS) {
+		printf("  hwreg_get_children(%llu) failed: 0x%x\n",
+		    (unsigned long long)id, (unsigned)kr);
+		failed = 1;
+		return;
+	}
+	for (i = 0; i < nkids; i++)
+		walk(svc, kids[i], depth + 1);
+}
+
+int
+main(void)
+{
+	mach_port_t svc = MACH_PORT_NULL;
+	kern_return_t kr;
+	uint64_t root = 0;
+
+	kr = bootstrap_look_up(bootstrap_port, "org.freebsd.hwregd", &svc);
+	if (kr != KERN_SUCCESS) {
+		printf("HWREG-RPC-FAIL: bootstrap_look_up: 0x%x\n",
+		    (unsigned)kr);
+		return 1;
+	}
+
+	kr = hwreg_get_root(svc, &root);
+	if (kr != KERN_SUCCESS) {
+		printf("HWREG-RPC-FAIL: hwreg_get_root: 0x%x\n", (unsigned)kr);
+		return 1;
+	}
+	if (root == 0) {
+		printf("HWREG-RPC-FAIL: registry is empty\n");
+		return 1;
+	}
+
+	walk(svc, root, 0);
+	if (failed) {
+		printf("HWREG-RPC-FAIL: registry tree walk hit an error\n");
+		return 1;
+	}
+
+	printf("HWREG-RPC-OK: walked %d registry nodes from root id=%llu\n",
+	    walked, (unsigned long long)root);
+	return 0;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -381,6 +381,18 @@ expect {
     "HWREG-PUBSUB-OK" { puts "\nOK: hwregd Mach pub/sub works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: HWREG-RPC marker not seen"
+        exit 1
+    }
+    "HWREG-RPC-FAIL" {
+        puts "\nFAIL: hwregd Mach-RPC registry query failed"
+        exit 1
+    }
+    "HWREG-RPC-OK" { puts "\nOK: hwregd Mach-RPC registry query works" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

Phase 1 **iter 2a** — the MIG-generated query RPC for hwregd's hardware registry (plan §3.3). The tree-walk subset; the typed `xpc` property bag + `hwreg_lookup` are **iter 2b**.

- **`hwreg.defs`** — MIG subsystem `hwreg` with `hwreg_get_root`, `hwreg_get_children`, `hwreg_get_node`. MIG needs arrays/strings as named types and doesn't emit C typedefs for them, so **`hwreg_mig_types.h`** supplies them and is `import`ed into the generated stubs.
- **`hwreg_server()` demux** runs inside hwregd's existing raw `mach_msg` receive loop, beside the hand-rolled pub/sub `SUBSCRIBE` (its `msgh_id` sits outside the subsystem's routine range, so the loop tells them apart). `build.sh` runs `mig` and passes `MIGOUT=`; the `Makefile` compiles `hwregServer.c` with `-w` (MIG output isn't `WARNS`-clean).
- **Registry locking** — the RPC thread now reads the registry while devctl events mutate it on the main thread, so `hwreg_registry.c` is mutex-guarded. `hwreg_root_id` / `hwreg_children` / `hwreg_copy` are the locked query helpers the routines call.
- **`hwregquery`** test client walks the whole tree over RPC; new **`HWREG-RPC-OK`** marker, gated in `boot-test.sh`.

The MIG headers pull `<mach/notify.h>`, which redefines the `MACH_NOTIFY_*` macros `<mach/message.h>` also defines — identical values, whitespace differs — a benign inconsistency in the vendored mach headers, silenced for the hwregd build with `-Wno-macro-redefined` (worth a follow-up to reconcile the two headers).

## Test plan

Verified on the bsd01 test VM (FreeBSD 15.0, launchd PID 1):

- `hwregquery` looks up `org.freebsd.hwregd` and walks the registry over the MIG RPC — `hwreg_get_root` → recursive `hwreg_get_children` / `hwreg_get_node` — visiting all **62 nodes**: `HWREG-RPC-OK: walked 62 registry nodes from root id=1`.
- `HWREG-PUBSUB` pub/sub round-trip unaffected — `HWREG-PUBSUB-OK`.
- hwregd builds clean at `WARNS=6 -Werror` (hand-written TUs) and stays stable.

## Follow-up

- **iter 2b** — the `xpc` property bag + `hwreg_get_properties` / `hwreg_lookup(criteria)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)