### PR TITLE
feat(hwregd): Phase 1 iter 3 — criteria-filtered watch RPC

### DIFF
--- a/src/hwregd/hwreg.defs
+++ b/src/hwregd/hwreg.defs
@@ -100,3 +100,25 @@ routine hwreg_lookup(
 	criteria	: hwreg_blob_t;
 	out matches	: hwreg_id_array_t
 );
+
+/*
+ * hwreg_watch — register a criteria-filtered device-event watch
+ * (iter 3). The client passes a send right to its notify port;
+ * hwregd pushes an EVENT message to it whenever a device whose fields
+ * match `criteria` (name / class / driver, packed nvlist — empty =
+ * match any) generates an event in `event_mask` (the HWREG_EVT_*
+ * bits in hwreg_mig_types.h). Returns a watcher_id for hwreg_unwatch.
+ */
+routine hwreg_watch(
+	server		: mach_port_t;
+	criteria	: hwreg_blob_t;
+	event_mask	: uint32_t;
+	notify_port	: mach_port_make_send_t;
+	out watcher_id	: uint64_t
+);
+
+/* hwreg_unwatch — cancel the watch `watcher_id`. */
+routine hwreg_unwatch(
+	server		: mach_port_t;
+	watcher_id	: uint64_t
+);

--- a/src/hwregd/hwreg_mig_types.h
+++ b/src/hwregd/hwreg_mig_types.h
@@ -19,4 +19,9 @@ typedef char		hwreg_name_t[32];	/* c_string[32]  */
 typedef char		hwreg_path_t[256];	/* c_string[256] */
 typedef uint8_t		hwreg_blob_t[2048];	/* array[*:2048] of hwreg_byte_t */
 
+/* hwreg_watch event_mask bits (iter 3). */
+#define HWREG_EVT_ARRIVED	0x1u	/* a matching device attached */
+#define HWREG_EVT_DEPARTED	0x2u	/* a matching device detached */
+#define HWREG_EVT_CHANGED	0x4u	/* a matching device's state changed */
+
 #endif /* HWREG_MIG_TYPES_H */

--- a/src/hwregd/hwreg_registry.c
+++ b/src/hwregd/hwreg_registry.c
@@ -446,3 +446,18 @@ hwreg_copy(uint64_t id, struct hw_node *dst)
 	pthread_mutex_unlock(&reg_lock);
 	return found;
 }
+
+int
+hwreg_copy_by_name(const char *name, struct hw_node *dst)
+{
+	struct hw_node *n;
+	int found;
+
+	pthread_mutex_lock(&reg_lock);
+	n = find_by_name(name);
+	if (n != NULL)
+		*dst = *n;
+	found = (n != NULL);
+	pthread_mutex_unlock(&reg_lock);
+	return found;
+}

--- a/src/hwregd/hwreg_registry.h
+++ b/src/hwregd/hwreg_registry.h
@@ -92,6 +92,9 @@ int		hwreg_children(uint64_t parent_id, uint64_t *ids, int max);
  */
 int		hwreg_copy(uint64_t id, struct hw_node *dst);
 
+/* Like hwreg_copy(), but keyed on the newbus name. */
+int		hwreg_copy_by_name(const char *name, struct hw_node *dst);
+
 /* Human-readable name for a node state. */
 const char     *hw_state_name(enum hw_node_state s);
 

--- a/src/hwregd/hwregd.c
+++ b/src/hwregd/hwregd.c
@@ -123,6 +123,7 @@ struct hwreg_event_msg {
 };
 
 #define HWREGD_MAX_SUBSCRIBERS	32
+#define HWREGD_MAX_WATCHERS	32
 
 static volatile sig_atomic_t got_term = 0;
 
