### PR TITLE
feat(configd): iter 1 — SCDynamicStore daemon skeleton + MIG interface

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -949,6 +949,40 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hwregquery" \
     || { echo "FAIL: hwregquery not built"; exit 1; }
 
 #
+# 3r2. build configd (src/configd/) — configd iter 1.
+#      configd hosts the SCDynamicStore over the MIG `config` Mach
+#      subsystem (config.defs, base id 20000). iter 1 is the daemon
+#      skeleton: checks com.apple.SystemConfiguration.configd in and
+#      runs the config.defs receive loop with stub routine handlers.
+#      Generate the config.defs MIG stubs (config_server() demux),
+#      then build + install /usr/sbin/configd. Same mig.sh + migcom
+#      path as the launchd / hwregd MIG steps above.
+#      configd port plan: Mach-IPC track (not the sockets/DO plan).
+#
+echo "==> building configd (src/configd)"
+CONFIGD_MIG="$WORK/configd-mig"
+mkdir -p "$CONFIGD_MIG"
+( cd "$CONFIGD_MIG" && \
+  MIGCC=/usr/bin/cc MIGCOM="$WORK/rootfs/usr/libexec/migcom" \
+  /bin/sh "$ROOT/src/bootstrap_cmds/migcom.tproj/mig.sh" \
+    -I"$ROOT/src/libmach/include" \
+    -header config.h -user configUser.c \
+    -server configServer.c -sheader configServer.h \
+    "$ROOT/src/configd/config.defs" ) \
+  || { echo "FAIL: mig could not process config.defs"; exit 1; }
+test -s "$CONFIGD_MIG/configServer.c" \
+    || { echo "FAIL: mig produced no configServer.c"; exit 1; }
+make -C "$ROOT/src/configd" \
+    DESTDIR="$WORK/rootfs" \
+    SYSROOT="$WORK/rootfs" \
+    MIGOUT="$CONFIGD_MIG" \
+    all install
+ls -lh "$WORK/rootfs/usr/sbin/configd"
+test -x "$WORK/rootfs/usr/sbin/configd" \
+    || { echo "FAIL: /usr/sbin/configd not installed or not executable"; exit 1; }
+echo "==> CONFIGD-BUILD-OK"
+
+#
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at
 #     Phase J0 (commit 455a727). This step:

--- a/overlays/System/Library/LaunchDaemons/com.apple.configd.plist
+++ b/overlays/System/Library/LaunchDaemons/com.apple.configd.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.apple.configd.plist
+
+  Boot-time launchd plist for configd, the SCDynamicStore
+  configuration daemon (freebsd-launchd-mach port). configd hosts the
+  system dynamic store over the MIG `config` Mach subsystem.
+
+  iter 1 is the daemon skeleton: configd checks the
+  com.apple.SystemConfiguration.configd Mach service in and runs the
+  config.defs receive loop with stub routine handlers. RunAtLoad so
+  it starts at PID-1 launchd boot; KeepAlive so a crash is respawned.
+  StandardErrorPath/StandardOutPath route its log to
+  /var/log/configd.stderr — the path the CI boot test dumps.
+
+  Plan: see the configd-port plan (Mach-IPC track).
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.apple.configd</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/sbin/configd</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>MachServices</key>
+    <dict>
+        <key>com.apple.SystemConfiguration.configd</key>
+        <true/>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/var/log/configd.stderr</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/configd.stderr</string>
+</dict>
+</plist>

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -349,7 +349,7 @@ sleep 2
 # /var/log/<daemon>.stderr file. Dump those into the boot console
 # BEFORE the proc check so [T39-bs] / [T39-ll] traces (and any other
 # diagnostic output) survive the halt that follows a PROC-FAIL exit.
-for slog in /var/log/syslogd.stderr /var/log/notifyd.stderr /var/log/hwregd.stderr /var/log/aslmanager.stderr; do
+for slog in /var/log/syslogd.stderr /var/log/notifyd.stderr /var/log/hwregd.stderr /var/log/aslmanager.stderr /var/log/configd.stderr; do
     if [ -s "$slog" ]; then
         echo "=== begin $slog ==="
         cat "$slog" || true

