### PR TITLE
feat(hwregd): Phase 1 iter 4a — load-driver + retain/release RPC

### DIFF
--- a/src/hwregd/hwreg.defs
+++ b/src/hwregd/hwreg.defs
@@ -122,3 +122,33 @@ routine hwreg_unwatch(
 	server		: mach_port_t;
 	watcher_id	: uint64_t
 );
+
+/*
+ * hwreg_load_driver — kldload the driver for node `id` (plan §3.5).
+ * A node that already has a driver is a no-op (loaded_module = the
+ * existing driver). Otherwise the device's pnpinfo is matched against
+ * linker.hints and the claiming module loaded; error_code carries an
+ * errno (0 = ok, ENOENT = nothing in linker.hints claims the device).
+ * KERN_INVALID_ARGUMENT for an unknown id.
+ */
+routine hwreg_load_driver(
+	server		: mach_port_t;
+	id		: uint64_t;
+	out loaded_module : hwreg_name_t;
+	out error_code	: int
+);
+
+/*
+ * hwreg_retain / hwreg_release — adjust node `id`'s reference count.
+ * A detached node lingers in the registry until its count reaches
+ * zero. KERN_INVALID_ARGUMENT for an unknown id.
+ */
+routine hwreg_retain(
+	server		: mach_port_t;
+	id		: uint64_t
+);
+
+routine hwreg_release(
+	server		: mach_port_t;
+	id		: uint64_t
+);

--- a/src/hwregd/hwreg_registry.c
+++ b/src/hwregd/hwreg_registry.c
@@ -461,3 +461,34 @@ hwreg_copy_by_name(const char *name, struct hw_node *dst)
 	pthread_mutex_unlock(&reg_lock);
 	return found;
 }
+
+int
+hwreg_node_retain(uint64_t id)
+{
+	struct hw_node *n;
+	int rc = -1;
+
+	pthread_mutex_lock(&reg_lock);
+	n = find_by_id(id);
+	if (n != NULL)
+		rc = (int)++n->refcnt;
+	pthread_mutex_unlock(&reg_lock);
+	return rc;
+}
+
+int
+hwreg_node_release(uint64_t id)
+{
+	struct hw_node *n;
+	int rc = -1;
+
+	pthread_mutex_lock(&reg_lock);
+	n = find_by_id(id);
+	if (n != NULL) {
+		if (n->refcnt > 0)
+			n->refcnt--;
+		rc = (int)n->refcnt;
+	}
+	pthread_mutex_unlock(&reg_lock);
+	return rc;
+}

--- a/src/hwregd/hwreg_registry.h
+++ b/src/hwregd/hwreg_registry.h
@@ -95,6 +95,13 @@ int		hwreg_copy(uint64_t id, struct hw_node *dst);
 /* Like hwreg_copy(), but keyed on the newbus name. */
 int		hwreg_copy_by_name(const char *name, struct hw_node *dst);
 
+/*
+ * Adjust node `id`'s reference count. Returns the new count, or -1 if
+ * no node has that id. hwreg_node_release() floors the count at 0.
+ */
+int		hwreg_node_retain(uint64_t id);
+int		hwreg_node_release(uint64_t id);
+
 /* Human-readable name for a node state. */
 const char     *hw_state_name(enum hw_node_state s);
 

--- a/src/hwregd/hwregd.c
+++ b/src/hwregd/hwregd.c
@@ -609,21 +609,24 @@ pnpval_as_str(const char *val, const char *pnpinfo)
 /*
  * Walk linker.hints looking for a module whose MDT_PNP_INFO table
  * claims the device described by (bus, pnpinfo). Ported from
- * devmatch.c's search_hints(); on a match, kldload the module
- * instead of printing it. The dump_flag / verbose_flag branches are
- * dead (compile-time false) but kept so the port stays verbatim.
+ * devmatch.c's search_hints(); the first matching module name is
+ * copied into modout (left "" if nothing claims the device). The
+ * dump_flag / unbound_flag branches are dead (compile-time false) but
+ * kept so the port stays close to verbatim. Callers decide what to do
+ * with the module — handle_nomatch() auto-loads it, hwreg_load_driver()
+ * loads it on demand.
  */
 static void
