### PR TITLE
feat(configd): iter 4 — change notifications + per-session ports

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -996,6 +996,22 @@ cc -I"$CONFIGD_MIG" -I"$ROOT/src/configd" \
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/configtest" \
     || { echo "FAIL: configtest not built"; exit 1; }
 
+# notifytest — configd iter 4 change-notification round-trip test
+# client. Opens two sessions (per-session ports), watches a key,
+# registers a Mach notification port, changes the key from the other
+# session and confirms the notification + notifychanges. run.sh runs
+# it and checks for the CONFIGD-NOTIFY-OK marker.
+echo "==> building notifytest"
+cc -I"$CONFIGD_MIG" -I"$ROOT/src/configd" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/notifytest" \
+   "$ROOT/src/configd/notifytest.c" "$CONFIGD_MIG/configUser.c" \
+   -llaunch -lsystem_kernel
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/notifytest" \
+    || { echo "FAIL: notifytest not built"; exit 1; }
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -467,4 +467,15 @@ if [ ! -x "$configtest" ]; then
 fi
 "$configtest" || true	# marker (CONFIGD-STORE-OK/FAIL) gates in boot-test.sh
 
+# CONFIGD-NOTIFY — configd change notifications + per-session ports:
+# open two sessions, have one watch a key and register a Mach
+# notification port, change the key from the other session, and
+# confirm the notification message + notifychanges report it.
+notifytest=/usr/tests/freebsd-launchd-mach/notifytest
+if [ ! -x "$notifytest" ]; then
+    echo "CONFIGD-NOTIFY-FAIL: $notifytest missing"
+    exit 1
+fi
+"$notifytest" || true	# marker (CONFIGD-NOTIFY-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/configd/Makefile
+++ b/src/configd/Makefile
@@ -6,7 +6,10 @@
 # com.apple.SystemConfiguration.configd Mach service in and runs a raw
 # mach_msg loop over the MIG config.defs demux (config_server()).
 # iter 2 adds config_store.c — the SCDynamicStore key/value store
-# backing configopen / configget / configset / configremove.
+# backing configopen / configget / configset / configremove. iter 4
+# adds config_session.c — per-session ports, key watches and the
+# change-notification fan-out backing notifyadd / notifyviaport /
+# notifychanges.
 #
 # Build:   cd src/configd && make SYSROOT=/path/to/rootfs MIGOUT=...
 # Install: make DESTDIR=/path/to/rootfs install
@@ -14,7 +17,7 @@
 PROG=		configd
 MAN=
 
-SRCS=		configd.c config_store.c
+SRCS=		configd.c config_store.c config_session.c
 
 # configServer.c — MIG-generated server demux for config.defs.
 # configUser.c — MIG-generated client stubs, linked for the in-process
@@ -30,9 +33,10 @@ CFLAGS+=		-I${MIGOUT}
 CFLAGS+=		-I${.CURDIR}	# generated stubs #include "config_types.h"
 CFLAGS.configServer.c+=	-w
 CFLAGS.configUser.c+=	-w
-# The MIG stubs pull <mach/notify.h>, which redefines the MACH_NOTIFY_*
-# macros <mach/message.h> also defines (identical values, whitespace
-# differs) — a benign clash in the vendored mach headers.
+# <mach/notify.h> (pulled by the MIG stubs and, for the no-senders
+# notification, by configd.c / config_session.c) redefines the
+# MACH_NOTIFY_* macros <mach/message.h> also defines (identical values,
+# whitespace differs) — a benign clash in the vendored mach headers.
 CFLAGS+=		-Wno-macro-redefined
 .endif
 