--- a/src/configd/Makefile
+++ b/src/configd/Makefile
@@ -1,0 +1,62 @@
+# configd — SCDynamicStore configuration daemon (freebsd-launchd-mach).
+#
+# configd iter 1: the daemon skeleton. Builds to /usr/sbin/configd,
+# runs as a launchd-managed daemon under PID-1 launchd (plist at
+# /System/Library/LaunchDaemons/com.apple.configd.plist). It checks
+# the com.apple.SystemConfiguration.configd Mach service in and runs
+# a raw mach_msg loop over the MIG config.defs demux (config_server());
+# the routine handlers are stubs until iter 2's store engine.
+#
+# Build:   cd src/configd && make SYSROOT=/path/to/rootfs MIGOUT=...
+# Install: make DESTDIR=/path/to/rootfs install
+
+PROG=		configd
+MAN=
+
+SRCS=		configd.c
+
+# configServer.c — MIG-generated server demux + routine stubs for
+# config.defs. build.sh runs mig and passes MIGOUT=; a bare standalone
+# build without it fails at the generated #include "configServer.h",
+# which is expected — configd cannot build without the MIG output.
+MIGOUT?=
+.if !empty(MIGOUT)
+.PATH:			${MIGOUT}
+SRCS+=			configServer.c
+CFLAGS+=		-I${MIGOUT}
+CFLAGS+=		-I${.CURDIR}	# generated stubs #include "config_types.h"
+CFLAGS.configServer.c+=	-w
+# The MIG stubs pull <mach/notify.h>, which redefines the MACH_NOTIFY_*
+# macros <mach/message.h> also defines (identical values, whitespace
+# differs) — a benign clash in the vendored mach headers.
+CFLAGS+=		-Wno-macro-redefined
+.endif
+
+WARNS?=		6
+NO_MAN=		yes
+
+CFLAGS+=	-O2 -pipe
+CFLAGS+=	-Wall -Wextra -Wshadow -Wstrict-prototypes
+CFLAGS+=	-Wmissing-prototypes -Wpointer-arith
+
+# <servers/bootstrap.h> (bootstrap_check_in + the bootstrap_port
+# global) comes from liblaunch; its bootstrap.h pulls in Apple shim
+# headers (AvailabilityMacros.h, ...) from launchd/freebsd-shims.
+CFLAGS+=	-I${.CURDIR}/../launchd/liblaunch
+CFLAGS+=	-I${.CURDIR}/../launchd/freebsd-shims
+
+SYSROOT?=
+.if !empty(SYSROOT)
+CFLAGS+=	-I${SYSROOT}/usr/include
+LDFLAGS+=	-L${SYSROOT}/usr/lib/system
+LDFLAGS+=	-Wl,-rpath,/usr/lib/system
+LDFLAGS+=	-Wl,--allow-shlib-undefined
+.endif
+
+# -llaunch: bootstrap_check_in + the bootstrap_port global.
+# -lsystem_kernel: mach_msg and the Mach port syscalls.
+LDADD+=		-llaunch -lsystem_kernel -lpthread
+
+BINDIR=		/usr/sbin
+
+.include <bsd.prog.mk>

