### PR TITLE
feat(hwregd): Phase 1 iter 2b — registry property bag + lookup RPC

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -933,16 +933,18 @@ cc -I"$WORK/rootfs/usr/include" \
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hwregtest" \
     || { echo "FAIL: hwregtest not built"; exit 1; }
 
-# hwregquery — iter 2a test client for hwregd's Mach-RPC query API.
-# Links the MIG user stub hwregUser.c; run.sh walks the registry tree
-# with it and checks for the HWREG-RPC-OK marker.
+# hwregquery — iter 2a/2b test client for hwregd's Mach-RPC query API.
+# Links the MIG user stub hwregUser.c (+ libxpc for the nvlist API the
+# iter 2b property-bag / lookup routines use); run.sh exercises it and
+# checks for the HWREG-RPC-OK marker.
 echo "==> building hwregquery"
-cc -I"$HWREG_MIG" -I"$ROOT/src/hwregd" -I"$WORK/rootfs/usr/include" \
+cc -I"$HWREG_MIG" -I"$ROOT/src/hwregd" -I"$ROOT/src/libxpc" \
+   -I"$WORK/rootfs/usr/include" \
    -L"$WORK/rootfs/usr/lib/system" \
    -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
    -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hwregquery" \
    "$ROOT/src/hwregd/hwregquery.c" "$HWREG_MIG/hwregUser.c" \
-   -llaunch -lsystem_kernel
+   -llaunch -lsystem_kernel -lxpc
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hwregquery" \
     || { echo "FAIL: hwregquery not built"; exit 1; }
 

--- a/src/hwregd/Makefile
+++ b/src/hwregd/Makefile
@@ -50,6 +50,8 @@ CFLAGS+=	-Wmissing-prototypes -Wpointer-arith
 # the Mach headers come from the rootfs.
 CFLAGS+=	-I${.CURDIR}/../launchd/liblaunch
 CFLAGS+=	-I${.CURDIR}/../launchd/freebsd-shims
+# iter 2b: nv.h — the libxpc nvlist API hwregd packs property bags with.
+CFLAGS+=	-I${.CURDIR}/../libxpc
 
 SYSROOT?=
 .if !empty(SYSROOT)
@@ -61,7 +63,8 @@ LDFLAGS+=	-Wl,--allow-shlib-undefined
 
 # -llaunch: bootstrap_check_in + the bootstrap_port global.
 # -lsystem_kernel: mach_msg and the Mach port syscalls.
-LDADD+=		-llaunch -lsystem_kernel -lpthread
+# -lxpc: the nvlist API (nvlist_pack / _unpack / ...) for property bags.
+LDADD+=		-llaunch -lsystem_kernel -lpthread -lxpc
 
 BINDIR=		/usr/sbin
 

--- a/src/hwregd/hwreg.defs
+++ b/src/hwregd/hwreg.defs
@@ -33,6 +33,11 @@ import "hwreg_mig_types.h";
 type hwreg_id_array_t	= array[*:128] of uint64_t;
 type hwreg_name_t	= c_string[32];
 type hwreg_path_t	= c_string[256];
+/* hwreg_byte_t — a raw byte with an explicit C type: MIG expands an
+ * inline array into `<element-ctype> field[N]` and has no C type for a
+ * bare MACH_MSG_TYPE_BYTE element (it emits `(null)`). */
+type hwreg_byte_t	= MACH_MSG_TYPE_BYTE ctype: uint8_t;
+type hwreg_blob_t	= array[*:2048] of hwreg_byte_t;
 
 /*
  * hwreg_get_root — registry id of the tree root (the newbus root
@@ -70,4 +75,28 @@ routine hwreg_get_node(
 	out classname	: hwreg_name_t;
 	out driver	: hwreg_name_t;
 	out path	: hwreg_path_t
+);
+
+/*
+ * hwreg_get_properties — node `id`'s full property bag, as a packed
+ * nvlist dictionary (id / parent-id / state / name / class / driver /
+ * description / pnpinfo / location / path). KERN_INVALID_ARGUMENT for
+ * an unknown id. iter 4's PCI/USB enrichment adds keys here.
+ */
+routine hwreg_get_properties(
+	server		: mach_port_t;
+	id		: uint64_t;
+	out props	: hwreg_blob_t
+);
+
+/*
+ * hwreg_lookup — registry ids of the nodes matching `criteria`, a
+ * packed nvlist dictionary of field constraints. iter 2b matches the
+ * string fields name / class / driver; a node matches when every
+ * constraint present equals its field. Empty criteria matches nothing.
+ */
+routine hwreg_lookup(
+	server		: mach_port_t;
+	criteria	: hwreg_blob_t;
+	out matches	: hwreg_id_array_t
 );