--- a/src/configd/config_session.c
+++ b/src/configd/config_session.c
@@ -1,0 +1,394 @@
+/*
+ * config_session.c — configd's per-session state, key watches and
+ * change-notification fan-out (configd iter 4). See config_session.h
+ * for the model.
+ *
+ * The session table is a small dynamically grown array scanned
+ * linearly by port: a live store has a handful of clients, and every
+ * access is on configd's single mach_msg receive thread, so neither a
+ * hash table nor locking is warranted.
+ */
+
+#include "config_session.h"
+#include "config_types.h"		/* kSCStatus*, CONFIG_DATA_MAX */
+
+#include <mach/notify.h>		/* MACH_NOTIFY_NO_SENDERS */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* One key — a watch-list entry or a pending changed key. */
+struct keyref {
+	void	*key;
+	size_t	 klen;
+};
+
+struct session {
+	int		in_use;
+	mach_port_t	port;		/* per-session receive right */
+	mach_port_t	notify_port;	/* client notification port, or NULL */
+	struct keyref	*watch;		/* explicit watched keys */
+	size_t		n_watch;
+	size_t		watch_cap;
+	struct keyref	*changed;	/* keys changed since the last drain */
+	size_t		n_changed;
+	size_t		changed_cap;
+};
+
+static struct session	*sessions;
+static size_t		n_sessions;
+static size_t		sessions_cap;
+
+/* The port set every per-session port joins — recorded by configd. */
+static mach_port_t	config_pset = MACH_PORT_NULL;
+
+static int
+keyref_eq(const struct keyref *e, const void *key, size_t klen)
+{
+	return e->klen == klen && memcmp(e->key, key, klen) == 0;
+}
+
+/*
+ * keylist_add — append a copy of `key` to a keyref list, growing it.
+ * Already-present keys are skipped (the list is a set). Returns 0 on
+ * success, -1 on an allocation failure.
+ */
+static int
+keylist_add(struct keyref **list, size_t *n, size_t *cap,
+    const void *key, size_t klen)
+{
+	struct keyref	*entry;
+	void		*kcopy;
+	size_t		i;
+
+	for (i = 0; i < *n; i++) {
+		if (keyref_eq(&(*list)[i], key, klen))
+			return 0;	/* already present */
+	}
+
+	if (*n == *cap) {
+		size_t		ncap = (*cap != 0) ? *cap * 2 : 8;
+		struct keyref	*nl = realloc(*list, ncap * sizeof(*nl));
+
+		if (nl == NULL)
+			return -1;
+		*list = nl;
+		*cap = ncap;
+	}
+
+	kcopy = malloc(klen != 0 ? klen : 1);
+	if (kcopy == NULL)
+		return -1;
+	if (klen != 0)
+		memcpy(kcopy, key, klen);
+
+	entry = &(*list)[(*n)++];
+	entry->key = kcopy;
+	entry->klen = klen;
+	return 0;
+}
+
+/* keylist_remove — drop `key`; returns 0 if removed, -1 if absent. */
+static int
+keylist_remove(struct keyref *list, size_t *n, const void *key, size_t klen)
+{
+	size_t i;
+
+	for (i = 0; i < *n; i++) {
+		if (keyref_eq(&list[i], key, klen)) {
+			free(list[i].key);
+			list[i] = list[--(*n)];	/* compact */
+			return 0;
+		}
+	}
+	return -1;
+}
+
+/* keylist_free — free every key and the backing array. */
+static void
+keylist_free(struct keyref *list, size_t n)
+{
+	size_t i;
+
+	for (i = 0; i < n; i++)
+		free(list[i].key);
+	free(list);
+}
+
+static struct session *
+session_find(mach_port_t port)
+{
+	size_t i;
+
+	if (port == MACH_PORT_NULL)
+		return NULL;
+	for (i = 0; i < n_sessions; i++) {
+		if (sessions[i].in_use && sessions[i].port == port)
+			return &sessions[i];
+	}
+	return NULL;
+}
+
+/*
+ * send_notification — wake a session's client with a bare-header Mach
+ * message. Non-blocking (MACH_SEND_TIMEOUT 0): a dead or backed-up
+ * client must never stall configd. A lost notification is harmless —
+ * the change stays queued and the client still drains it via the next
+ * notification or notifychanges poll.
+ */
+static void
+send_notification(mach_port_t notify_port)
+{
+	mach_msg_header_t msg;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND, 0);
+	msg.msgh_size = sizeof(msg);
+	msg.msgh_remote_port = notify_port;
+	msg.msgh_local_port = MACH_PORT_NULL;
+	msg.msgh_id = CONFIGD_NOTIFY_MSGID;
+
+	(void)mach_msg(&msg, MACH_SEND_MSG | MACH_SEND_TIMEOUT,
+	    sizeof(msg), 0, MACH_PORT_NULL, 0, MACH_PORT_NULL);
+}
+
+void
+session_layer_init(mach_port_t port_set)
+{
+	config_pset = port_set;
+}
+
+int
+session_open(mach_port_t *port)
+{
+	mach_port_t	sport = MACH_PORT_NULL;
+	mach_port_t	prev = MACH_PORT_NULL;
+	struct session	*s = NULL;
+	size_t		i;
+
+	*port = MACH_PORT_NULL;
+
+	if (mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE,
+	    &sport) != KERN_SUCCESS)
+		return -1;
+
+	/* A MAKE_SEND right for the client; the configopen reply moves
+	 * it out. While it exists ip_srights is 1, so the no-senders
+	 * notification armed below only registers (it fires later). */
+	if (mach_port_insert_right(mach_task_self(), sport, sport,
+	    MACH_MSG_TYPE_MAKE_SEND) != KERN_SUCCESS)
+		goto fail;
+
+	/* Serve the session port from configd's single receive loop. */
+	if (mach_port_move_member(mach_task_self(), sport, config_pset)
+	    != KERN_SUCCESS)
+		goto fail;
+
+	/*
+	 * Arm a no-senders notification. When the client's last send
+	 * right to the session port dies — it exits, or the configopen
+	 * reply fails to send — the kernel posts MACH_NOTIFY_NO_SENDERS
+	 * to the port and configd_serve() calls session_close().
+	 */
+	(void)mach_port_request_notification(mach_task_self(), sport,
+	    MACH_NOTIFY_NO_SENDERS, 1, sport, MACH_MSG_TYPE_MAKE_SEND_ONCE,
+	    &prev);
+	if (prev != MACH_PORT_NULL)
+		(void)mach_port_deallocate(mach_task_self(), prev);
+
+	/* Take a free table slot, or grow the table. */
+	for (i = 0; i < n_sessions; i++) {
+		if (!sessions[i].in_use) {
+			s = &sessions[i];
+			break;
+		}
+	}
+	if (s == NULL) {
+		if (n_sessions == sessions_cap) {
+			size_t		ncap = (sessions_cap != 0)
+			    ? sessions_cap * 2 : 16;
+			struct session	*ns = realloc(sessions,
+			    ncap * sizeof(*ns));
+
+			if (ns == NULL)
+				goto fail;
+			sessions = ns;
+			sessions_cap = ncap;
+		}
+		s = &sessions[n_sessions++];
+	}
+
+	memset(s, 0, sizeof(*s));
+	s->in_use = 1;
+	s->port = sport;
+	*port = sport;
+	return 0;
+
+fail:
+	/*
+	 * Drop the send right (if insert_right got that far — harmless
+	 * if not), then the receive right; destroying the receive right
+	 * removes the port from the set and tears down any armed
+	 * notification.
+	 */
+	(void)mach_port_deallocate(mach_task_self(), sport);
+	(void)mach_port_mod_refs(mach_task_self(), sport,
+	    MACH_PORT_RIGHT_RECEIVE, -1);
+	return -1;
+}
+
+int
+session_close(mach_port_t port)
+{
+	struct session *s = session_find(port);
+
+	if (s == NULL)
+		return -1;
+
+	keylist_free(s->watch, s->n_watch);
+	keylist_free(s->changed, s->n_changed);
+	if (s->notify_port != MACH_PORT_NULL)
+		(void)mach_port_deallocate(mach_task_self(), s->notify_port);
+	/*
+	 * The client's send right is already gone (no-senders fired);
+	 * dropping configd's receive right destroys the port and
+	 * removes it from the configd port set.
+	 */
+	(void)mach_port_mod_refs(mach_task_self(), s->port,
+	    MACH_PORT_RIGHT_RECEIVE, -1);
+	memset(s, 0, sizeof(*s));
+	return 0;
+}
+
+int
+session_valid(mach_port_t port)
+{
+	return session_find(port) != NULL;
+}
+
+int
+session_set_notify_port(mach_port_t port, mach_port_t notify)
+{
+	struct session *s = session_find(port);
+
+	if (s == NULL) {
+		if (notify != MACH_PORT_NULL)
+			(void)mach_port_deallocate(mach_task_self(), notify);
+		return kSCStatusNoStoreSession;
+	}
+	if (notify == MACH_PORT_NULL)
+		return kSCStatusInvalidArgument;
+
+	/* Replace any previously registered port. */
+	if (s->notify_port != MACH_PORT_NULL)
+		(void)mach_port_deallocate(mach_task_self(), s->notify_port);
+	s->notify_port = notify;
+	return kSCStatusOK;
+}
+
+int
+session_clear_notify_port(mach_port_t port)
+{
+	struct session *s = session_find(port);
+
+	if (s == NULL)
+		return kSCStatusNoStoreSession;
+	if (s->notify_port != MACH_PORT_NULL) {
+		(void)mach_port_deallocate(mach_task_self(), s->notify_port);
+		s->notify_port = MACH_PORT_NULL;
+	}
+	return kSCStatusOK;
+}
+
+int
+session_watch_add(mach_port_t port, const void *key, size_t klen)
+{
+	struct session *s = session_find(port);
+
+	if (s == NULL)
+		return kSCStatusNoStoreSession;
+	if (keylist_add(&s->watch, &s->n_watch, &s->watch_cap, key, klen) != 0)
+		return kSCStatusFailed;
+	return kSCStatusOK;
+}
+
+int
+session_watch_remove(mach_port_t port, const void *key, size_t klen)
+{
+	struct session *s = session_find(port);
+
+	if (s == NULL)
+		return kSCStatusNoStoreSession;
+	if (keylist_remove(s->watch, &s->n_watch, key, klen) != 0)
+		return kSCStatusNoKey;
+	return kSCStatusOK;
+}
+
+ssize_t
+session_drain_changes(mach_port_t port, void *buf, size_t cap)
+{
+	struct session	*s = session_find(port);
+	uint8_t		*p = buf;
+	size_t		i;
+	size_t		off = 0;
+
+	if (s == NULL)
+		return -1;
+
+	for (i = 0; i < s->n_changed; i++) {
+		size_t		klen = s->changed[i].klen;
+		uint32_t	l32 = (uint32_t)klen;
+
+		if (off + sizeof(l32) + klen > cap)
+			return -1;	/* would not fit the reply array */
+		memcpy(p + off, &l32, sizeof(l32));
+		off += sizeof(l32);
+		memcpy(p + off, s->changed[i].key, klen);
+		off += klen;
+	}
+
+	/* The client has now seen these — clear the pending list. */
+	keylist_free(s->changed, s->n_changed);
+	s->changed = NULL;
+	s->n_changed = 0;
+	s->changed_cap = 0;
+	return (ssize_t)off;
+}
+
+void
+session_key_changed(const void *key, size_t klen)
+{
+	size_t i, w;
+
+	for (i = 0; i < n_sessions; i++) {
+		struct session	*s = &sessions[i];
+		int		watched = 0;
+		int		was_empty;
+
+		if (!s->in_use)
+			continue;
+
+		for (w = 0; w < s->n_watch; w++) {
+			if (keyref_eq(&s->watch[w], key, klen)) {
+				watched = 1;
+				break;
+			}
+		}
+		if (!watched)
+			continue;
+
+		/*
+		 * Record the change. A notification is sent only on the
+		 * empty -> non-empty edge: further changes before the
+		 * client drains coalesce under the one notification.
+		 */
+		was_empty = (s->n_changed == 0);
+		if (keylist_add(&s->changed, &s->n_changed, &s->changed_cap,
+		    key, klen) != 0)
+			continue;	/* allocation failure — drop */
+		if (was_empty && s->n_changed != 0 &&
+		    s->notify_port != MACH_PORT_NULL)
+			send_notification(s->notify_port);
+	}
+}