-search_hints(const char *bus, const char *pnpinfo)
+search_hints(const char *bus, const char *pnpinfo, char *modout, size_t modsz)
 {
 	char val1[256], val2[256];
-	int ival, len, ents, i, notme, mask, bit, v, found;
+	int ival, len, ents, i, notme, mask, bit, v;
 	void *ptr, *walker;
 	char *lastmod = NULL, *cp, *s;
 
+	modout[0] = '\0';
 	walker = hints;
 	getint(&walker);
-	found = 0;
 	while (walker < hints_end) {
 		len = getint(&walker);
 		ival = getint(&walker);
@@ -736,10 +739,9 @@ search_hints(const char *bus, const char *pnpinfo)
 					if (cp)
 						cp++;
 				} while (cp && *cp);
-				if (!dump_flag && !notme) {
-					act_on_match(lastmod);
-					found++;
-				}
+				if (!dump_flag && !notme &&
+				    lastmod != NULL && modout[0] == '\0')
+					strlcpy(modout, lastmod, modsz);
 			}
 			break;
 		default:
@@ -747,9 +749,6 @@ search_hints(const char *bus, const char *pnpinfo)
 		}
 		walker = (void *)(len - sizeof(int) + (intptr_t)walker);
 	}
-	if (found == 0)
-		xlog("nomatch: no module in linker.hints claims '%s'",
-		    pnpinfo);
 	free(lastmod);
 }
 
@@ -806,7 +805,16 @@ handle_nomatch(char *nomatch)
 	}
 	if (hints == NULL)
 		return;
-	search_hints(bus, pnpinfo);
+	{
+		char mod[64] = "";
+
+		search_hints(bus, pnpinfo, mod, sizeof(mod));
+		if (mod[0] != '\0')
+			act_on_match(mod);
+		else
+			xlog("nomatch: no module in linker.hints "
+			    "claims '%s'", pnpinfo);
+	}
 }
 
 /*
@@ -1212,6 +1220,80 @@ hwreg_unwatch(mach_port_t server, uint64_t watcher_id)
 		return KERN_INVALID_ARGUMENT;	/* unknown watcher_id */
 	(void)mach_port_deallocate(mach_task_self(), port);
 	xlog("Mach: watcher %ju cancelled", (uintmax_t)watcher_id);
+	return KERN_SUCCESS;
+}
+
+/*
+ * hwreg_load_driver — kldload the driver for node `id`. A node that
+ * already has a driver needs nothing; otherwise its pnpinfo is run
+ * through linker.hints and the claiming module is loaded. error_code
+ * carries an errno (0 = ok, ENOENT = nothing in linker.hints claims
+ * the device).
+ */
+kern_return_t
+hwreg_load_driver(mach_port_t server, uint64_t id, hwreg_name_t loaded_module,
+    int *error_code)
+{
+	struct hw_node n, parent;
+	char bus[32], mod[64] = "";
+	size_t k;
+
+	(void)server;
+	loaded_module[0] = '\0';
+	*error_code = 0;
+	if (!hwreg_copy(id, &n))
+		return KERN_INVALID_ARGUMENT;		/* unknown id */
+
+	if (n.driver[0] != '\0') {			/* already attached */
+		strlcpy(loaded_module, n.driver, sizeof(hwreg_name_t));
+		return KERN_SUCCESS;
+	}
+	if (hints == NULL) {
+		*error_code = ENOENT;			/* no linker.hints */
+		return KERN_SUCCESS;
+	}
+
+	/* Bus name = the parent device's name with its unit stripped. */
+	bus[0] = '\0';
+	if (hwreg_copy(n.parent_id, &parent)) {
+		strlcpy(bus, parent.name, sizeof(bus));
+		k = strlen(bus);
+		while (k > 0 && bus[k - 1] >= '0' && bus[k - 1] <= '9')
+			bus[--k] = '\0';
+	}
+	search_hints(bus[0] != '\0' ? bus : NULL, n.pnpinfo, mod, sizeof(mod));
+	if (mod[0] == '\0' || strcmp(mod, "kernel") == 0) {
+		*error_code = ENOENT;			/* nothing claims it */
+		return KERN_SUCCESS;
+	}
+	if (kldload(mod) < 0 && errno != EEXIST) {
+		*error_code = errno;
+		xlog("hwreg_load_driver(%ju): kldload(%s): %s",
+		    (uintmax_t)id, mod, strerror(errno));
+		return KERN_SUCCESS;
+	}
+	strlcpy(loaded_module, mod, sizeof(hwreg_name_t));
+	xlog("hwreg_load_driver(%ju): module %s loaded", (uintmax_t)id, mod);
+	return KERN_SUCCESS;
+}
+
+/* hwreg_retain — bump node `id`'s reference count. */
+kern_return_t
+hwreg_retain(mach_port_t server, uint64_t id)
+{
+	(void)server;
+	if (hwreg_node_retain(id) < 0)
+		return KERN_INVALID_ARGUMENT;		/* unknown id */
+	return KERN_SUCCESS;
+}
+
+/* hwreg_release — drop a reference on node `id`. */
+kern_return_t
+hwreg_release(mach_port_t server, uint64_t id)
+{
+	(void)server;
+	if (hwreg_node_release(id) < 0)
+		return KERN_INVALID_ARGUMENT;		/* unknown id */
 	return KERN_SUCCESS;
 }
 