--- a/src/hwregd/hwreg_mig_types.h
+++ b/src/hwregd/hwreg_mig_types.h
@@ -17,5 +17,6 @@
 typedef uint64_t	hwreg_id_array_t[128];	/* array[*:128] of uint64_t */
 typedef char		hwreg_name_t[32];	/* c_string[32]  */
 typedef char		hwreg_path_t[256];	/* c_string[256] */
+typedef uint8_t		hwreg_blob_t[2048];	/* array[*:2048] of hwreg_byte_t */
 
 #endif /* HWREG_MIG_TYPES_H */

--- a/src/hwregd/hwregd.c
+++ b/src/hwregd/hwregd.c
@@ -79,6 +79,7 @@
 
 #include "hwreg_registry.h"
 #include "hwregServer.h"		/* MIG: hwreg_server() demux + routine protos */
+#include "nv.h"			/* libxpc nvlist — property-bag (de)serialise */
 
 #define DEVCTL_PATH		"/dev/devctl"
 #define READ_BUF_SIZE		(64 * 1024)
@@ -112,6 +113,7 @@
  */
 #define HWREG_RPC_BUFSZ		4096
 #define HWREG_RPC_MAX_CHILDREN	128
+#define HWREG_RPC_BLOBSZ	2048	/* hwreg_blob_t bound — matches hwreg.defs */
 
 /* The event message hwregd pushes to each subscriber. */
 struct hwreg_event_msg {
@@ -925,6 +927,119 @@ hwreg_get_node(mach_port_t server, uint64_t id, uint64_t *parent_id,
 	strlcpy(classname, n.classname, sizeof(n.classname));
 	strlcpy(driver, n.driver, sizeof(n.driver));
 	strlcpy(path, n.path, sizeof(n.path));
+	return KERN_SUCCESS;
+}
+
+/*
+ * hwreg_get_properties — node `id`'s property bag as a packed nvlist
+ * dictionary. The bag is built on demand from the hw_node fields;
+ * there is no stored bag until iter 4's enrichment needs one.
+ */
+kern_return_t
+hwreg_get_properties(mach_port_t server, uint64_t id, hwreg_blob_t props,
+    mach_msg_type_number_t *propsCnt)
+{
+	struct hw_node n;
+	nvlist_t *nv;
+	void *packed;
+	size_t size;
+
+	(void)server;
+	if (!hwreg_copy(id, &n))
+		return KERN_INVALID_ARGUMENT;	/* unknown id */
+
+	nv = nvlist_create_dictionary(0);
+	if (nv == NULL)
+		return KERN_RESOURCE_SHORTAGE;
+	nvlist_add_number(nv, "id", n.id);
+	nvlist_add_number(nv, "parent-id", n.parent_id);
+	nvlist_add_number(nv, "state", (uint64_t)n.state);
+	nvlist_add_string(nv, "name", n.name);
+	nvlist_add_string(nv, "class", n.classname);
+	nvlist_add_string(nv, "driver", n.driver);
+	nvlist_add_string(nv, "description", n.desc);
+	nvlist_add_string(nv, "pnpinfo", n.pnpinfo);
+	nvlist_add_string(nv, "location", n.location);
+	nvlist_add_string(nv, "path", n.path);
+
+	packed = nvlist_pack(nv, &size);
+	nvlist_destroy(nv);
+	if (packed == NULL)
+		return KERN_RESOURCE_SHORTAGE;
+	if (size > HWREG_RPC_BLOBSZ) {		/* a node bag never gets this big */
+		free(packed);
+		return KERN_NO_SPACE;
+	}
+	memcpy(props, packed, size);
+	free(packed);
+	*propsCnt = (mach_msg_type_number_t)size;
+	return KERN_SUCCESS;
+}
+
+/* hwreg_lookup match state, threaded through hwreg_foreach(). */
+struct lookup_ctx {
+	const char	*want_name;
+	const char	*want_class;
+	const char	*want_driver;
+	uint64_t	*ids;
+	int		 max;
+	int		 count;
+};
+
+/* hwreg_foreach() callback — record `n` if it meets every criterion. */
+static void
+lookup_match(const struct hw_node *n, void *arg)
+{
+	struct lookup_ctx *c = arg;
+
+	if (c->want_name != NULL && strcmp(c->want_name, n->name) != 0)
+		return;
+	if (c->want_class != NULL && strcmp(c->want_class, n->classname) != 0)
+		return;
+	if (c->want_driver != NULL && strcmp(c->want_driver, n->driver) != 0)
+		return;
+	if (c->count < c->max)
+		c->ids[c->count] = n->id;
+	c->count++;
+}
+
+/*
+ * hwreg_lookup — ids of the nodes matching the packed-nvlist criteria.
+ * iter 2b matches the string fields name / class / driver; empty
+ * criteria matches nothing.
+ */
+kern_return_t
+hwreg_lookup(mach_port_t server, hwreg_blob_t criteria,
+    mach_msg_type_number_t criteriaCnt, hwreg_id_array_t matches,
+    mach_msg_type_number_t *matchesCnt)
+{
+	struct lookup_ctx ctx;
+	nvlist_t *nv;
+
+	(void)server;
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.ids = matches;
+	ctx.max = HWREG_RPC_MAX_CHILDREN;	/* hwreg_id_array_t bound */
+
+	nv = nvlist_unpack(criteria, criteriaCnt);
+	if (nv == NULL)
+		return KERN_INVALID_ARGUMENT;	/* malformed criteria */
+	if (nvlist_empty(nv)) {
+		nvlist_destroy(nv);
+		*matchesCnt = 0;
+		return KERN_SUCCESS;
+	}
+	if (nvlist_exists_string(nv, "name"))
+		ctx.want_name = nvlist_get_string(nv, "name");
+	if (nvlist_exists_string(nv, "class"))
+		ctx.want_class = nvlist_get_string(nv, "class");
+	if (nvlist_exists_string(nv, "driver"))
+		ctx.want_driver = nvlist_get_string(nv, "driver");
+
+	hwreg_foreach(lookup_match, &ctx);	/* strings stay valid: nv alive */
+	nvlist_destroy(nv);
+	*matchesCnt = (mach_msg_type_number_t)
+	    (ctx.count > ctx.max ? ctx.max : ctx.count);
 	return KERN_SUCCESS;
 }
 

--- a/src/hwregd/hwregquery.c
+++ b/src/hwregd/hwregquery.c
@@ -1,18 +1,23 @@
 /*
- * hwregquery — iter 2a test client for hwregd's Mach-RPC query API.
+ * hwregquery — iter 2a/2b test client for hwregd's Mach-RPC query API.
  *
- * Looks up the org.freebsd.hwregd Mach service, then uses the MIG
- * hwreg.defs routines (hwreg_get_root / hwreg_get_children /
- * hwreg_get_node) to walk the hardware registry tree. Prints
- * HWREG-RPC-OK on success — the CI boot test (run.sh / boot-test.sh)
- * matches that marker. Built against the MIG user stub hwregUser.c.
+ * Looks up the org.freebsd.hwregd Mach service, then exercises the MIG
+ * hwreg.defs routines: walks the registry tree (hwreg_get_root /
+ * hwreg_get_children / hwreg_get_node), unpacks a node's property bag
+ * (hwreg_get_properties), and runs a criteria lookup (hwreg_lookup).
+ * Prints HWREG-RPC-OK on success — the CI boot test (run.sh /
+ * boot-test.sh) matches that marker. Built against the MIG user stub
+ * hwregUser.c.
  */
 #include <mach/mach.h>
 #include <servers/bootstrap.h>
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "hwreg.h"		/* MIG user-side routine prototypes + types */
+#include "nv.h"			/* libxpc nvlist — property bag (de)serialise */
 
 #define MAXKIDS	128		/* matches array[*:128] in hwreg.defs */
 
@@ -86,7 +91,59 @@ main(void)
 		return 1;
 	}
 