--- a/src/configd/config_session.h
+++ b/src/configd/config_session.h
@@ -1,0 +1,115 @@
+/*
+ * config_session.h — configd's per-session state, key watches and
+ * change-notification fan-out (configd iter 4).
+ *
+ * Apple's configd keeps a `serverSession` per client, keyed by the
+ * client's session Mach port, and a watcher list alongside each store
+ * value (configd.tproj/session.c, _SCD.c). This port mirrors that with
+ * a CF-free model:
+ *
+ *   - configopen allocates a fresh per-session receive right, hands the
+ *     client a send right to it, and arms a MACH_NOTIFY_NO_SENDERS
+ *     notification so the session is torn down when the client exits.
+ *     Every per-session port joins configd's port set, so the single
+ *     mach_msg receive loop serves every session; the port a request
+ *     arrives on (the MIG `server` argument) identifies the session.
+ *   - a session can watch explicit store keys (SCDynamicStoreAddWatchedKey)
+ *     and register one notification port (SCDynamicStoreNotifyMachPort).
+ *   - when a watched key changes, the key is appended to the watching
+ *     session's pending-changes list and — on the 0->1 edge — an empty
+ *     Mach message is sent to its notification port; the client then
+ *     drains the list with notifychanges.
+ *
+ * Regex/pattern watches (Apple's pattern.c) are deferred to a later
+ * iteration; iter 4 supports explicit keys only.
+ *
+ * Everything here runs on configd's single mach_msg receive thread, so
+ * no locking is needed.
+ */
+
+#ifndef _CONFIG_SESSION_H
+#define _CONFIG_SESSION_H
+
+#include <sys/types.h>
+#include <mach/mach.h>
+
+/*
+ * Mach msgh_id of the change notification configd sends to a session's
+ * notification port. The payload is a bare header — it only wakes the
+ * client, which then calls notifychanges to learn which keys changed
+ * (Apple's SCDynamicStore notification port works the same way: the
+ * message id carries no information).
+ */
+#define CONFIGD_NOTIFY_MSGID	0x434e4654	/* 'CNFT' */
+
+/*
+ * session_layer_init — record the port set every per-session port is
+ * added to. configd creates the set; session_open() moves new session
+ * ports into it so the main receive loop serves them.
+ */
+void session_layer_init(mach_port_t port_set);
+
+/*
+ * session_open — create a session on a fresh per-session port. On
+ * success *port holds a new receive right (already a member of the
+ * configd port set, with a no-senders notification armed) and a
+ * MACH_MSG_TYPE_MAKE_SEND right has been inserted for the caller to
+ * hand to the client. Returns 0, or -1 on failure (nothing leaks).
+ */
+int session_open(mach_port_t *port);
+
+/*
+ * session_close — tear the session bound to `port` down: drop its
+ * watches, deallocate its notification port, and destroy the session
+ * port (which also removes it from the port set). Called when the
+ * no-senders notification fires. Returns 0 if a session was closed,
+ * -1 if `port` named no session.
+ */
+int session_close(mach_port_t port);
+
+/*
+ * session_valid — 1 if `port` names a live session, else 0. The notify
+ * routines require an open session; the data routines act on the
+ * global store and do not.
+ */
+int session_valid(mach_port_t port);
+
+/*
+ * session_set_notify_port — register `notify` (a send right configd
+ * takes ownership of) as the session's change-notification port. Any
+ * previously registered port is deallocated. Returns a kSCStatus code.
+ */
+int session_set_notify_port(mach_port_t port, mach_port_t notify);
+
+/*
+ * session_clear_notify_port — drop the session's notification port
+ * (SCDynamicStoreNotifyCancel). Returns a kSCStatus code.
+ */
+int session_clear_notify_port(mach_port_t port);
+
+/*
+ * session_watch_add / session_watch_remove — add or drop an explicit
+ * watched key for the session. Adding a key already watched is a
+ * no-op success. Returns a kSCStatus code.
+ */
+int session_watch_add(mach_port_t port, const void *key, size_t klen);
+int session_watch_remove(mach_port_t port, const void *key, size_t klen);
+
+/*
+ * session_drain_changes — copy the session's pending changed-key list
+ * into `buf` (capacity `cap`) and clear it. The list is encoded as a
+ * run of records, each a uint32 little-endian key length followed by
+ * that many key bytes. Returns the number of bytes written (0 if no
+ * keys are pending), or -1 if the encoding would not fit in `cap`.
+ */
+ssize_t session_drain_changes(mach_port_t port, void *buf, size_t cap);
+
+/*
+ * session_key_changed — a store key changed (configset / configremove /
+ * confignotify). Every session watching `key` records it as pending
+ * and, if it has a notification port and had no pending changes, is
+ * sent a change notification message.
+ */
+void session_key_changed(const void *key, size_t klen);
+
+#endif /* !_CONFIG_SESSION_H */

