### PR TITLE
feat(hwregd): Phase 1 iter 4b — PCI property enrichment

### DIFF
--- a/src/hwregd/hwreg_registry.c
+++ b/src/hwregd/hwreg_registry.c
@@ -492,3 +492,23 @@ hwreg_node_release(uint64_t id)
 	pthread_mutex_unlock(&reg_lock);
 	return rc;
 }
+
+int
+hwreg_set_pci(const char *name, uint32_t vendor, uint32_t device,
+    uint32_t subvendor, uint32_t class_code)
+{
+	struct hw_node *n;
+	int found;
+
+	pthread_mutex_lock(&reg_lock);
+	n = find_by_name(name);
+	if (n != NULL) {
+		n->pci_vendor = vendor;
+		n->pci_device = device;
+		n->pci_subvendor = subvendor;
+		n->pci_class = class_code;
+	}
+	found = (n != NULL);
+	pthread_mutex_unlock(&reg_lock);
+	return found;
+}

--- a/src/hwregd/hwreg_registry.h
+++ b/src/hwregd/hwreg_registry.h
@@ -48,6 +48,11 @@ struct hw_node {
 	char			path[256];	/* "/nexus0/.../em0" */
 	enum hw_node_state	state;
 	uint32_t		refcnt;		/* iter 4 stale-handle detection */
+	/* PCI enrichment (iter 4b); pci_vendor == 0 means "not enriched". */
+	uint32_t		pci_vendor;	/* chip vendor id */
+	uint32_t		pci_device;	/* chip device id */
+	uint32_t		pci_subvendor;	/* card subvendor id */
+	uint32_t		pci_class;	/* (class<<16)|(subclass<<8)|progif */
 	struct hw_node		*next;		/* registry-internal list link */
 };
 
@@ -101,6 +106,13 @@ int		hwreg_copy_by_name(const char *name, struct hw_node *dst);
  */
 int		hwreg_node_retain(uint64_t id);
 int		hwreg_node_release(uint64_t id);
+
+/*
+ * Attach PCI identity to the node named `name` (iter 4b enrichment).
+ * Returns 1 if the node was found and updated, 0 if not.
+ */
+int		hwreg_set_pci(const char *name, uint32_t vendor,
+		    uint32_t device, uint32_t subvendor, uint32_t class_code);
 
 /* Human-readable name for a node state. */
 const char     *hw_state_name(enum hw_node_state s);

--- a/src/hwregd/hwregd.c
+++ b/src/hwregd/hwregd.c
@@ -54,8 +54,10 @@
 
 #include <sys/types.h>
 #include <sys/param.h>
+#include <sys/ioctl.h>
 #include <sys/linker.h>
 #include <sys/module.h>
+#include <sys/pciio.h>
 #include <sys/select.h>
 #include <sys/stat.h>
 #include <sys/sysctl.h>
@@ -1061,6 +1063,13 @@ hwreg_get_properties(mach_port_t server, uint64_t id, hwreg_blob_t props,
 	nvlist_add_string(nv, "pnpinfo", n.pnpinfo);
 	nvlist_add_string(nv, "location", n.location);
 	nvlist_add_string(nv, "path", n.path);
+	/* PCI identity, present only on enriched PCI nodes (iter 4b). */
+	if (n.pci_vendor != 0) {
+		nvlist_add_number(nv, "pci-vendor", n.pci_vendor);
+		nvlist_add_number(nv, "pci-device", n.pci_device);
+		nvlist_add_number(nv, "pci-subvendor", n.pci_subvendor);
+		nvlist_add_number(nv, "pci-class", n.pci_class);
+	}
 
 	packed = nvlist_pack(nv, &size);
 	nvlist_destroy(nv);
@@ -1393,6 +1402,64 @@ mach_service_thread(void *arg)
 	return NULL;
 }
 