--- a/src/configd/config.defs
+++ b/src/configd/config.defs
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2000, 2001, 2003-2005, 2011, 2012, 2015, 2018-2022 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/*
+ * config.defs — the SCDynamicStore client<->configd Mach RPC protocol.
+ *
+ * freebsd-launchd-mach port (configd iter 1). Two changes from Apple's
+ * SystemConfiguration.fproj/config.defs:
+ *   - `UseSpecialReplyPort 1;` dropped — special reply ports need
+ *     kernel/runtime support this port does not have; plain reply
+ *     ports work identically.
+ *   - the `ServerAuditToken audit_token` out-of-band arg on configopen
+ *     is dropped for iter 1 (the skeleton has no per-client identity
+ *     yet); it is re-added with real session management in iter 2.
+ * The routine ORDER and the `skip;` slots are preserved exactly — a
+ * routine's Mach msgh_id is its position from base 20000, and the
+ * SystemConfiguration client must agree on every id.
+ */
+
+#include <mach/std_types.defs>
+#include <mach/mach_types.defs>
+
+subsystem config 20000;
+serverprefix _;
+
+import "config_types.h";
+
+/*
+ * serialized XML or UTF8 data (client->server)
+ */
+type xmlData    = ^ array [] of MACH_MSG_TYPE_BYTE
+	ctype : xmlData_t;
+
+/*
+ * serialized XML or UTF8 data (server->client)
+ */
+type xmlDataOut = ^ array [] of MACH_MSG_TYPE_BYTE
+	ctype : xmlDataOut_t;
+
+/*
+ * Connection management API's
+ */
+
+routine configopen	(	server		: mach_port_t;
+				name		: xmlData;
+				options		: xmlData;
+			 out	session		: mach_port_move_send_t;
+			 out	status		: int);
+
+	skip;	/* was configclose */
+	skip;	/* was configlock */
+	skip;	/* was configunlock */
+
+	skip;	/* reserved for future use */
+	skip;	/* reserved for future use */
+	skip;	/* reserved for future use */
+	skip;	/* reserved for future use */
+
+/*
+ * Dynamic store access API's
+ */
+
+routine configlist	(	server		: mach_port_t;
+				xmlData		: xmlData;
+				isRegex		: int;
+			 out	list		: xmlDataOut, dealloc;
+			 out	status		: int);
+
+routine configadd	(	server		: mach_port_t;
+				key		: xmlData;
+				data		: xmlData;
+			 out	newInstance	: int;		// no longer used
+			 out	status		: int);
+
+routine configget	(	server		: mach_port_t;
+				key		: xmlData;
+			 out	data		: xmlDataOut, dealloc;
+			 out	newInstance	: int;		// no longer used
+			 out	status		: int);
+
+routine configset	(	server		: mach_port_t;
+				key		: xmlData;
+				data		: xmlData;
+				instance	: int;
+			 out	newInstance	: int;		// no longer used
+			 out	status		: int);
+
+routine configremove	(	server		: mach_port_t;
+				key		: xmlData;
+			 out	status		: int);
+
+	skip;	/* was configtouch */
+
+routine configadd_s	(	server		: mach_port_t;
+				key		: xmlData;
+				data		: xmlData;
+			 out	newInstance	: int;		// no longer used
+			 out	status		: int);
+
+routine confignotify	(	server		: mach_port_t;
+				key		: xmlData;
+			 out	status		: int);
+
+routine configget_m	(	server		: mach_port_t;
+				keys		: xmlData;
+				patterns	: xmlData;
+			 out	data		: xmlDataOut, dealloc;
+			 out	status		: int);
+
+routine configset_m	(	server		: mach_port_t;
+				data		: xmlData;
+				remove		: xmlData;
+				notify		: xmlData;
+			 out	status		: int);
+
+/*
+ * Notification API's
+ */
+
+routine notifyadd	(	server		: mach_port_t;
+				key		: xmlData;
+				isRegex		: int;
+			 out	status		: int);
+
+routine notifyremove	(	server		: mach_port_t;
+				key		: xmlData;
+				isRegex		: int;
+			 out	status		: int);
+
+routine notifychanges	(	server		: mach_port_t;
+			 out	list		: xmlDataOut, dealloc;
+			 out	status		: int);
+
+routine notifyviaport	(	server		: mach_port_t;
+				port		: mach_port_move_send_t;
+				msgid           : mach_msg_id_t;	/* must be zero */
+			 out	status		: int);
+
+	skip;	/* was notifyviafd (passing UNIX domain socket filename) */
+
+	skip;	/* was notifyviasignal */
+
+routine notifycancel	(	server		: mach_port_t;
+			 out	status		: int);
+
+routine notifyset	(	server		: mach_port_t;
+				keys		: xmlData;
+				patterns	: xmlData;
+			 out	status		: int);
+
+routine notifyviafd	(	server		: mach_port_t;
+				fileport	: mach_port_move_send_t;
+				identifier	: int;
+			 out	status		: int);
+
+	skip;	/* reserved for future use */
+	skip;	/* reserved for future use */
+
+/*
+ * Miscellaneous API's
+ */
+
+routine snapshot	(	server		: mach_port_t;
+			 out	status		: int);

--- a/src/configd/config_types.h
+++ b/src/configd/config_types.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2000-2022 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/*
+ * config_types.h — types and constants imported into config.defs and
+ * the MIG-generated config{User,Server}.{c,h} stubs.
+ *
+ * freebsd-launchd-mach port: Apple's config_types.h gates on
+ * <TargetConditionals.h> for the iOS-simulator service name and uses
+ * `__private_extern__` for mig_external. This port has no simulator
+ * variant and builds configd as a plain daemon, so the service name
+ * is defined unconditionally and mig_external is plain `extern`.
+ */
+
+#ifndef _CONFIG_TYPES_H
+#define _CONFIG_TYPES_H
+
+/*
+ * Keep the MIG IPC functions at plain external linkage.
+ */
+#ifdef mig_external
+#undef mig_external
+#endif
+#define mig_external extern
+
+/* Turn MIG type checking on by default */
+#ifdef __MigTypeCheck
+#undef __MigTypeCheck
+#endif
+#define __MigTypeCheck	1
+
+/*
+ * Mach server port name — the bootstrap service configd checks in and
+ * the SystemConfiguration framework looks up.
+ */
+#define SCD_SERVER	"com.apple.SystemConfiguration.configd"
+
+/*
+ * Input arguments: serialized key's, list delimiters, ...
+ *	(sent as out-of-line data in a message)
+ */
+typedef const void * xmlData_t;
+
+/* Output arguments: serialized data, lists, ...
+ *	(sent as out-of-line data in a message)
+ */
+typedef const void * xmlDataOut_t;
+
+#endif	/* !_CONFIG_TYPES_H */