--- a/src/configd/config_types.h
+++ b/src/configd/config_types.h
@@ -58,6 +58,22 @@
 #define SCD_SERVER	"com.apple.SystemConfiguration.configd"
 
 /*
+ * SCDynamicStore status codes — a subset of Apple's SCError.h. configd
+ * and its clients must agree on these values: they cross the wire as
+ * the `status` reply field of every config.defs routine.
+ */
+#define kSCStatusOK			0	/* success */
+#define kSCStatusFailed			1001	/* non-specific failure */
+#define kSCStatusInvalidArgument	1002	/* invalid argument */
+#define kSCStatusNoKey			1004	/* no such key */
+#define kSCStatusKeyExists		1005	/* key already defined */
+#define kSCStatusNoStoreSession		2001	/* no open store session */
+#define kSCStatusNotifierActive		2003	/* notifier already active */
+
+/* Maximum key / value size — config.defs' array[*:8192] bound. */
+#define CONFIG_DATA_MAX			8192
+
+/*
  * config.defs' xmlData / xmlDataOut MIG types. MIG records a `type`
  * declaration's wire layout but emits no C typedef for it — the
  * generated stubs use the name as-is and expect this imported header

--- a/src/configd/configd.c
+++ b/src/configd/configd.c
@@ -7,58 +7,56 @@
  * (config.defs, base id 20000). This port keeps that real Mach IPC
  * design (see the configd-port memory / plan).
  *
- * The daemon checks the bootstrap service in with launchd and runs a
- * raw mach_msg receive loop that hands each message to the
- * MIG-generated config_server() demux. Apple's configd.tproj drives
- * IPC through libdispatch's dispatch_mach channel API; that API is
- * unfinished in this port, so configd uses a raw mach_msg loop
- * instead — the same proven pattern hwregd and launchd use here.
- * configd is a single-purpose server, so its main thread is the
- * receive loop (no worker thread needed).
+ * configd checks the bootstrap service in with launchd and runs a raw
+ * mach_msg receive loop that hands each message to the MIG-generated
+ * config_server() demux. Apple's configd.tproj drives IPC through
+ * libdispatch's dispatch_mach channel API; that API is unfinished in
+ * this port, so configd uses a raw mach_msg loop instead — the same
+ * proven pattern hwregd and launchd use here.
  *
- * configopen / configget / configset / configremove are implemented
- * against config_store.c; configlist, the add / multi variants, the
- * notify* routines and snapshot are still stubs (later iterations).
- * config.defs carries the key/value payloads INLINE in bounded
- * arrays — out-of-line Mach data is broken cross-process in this
- * repo's kernel (see config.defs) — so a handler's xmlData argument
- * is the byte buffer itself; there is no out-of-line memory to free.
+ * iter 4 adds per-session ports and change notifications:
+ *   - configopen allocates a fresh per-session Mach port (config_session.c),
+ *     hands the client a send right, and arms a no-senders notification
+ *     so the session is torn down when the client exits. Every session
+ *     port joins a port set, so the one receive loop serves them all;
+ *     the port a request arrives on (the MIG `server` argument) names
+ *     the session.
+ *   - notifyadd / notifyviaport / notifychanges let a session watch
+ *     explicit keys, register a notification port, and drain the keys
+ *     that changed. configset / configremove / confignotify fan a
+ *     change out to every watching session.
+ * Regex/pattern watches and the multi-get/set variants remain stubs.
+ *
+ * config.defs carries the key/value payloads INLINE in bounded arrays
+ * — out-of-line Mach data is broken cross-process in this port's
+ * kernel (see config.defs) — so a handler's xmlData argument is the
+ * byte buffer itself; there is no out-of-line memory to free.
  *
  * `configd --selftest` runs an in-process round trip (a server thread
  * plus the client stubs) — no launchd or bootstrap — as a quick
- * self-check of the config.defs RPC path.
+ * self-check of the config.defs RPC and notification path.
  */
 
 #include <sys/types.h>
 
 #include <mach/mach.h>
+#include <mach/notify.h>		/* MACH_NOTIFY_NO_SENDERS */
 #include <servers/bootstrap.h>
 
 #include <pthread.h>
 #include <signal.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
 
-#include "config_types.h"
+#include "config_types.h"		/* SCD_SERVER, kSCStatus*, CONFIG_DATA_MAX */
 #include "config_store.h"
+#include "config_session.h"
 #include "configServer.h"	/* MIG: config_server() demux + _config* protos */
-
-/*
- * SCDynamicStore status codes — a subset of Apple's SCError.h. configd
- * and the SystemConfiguration client must agree on these values: they
- * cross the wire as the `status` reply field.
- */
-#define kSCStatusOK			0
-#define kSCStatusFailed			1001
-#define kSCStatusInvalidArgument	1002
-#define kSCStatusNoKey			1004
-
-/* Maximum key / value size — config.defs' array[*:8192] bound. */
-#define CONFIG_DATA_MAX			8192
 
 /*
  * Inline message buffer. config.defs carries the xmlData payloads
@@ -102,7 +100,7 @@ clog(const char *fmt, ...)
  * carries the payloads inline); the matching mach_msg_type_number_t
  * carries its length. Out-parameters are given a safe value first so
  * the MIG reply marshalling never ships an uninitialised port or
- * count. configlist, the add / multi variants and every notify* are
+ * count. The add / multi variants, the regex paths and snapshot are
  * still stubs returning kSCStatusFailed.
  */
 