@@ -133,6 +134,25 @@ static volatile sig_atomic_t got_term = 0;
 static mach_port_t	subscribers[HWREGD_MAX_SUBSCRIBERS];
 static int		n_subscribers;
 static pthread_mutex_t	subscribers_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/*
+ * Watcher registry (iter 3). Like the subscriber registry, but each
+ * entry carries a criteria filter + an event mask: the Mach thread
+ * adds/removes on hwreg_watch/_unwatch, the devctl thread reads it in
+ * notify_watchers(). An empty criterion string means "match any".
+ */
+struct hwreg_watcher {
+	uint64_t	id;		/* watcher id; 0 = free slot */
+	mach_port_t	port;		/* client notify port (send right) */
+	uint32_t	mask;		/* HWREG_EVT_* bits */
+	char		want_name[32];
+	char		want_class[32];
+	char		want_driver[32];
+};
+static struct hwreg_watcher watchers[HWREGD_MAX_WATCHERS];
+static int		n_watchers;
+static uint64_t		next_watcher_id = 1;
+static pthread_mutex_t	watchers_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /*
  * devmatch carried these as command-line flags. hwregd only runs
@@ -273,6 +293,75 @@ publish_event(char kind, const char *text)
 		if (send_event_to(snap[i], kind, text) ==
 		    MACH_SEND_INVALID_DEST)
 			drop_subscriber(snap[i]);
+	}
+}
+
+/*
+ * Drop the watcher holding `port` — called when an event push fails
+ * MACH_SEND_INVALID_DEST (the client exited). Mirrors drop_subscriber.
+ */
+static void
+watcher_drop(mach_port_t port)
+{
+	int i, found = 0;
+
+	pthread_mutex_lock(&watchers_lock);
+	for (i = 0; i < n_watchers; i++) {
+		if (watchers[i].port == port) {
+			xlog("Mach: dropped dead watcher %ju (port 0x%x)",
+			    (uintmax_t)watchers[i].id, (unsigned)port);
+			watchers[i] = watchers[--n_watchers];
+			found = 1;
+			break;
+		}
+	}
+	pthread_mutex_unlock(&watchers_lock);
+	if (found)
+		(void)mach_port_deallocate(mach_task_self(), port);
+}
+
+/*
+ * Fan a device arrival/departure out to the watchers whose criteria
+ * and event mask match it. Called from the devctl thread after the
+ * registry has absorbed the event, so the node's class and driver
+ * are available to match against. An empty criterion matches any.
+ */
+static void
+notify_watchers(char kind, const char *devname)
+{
+	uint32_t evt = (kind == '+') ? HWREG_EVT_ARRIVED : HWREG_EVT_DEPARTED;
+	struct hwreg_watcher snap[HWREGD_MAX_WATCHERS];
+	struct hw_node n;
+	char text[EVENT_LINE_MAX];
+	int i, ns;
+
+	if (!hwreg_copy_by_name(devname, &n))
+		return;			/* not in the registry — nothing to match */
+
+	pthread_mutex_lock(&watchers_lock);
+	ns = n_watchers;
+	memcpy(snap, watchers, (size_t)ns * sizeof(snap[0]));
+	pthread_mutex_unlock(&watchers_lock);
+
+	(void)snprintf(text, sizeof(text), "%s id=%ju name=%s class=%s",
+	    (kind == '+') ? "arrived" : "departed",
+	    (uintmax_t)n.id, n.name, n.classname);
+
+	for (i = 0; i < ns; i++) {
+		if ((snap[i].mask & evt) == 0)
+			continue;
+		if (snap[i].want_name[0] != '\0' &&
+		    strcmp(snap[i].want_name, n.name) != 0)
+			continue;
+		if (snap[i].want_class[0] != '\0' &&
+		    strcmp(snap[i].want_class, n.classname) != 0)
+			continue;
+		if (snap[i].want_driver[0] != '\0' &&
+		    strcmp(snap[i].want_driver, n.driver) != 0)
+			continue;
+		if (send_event_to(snap[i].port, kind, text) ==
+		    MACH_SEND_INVALID_DEST)
+			watcher_drop(snap[i].port);
 	}
 }
 
@@ -820,6 +909,9 @@ handle_attach_detach(char *line, const char *kind)
 		hwreg_note_attach(dev, parent, loc);
 	else
 		hwreg_note_detach(dev);
+
+	/* Fan it out to the matching iter-3 watchers. */
+	notify_watchers(line[0], dev);
 }
 
 /* --- devctl event loop -------------------------------------------- */