-	printf("HWREG-RPC-OK: walked %d registry nodes from root id=%llu\n",
-	    walked, (unsigned long long)root);
+	/* hwreg_get_properties — unpack the root node's property bag. */
+	{
+		hwreg_blob_t props;
+		mach_msg_type_number_t propcnt = 0;
+		nvlist_t *nv;
+
+		kr = hwreg_get_properties(svc, root, props, &propcnt);
+		if (kr != KERN_SUCCESS) {
+			printf("HWREG-RPC-FAIL: hwreg_get_properties: 0x%x\n",
+			    (unsigned)kr);
+			return 1;
+		}
+		nv = nvlist_unpack(props, propcnt);
+		if (nv == NULL) {
+			printf("HWREG-RPC-FAIL: property bag did not unpack\n");
+			return 1;
+		}
+		printf("  root props: name=%s class=%s path=%s\n",
+		    nvlist_get_string(nv, "name"),
+		    nvlist_get_string(nv, "class"),
+		    nvlist_get_string(nv, "path"));
+		nvlist_destroy(nv);
+	}
+
+	/* hwreg_lookup — count the CPU-class nodes via a criteria dict. */
+	{
+		nvlist_t *crit = nvlist_create_dictionary(0);
+		void *packed;
+		size_t psz = 0;
+		hwreg_blob_t critblob;
+		uint64_t ids[MAXKIDS];
+		mach_msg_type_number_t nids = 0;
+
+		nvlist_add_string(crit, "class", "CPU");
+		packed = nvlist_pack(crit, &psz);
+		nvlist_destroy(crit);
+		if (packed == NULL || psz > sizeof(critblob)) {
+			printf("HWREG-RPC-FAIL: criteria pack failed\n");
+			return 1;
+		}
+		memcpy(critblob, packed, psz);
+		free(packed);
+		kr = hwreg_lookup(svc, critblob, (mach_msg_type_number_t)psz,
+		    ids, &nids);
+		if (kr != KERN_SUCCESS) {
+			printf("HWREG-RPC-FAIL: hwreg_lookup: 0x%x\n",
+			    (unsigned)kr);
+			return 1;
+		}
+		printf("  lookup class=CPU: %u match(es)\n", (unsigned)nids);
+	}
+
+	printf("HWREG-RPC-OK: walked %d nodes, props + lookup OK "
+	    "(root id=%llu)\n", walked, (unsigned long long)root);
 	return 0;
 }