@@ -112,23 +110,22 @@ _configopen(mach_port_t server, xmlData name, mach_msg_type_number_t nameCnt,
     mach_port_t *session, int *status)
 {
 	/*
-	 * iter 2 session model: hand the client a send right to this
-	 * same service port — per-session ports arrive with change
-	 * notifications. Insert a MAKE_SEND right onto the receive-right
-	 * name; MIG's mach_port_move_send_t moves it out in the reply.
+	 * Hand the client its own per-session port. session_open()
+	 * allocates the receive right, inserts a MAKE_SEND right (MIG's
+	 * mach_port_move_send_t moves it out in the reply), joins it to
+	 * configd's port set and arms the no-senders notification.
 	 */
+	(void)server;
 	(void)name;
 	(void)nameCnt;
 	(void)options;
 	(void)optionsCnt;
 
-	if (mach_port_insert_right(mach_task_self(), server, server,
-	    MACH_MSG_TYPE_MAKE_SEND) != KERN_SUCCESS) {
+	if (session_open(session) != 0) {
 		*session = MACH_PORT_NULL;
 		*status = kSCStatusFailed;
 		return KERN_SUCCESS;
 	}
-	*session = server;
 	*status = kSCStatusOK;
 	return KERN_SUCCESS;
 }
@@ -192,12 +189,15 @@ _configset(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
 	(void)instance;		/* the "instance" generation count is unused */
 	*newInstance = 0;
 
-	if (keyCnt == 0)
+	if (keyCnt == 0) {
 		*status = kSCStatusInvalidArgument;
-	else if (store_set(key, keyCnt, data, dataCnt) != 0)
+	} else if (store_set(key, keyCnt, data, dataCnt) != 0) {
 		*status = kSCStatusFailed;
-	else
+	} else {
+		/* fan the change out to every watching session */
+		session_key_changed(key, keyCnt);
 		*status = kSCStatusOK;
+	}
 	return KERN_SUCCESS;
 }
 
@@ -207,12 +207,15 @@ _configremove(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
 {
 	(void)server;
 
-	if (keyCnt == 0)
+	if (keyCnt == 0) {
 		*status = kSCStatusInvalidArgument;
-	else if (store_remove(key, keyCnt) != 0)
+	} else if (store_remove(key, keyCnt) != 0) {
 		*status = kSCStatusNoKey;
-	else
+	} else {
+		/* removing a key is a change watchers must hear about */
+		session_key_changed(key, keyCnt);
 		*status = kSCStatusOK;
+	}
 	return KERN_SUCCESS;
 }
 
@@ -227,12 +230,22 @@ _configadd_s(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
 	return KERN_SUCCESS;
 }
 
+/*
+ * confignotify (SCDynamicStoreNotifyValue) — force a change
+ * notification for a key without touching its value.
+ */
 kern_return_t
 _confignotify(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
     int *status)
 {
-	(void)server; (void)key; (void)keyCnt;
-	*status = kSCStatusFailed;
+	(void)server;
+
+	if (keyCnt == 0) {
+		*status = kSCStatusInvalidArgument;
+	} else {
+		session_key_changed(key, keyCnt);
+		*status = kSCStatusOK;
+	}
 	return KERN_SUCCESS;
 }
 
@@ -259,48 +272,98 @@ _configset_m(mach_port_t server, xmlData data, mach_msg_type_number_t dataCnt,
 	return KERN_SUCCESS;
 }
 
+/*
+ * notifyadd (SCDynamicStoreAddWatchedKey) — add an explicit key to the
+ * session's watch list. Regex/pattern watches (isRegex != 0) are
+ * deferred to a later iteration.
+ */
 kern_return_t
 _notifyadd(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
     int isRegex, int *status)
 {
-	(void)server; (void)key; (void)keyCnt; (void)isRegex;
-	*status = kSCStatusFailed;
+	if (keyCnt == 0)
+		*status = kSCStatusInvalidArgument;
+	else if (isRegex != 0)
+		*status = kSCStatusFailed;	/* pattern watches: later iter */
+	else
+		*status = session_watch_add(server, key, keyCnt);
 	return KERN_SUCCESS;
 }
 
+/*
+ * notifyremove (SCDynamicStoreRemoveWatchedKey) — drop an explicit key
+ * from the session's watch list.
+ */
 kern_return_t
 _notifyremove(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
     int isRegex, int *status)
 {
-	(void)server; (void)key; (void)keyCnt; (void)isRegex;
-	*status = kSCStatusFailed;
+	if (keyCnt == 0)
+		*status = kSCStatusInvalidArgument;
+	else if (isRegex != 0)
+		*status = kSCStatusFailed;	/* pattern watches: later iter */
+	else
+		*status = session_watch_remove(server, key, keyCnt);
 	return KERN_SUCCESS;
 }
 
+/*
+ * notifychanges (SCDynamicStoreCopyNotifiedKeys) — return and clear the
+ * session's list of keys that changed since the last call. The list is
+ * encoded as a run of [uint32 little-endian length][key bytes] records.
+ */
 kern_return_t
 _notifychanges(mach_port_t server, xmlDataOut list,
     mach_msg_type_number_t *listCnt, int *status)
 {
-	(void)server; (void)list;
+	ssize_t n;
+
 	*listCnt = 0;
-	*status = kSCStatusFailed;
+
+	if (!session_valid(server)) {
+		*status = kSCStatusNoStoreSession;
+		return KERN_SUCCESS;
+	}
+
+	n = session_drain_changes(server, list, CONFIG_DATA_MAX);
+	if (n < 0) {
+		/* the encoded change list overflowed the inline reply */
+		*status = kSCStatusFailed;
+		return KERN_SUCCESS;
+	}
+	*listCnt = (mach_msg_type_number_t)n;
+	*status = kSCStatusOK;
 	return KERN_SUCCESS;
 }
 
+/*
+ * notifyviaport (SCDynamicStoreNotifyMachPort) — register the Mach
+ * port configd messages when a watched key changes. `port` arrives as
+ * a moved-in send right configd takes ownership of.
+ */
 kern_return_t
 _notifyviaport(mach_port_t server, mach_port_t port, mach_msg_id_t msgid,
     int *status)
 {
-	(void)server; (void)port; (void)msgid;
-	*status = kSCStatusFailed;
+	if (msgid != 0) {
+		/* Apple's per-message identifier is obsolete; reject it. */
+		if (port != MACH_PORT_NULL)
+			(void)mach_port_deallocate(mach_task_self(), port);
+		*status = kSCStatusInvalidArgument;
+		return KERN_SUCCESS;
+	}
+	*status = session_set_notify_port(server, port);
 	return KERN_SUCCESS;
 }
 
+/*
+ * notifycancel (SCDynamicStoreNotifyCancel) — drop the session's
+ * notification port and watch list.
+ */
 kern_return_t
 _notifycancel(mach_port_t server, int *status)
 {
-	(void)server;
-	*status = kSCStatusFailed;
+	*status = session_clear_notify_port(server);
 	return KERN_SUCCESS;
 }
 
@@ -332,13 +395,17 @@ _snapshot(mach_port_t server, int *status)
 }
 
 /*
- * configd_serve — the raw mach_msg receive loop. config_server() is
- * the MIG demux for the config subsystem; it writes the routine's
- * reply (or a MIG error) into `rep`. The 1s receive timeout lets the
- * loop notice a SIGTERM for a clean shutdown.
+ * configd_serve — the raw mach_msg receive loop. It receives on a
+ * port set holding the bootstrap service port and every per-session
+ * port. config_server() is the MIG demux for the config subsystem; it
+ * writes the routine's reply (or a MIG error) into `rep`. A
+ * MACH_NOTIFY_NO_SENDERS message means a client exited — its session
+ * port's no-senders notification fired — so the session is closed.
+ * The 1s receive timeout lets the loop notice a SIGTERM for a clean
+ * shutdown.
  */
 static void
-configd_serve(mach_port_t service_port)
+configd_serve(mach_port_t port_set)
 {
 	while (!got_term) {
 		union {
@@ -349,13 +416,21 @@ configd_serve(mach_port_t service_port)
 
 		memset(&req, 0, sizeof(req));
 		mr = mach_msg(&req.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0,
-		    sizeof(req), service_port, 1000, MACH_PORT_NULL);
+		    sizeof(req), port_set, 1000, MACH_PORT_NULL);
 		if (mr == MACH_RCV_TIMED_OUT)
 			continue;
 		if (mr != MACH_MSG_SUCCESS) {
 			clog("mach_msg receive failed: 0x%x — exiting",
 			    (unsigned)mr);
 			break;
+		}
+
+		/* A client exited: tear its session down. */
+		if (req.hdr.msgh_id == MACH_NOTIFY_NO_SENDERS) {
+			if (session_close(req.hdr.msgh_local_port) == 0)
+				clog("session port 0x%x closed (client gone)",
+				    (unsigned)req.hdr.msgh_local_port);
+			continue;
 		}
 
 		memset(&rep, 0, sizeof(rep));
@@ -374,11 +449,38 @@ configd_serve(mach_port_t service_port)
 }
 
 /*
+ * configd_make_port_set — allocate the port set configd_serve()
+ * receives on and move `initial` (the bootstrap service port, or the
+ * selftest port) into it. The session layer adds new session ports to
+ * the same set. Returns 0 / -1.
+ */
+static int
+configd_make_port_set(mach_port_t initial, mach_port_t *port_set)
+{
+	kern_return_t kr;
+
+	kr = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_PORT_SET,
+	    port_set);
+	if (kr != KERN_SUCCESS) {
+		clog("port set allocate failed: 0x%x", (unsigned)kr);
+		return -1;
+	}
+	kr = mach_port_move_member(mach_task_self(), initial, *port_set);
+	if (kr != KERN_SUCCESS) {
+		clog("port set move_member failed: 0x%x", (unsigned)kr);
+		return -1;
+	}
+	session_layer_init(*port_set);
+	return 0;
+}
+
+/*
  * In-process self test (`configd --selftest`). A server thread runs
- * configd_serve() on a private port; the main thread drives the
+ * configd_serve() on a private port set; the main thread drives the
  * config.defs client stubs against it — configopen / configset /
- * configget — with no launchd or bootstrap in the loop. The client
- * stubs come from the MIG-generated configUser.c.
+ * configget, then notifyadd / configset / notifychanges — with no
+ * launchd or bootstrap in the loop. The client stubs come from the
+ * MIG-generated configUser.c.
  */
 extern kern_return_t configopen(mach_port_t, xmlData,
     mach_msg_type_number_t, xmlData, mach_msg_type_number_t,
@@ -389,14 +491,20 @@ extern kern_return_t configset(mach_port_t, xmlData,
 extern kern_return_t configget(mach_port_t, xmlData,
     mach_msg_type_number_t, xmlDataOut, mach_msg_type_number_t *,
     int *, int *);
+extern kern_return_t notifyadd(mach_port_t, xmlData,
+    mach_msg_type_number_t, int, int *);
+extern kern_return_t notifyviaport(mach_port_t, mach_port_t,
+    mach_msg_id_t, int *);
+extern kern_return_t notifychanges(mach_port_t, xmlDataOut,
+    mach_msg_type_number_t *, int *);
 
-static mach_port_t selftest_port;
+static mach_port_t selftest_pset;
 
 static void *
 selftest_server(void *arg)
 {
 	(void)arg;
-	configd_serve(selftest_port);
+	configd_serve(selftest_pset);
 	return NULL;
 }
 
@@ -405,7 +513,9 @@ run_selftest(void)
 {
 	pthread_t		th;
 	kern_return_t		kr;
+	mach_port_t		selftest_port = MACH_PORT_NULL;
 	mach_port_t		session = MACH_PORT_NULL;
+	mach_port_t		notify_port = MACH_PORT_NULL;
 	int			status = -1;
 	int			newInstance = 0;
 	/* Non-const uint8_t arrays — xmlData is uint8_t[], and a cast
@@ -414,8 +524,13 @@ run_selftest(void)
 	uint8_t			empty[1] = { 0 };
 	uint8_t			key[] = "selftest:key";
 	uint8_t			val[] = "configd selftest value blob";
+	uint8_t			val2[] = "configd selftest changed value";
 	xmlDataOut		got;
 	mach_msg_type_number_t	gotCnt = 0;
+	union {
+		mach_msg_header_t	hdr;
+		uint8_t			buf[256];	/* header + trailer */
+	} nmsg;
 
 	kr = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE,
 	    &selftest_port);
@@ -429,6 +544,8 @@ run_selftest(void)
 		clog("selftest: insert_right failed: 0x%x", (unsigned)kr);
 		return 1;
 	}
+	if (configd_make_port_set(selftest_port, &selftest_pset) != 0)
+		return 1;
 
 	if (pthread_create(&th, NULL, selftest_server, NULL) != 0) {
 		clog("selftest: pthread_create failed");
@@ -467,7 +584,103 @@ run_selftest(void)
 		return 1;
 	}
 
-	clog("CONFIGD-SELFTEST-OK: in-process config.defs round-trip works");
+	/*
+	 * Change-notification path: watch the key, change it, and
+	 * confirm notifychanges reports exactly that key.
+	 */
+	kr = notifyadd(session, key, (mach_msg_type_number_t)(sizeof(key) - 1),
+	    0, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		clog("selftest: notifyadd kr=0x%x status=%d", (unsigned)kr,
+		    status);
+		return 1;
+	}
+
+	kr = configset(session, key, (mach_msg_type_number_t)(sizeof(key) - 1),
+	    val2, (mach_msg_type_number_t)(sizeof(val2) - 1), 0, &newInstance,
+	    &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		clog("selftest: configset(notify) kr=0x%x status=%d",
+		    (unsigned)kr, status);
+		return 1;
+	}
+
+	gotCnt = 0;
+	kr = notifychanges(session, got, &gotCnt, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		clog("selftest: notifychanges kr=0x%x status=%d", (unsigned)kr,
+		    status);
+		return 1;
+	}
+	{
+		/* The list is one [uint32 len][key bytes] record. */
+		uint32_t	klen;
+		size_t		want = sizeof(key) - 1;
+
+		if (gotCnt != (mach_msg_type_number_t)(sizeof(klen) + want)) {
+			clog("selftest: notifychanges list size %u (want %zu)",
+			    (unsigned)gotCnt, sizeof(klen) + want);
+			return 1;
+		}
+		memcpy(&klen, got, sizeof(klen));
+		if (klen != want ||
+		    memcmp(got + sizeof(klen), key, want) != 0) {
+			clog("selftest: notifychanges key MISMATCH");
+			return 1;
+		}
+	}
+
+	/*
+	 * Notification-port path: register a Mach notification port,
+	 * change the watched key again, and confirm configd messages
+	 * the port.
+	 */
+	kr = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE,
+	    &notify_port);
+	if (kr != KERN_SUCCESS) {
+		clog("selftest: notify-port allocate failed: 0x%x",
+		    (unsigned)kr);
+		return 1;
+	}
+	kr = mach_port_insert_right(mach_task_self(), notify_port,
+	    notify_port, MACH_MSG_TYPE_MAKE_SEND);
+	if (kr != KERN_SUCCESS) {
+		clog("selftest: notify-port insert_right failed: 0x%x",
+		    (unsigned)kr);
+		return 1;
+	}
+	kr = notifyviaport(session, notify_port, 0, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		clog("selftest: notifyviaport kr=0x%x status=%d", (unsigned)kr,
+		    status);
+		return 1;
+	}
+
+	kr = configset(session, key, (mach_msg_type_number_t)(sizeof(key) - 1),
+	    val, (mach_msg_type_number_t)(sizeof(val) - 1), 0, &newInstance,
+	    &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		clog("selftest: configset(viaport) kr=0x%x status=%d",
+		    (unsigned)kr, status);
+		return 1;
+	}
+
+	memset(&nmsg, 0, sizeof(nmsg));
+	kr = mach_msg(&nmsg.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0,
+	    sizeof(nmsg), notify_port, 5000, MACH_PORT_NULL);
+	if (kr != MACH_MSG_SUCCESS) {
+		clog("selftest: no notification message (mach_msg: 0x%x)",
+		    (unsigned)kr);
+		return 1;
+	}
+	if (nmsg.hdr.msgh_id != CONFIGD_NOTIFY_MSGID) {
+		clog("selftest: notification msgh_id 0x%x (expected 0x%x)",
+		    (unsigned)nmsg.hdr.msgh_id, (unsigned)CONFIGD_NOTIFY_MSGID);
+		return 1;
+	}
+
+	clog("CONFIGD-SELFTEST-OK: in-process config.defs round-trip + "
+	    "change notification + notify port works");
 	return 0;
 }
 
