### PR TITLE
feat(configd): iter 2 — SCDynamicStore key/value store

### DIFF
--- a/src/configd/Makefile
+++ b/src/configd/Makefile
@@ -1,11 +1,12 @@
 # configd — SCDynamicStore configuration daemon (freebsd-launchd-mach).
 #
-# configd iter 1: the daemon skeleton. Builds to /usr/sbin/configd,
-# runs as a launchd-managed daemon under PID-1 launchd (plist at
-# /System/Library/LaunchDaemons/com.apple.configd.plist). It checks
-# the com.apple.SystemConfiguration.configd Mach service in and runs
-# a raw mach_msg loop over the MIG config.defs demux (config_server());
-# the routine handlers are stubs until iter 2's store engine.
+# configd builds to /usr/sbin/configd and runs as a launchd-managed
+# daemon under PID-1 launchd (plist at /System/Library/LaunchDaemons/
+# com.apple.configd.plist). It checks the
+# com.apple.SystemConfiguration.configd Mach service in and runs a raw
+# mach_msg loop over the MIG config.defs demux (config_server()).
+# iter 2 adds config_store.c — the SCDynamicStore key/value store
+# backing configopen / configget / configset / configremove.
 #
 # Build:   cd src/configd && make SYSROOT=/path/to/rootfs MIGOUT=...
 # Install: make DESTDIR=/path/to/rootfs install
@@ -13,7 +14,7 @@
 PROG=		configd
 MAN=
 
-SRCS=		configd.c
+SRCS=		configd.c config_store.c
 
 # configServer.c — MIG-generated server demux + routine stubs for
 # config.defs. build.sh runs mig and passes MIGOUT=; a bare standalone

--- a/src/configd/config_store.c
+++ b/src/configd/config_store.c
@@ -1,0 +1,121 @@
+/*
+ * config_store.c — configd's SCDynamicStore key/value store (iter 2).
+ *
+ * iter 2 keeps the store deliberately simple: a dynamically grown
+ * array of {key, value} byte-blob pairs with linear lookup. The live
+ * store holds at most a few hundred keys, and every access is on the
+ * single mach_msg receive thread, so a hash table / locking would be
+ * premature. iter 4 (change notifications + pattern keys) is the
+ * point to revisit the data structure.
+ */
+
+#include "config_store.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+struct entry {
+	void	*key;
+	size_t	klen;
+	void	*val;
+	size_t	vlen;
+};
+
+static struct entry	*entries;
+static size_t		n_entries;
+static size_t		cap;
+
+static struct entry *
+store_find(const void *key, size_t klen)
+{
+	size_t i;
+
+	for (i = 0; i < n_entries; i++) {
+		if (entries[i].klen == klen &&
+		    memcmp(entries[i].key, key, klen) == 0)
+			return &entries[i];
+	}
+	return NULL;
+}
+
+int
+store_set(const void *key, size_t klen, const void *val, size_t vlen)
+{
+	struct entry	*e;
+	void		*vcopy;
+
+	/* malloc(0) may return NULL; ask for at least one byte. */
+	vcopy = malloc(vlen != 0 ? vlen : 1);
+	if (vcopy == NULL)
+		return -1;
+	if (vlen != 0)
+		memcpy(vcopy, val, vlen);
+
+	/* Existing key — swap the value in place. */
+	e = store_find(key, klen);
+	if (e != NULL) {
+		free(e->val);
+		e->val = vcopy;
+		e->vlen = vlen;
+		return 0;
+	}
+
+	/* New key — grow the array if it is full. */
+	if (n_entries == cap) {
+		size_t		ncap = (cap != 0) ? cap * 2 : 16;
+		struct entry	*ne;
+
+		ne = realloc(entries, ncap * sizeof(*ne));
+		if (ne == NULL) {
+			free(vcopy);
+			return -1;
+		}
+		entries = ne;
+		cap = ncap;
+	}
+
+	e = &entries[n_entries];
+	e->key = malloc(klen != 0 ? klen : 1);
+	if (e->key == NULL) {
+		free(vcopy);
+		return -1;
+	}
+	if (klen != 0)
+		memcpy(e->key, key, klen);
+	e->klen = klen;
+	e->val = vcopy;
+	e->vlen = vlen;
+	n_entries++;
+	return 0;
+}
+
+int
+store_get(const void *key, size_t klen, const void **val, size_t *vlen)
+{
+	struct entry *e;
+
+	e = store_find(key, klen);
+	if (e == NULL)
+		return -1;
+	*val = e->val;
+	*vlen = e->vlen;
+	return 0;
+}
+
+int
+store_remove(const void *key, size_t klen)
+{
+	struct entry	*e;
+	size_t		idx;
+
+	e = store_find(key, klen);
+	if (e == NULL)
+		return -1;
+
+	idx = (size_t)(e - entries);
+	free(e->key);
+	free(e->val);
+	/* Compact: move the last entry into the freed slot. */
+	entries[idx] = entries[--n_entries];
+	return 0;
+}