--- a/src/libxpc/subr_nvlist.c
+++ b/src/libxpc/subr_nvlist.c
@@ -175,7 +175,6 @@ nvlist_create_dictionary(int flags)
 	TAILQ_INIT(&nvl->nvl_head);
 	nvl->nvl_magic = NVLIST_MAGIC;
 
-	printf("1 nvl = %p\n", nvl);
 	return (nvl);
 }
 


### PR DESCRIPTION
## Summary

Phase 1 **iter 2b** — completes the registry query API (plan §3.3) with the two xpc-flavoured routines iter 2a deferred:

- **`hwreg_get_properties(id)`** — a node's full property bag (id / parent / state / name / class / driver / description / pnpinfo / location / path), built on demand from the `hw_node` fields.
- **`hwreg_lookup(criteria)`** — registry ids of the nodes matching a criteria dictionary (iter 2b matches `name` / `class` / `driver`).

**Serialization** — this libxpc port is nvlist-backed, so dictionaries cross MIG as **`nvlist_pack` / `nvlist_unpack`** blobs (the public API, exported by `libxpc.so`; `xpc_pack`/`xpc_unpack` in `xpc_misc.c` are `static`). hwregd now links `-lxpc`. The blob is an inline bounded byte array — `hwreg_byte_t` carries an explicit `ctype: uint8_t` because a bare `MACH_MSG_TYPE_BYTE` element makes MIG emit `(null)` for the struct field.

`hwregquery` is extended to unpack `root0`'s property bag and run a `class=CPU` lookup, still under the `HWREG-RPC` marker.

Also drops a stray `printf("1 nvl = %p")` debug line left in libxpc's `nvlist_create_dictionary()` — hwregd is the first consumer to surface it on a user-visible path (CI's libxpc rebuild picks up the clean version).

## Test plan

Verified on the bsd01 test VM (FreeBSD 15.0, launchd PID 1):

- `hwregquery` walks all 62 nodes, then `hwreg_get_properties(root)` → `root props: name=root0 class=Device path=/root0`, then `hwreg_lookup(class=CPU)` → **2 matches** (cpu0, cpu1): `HWREG-RPC-OK`.
- `HWREG-PUBSUB` pub/sub round-trip unaffected.
- hwregd builds clean at `WARNS=6 -Werror` (hand-written TUs) and stays stable.

## Phase 1 status

iters 1 (registry tree), 2a (MIG query RPC), 2b (this) complete the registry + query API. **iter 4** (PCI/USB/sysctl enrichment + `hwreg_load_driver` + retain/release) and the **launchd `HardwareMatch`** integration remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)