--- a/src/hwregd/hwregquery.c
+++ b/src/hwregd/hwregquery.c
@@ -6,7 +6,8 @@
  * hwreg_get_children / hwreg_get_node), unpacks a node's property bag
  * (hwreg_get_properties), runs a criteria lookup (hwreg_lookup), and
  * registers + cancels a device-event watch (hwreg_watch /
- * hwreg_unwatch). Prints HWREG-RPC-OK on success — the CI boot test
+ * hwreg_unwatch), and exercises hwreg_load_driver / hwreg_retain /
+ * hwreg_release. Prints HWREG-RPC-OK on success — the CI boot test
  * (run.sh / boot-test.sh) matches that marker. Built against the MIG
  * user stub hwregUser.c.
  */
@@ -186,7 +187,36 @@ main(void)
 		}
 	}
 
-	printf("HWREG-RPC-OK: walked %d nodes; props, lookup, watch OK "
-	    "(root id=%llu)\n", walked, (unsigned long long)root);
+	/* hwreg_load_driver / hwreg_retain / hwreg_release on the root. */
+	{
+		hwreg_name_t loaded;
+		int err = 0;
+
+		kr = hwreg_load_driver(svc, root, loaded, &err);
+		if (kr != KERN_SUCCESS) {
+			printf("HWREG-RPC-FAIL: hwreg_load_driver: 0x%x\n",
+			    (unsigned)kr);
+			return 1;
+		}
+		printf("  load_driver(root): module=%s error=%d\n",
+		    loaded[0] ? loaded : "-", err);
+
+		kr = hwreg_retain(svc, root);
+		if (kr != KERN_SUCCESS) {
+			printf("HWREG-RPC-FAIL: hwreg_retain: 0x%x\n",
+			    (unsigned)kr);
+			return 1;
+		}
+		kr = hwreg_release(svc, root);
+		if (kr != KERN_SUCCESS) {
+			printf("HWREG-RPC-FAIL: hwreg_release: 0x%x\n",
+			    (unsigned)kr);
+			return 1;
+		}
+	}
+
+	printf("HWREG-RPC-OK: walked %d nodes; props, lookup, watch, "
+	    "load+retain OK (root id=%llu)\n", walked,
+	    (unsigned long long)root);
 	return 0;
 }


### PR DESCRIPTION
## Summary

Phase 1 **iter 4a** — completes the `hwreg.defs` RPC surface (plan §3.3 / §3.5) with the last three routines:

- **`hwreg_load_driver(id)`** — kldload the driver for a device. A node that already has a driver is a no-op (`loaded_module` = the existing driver); otherwise the device's `pnpinfo` is matched against `linker.hints` and the claiming module loaded. `error_code` carries an errno (`0` = ok, `ENOENT` = nothing claims it).
- **`hwreg_retain` / `hwreg_release`** — adjust a node's reference count (`hw_node.refcnt`) — groundwork for the *detached node lingers until refcount zero* lifecycle (plan §3.6).

**`search_hints()` refactor** — it no longer kldloads on a match; it copies the first matching module name into an out-param. `handle_nomatch()` keeps the boot-time auto-load behaviour by calling `act_on_match()` on the result, and `hwreg_load_driver()` reuses the same matcher for on-demand loads. The devmatch-ported parsing loop is untouched. `hwreg_node_retain/_release` added to the mutex-guarded registry.

## Test plan

Verified on the bsd01 test VM (FreeBSD 15.0, launchd PID 1):

- `hwregquery` exercises all **ten** `hwreg.defs` routines. `hwreg_load_driver(root0)` → `module=root error=0` (already attached — returns the existing driver, no kldload); `hwreg_retain`/`hwreg_release` round-trip — `HWREG-RPC-OK`.
- `HWREG-PUBSUB` pub/sub round-trip unaffected; the boot-time nomatch auto-load path (`handle_nomatch` → refactored `search_hints` → `act_on_match`) preserved.
- Clean build at `WARNS=6 -Werror`; hwregd stable.

## Phase 1 status

Registry tree (iter 1), query RPC (2a/2b), watch RPC (3), and now the full RPC surface (4a) are done. **iter 4b** — PCI/USB/sysctl property *enrichment* (the one part needing new kernel interfaces: `/dev/pci` + `PCIOCGETCONF`, USB ioctls, thermal/CPU sysctls) — is the last Phase 1 piece, then launchd `HardwareMatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)