--- a/src/configd/config_store.h
+++ b/src/configd/config_store.h
@@ -1,0 +1,41 @@
+/*
+ * config_store.h — configd's SCDynamicStore key/value store (iter 2).
+ *
+ * A flat key->value table. Keys are the UTF-8 bytes of an
+ * SCDynamicStore key (what CFStringCreateExternalRepresentation
+ * produces, and what _SCSerializeString sends on the wire); values
+ * are opaque serialized-property-list blobs that configd stores and
+ * returns verbatim — it never interprets them. Keys and values are
+ * both copied in, so callers keep ownership of what they pass.
+ *
+ * iter 2 runs entirely on configd's single mach_msg receive thread,
+ * so the store needs no locking. iter 4's change notifications will
+ * add the per-key watcher / pattern bookkeeping Apple keeps in a
+ * sub-dictionary alongside each value.
+ */
+
+#ifndef _CONFIG_STORE_H
+#define _CONFIG_STORE_H
+
+#include <sys/types.h>
+
+/*
+ * store_set — insert key, or replace its value if already present.
+ * The key and value bytes are both copied. Returns 0 on success,
+ * -1 on an allocation failure.
+ */
+int store_set(const void *key, size_t klen, const void *val, size_t vlen);
+
+/*
+ * store_get — look key up. On a hit, *val points at the stored value
+ * (borrowed — valid only until the next store mutation) and *vlen is
+ * its length; returns 0. Returns -1 if the key is absent.
+ */
+int store_get(const void *key, size_t klen, const void **val, size_t *vlen);
+
+/*
+ * store_remove — drop key. Returns 0 if it was removed, -1 if absent.
+ */
+int store_remove(const void *key, size_t klen);
+
+#endif /* _CONFIG_STORE_H */

--- a/src/configd/configd.c
+++ b/src/configd/configd.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 
 #include <mach/mach.h>
+#include <mach/mig_errors.h>	/* mig_allocate — OOL reply-buffer hook */
 #include <servers/bootstrap.h>
 
 #include <signal.h>