@@ -1040,6 +1132,86 @@ hwreg_lookup(mach_port_t server, hwreg_blob_t criteria,
 	nvlist_destroy(nv);
 	*matchesCnt = (mach_msg_type_number_t)
 	    (ctx.count > ctx.max ? ctx.max : ctx.count);
+	return KERN_SUCCESS;
+}
+
+/*
+ * hwreg_watch — register a criteria-filtered device-event watch. The
+ * notify_port arrives as a send right hwregd keeps until hwreg_unwatch
+ * (or until a push to it fails and watcher_drop() prunes it).
+ */
+kern_return_t
+hwreg_watch(mach_port_t server, hwreg_blob_t criteria,
+    mach_msg_type_number_t criteriaCnt, uint32_t event_mask,
+    mach_port_t notify_port, uint64_t *watcher_id)
+{
+	struct hwreg_watcher w;
+	nvlist_t *nv;
+	int total;
+
+	(void)server;
+	memset(&w, 0, sizeof(w));
+	w.port = notify_port;
+	w.mask = event_mask;
+
+	/* Criteria is optional — a zero-length blob matches any device. */
+	if (criteriaCnt > 0) {
+		nv = nvlist_unpack(criteria, criteriaCnt);
+		if (nv == NULL) {
+			(void)mach_port_deallocate(mach_task_self(),
+			    notify_port);
+			return KERN_INVALID_ARGUMENT;	/* malformed criteria */
+		}
+		if (nvlist_exists_string(nv, "name"))
+			strlcpy(w.want_name, nvlist_get_string(nv, "name"),
+			    sizeof(w.want_name));
+		if (nvlist_exists_string(nv, "class"))
+			strlcpy(w.want_class, nvlist_get_string(nv, "class"),
+			    sizeof(w.want_class));
+		if (nvlist_exists_string(nv, "driver"))
+			strlcpy(w.want_driver, nvlist_get_string(nv, "driver"),
+			    sizeof(w.want_driver));
+		nvlist_destroy(nv);
+	}
+
+	pthread_mutex_lock(&watchers_lock);
+	if (n_watchers >= HWREGD_MAX_WATCHERS) {
+		pthread_mutex_unlock(&watchers_lock);
+		(void)mach_port_deallocate(mach_task_self(), notify_port);
+		return KERN_RESOURCE_SHORTAGE;
+	}
+	w.id = next_watcher_id++;
+	watchers[n_watchers++] = w;
+	total = n_watchers;
+	*watcher_id = w.id;
+	pthread_mutex_unlock(&watchers_lock);
+
+	xlog("Mach: watcher %ju registered (mask=0x%x, total=%d)",
+	    (uintmax_t)w.id, (unsigned)event_mask, total);
+	return KERN_SUCCESS;
+}
+
+/* hwreg_unwatch — cancel the watch `watcher_id`. */
+kern_return_t
+hwreg_unwatch(mach_port_t server, uint64_t watcher_id)
+{
+	mach_port_t port = MACH_PORT_NULL;
+	int i;
+
+	(void)server;
+	pthread_mutex_lock(&watchers_lock);
+	for (i = 0; i < n_watchers; i++) {
+		if (watchers[i].id == watcher_id) {
+			port = watchers[i].port;
+			watchers[i] = watchers[--n_watchers];
+			break;
+		}
+	}
+	pthread_mutex_unlock(&watchers_lock);
+	if (port == MACH_PORT_NULL)
+		return KERN_INVALID_ARGUMENT;	/* unknown watcher_id */
+	(void)mach_port_deallocate(mach_task_self(), port);
+	xlog("Mach: watcher %ju cancelled", (uintmax_t)watcher_id);
 	return KERN_SUCCESS;
 }
 

--- a/src/hwregd/hwregquery.c
+++ b/src/hwregd/hwregquery.c
@@ -4,10 +4,11 @@
  * Looks up the org.freebsd.hwregd Mach service, then exercises the MIG
  * hwreg.defs routines: walks the registry tree (hwreg_get_root /
  * hwreg_get_children / hwreg_get_node), unpacks a node's property bag
- * (hwreg_get_properties), and runs a criteria lookup (hwreg_lookup).
- * Prints HWREG-RPC-OK on success — the CI boot test (run.sh /
- * boot-test.sh) matches that marker. Built against the MIG user stub
- * hwregUser.c.
+ * (hwreg_get_properties), runs a criteria lookup (hwreg_lookup), and
+ * registers + cancels a device-event watch (hwreg_watch /
+ * hwreg_unwatch). Prints HWREG-RPC-OK on success — the CI boot test
+ * (run.sh / boot-test.sh) matches that marker. Built against the MIG
+ * user stub hwregUser.c.
  */
 #include <mach/mach.h>
 #include <servers/bootstrap.h>
@@ -143,7 +144,49 @@ main(void)
 		printf("  lookup class=CPU: %u match(es)\n", (unsigned)nids);
 	}
 