--- a/src/configd/configd.c
+++ b/src/configd/configd.c
@@ -1,0 +1,341 @@
+/*
+ * configd.c — SCDynamicStore configuration daemon (freebsd-launchd-mach
+ * port), iteration 1: the daemon skeleton.
+ *
+ * Apple's configd hosts the SCDynamicStore — a system-wide key->plist
+ * store with change notifications — over the MIG `config` subsystem
+ * (config.defs, base id 20000). This port keeps that real Mach IPC
+ * design (see the configd-port memory / plan).
+ *
+ * iter 1 brings up the daemon shell only: check the bootstrap service
+ * in with launchd and run a raw mach_msg receive loop that hands each
+ * message to the MIG-generated config_server() demux. The routine
+ * handlers (_configopen ... _snapshot) are stubs here — they return a
+ * "not implemented" status with all out-parameters zeroed. iter 2
+ * replaces them with the real store engine (session.c + _SCD.c).
+ *
+ * Apple's configd.tproj drives IPC through libdispatch's dispatch_mach
+ * channel API; that API is unfinished in this port, so configd uses a
+ * raw mach_msg loop instead — the same proven pattern hwregd and
+ * launchd use here. configd is a single-purpose server, so its main
+ * thread is the receive loop (no worker thread needed).
+ */
+
+#include <sys/types.h>
+
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "config_types.h"
+#include "configServer.h"	/* MIG: config_server() demux + _config* protos */
+
+/*
+ * SCDynamicStore status returned by the iter-1 stub handlers. 1001 is
+ * Apple's kSCStatusFailed; iter 2 pulls in the real SC status codes.
+ */
+#define SCD_STATUS_NOTYET	1001
+
+/* Inline message buffer. config.defs payloads (xmlData) travel as
+ * out-of-line descriptors, so the inline message is small — header,
+ * a couple of descriptors, scalars, trailer. 8 KiB is ample. */
+#define CONFIGD_MSG_BUFSZ	8192
+
+static volatile sig_atomic_t	got_term;
+
+static void
+on_signal(int sig)
+{
+	got_term = sig;
+}
+
+/* Timestamped diagnostic line to stderr (the configd launchd plist
+ * routes stderr to /var/log/configd.stderr, the CI boot test's path). */
+static void
+clog(const char *fmt, ...)
+{
+	struct timespec ts;
+	struct tm tm;
+	char tbuf[32];
+	va_list ap;
+
+	(void)clock_gettime(CLOCK_REALTIME, &ts);
+	(void)gmtime_r(&ts.tv_sec, &tm);
+	(void)strftime(tbuf, sizeof(tbuf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+	(void)fprintf(stderr, "configd %s ", tbuf);
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+/*
+ * MIG routine handlers — config_server() dispatches to these. iter 1
+ * stubs: every out-parameter is given a safe zero value (so the
+ * MIG-generated reply marshalling never sends an uninitialised port
+ * or out-of-line pointer) and the SCDynamicStore status reports
+ * "not implemented". Real implementations land in iter 2.
+ */
+
+kern_return_t
+_configopen(mach_port_t server, xmlData_t name, mach_msg_type_number_t nameCnt,
+    xmlData_t options, mach_msg_type_number_t optionsCnt,
+    mach_port_t *session, int *status)
+{
+	(void)server; (void)name; (void)nameCnt;
+	(void)options; (void)optionsCnt;
+	*session = MACH_PORT_NULL;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_configlist(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
+    int isRegex, xmlDataOut_t *list, mach_msg_type_number_t *listCnt,
+    int *status)
+{
+	(void)server; (void)key; (void)keyCnt; (void)isRegex;
+	*list = NULL;
+	*listCnt = 0;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_configadd(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
+    xmlData_t data, mach_msg_type_number_t dataCnt, int *newInstance,
+    int *status)
+{
+	(void)server; (void)key; (void)keyCnt; (void)data; (void)dataCnt;
+	*newInstance = 0;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_configget(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
+    xmlDataOut_t *data, mach_msg_type_number_t *dataCnt, int *newInstance,
+    int *status)
+{
+	(void)server; (void)key; (void)keyCnt;
+	*data = NULL;
+	*dataCnt = 0;
+	*newInstance = 0;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_configset(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
+    xmlData_t data, mach_msg_type_number_t dataCnt, int instance,
+    int *newInstance, int *status)
+{
+	(void)server; (void)key; (void)keyCnt; (void)data; (void)dataCnt;
+	(void)instance;
+	*newInstance = 0;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_configremove(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
+    int *status)
+{
+	(void)server; (void)key; (void)keyCnt;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_configadd_s(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
+    xmlData_t data, mach_msg_type_number_t dataCnt, int *newInstance,
+    int *status)
+{
+	(void)server; (void)key; (void)keyCnt; (void)data; (void)dataCnt;
+	*newInstance = 0;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_confignotify(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
+    int *status)
+{
+	(void)server; (void)key; (void)keyCnt;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_configget_m(mach_port_t server, xmlData_t keys, mach_msg_type_number_t keysCnt,
+    xmlData_t patterns, mach_msg_type_number_t patternsCnt,
+    xmlDataOut_t *data, mach_msg_type_number_t *dataCnt, int *status)
+{
+	(void)server; (void)keys; (void)keysCnt;
+	(void)patterns; (void)patternsCnt;
+	*data = NULL;
+	*dataCnt = 0;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_configset_m(mach_port_t server, xmlData_t data, mach_msg_type_number_t dataCnt,
+    xmlData_t removeData, mach_msg_type_number_t removeCnt,
+    xmlData_t notify, mach_msg_type_number_t notifyCnt, int *status)
+{
+	(void)server; (void)data; (void)dataCnt;
+	(void)removeData; (void)removeCnt; (void)notify; (void)notifyCnt;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_notifyadd(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
+    int isRegex, int *status)
+{
+	(void)server; (void)key; (void)keyCnt; (void)isRegex;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_notifyremove(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
+    int isRegex, int *status)
+{
+	(void)server; (void)key; (void)keyCnt; (void)isRegex;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_notifychanges(mach_port_t server, xmlDataOut_t *list,
+    mach_msg_type_number_t *listCnt, int *status)
+{
+	(void)server;
+	*list = NULL;
+	*listCnt = 0;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_notifyviaport(mach_port_t server, mach_port_t port, mach_msg_id_t msgid,
+    int *status)
+{
+	(void)server; (void)port; (void)msgid;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_notifycancel(mach_port_t server, int *status)
+{
+	(void)server;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_notifyset(mach_port_t server, xmlData_t keys, mach_msg_type_number_t keysCnt,
+    xmlData_t patterns, mach_msg_type_number_t patternsCnt, int *status)
+{
+	(void)server; (void)keys; (void)keysCnt;
+	(void)patterns; (void)patternsCnt;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_notifyviafd(mach_port_t server, mach_port_t fileport, int identifier,
+    int *status)
+{
+	(void)server; (void)fileport; (void)identifier;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+kern_return_t
+_snapshot(mach_port_t server, int *status)
+{
+	(void)server;
+	*status = SCD_STATUS_NOTYET;
+	return KERN_SUCCESS;
+}
+
+int
+main(int argc, char **argv)
+{
+	mach_port_t	service_port = MACH_PORT_NULL;
+	kern_return_t	kr;
+	const char	*service_name = SCD_SERVER;
+
+	(void)argc;
+	(void)argv;
+
+	(void)signal(SIGTERM, on_signal);
+	(void)signal(SIGINT, on_signal);
+
+	/*
+	 * Check the SCDynamicStore service in with launchd. configd is a
+	 * launchd job whose plist declares this MachService, so launchd
+	 * created the port and hands us the receive right here.
+	 */
+	kr = bootstrap_check_in(bootstrap_port, service_name, &service_port);
+	if (kr != BOOTSTRAP_SUCCESS) {
+		clog("bootstrap_check_in(%s) failed: 0x%x — exiting",
+		    service_name, (unsigned)kr);
+		return 1;
+	}
+	clog("Mach service '%s' checked in (port=0x%x)",
+	    service_name, (unsigned)service_port);
+
+	/*
+	 * Raw mach_msg receive loop. config_server() is the MIG demux for
+	 * the config subsystem; it writes the routine's reply (or a MIG
+	 * error) into `rep`. The 1s receive timeout lets the loop notice
+	 * a SIGTERM for a clean shutdown.
+	 */
+	while (!got_term) {
+		union {
+			mach_msg_header_t hdr;
+			char buf[CONFIGD_MSG_BUFSZ];
+		} req, rep;
+		mach_msg_return_t mr;
+
+		memset(&req, 0, sizeof(req));
+		mr = mach_msg(&req.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0,
+		    sizeof(req), service_port, 1000, MACH_PORT_NULL);
+		if (mr == MACH_RCV_TIMED_OUT)
+			continue;
+		if (mr != MACH_MSG_SUCCESS) {
+			clog("mach_msg receive failed: 0x%x — exiting",
+			    (unsigned)mr);
+			break;
+		}
+
+		memset(&rep, 0, sizeof(rep));
+		if (!config_server(&req.hdr, &rep.hdr)) {
+			clog("unhandled message id=%d", req.hdr.msgh_id);
+			continue;
+		}
+		if (rep.hdr.msgh_remote_port != MACH_PORT_NULL) {
+			mr = mach_msg(&rep.hdr, MACH_SEND_MSG | MACH_SEND_TIMEOUT,
+			    rep.hdr.msgh_size, 0, MACH_PORT_NULL, 1000,
+			    MACH_PORT_NULL);
+			if (mr != MACH_MSG_SUCCESS)
+				clog("reply send failed: 0x%x", (unsigned)mr);
+		}
+	}
+
+	clog("shutting down (signal %d)", (int)got_term);
+	return 0;
+}


### PR DESCRIPTION
## configd port — iteration 1 (Mach-IPC track)

Begins the **configd** port. configd hosts the **SCDynamicStore** — a system-wide key→plist store with change notifications — over the MIG `config` Mach subsystem (`config.defs`, base id 20000). The foundation the network stack, `scutil`, and config tooling sit on.

**This is the Mach-native port.** The existing `freebsd-configd-plan.html` targets the *sibling* `freebsd-launchd` repo's sockets / GNUstep-Distributed-Objects model and does **not** apply here — this repo has real Mach IPC + MIG, so configd keeps its real Mach protocol.

### iter 1 — the daemon skeleton

- **`src/configd/config.defs`** — the `config.defs` MIG protocol, ported from Apple's `SystemConfiguration.fproj`. Two deliberate changes: `UseSpecialReplyPort` dropped (plain reply ports work identically; special reply ports need runtime support this port lacks), and `configopen`'s `ServerAuditToken` arg deferred to iter 2. Routine order + `skip;` slots preserved **exactly** — a routine's `msgh_id` is positional and must match the SystemConfiguration client.
- **`src/configd/configd.c`** — `main()`: `bootstrap_check_in` of `com.apple.SystemConfiguration.configd`, then a **raw `mach_msg` receive loop** over the MIG `config_server()` demux. Apple's `configd_server.c` drives IPC through libdispatch's `dispatch_mach` channel API, which is unfinished in this port — the raw loop is the proven hwregd / launchd pattern, so the port doesn't depend on that gap. The 18 routine handlers (`_configopen` … `_snapshot`) are **stubs** returning a not-implemented status with every out-parameter zeroed; the store engine is iter 2.
- **`config_types.h`, `Makefile`** — MIG types + `bsd.prog.mk` build, mirroring hwregd's MIG wiring.
- **`com.apple.configd.plist`** — boot-time launchd job (`RunAtLoad` + `KeepAlive`), stderr → `/var/log/configd.stderr`.
- **`build.sh`** — generate the `config.defs` MIG stubs + build/install `/usr/sbin/configd`; `run.sh` dumps `configd.stderr` with the other daemon logs.

### Verification

`build` job: `build.sh` generates the MIG stubs and installs `/usr/sbin/configd` (gated by `test -x`). `test` job: configd boots as a launchd daemon and checks its Mach service in — a crash shows in the `configd.stderr` dump. iter 1 is daemon plumbing; the **demonstrable SCDynamicStore milestone is iter 3** (a client storing/reading a key end-to-end).

### Roadmap

| Iter | Deliverable |
|------|-------------|
| **1 (this PR)** | daemon skeleton + `config.defs` MIG interface |
| 2 | store engine (`_SCD.c`) + `open`/`get`/`set`/`list` handlers |
| 3 | `SCDynamicStore` client API — end-to-end store over Mach IPC |
| 4 | notifications + pattern keys |

🤖 Generated with [Claude Code](https://claude.com/claude-code)