@@ -475,6 +688,7 @@ int
 main(int argc, char **argv)
 {
 	mach_port_t	service_port = MACH_PORT_NULL;
+	mach_port_t	port_set = MACH_PORT_NULL;
 	kern_return_t	kr;
 	const char	*service_name = SCD_SERVER;
 
@@ -498,7 +712,17 @@ main(int argc, char **argv)
 	clog("Mach service '%s' checked in (port=0x%x)",
 	    service_name, (unsigned)service_port);
 
-	configd_serve(service_port);
+	/*
+	 * configd serves the bootstrap service port and every
+	 * per-session port from one receive loop: a port set holds them
+	 * all, and configopen joins new session ports to it.
+	 */
+	if (configd_make_port_set(service_port, &port_set) != 0) {
+		clog("could not set up the configd port set — exiting");
+		return 1;
+	}
+
+	configd_serve(port_set);
 
 	clog("shutting down (signal %d)", (int)got_term);
 	return 0;

--- a/src/configd/notifytest.c
+++ b/src/configd/notifytest.c
@@ -1,0 +1,189 @@
+/*
+ * notifytest — configd change-notification round-trip test client
+ * (configd iter 4).
+ *
+ * Opens two independent SCDynamicStore sessions with configd, which
+ * exercises per-session Mach ports: session A is the watcher, session
+ * B the writer. session A watches a key (notifyadd) and registers a
+ * Mach notification port (notifyviaport); session B then changes that
+ * key (configset). configd must message session A's notification port,
+ * and notifychanges on session A must report the changed key. Prints
+ * CONFIGD-NOTIFY-OK on success — the CI boot test (run.sh /
+ * boot-test.sh) matches that marker.
+ *
+ * Speaks config.defs directly via the MIG user stub configUser.c, the
+ * same way configtest exercises the store round-trip.
+ */
+
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"		/* MIG user stubs + xmlData; pulls config_types.h */
+#include "config_session.h"	/* CONFIGD_NOTIFY_MSGID — the notify-msg contract */
+
+#define SERVICE		"com.apple.SystemConfiguration.configd"
+
+/* Open a configd session on `server`; returns the session port or NULL. */
+static mach_port_t
+open_session(mach_port_t server, const char *name)
+{
+	mach_port_t	session = MACH_PORT_NULL;
+	int		status = -1;
+	kern_return_t	kr;
+
+	kr = configopen(server, (uint8_t *)name,
+	    (mach_msg_type_number_t)strlen(name), (uint8_t *)"", 0,
+	    &session, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-NOTIFY-FAIL: configopen(%s) kr=0x%x status=%d\n",
+		    name, (unsigned)kr, status);
+		return MACH_PORT_NULL;
+	}
+	return session;
+}
+
+/*
+ * change_list_has — walk the [uint32 little-endian length][key bytes]
+ * records notifychanges returns; 1 if `key` is among them.
+ */
+static int
+change_list_has(const uint8_t *list, size_t len, const char *key)
+{
+	size_t klen = strlen(key);
+	size_t off = 0;
+
+	while (off + sizeof(uint32_t) <= len) {
+		uint32_t reclen;
+
+		memcpy(&reclen, list + off, sizeof(reclen));
+		off += sizeof(reclen);
+		if (off + reclen > len)
+			break;		/* truncated record */
+		if (reclen == klen && memcmp(list + off, key, klen) == 0)
+			return 1;
+		off += reclen;
+	}
+	return 0;
+}
+
+int
+main(void)
+{
+	mach_port_t		server = MACH_PORT_NULL;
+	mach_port_t		sessionA = MACH_PORT_NULL;
+	mach_port_t		sessionB = MACH_PORT_NULL;
+	mach_port_t		notify_port = MACH_PORT_NULL;
+	kern_return_t		kr;
+	int			status = -1;
+	int			newInstance = 0;
+	const char		*key = "notifytest:watched";
+	const char		*val = "configd iter 4 notification value";
+	xmlDataOut		list;
+	mach_msg_type_number_t	listCnt = 0;
+	union {
+		mach_msg_header_t	hdr;
+		uint8_t			buf[256];	/* header + trailer */
+	} nmsg;
+
+	kr = bootstrap_look_up(bootstrap_port, SERVICE, &server);
+	if (kr != KERN_SUCCESS) {
+		printf("CONFIGD-NOTIFY-FAIL: bootstrap_look_up: 0x%x\n",
+		    (unsigned)kr);
+		return 1;
+	}
+
+	/* Two independent sessions — each gets its own per-session port. */
+	sessionA = open_session(server, "notifytest-watcher");
+	if (sessionA == MACH_PORT_NULL)
+		return 1;
+	sessionB = open_session(server, "notifytest-writer");
+	if (sessionB == MACH_PORT_NULL)
+		return 1;
+	if (sessionA == sessionB) {
+		printf("CONFIGD-NOTIFY-FAIL: both sessions share port 0x%x "
+		    "(per-session ports not working)\n", (unsigned)sessionA);
+		return 1;
+	}
+
+	/* session A watches the key. */
+	kr = notifyadd(sessionA, (uint8_t *)key,
+	    (mach_msg_type_number_t)strlen(key), 0, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-NOTIFY-FAIL: notifyadd kr=0x%x status=%d\n",
+		    (unsigned)kr, status);
+		return 1;
+	}
+
+	/*
+	 * A notification port: allocate a receive right and hand configd
+	 * a send right — notifyviaport's mach_port_move_send_t moves it
+	 * in. notifytest keeps the receive right to listen on.
+	 */
+	kr = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE,
+	    &notify_port);
+	if (kr != KERN_SUCCESS) {
+		printf("CONFIGD-NOTIFY-FAIL: mach_port_allocate: 0x%x\n",
+		    (unsigned)kr);
+		return 1;
+	}
+	kr = mach_port_insert_right(mach_task_self(), notify_port,
+	    notify_port, MACH_MSG_TYPE_MAKE_SEND);
+	if (kr != KERN_SUCCESS) {
+		printf("CONFIGD-NOTIFY-FAIL: insert_right: 0x%x\n",
+		    (unsigned)kr);
+		return 1;
+	}
+	kr = notifyviaport(sessionA, notify_port, 0, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-NOTIFY-FAIL: notifyviaport kr=0x%x status=%d\n",
+		    (unsigned)kr, status);
+		return 1;
+	}
+
+	/* session B changes the key session A is watching. */
+	kr = configset(sessionB, (uint8_t *)key,
+	    (mach_msg_type_number_t)strlen(key), (uint8_t *)val,
+	    (mach_msg_type_number_t)strlen(val), 0, &newInstance, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-NOTIFY-FAIL: configset kr=0x%x status=%d\n",
+		    (unsigned)kr, status);
+		return 1;
+	}
+
+	/* configd must have messaged session A's notification port. */
+	memset(&nmsg, 0, sizeof(nmsg));
+	kr = mach_msg(&nmsg.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0,
+	    sizeof(nmsg), notify_port, 5000, MACH_PORT_NULL);
+	if (kr != MACH_MSG_SUCCESS) {
+		printf("CONFIGD-NOTIFY-FAIL: no notification message "
+		    "(mach_msg: 0x%x)\n", (unsigned)kr);
+		return 1;
+	}
+	if (nmsg.hdr.msgh_id != CONFIGD_NOTIFY_MSGID) {
+		printf("CONFIGD-NOTIFY-FAIL: notification msgh_id 0x%x "
+		    "(expected 0x%x)\n", (unsigned)nmsg.hdr.msgh_id,
+		    (unsigned)CONFIGD_NOTIFY_MSGID);
+		return 1;
+	}
+
+	/* notifychanges on session A must report the changed key. */
+	kr = notifychanges(sessionA, list, &listCnt, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-NOTIFY-FAIL: notifychanges kr=0x%x status=%d\n",
+		    (unsigned)kr, status);
+		return 1;
+	}
+	if (!change_list_has(list, listCnt, key)) {
+		printf("CONFIGD-NOTIFY-FAIL: changed-key list (%u bytes) "
+		    "does not contain '%s'\n", (unsigned)listCnt, key);
+		return 1;
+	}
+
+	printf("CONFIGD-NOTIFY-OK: configd change notification round-trip "
+	    "(2 sessions, watch + notify port + notifychanges)\n");
+	return 0;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -405,6 +405,18 @@ expect {
     "CONFIGD-STORE-OK" { puts "\nOK: configd SCDynamicStore round-trip works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: CONFIGD-NOTIFY marker not seen"
+        exit 1
+    }
+    "CONFIGD-NOTIFY-FAIL" {
+        puts "\nFAIL: configd change-notification round-trip failed"
+        exit 1
+    }
+    "CONFIGD-NOTIFY-OK" { puts "\nOK: configd change notifications work" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## configd iter 4 — change notifications + per-session ports

Builds on iter 3 (merged PR #14, working SCDynamicStore round-trip). configd is now a SCDynamicStore that delivers change notifications.

### Per-session ports
`configopen` now hands each client its own per-session Mach port instead of the shared service-port send right of iter 2/3. Every session port joins a port set, so configd's single `mach_msg` loop serves them all, and the port a request arrives on (the MIG `server` argument) identifies the session. A `MACH_NOTIFY_NO_SENDERS` notification armed per session port tears the session down when its client exits.

### Change notifications
New `config_session.{c,h}` holds the per-session state: explicit key watches, one notification port per session, and the changed-key fan-out. `session_key_changed()` walks watching sessions, appends the changed key to each pending list, and — on the empty→non-empty edge — sends a bare-header notification message (`CONFIGD_NOTIFY_MSGID`). `configset` / `configremove` / `confignotify` drive the fan-out.

The notify routines are now real: `notifyadd` / `notifyremove` / `notifyviaport` / `notifychanges` / `notifycancel`. `notifychanges` returns the changed-key list as a run of `[uint32 LE length][key bytes]` records. Regex/pattern watches (`pattern.c`), `notifyset`, the multi-get/set variants, `configlist`, `notifyviafd` and `snapshot` remain stubs for a later iteration.

### Tests
- **`notifytest`** (new) — opens two sessions (proving per-session ports), has one watch a key and register a Mach notification port, then changes the key from the other session; the watcher must receive the notification message and `notifychanges` must report the key. Gates the new `CONFIGD-NOTIFY` marker in the QEMU boot test.
- **`configd --selftest`** extended to cover the watch + notify-port path in-process.

### Verification
Generated the config.defs MIG stubs with `mig`, built configd against real Mach, and ran `configd --selftest` → `CONFIGD-SELFTEST-OK: in-process config.defs round-trip + change notification + notify port works`. All sources compile clean under `WARNS=6`. The cross-process paths (no-senders teardown, bootstrap check-in, `notifytest`) are exercised by this PR's CI boot test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)