-	printf("HWREG-RPC-OK: walked %d nodes, props + lookup OK "
+	/* hwreg_watch / hwreg_unwatch — register a criteria watch, cancel it. */
+	{
+		mach_port_t notify = MACH_PORT_NULL;
+		nvlist_t *crit = nvlist_create_dictionary(0);
+		void *packed;
+		size_t psz = 0;
+		hwreg_blob_t critblob;
+		uint64_t wid = 0;
+
+		kr = mach_port_allocate(mach_task_self(),
+		    MACH_PORT_RIGHT_RECEIVE, &notify);
+		if (kr != KERN_SUCCESS) {
+			printf("HWREG-RPC-FAIL: mach_port_allocate: 0x%x\n",
+			    (unsigned)kr);
+			return 1;
+		}
+		nvlist_add_string(crit, "class", "CPU");
+		packed = nvlist_pack(crit, &psz);
+		nvlist_destroy(crit);
+		if (packed == NULL || psz > sizeof(critblob)) {
+			printf("HWREG-RPC-FAIL: watch criteria pack failed\n");
+			return 1;
+		}
+		memcpy(critblob, packed, psz);
+		free(packed);
+		kr = hwreg_watch(svc, critblob, (mach_msg_type_number_t)psz,
+		    HWREG_EVT_ARRIVED | HWREG_EVT_DEPARTED, notify, &wid);
+		if (kr != KERN_SUCCESS || wid == 0) {
+			printf("HWREG-RPC-FAIL: hwreg_watch: 0x%x wid=%llu\n",
+			    (unsigned)kr, (unsigned long long)wid);
+			return 1;
+		}
+		printf("  watch class=CPU registered: watcher_id=%llu\n",
+		    (unsigned long long)wid);
+		kr = hwreg_unwatch(svc, wid);
+		if (kr != KERN_SUCCESS) {
+			printf("HWREG-RPC-FAIL: hwreg_unwatch: 0x%x\n",
+			    (unsigned)kr);
+			return 1;
+		}
+	}
+
+	printf("HWREG-RPC-OK: walked %d nodes; props, lookup, watch OK "
 	    "(root id=%llu)\n", walked, (unsigned long long)root);
 	return 0;
 }


### PR DESCRIPTION
## Summary

Phase 1 **iter 3** — `hwreg_watch` / `hwreg_unwatch` (plan §3.3), the criteria-filtered device-event watch. Phase 0's pub/sub broadcasts *every* event to *every* subscriber; a watch is filtered by criteria + event mask, the shape launchd's `HardwareMatch` needs.

- **`hwreg.defs`** gains `hwreg_watch` (criteria nvlist + `event_mask` + a client notify port → `watcher_id`) and `hwreg_unwatch`. The notify port crosses MIG as `mach_port_make_send_t` — the client passes its receive right, hwregd keeps a send right.
- **Watcher registry** — mutex-guarded, modelled on the subscriber registry; each entry holds the parsed criteria (`name` / `class` / `driver`) and an `HWREG_EVT_ARRIVED|_DEPARTED|_CHANGED` mask.
- **`notify_watchers()`** — called from the devctl thread *after* the registry absorbs an attach/detach, so the device's class/driver are available to match. Fans the event to matching watchers, reusing `send_event_to()` and the dead-port pruning from `publish_event()`.
- **`hwreg_copy_by_name()`** added to the registry so `notify_watchers` can resolve the event's device.
- `hwregquery` registers a `class=CPU` watch and cancels it.

## Test plan

Verified on the bsd01 test VM (FreeBSD 15.0, launchd PID 1):

- `hwregquery` walks 62 nodes, reads properties, runs a lookup, then `hwreg_watch(class=CPU)` → `watcher_id=1` → `hwreg_unwatch` — `HWREG-RPC-OK`. hwregd's log confirms server-side: `watcher 1 registered (mask=0x3, total=1)` then `watcher 1 cancelled`.
- `HWREG-PUBSUB` pub/sub round-trip unaffected.
- Clean build at `WARNS=6 -Werror` (hand-written TUs); hwregd stable.

The CI marker covers the watch/unwatch RPC round-trip; the `notify_watchers` fan-out is structurally identical to the verified `publish_event` path (snapshot-under-lock → `send_event_to` → INVALID_DEST pruning).

## Phase 1 status

Registry tree (iter 1), query RPC (2a/2b), watch RPC (3) done. **iter 4** — PCI/USB/sysctl enrichment + `hwreg_load_driver` + retain/release — is the last Phase 1 iteration, then launchd `HardwareMatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)