@@ -179,13 +180,16 @@ _configget(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
 	} else {
 		vm_address_t buf = 0;
 
-		if (vm_allocate(mach_task_self(), &buf, vlen,
-		    VM_FLAGS_ANYWHERE) != KERN_SUCCESS) {
+		/*
+		 * mig_allocate is the out-of-line buffer hook the
+		 * generated MIG stubs use; config.defs marks `data`
+		 * `dealloc`, so MIG releases it with the matching
+		 * mig_deallocate once the reply is sent.
+		 */
+		if (mig_allocate(&buf, vlen) != KERN_SUCCESS) {
 			*status = kSCStatusFailed;
 		} else {
 			memcpy((void *)buf, val, vlen);
-			/* MIG ships *data out of line and (`dealloc`)
-			 * vm_deallocate()s it once the reply is sent. */
 			*data = (xmlDataOut_t)buf;
 			*dataCnt = (mach_msg_type_number_t)vlen;
 			*status = kSCStatusOK;

--- a/src/configd/configd.c
+++ b/src/configd/configd.c
@@ -1,24 +1,27 @@
 /*
  * configd.c — SCDynamicStore configuration daemon (freebsd-launchd-mach
- * port), iteration 1: the daemon skeleton.
+ * port).
  *
  * Apple's configd hosts the SCDynamicStore — a system-wide key->plist
  * store with change notifications — over the MIG `config` subsystem
  * (config.defs, base id 20000). This port keeps that real Mach IPC
  * design (see the configd-port memory / plan).
  *
- * iter 1 brings up the daemon shell only: check the bootstrap service
- * in with launchd and run a raw mach_msg receive loop that hands each
- * message to the MIG-generated config_server() demux. The routine
- * handlers (_configopen ... _snapshot) are stubs here — they return a
- * "not implemented" status with all out-parameters zeroed. iter 2
- * replaces them with the real store engine (session.c + _SCD.c).
+ * The daemon checks the bootstrap service in with launchd and runs a
+ * raw mach_msg receive loop that hands each message to the
+ * MIG-generated config_server() demux. Apple's configd.tproj drives
+ * IPC through libdispatch's dispatch_mach channel API; that API is
+ * unfinished in this port, so configd uses a raw mach_msg loop
+ * instead — the same proven pattern hwregd and launchd use here.
+ * configd is a single-purpose server, so its main thread is the
+ * receive loop (no worker thread needed).
  *
- * Apple's configd.tproj drives IPC through libdispatch's dispatch_mach
- * channel API; that API is unfinished in this port, so configd uses a
- * raw mach_msg loop instead — the same proven pattern hwregd and
- * launchd use here. configd is a single-purpose server, so its main
- * thread is the receive loop (no worker thread needed).
+ * iter 1 was the daemon skeleton (all routine handlers stubbed).
+ * iter 2 implements the store core — configopen / configget /
+ * configset / configremove against config_store.c. configlist, the
+ * add / multi variants, the notify* routines, and snapshot are still
+ * stubs; they land in later iterations (notifications need iter 4's
+ * per-session ports).
  */
 
 #include <sys/types.h>
@@ -35,13 +38,18 @@
 #include <unistd.h>
 
 #include "config_types.h"
+#include "config_store.h"
 #include "configServer.h"	/* MIG: config_server() demux + _config* protos */
 
 /*
- * SCDynamicStore status returned by the iter-1 stub handlers. 1001 is
- * Apple's kSCStatusFailed; iter 2 pulls in the real SC status codes.
+ * SCDynamicStore status codes — a subset of Apple's SCError.h. configd
+ * and the SystemConfiguration client must agree on these values: they
+ * cross the wire as the `status` reply field.
  */
-#define SCD_STATUS_NOTYET	1001
+#define kSCStatusOK			0
+#define kSCStatusFailed			1001
+#define kSCStatusInvalidArgument	1002
+#define kSCStatusNoKey			1004
 
 /* Inline message buffer. config.defs payloads (xmlData) travel as
  * out-of-line descriptors, so the inline message is small — header,
@@ -78,11 +86,25 @@ clog(const char *fmt, ...)
 }
 
 /*
- * MIG routine handlers — config_server() dispatches to these. iter 1
- * stubs: every out-parameter is given a safe zero value (so the
- * MIG-generated reply marshalling never sends an uninitialised port
- * or out-of-line pointer) and the SCDynamicStore status reports
- * "not implemented". Real implementations land in iter 2.
+ * Release a received out-of-line argument. config.defs marks the
+ * xmlData in-args without `dealloc`, so MIG does not free them — the
+ * handler owns them once unpacked (cf. Apple's _SCUnserialize).
+ */
+static void
+release_ool(const void *p, mach_msg_type_number_t len)
+{
+	if (len != 0)
+		(void)vm_deallocate(mach_task_self(), (vm_address_t)p, len);
+}
+
+/*
+ * MIG routine handlers — config_server() dispatches to these. iter 2
+ * implements the store core — configopen / configget / configset /
+ * configremove against config_store.c. The remaining routines (list,
+ * the add / multi-get / multi-set variants, and every notify*) are
+ * still stubs returning kSCStatusFailed; they land in later iters.
+ * Every out-parameter is given a safe value first so the MIG reply
+ * marshalling never sends an uninitialised port or OOL pointer.
  */
 
 kern_return_t
@@ -90,10 +112,24 @@ _configopen(mach_port_t server, xmlData_t name, mach_msg_type_number_t nameCnt,
     xmlData_t options, mach_msg_type_number_t optionsCnt,
     mach_port_t *session, int *status)
 {
-	(void)server; (void)name; (void)nameCnt;
-	(void)options; (void)optionsCnt;
-	*session = MACH_PORT_NULL;
-	*status = SCD_STATUS_NOTYET;
+	/*
+	 * iter 2 has no per-session ports yet (iter 4 adds them, where
+	 * change notifications need a per-client delivery port). Hand
+	 * the client a send right to this same service port: insert a
+	 * MAKE_SEND right onto the receive-right name and let MIG's
+	 * mach_port_move_send_t move it out in the reply.
+	 */
+	release_ool(name, nameCnt);
+	release_ool(options, optionsCnt);
+
+	if (mach_port_insert_right(mach_task_self(), server, server,
+	    MACH_MSG_TYPE_MAKE_SEND) != KERN_SUCCESS) {
+		*session = MACH_PORT_NULL;
+		*status = kSCStatusFailed;
+		return KERN_SUCCESS;
+	}
+	*session = server;
+	*status = kSCStatusOK;
 	return KERN_SUCCESS;
 }
 
@@ -105,7 +141,7 @@ _configlist(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
 	(void)server; (void)key; (void)keyCnt; (void)isRegex;
 	*list = NULL;
 	*listCnt = 0;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -116,7 +152,7 @@ _configadd(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
 {
 	(void)server; (void)key; (void)keyCnt; (void)data; (void)dataCnt;
 	*newInstance = 0;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -125,11 +161,38 @@ _configget(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
     xmlDataOut_t *data, mach_msg_type_number_t *dataCnt, int *newInstance,
     int *status)
 {
-	(void)server; (void)key; (void)keyCnt;
+	const void	*val;
+	size_t		vlen;
+
+	(void)server;
 	*data = NULL;
 	*dataCnt = 0;
 	*newInstance = 0;
-	*status = SCD_STATUS_NOTYET;
+
+	if (keyCnt == 0) {
+		*status = kSCStatusInvalidArgument;
+	} else if (store_get(key, keyCnt, &val, &vlen) != 0) {
+		*status = kSCStatusNoKey;
+	} else if (vlen == 0) {
+		/* A stored empty value — nothing to ship out of line. */
+		*status = kSCStatusOK;
+	} else {
+		vm_address_t buf = 0;
+
+		if (vm_allocate(mach_task_self(), &buf, vlen,
+		    VM_FLAGS_ANYWHERE) != KERN_SUCCESS) {
+			*status = kSCStatusFailed;
+		} else {
+			memcpy((void *)buf, val, vlen);
+			/* MIG ships *data out of line and (`dealloc`)
+			 * vm_deallocate()s it once the reply is sent. */
+			*data = (xmlDataOut_t)buf;
+			*dataCnt = (mach_msg_type_number_t)vlen;
+			*status = kSCStatusOK;
+		}
+	}
+
+	release_ool(key, keyCnt);
 	return KERN_SUCCESS;
 }
 
@@ -138,10 +201,19 @@ _configset(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
     xmlData_t data, mach_msg_type_number_t dataCnt, int instance,
     int *newInstance, int *status)
 {
-	(void)server; (void)key; (void)keyCnt; (void)data; (void)dataCnt;
-	(void)instance;
+	(void)server;
+	(void)instance;		/* the "instance" generation count is unused */
 	*newInstance = 0;
-	*status = SCD_STATUS_NOTYET;
+
+	if (keyCnt == 0)
+		*status = kSCStatusInvalidArgument;
+	else if (store_set(key, keyCnt, data, dataCnt) != 0)
+		*status = kSCStatusFailed;
+	else
+		*status = kSCStatusOK;
+
+	release_ool(key, keyCnt);
+	release_ool(data, dataCnt);
 	return KERN_SUCCESS;
 }
 
@@ -149,8 +221,16 @@ kern_return_t
 _configremove(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
     int *status)
 {
-	(void)server; (void)key; (void)keyCnt;
-	*status = SCD_STATUS_NOTYET;
+	(void)server;
+
+	if (keyCnt == 0)
+		*status = kSCStatusInvalidArgument;
+	else if (store_remove(key, keyCnt) != 0)
+		*status = kSCStatusNoKey;
+	else
+		*status = kSCStatusOK;
+
+	release_ool(key, keyCnt);
 	return KERN_SUCCESS;
 }
 
@@ -161,7 +241,7 @@ _configadd_s(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
 {
 	(void)server; (void)key; (void)keyCnt; (void)data; (void)dataCnt;
 	*newInstance = 0;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -170,7 +250,7 @@ _confignotify(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
     int *status)
 {
 	(void)server; (void)key; (void)keyCnt;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -183,7 +263,7 @@ _configget_m(mach_port_t server, xmlData_t keys, mach_msg_type_number_t keysCnt,
 	(void)patterns; (void)patternsCnt;
 	*data = NULL;
 	*dataCnt = 0;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -194,7 +274,7 @@ _configset_m(mach_port_t server, xmlData_t data, mach_msg_type_number_t dataCnt,
 {
 	(void)server; (void)data; (void)dataCnt;
 	(void)removeData; (void)removeCnt; (void)notify; (void)notifyCnt;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -203,7 +283,7 @@ _notifyadd(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
     int isRegex, int *status)
 {
 	(void)server; (void)key; (void)keyCnt; (void)isRegex;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -212,7 +292,7 @@ _notifyremove(mach_port_t server, xmlData_t key, mach_msg_type_number_t keyCnt,
     int isRegex, int *status)
 {
 	(void)server; (void)key; (void)keyCnt; (void)isRegex;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -223,7 +303,7 @@ _notifychanges(mach_port_t server, xmlDataOut_t *list,
 	(void)server;
 	*list = NULL;
 	*listCnt = 0;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -232,7 +312,7 @@ _notifyviaport(mach_port_t server, mach_port_t port, mach_msg_id_t msgid,
     int *status)
 {
 	(void)server; (void)port; (void)msgid;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -240,7 +320,7 @@ kern_return_t
 _notifycancel(mach_port_t server, int *status)
 {
 	(void)server;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -250,7 +330,7 @@ _notifyset(mach_port_t server, xmlData_t keys, mach_msg_type_number_t keysCnt,
 {
 	(void)server; (void)keys; (void)keysCnt;
 	(void)patterns; (void)patternsCnt;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -259,7 +339,7 @@ _notifyviafd(mach_port_t server, mach_port_t fileport, int identifier,
     int *status)
 {
 	(void)server; (void)fileport; (void)identifier;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
@@ -267,7 +347,7 @@ kern_return_t
 _snapshot(mach_port_t server, int *status)
 {
 	(void)server;
-	*status = SCD_STATUS_NOTYET;
+	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 


### PR DESCRIPTION
## configd port — iteration 2

iter 1 (merged) brought up the configd daemon skeleton. **iter 2 makes the store real** — the `configopen` / `configget` / `configset` / `configremove` MIG handlers now back a working SCDynamicStore.

### What's here

- **`src/configd/config_store.{c,h}`** — the store: a flat key→value table. Keys are the UTF-8 bytes of an SCDynamicStore key (what `_SCSerializeString` sends on the wire); values are **opaque serialized-plist blobs** configd stores and returns verbatim — it never interprets them. Because `config.defs`' `xmlData` in-args carry no CoreFoundation-specific framing for plain get/set/remove, the store needs **no CF dependency** — it stays pure libc, like iter 1. Single-threaded (configd's one `mach_msg` loop), so no locking.

- **`configd.c`** — real handlers:
  - `configopen` — hands the client a send right to the service port (iter 2 has no per-session ports; those arrive in iter 4 with change notifications).
  - `configget` — store lookup; ships the value out of line in a `vm_allocate`'d buffer MIG deallocates after the reply. `kSCStatusNoKey` when absent.
  - `configset` — copies key + value into the store.
  - `configremove` — drops the key.
  - A `release_ool()` helper `vm_deallocate()`s the received `xmlData` in-args — `config.defs` marks them without `dealloc`, so the handler owns them once unpacked (cf. Apple's `_SCUnserialize`).
  - The iter-1 `SCD_STATUS_NOTYET` placeholder is replaced with the real `SCError.h` status codes.

`configlist`, the `add` / multi-get / multi-set variants, the `notify*` routines and `snapshot` remain stubs — later iterations (notifications need iter 4's per-session ports).

### Verification

`build` (compiles clean) + `test` (configd still boots as a launchd daemon). The store logic has no consumer yet — it is exercised **end-to-end in iter 3**, which ports the `SCDynamicStore` client API: a client storing and reading a key over real Mach IPC. That's the first demonstrable milestone.

### Roadmap

| Iter | Deliverable | State |
|------|-------------|-------|
| 1 | daemon skeleton + MIG interface | merged |
| **2 (this PR)** | store engine + get/set/remove handlers | |
| 3 | `SCDynamicStore` client API — end-to-end store | next |
| 4 | notifications + pattern keys + per-session ports | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)