+/*
+ * PCI property enrichment (Phase 1 iter 4b). Walk /dev/pci via
+ * PCIOCGETCONF and attach each device's vendor / device / subvendor /
+ * class ids to its registry node, matched by driver name + unit.
+ */
+static void
+enrich_pci(void)
+{
+	struct pci_conf conf[32];
+	struct pci_conf_io io;
+	int fd, enriched = 0, restarts = 0;
+
+	fd = open("/dev/pci", O_RDONLY | O_CLOEXEC);
+	if (fd < 0) {
+		xlog("hwreg: /dev/pci unavailable (%s) — PCI enrichment skipped",
+		    strerror(errno));
+		return;
+	}
+	memset(&io, 0, sizeof(io));
+	do {
+		unsigned int i;
+
+		io.matches = conf;
+		io.match_buf_len = sizeof(conf);
+		if (ioctl(fd, PCIOCGETCONF, &io) < 0) {
+			xlog("hwreg: PCIOCGETCONF failed: %s", strerror(errno));
+			break;
+		}
+		if (io.status == PCI_GETCONF_LIST_CHANGED) {
+			/* The device list moved under us — restart the scan. */
+			if (++restarts > 4)
+				break;
+			memset(&io, 0, sizeof(io));
+			enriched = 0;
+			continue;
+		}
+		if (io.status == PCI_GETCONF_ERROR)
+			break;
+		for (i = 0; i < io.num_matches; i++) {
+			char name[32];
+			uint32_t cls;
+
+			if (conf[i].pd_name[0] == '\0')
+				continue;	/* no driver — no node to match */
+			(void)snprintf(name, sizeof(name), "%s%lu",
+			    conf[i].pd_name, conf[i].pd_unit);
+			cls = ((uint32_t)conf[i].pc_class << 16) |
+			    ((uint32_t)conf[i].pc_subclass << 8) |
+			    (uint32_t)conf[i].pc_progif;
+			if (hwreg_set_pci(name, conf[i].pc_vendor,
+			    conf[i].pc_device, conf[i].pc_subvendor, cls))
+				enriched++;
+		}
+	} while (io.status == PCI_GETCONF_MORE_DEVS);
+	(void)close(fd);
+	xlog("hwreg: PCI enrichment — %d device node(s) enriched", enriched);
+}
+
 /* hwreg_foreach() callback — log one registry node. */
 static void
 log_hw_node(const struct hw_node *n, void *arg)
@@ -1436,6 +1503,7 @@ main(int argc, char **argv)
 		else {
 			xlog("hwreg: registry built — %d device nodes",
 			    nnodes);
+			enrich_pci();		/* Phase 1 iter 4b */
 			hwreg_foreach(log_hw_node, NULL);
 		}
 	}

--- a/src/hwregd/hwregquery.c
+++ b/src/hwregd/hwregquery.c
@@ -215,8 +215,68 @@ main(void)
 		}
 	}
 
+	/* PCI enrichment — look up the PCIDevice nodes and confirm at
+	 * least one carries the pci-vendor property iter 4b adds. */
+	{
+		nvlist_t *crit = nvlist_create_dictionary(0);
+		void *packed;
+		size_t psz = 0;
+		hwreg_blob_t critblob, props;
+		uint64_t ids[MAXKIDS];
+		mach_msg_type_number_t nids = 0, propcnt;
+		unsigned int i;
+		int enriched = 0;
+
+		nvlist_add_string(crit, "class", "PCIDevice");
+		packed = nvlist_pack(crit, &psz);
+		nvlist_destroy(crit);
+		if (packed == NULL || psz > sizeof(critblob)) {
+			printf("HWREG-RPC-FAIL: PCI criteria pack failed\n");
+			return 1;
+		}
+		memcpy(critblob, packed, psz);
+		free(packed);
+		kr = hwreg_lookup(svc, critblob, (mach_msg_type_number_t)psz,
+		    ids, &nids);
+		if (kr != KERN_SUCCESS) {
+			printf("HWREG-RPC-FAIL: PCI lookup: 0x%x\n",
+			    (unsigned)kr);
+			return 1;
+		}
+		for (i = 0; i < nids; i++) {
+			nvlist_t *nv;
+
+			propcnt = 0;
+			if (hwreg_get_properties(svc, ids[i], props,
+			    &propcnt) != KERN_SUCCESS)
+				continue;
+			nv = nvlist_unpack(props, propcnt);
+			if (nv == NULL)
+				continue;
+			if (nvlist_exists_number(nv, "pci-vendor")) {
+				if (enriched == 0)
+					printf("  PCI node %s: vendor=0x%04llx "
+					    "device=0x%04llx\n",
+					    nvlist_get_string(nv, "name"),
+					    (unsigned long long)
+					    nvlist_get_number(nv, "pci-vendor"),
+					    (unsigned long long)
+					    nvlist_get_number(nv, "pci-device"));
+				enriched++;
+			}
+			nvlist_destroy(nv);
+		}
+		printf("  class=PCIDevice: %u node(s), %d PCI-enriched\n",
+		    (unsigned)nids, enriched);
+		if (nids > 0 && enriched == 0) {
+			printf("HWREG-RPC-FAIL: PCI nodes exist but none "
+			    "enriched\n");
+			return 1;
+		}
+	}
+
 	printf("HWREG-RPC-OK: walked %d nodes; props, lookup, watch, "
-	    "load+retain OK (root id=%llu)\n", walked,
+	    "load+retain, PCI OK (root id=%llu)\n", walked,
 	    (unsigned long long)root);
 	return 0;
 }


### PR DESCRIPTION
## Summary

Phase 1 **iter 4b** — PCI device-identity enrichment, the last piece of the Phase 1 registry (plan §3.1).

`enrich_pci()` walks `/dev/pci` via `PCIOCGETCONF` after the newbus snapshot and attaches each device's **vendor / device / subvendor / class** ids to its registry node, matched by driver name + unit. `hw_node` grows four `pci_*` fields; `hwreg_set_pci()` is the registry setter; `hwreg_get_properties()` surfaces the ids as `pci-vendor` / `pci-device` / `pci-subvendor` / `pci-class` on the enriched nodes.

USB and thermal/CPU-sysctl enrichment (the rest of §3.1) are left for a follow-up — PCI is the IOKit-shaped headline and the one the launchd `HardwareMatch` work needs first.

## Test plan

Verified on the bsd01 test VM (FreeBSD 15.0, launchd PID 1):

- Boot log: `hwreg: PCI enrichment — 8 device node(s) enriched`.
- `hwregquery` — `class=PCIDevice: 11 node(s), 8 PCI-enriched`, and the first enriched node prints `PCI node hostb0: vendor=0x8086 device=0x1237` (the emulated Intel 440FX host bridge). The test fails if PCI nodes exist but none carry enrichment. `HWREG-RPC-OK`.
- `HWREG-PUBSUB` unaffected; clean build at `WARNS=6 -Werror`; hwregd stable.

## Phase 1 complete 🎉

This finishes hwregd **Phase 1**:

- **iter 1** — the `hw_node` registry tree (newbus snapshot via `hw.bus.*` sysctls + devctl maintenance)
- **iter 2a/2b** — the MIG query RPC (`get_root`/`get_children`/`get_node`/`get_properties`/`lookup`)
- **iter 3** — the criteria-filtered watch RPC (`hwreg_watch`/`hwreg_unwatch`)
- **iter 4a** — `hwreg_load_driver` + `hwreg_retain`/`hwreg_release`
- **iter 4b** — PCI property enrichment

hwregd is now a working IORegistry-shaped daemon: a structured device tree with a 10-routine Mach-RPC API for query, watch, driver-load, and refcounting. Next on the roadmap: the launchd `HardwareMatch` plist key, then the IOKitUser facade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)