### PR TITLE
feat(configd): iter 5 — regex pattern watches

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1012,6 +1012,22 @@ cc -I"$CONFIGD_MIG" -I"$ROOT/src/configd" \
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/notifytest" \
     || { echo "FAIL: notifytest not built"; exit 1; }
 
+# patterntest — configd iter 5 regex pattern-watch test client. Opens
+# two sessions, watches a POSIX regex, changes a matching and a
+# non-matching key from the other session and confirms configd
+# notifies only for the match. run.sh runs it and checks for the
+# CONFIGD-PATTERN-OK marker.
+echo "==> building patterntest"
+cc -I"$CONFIGD_MIG" -I"$ROOT/src/configd" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/patterntest" \
+   "$ROOT/src/configd/patterntest.c" "$CONFIGD_MIG/configUser.c" \
+   -llaunch -lsystem_kernel
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/patterntest" \
+    || { echo "FAIL: patterntest not built"; exit 1; }
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -478,4 +478,14 @@ if [ ! -x "$notifytest" ]; then
 fi
 "$notifytest" || true	# marker (CONFIGD-NOTIFY-OK/FAIL) gates in boot-test.sh
 
+# CONFIGD-PATTERN — configd regex pattern watches: a session watches a
+# POSIX regex, another changes a matching and a non-matching key, and
+# configd must notify only for the match.
+patterntest=/usr/tests/freebsd-launchd-mach/patterntest
+if [ ! -x "$patterntest" ]; then
+    echo "CONFIGD-PATTERN-FAIL: $patterntest missing"
+    exit 1
+fi
+"$patterntest" || true	# marker (CONFIGD-PATTERN-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/configd/config_session.c
+++ b/src/configd/config_session.c
@@ -14,6 +14,7 @@
 
 #include <mach/notify.h>		/* MACH_NOTIFY_NO_SENDERS */
 
+#include <regex.h>			/* regcomp / regexec — pattern watches */
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -24,6 +25,18 @@ struct keyref {
 	size_t	 klen;
 };
 
+/*
+ * One regex watch. `src` keeps the client's original (un-anchored)
+ * pattern bytes so session_pattern_remove can match by value; `preg`
+ * is the compiled, anchored expression. preg is heap-allocated so the
+ * pattern array can be realloc'd without relocating compiled state.
+ */
+struct pattern {
+	void	*src;
+	size_t	 slen;
+	regex_t	*preg;
+};
+
 struct session {
 	int		in_use;
 	mach_port_t	port;		/* per-session receive right */
@@ -31,6 +44,9 @@ struct session {
 	struct keyref	*watch;		/* explicit watched keys */
 	size_t		n_watch;
 	size_t		watch_cap;
+	struct pattern	*patterns;	/* regex watches */
+	size_t		n_patterns;
+	size_t		patterns_cap;
 	struct keyref	*changed;	/* keys changed since the last drain */
 	size_t		n_changed;
 	size_t		changed_cap;
@@ -113,6 +129,20 @@ keylist_free(struct keyref *list, size_t n)
 
 	for (i = 0; i < n; i++)
 		free(list[i].key);
+	free(list);
+}
+
+/* patternlist_free — free every regex watch and the backing array. */
+static void
+patternlist_free(struct pattern *list, size_t n)
+{
+	size_t i;
+
+	for (i = 0; i < n; i++) {
+		regfree(list[i].preg);
+		free(list[i].preg);
+		free(list[i].src);
+	}
 	free(list);
 }
 
@@ -248,6 +278,7 @@ session_close(mach_port_t port)
 
 	keylist_free(s->watch, s->n_watch);
 	keylist_free(s->changed, s->n_changed);
+	patternlist_free(s->patterns, s->n_patterns);
 	if (s->notify_port != MACH_PORT_NULL)
 		(void)mach_port_deallocate(mach_task_self(), s->notify_port);
 	/*
@@ -325,6 +356,100 @@ session_watch_remove(mach_port_t port, const void *key, size_t klen)
 	return kSCStatusOK;
 }
 
+int
+session_pattern_add(mach_port_t port, const void *pat, size_t plen)
+{
+	struct session	*s = session_find(port);
+	const char	*p = pat;
+	struct pattern	*entry;
+	regex_t		*preg;
+	void		*scopy;
+	char		buf[CONFIG_DATA_MAX + 3];	/* ^ + pattern + $ + NUL */
+	size_t		off = 0;
+	size_t		i;
+
+	if (s == NULL)
+		return kSCStatusNoStoreSession;
+	if (plen > CONFIG_DATA_MAX)
+		return kSCStatusInvalidArgument;
+
+	/* Already watching this exact pattern — idempotent success. */
+	for (i = 0; i < s->n_patterns; i++) {
+		if (s->patterns[i].slen == plen &&
+		    memcmp(s->patterns[i].src, pat, plen) == 0)
+			return kSCStatusOK;
+	}
+
+	/*
+	 * Anchor the expression to a full-key match: prepend '^' unless
+	 * it is already there, append '$' unless the pattern already
+	 * ends in an unescaped '$' (mirrors Apple's pattern.c).
+	 */
+	if (plen == 0 || p[0] != '^')
+		buf[off++] = '^';
+	memcpy(buf + off, p, plen);
+	off += plen;
+	if (plen == 0 || p[plen - 1] != '$' ||
+	    (plen >= 2 && p[plen - 2] == '\\'))
+		buf[off++] = '$';
+	buf[off] = '\0';
+
+	if (s->n_patterns == s->patterns_cap) {
+		size_t		ncap = (s->patterns_cap != 0)
+		    ? s->patterns_cap * 2 : 4;
+		struct pattern	*np = realloc(s->patterns,
+		    ncap * sizeof(*np));
+
+		if (np == NULL)
+			return kSCStatusFailed;
+		s->patterns = np;
+		s->patterns_cap = ncap;
+	}
+
+	preg = malloc(sizeof(*preg));
+	if (preg == NULL)
+		return kSCStatusFailed;
+	if (regcomp(preg, buf, REG_EXTENDED) != 0) {
+		free(preg);
+		return kSCStatusInvalidArgument;	/* uncompilable regex */
+	}
+	scopy = malloc(plen != 0 ? plen : 1);
+	if (scopy == NULL) {
+		regfree(preg);
+		free(preg);
+		return kSCStatusFailed;
+	}
+	if (plen != 0)
+		memcpy(scopy, pat, plen);
+
+	entry = &s->patterns[s->n_patterns++];
+	entry->src = scopy;
+	entry->slen = plen;
+	entry->preg = preg;
+	return kSCStatusOK;
+}
+
+int
+session_pattern_remove(mach_port_t port, const void *pat, size_t plen)
+{
+	struct session	*s = session_find(port);
+	size_t		i;
+
+	if (s == NULL)
+		return kSCStatusNoStoreSession;
+	for (i = 0; i < s->n_patterns; i++) {
+		if (s->patterns[i].slen == plen &&
+		    memcmp(s->patterns[i].src, pat, plen) == 0) {
+			regfree(s->patterns[i].preg);
+			free(s->patterns[i].preg);
+			free(s->patterns[i].src);
+			s->patterns[i] = s->patterns[--s->n_patterns];
+			return kSCStatusOK;
+		}
+	}
+	return kSCStatusNoKey;
+}
+
 ssize_t
 session_drain_changes(mach_port_t port, void *buf, size_t cap)
 {
@@ -359,23 +484,47 @@ session_drain_changes(mach_port_t port, void *buf, size_t cap)
 void
 session_key_changed(const void *key, size_t klen)
 {
-	size_t i, w;
+	char	keystr[CONFIG_DATA_MAX + 1];	/* NUL-terminated for regexec */
+	int	have_keystr = 0;
+	size_t	i, w;
 
 	for (i = 0; i < n_sessions; i++) {
 		struct session	*s = &sessions[i];
-		int		watched = 0;
+		int		interested = 0;
 		int		was_empty;
 
 		if (!s->in_use)
 			continue;
 
+		/* explicit-key watch? */
 		for (w = 0; w < s->n_watch; w++) {
 			if (keyref_eq(&s->watch[w], key, klen)) {
-				watched = 1;
+				interested = 1;
 				break;
 			}
 		}
-		if (!watched)
+
+		/*
+		 * regex watch? Build the NUL-terminated key string once,
+		 * lazily — only if some session has a pattern to test.
+		 */
+		if (!interested && s->n_patterns != 0 &&
+		    klen < sizeof(keystr)) {
+			if (!have_keystr) {
+				memcpy(keystr, key, klen);
+				keystr[klen] = '\0';
+				have_keystr = 1;
+			}
+			for (w = 0; w < s->n_patterns; w++) {
+				if (regexec(s->patterns[w].preg, keystr,
+				    0, NULL, 0) == 0) {
+					interested = 1;
+					break;
+				}
+			}
+		}
+
+		if (!interested)
 			continue;
 
 		/*

--- a/src/configd/config_session.h
+++ b/src/configd/config_session.h
@@ -15,13 +15,12 @@
  *     arrives on (the MIG `server` argument) identifies the session.
  *   - a session can watch explicit store keys (SCDynamicStoreAddWatchedKey)
  *     and register one notification port (SCDynamicStoreNotifyMachPort).
+ *   - a session can also watch a POSIX regular expression (iter 5):
+ *     any store key matching the pattern triggers the same fan-out.
  *   - when a watched key changes, the key is appended to the watching
  *     session's pending-changes list and — on the 0->1 edge — an empty
  *     Mach message is sent to its notification port; the client then
  *     drains the list with notifychanges.
- *
- * Regex/pattern watches (Apple's pattern.c) are deferred to a later
- * iteration; iter 4 supports explicit keys only.
  *
  * Everything here runs on configd's single mach_msg receive thread, so
  * no locking is needed.
@@ -94,6 +93,18 @@ int session_clear_notify_port(mach_port_t port);
  */
 int session_watch_add(mach_port_t port, const void *key, size_t klen);
 int session_watch_remove(mach_port_t port, const void *key, size_t klen);
+
+/*
+ * session_pattern_add / session_pattern_remove — add or drop a regex
+ * watch for the session. The pattern bytes are a POSIX extended regular
+ * expression; configd anchors it (^...$) and compiles it. Any store key
+ * matching it triggers a change notification, exactly like an explicit
+ * watch. Adding a pattern already watched is a no-op success; an
+ * uncompilable pattern returns kSCStatusInvalidArgument. Returns a
+ * kSCStatus code.
+ */
+int session_pattern_add(mach_port_t port, const void *pat, size_t plen);
+int session_pattern_remove(mach_port_t port, const void *pat, size_t plen);
 
 /*
  * session_drain_changes — copy the session's pending changed-key list

--- a/src/configd/configd.c
+++ b/src/configd/configd.c
@@ -22,10 +22,11 @@
  *     the port a request arrives on (the MIG `server` argument) names
  *     the session.
  *   - notifyadd / notifyviaport / notifychanges let a session watch
- *     explicit keys, register a notification port, and drain the keys
- *     that changed. configset / configremove / confignotify fan a
- *     change out to every watching session.
- * Regex/pattern watches and the multi-get/set variants remain stubs.
+ *     explicit keys or POSIX-regex patterns (iter 5), register a
+ *     notification port, and drain the keys that changed. configset /
+ *     configremove / confignotify fan a change out to every watching
+ *     session.
+ * configlist, the multi-get/set variants and snapshot remain stubs.
  *
  * config.defs carries the key/value payloads INLINE in bounded arrays
  * — out-of-line Mach data is broken cross-process in this port's
@@ -273,9 +274,8 @@ _configset_m(mach_port_t server, xmlData data, mach_msg_type_number_t dataCnt,
 }
 
 /*
- * notifyadd (SCDynamicStoreAddWatchedKey) — add an explicit key to the
- * session's watch list. Regex/pattern watches (isRegex != 0) are
- * deferred to a later iteration.
+ * notifyadd (SCDynamicStoreAddWatchedKey) — add a watch to the session.
+ * isRegex selects an explicit-key watch or a POSIX-regex pattern watch.
  */
 kern_return_t
 _notifyadd(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
@@ -284,15 +284,15 @@ _notifyadd(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
 	if (keyCnt == 0)
 		*status = kSCStatusInvalidArgument;
 	else if (isRegex != 0)
-		*status = kSCStatusFailed;	/* pattern watches: later iter */
+		*status = session_pattern_add(server, key, keyCnt);
 	else
 		*status = session_watch_add(server, key, keyCnt);
 	return KERN_SUCCESS;
 }
 
 /*
- * notifyremove (SCDynamicStoreRemoveWatchedKey) — drop an explicit key
- * from the session's watch list.
+ * notifyremove (SCDynamicStoreRemoveWatchedKey) — drop a watch from the
+ * session; isRegex picks the explicit-key or the pattern watch list.
  */
 kern_return_t
 _notifyremove(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
@@ -301,7 +301,7 @@ _notifyremove(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
 	if (keyCnt == 0)
 		*status = kSCStatusInvalidArgument;
 	else if (isRegex != 0)
-		*status = kSCStatusFailed;	/* pattern watches: later iter */
+		*status = session_pattern_remove(server, key, keyCnt);
 	else
 		*status = session_watch_remove(server, key, keyCnt);
 	return KERN_SUCCESS;
@@ -523,6 +523,8 @@ run_selftest(void)
 	uint8_t			name[] = "selftest";
 	uint8_t			empty[1] = { 0 };
 	uint8_t			key[] = "selftest:key";
+	uint8_t			pat[] = "selftest:pat[0-9]+";
+	uint8_t			patkey[] = "selftest:pat42";
 	uint8_t			val[] = "configd selftest value blob";
 	uint8_t			val2[] = "configd selftest changed value";
 	xmlDataOut		got;
@@ -679,8 +681,62 @@ run_selftest(void)
 		return 1;
 	}
 
+	/* Drain the change left pending by the notify-port step. */
+	gotCnt = 0;
+	kr = notifychanges(session, got, &gotCnt, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		clog("selftest: notifychanges(drain) kr=0x%x status=%d",
+		    (unsigned)kr, status);
+		return 1;
+	}
+
+	/*
+	 * Pattern watch: register a POSIX regex, change a key that
+	 * matches it, and confirm notifychanges reports that key.
+	 */
+	kr = notifyadd(session, pat, (mach_msg_type_number_t)(sizeof(pat) - 1),
+	    1, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		clog("selftest: notifyadd(regex) kr=0x%x status=%d",
+		    (unsigned)kr, status);
+		return 1;
+	}
+	kr = configset(session, patkey,
+	    (mach_msg_type_number_t)(sizeof(patkey) - 1), val,
+	    (mach_msg_type_number_t)(sizeof(val) - 1), 0, &newInstance,
+	    &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		clog("selftest: configset(regex) kr=0x%x status=%d",
+		    (unsigned)kr, status);
+		return 1;
+	}
+	gotCnt = 0;
+	kr = notifychanges(session, got, &gotCnt, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		clog("selftest: notifychanges(regex) kr=0x%x status=%d",
+		    (unsigned)kr, status);
+		return 1;
+	}
+	{
+		/* One [uint32 len][key bytes] record — the matched key. */
+		uint32_t	klen2;
+		size_t		want2 = sizeof(patkey) - 1;
+
+		if (gotCnt != (mach_msg_type_number_t)(sizeof(klen2) + want2)) {
+			clog("selftest: regex change list size %u (want %zu)",
+			    (unsigned)gotCnt, sizeof(klen2) + want2);
+			return 1;
+		}
+		memcpy(&klen2, got, sizeof(klen2));
+		if (klen2 != want2 ||
+		    memcmp(got + sizeof(klen2), patkey, want2) != 0) {
+			clog("selftest: regex change key MISMATCH");
+			return 1;
+		}
+	}
+
 	clog("CONFIGD-SELFTEST-OK: in-process config.defs round-trip + "
-	    "change notification + notify port works");
+	    "change notification + notify port + regex watch works");
 	return 0;
 }
 

--- a/src/configd/patterntest.c
+++ b/src/configd/patterntest.c
@@ -1,0 +1,218 @@
+/*
+ * patterntest — configd regex pattern-watch test client (configd
+ * iter 5).
+ *
+ * Like notifytest, but the watcher registers a POSIX regular
+ * expression instead of an explicit key. session A watches the
+ * pattern "patterntest:[0-9]+" and a notification port; session B
+ * then changes two keys — one that matches the pattern and one that
+ * does not. configd must notify session A for the matching key only:
+ * the matching change must arrive (notification message +
+ * notifychanges), and the non-matching change must not. Prints
+ * CONFIGD-PATTERN-OK on success — the CI boot test (run.sh /
+ * boot-test.sh) matches that marker.
+ *
+ * Speaks config.defs directly via the MIG user stub configUser.c, the
+ * same way configtest and notifytest do.
+ */
+
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"		/* MIG user stubs + xmlData; pulls config_types.h */
+#include "config_session.h"	/* CONFIGD_NOTIFY_MSGID — the notify-msg contract */
+
+#define SERVICE		"com.apple.SystemConfiguration.configd"
+
+/* Open a configd session on `server`; returns the session port or NULL. */
+static mach_port_t
+open_session(mach_port_t server, const char *name)
+{
+	mach_port_t	session = MACH_PORT_NULL;
+	int		status = -1;
+	kern_return_t	kr;
+
+	kr = configopen(server, (uint8_t *)name,
+	    (mach_msg_type_number_t)strlen(name), (uint8_t *)"", 0,
+	    &session, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-PATTERN-FAIL: configopen(%s) kr=0x%x "
+		    "status=%d\n", name, (unsigned)kr, status);
+		return MACH_PORT_NULL;
+	}
+	return session;
+}
+
+/*
+ * change_list_has — walk the [uint32 little-endian length][key bytes]
+ * records notifychanges returns; 1 if `key` is among them.
+ */
+static int
+change_list_has(const uint8_t *list, size_t len, const char *key)
+{
+	size_t klen = strlen(key);
+	size_t off = 0;
+
+	while (off + sizeof(uint32_t) <= len) {
+		uint32_t reclen;
+
+		memcpy(&reclen, list + off, sizeof(reclen));
+		off += sizeof(reclen);
+		if (off + reclen > len)
+			break;		/* truncated record */
+		if (reclen == klen && memcmp(list + off, key, klen) == 0)
+			return 1;
+		off += reclen;
+	}
+	return 0;
+}
+
+/* Store `key`=`val` from session B. Returns 0 on success. */
+static int
+set_key(mach_port_t session, const char *key, const char *val)
+{
+	kern_return_t	kr;
+	int		status = -1;
+	int		newInstance = 0;
+
+	kr = configset(session, (uint8_t *)key,
+	    (mach_msg_type_number_t)strlen(key), (uint8_t *)val,
+	    (mach_msg_type_number_t)strlen(val), 0, &newInstance, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-PATTERN-FAIL: configset(%s) kr=0x%x "
+		    "status=%d\n", key, (unsigned)kr, status);
+		return -1;
+	}
+	return 0;
+}
+
+int
+main(void)
+{
+	mach_port_t		server = MACH_PORT_NULL;
+	mach_port_t		sessionA = MACH_PORT_NULL;
+	mach_port_t		sessionB = MACH_PORT_NULL;
+	mach_port_t		notify_port = MACH_PORT_NULL;
+	kern_return_t		kr;
+	int			status = -1;
+	const char		*pattern = "patterntest:[0-9]+";
+	const char		*matchKey = "patterntest:42";
+	const char		*missKey = "patterntest:nodigits";
+	const char		*val = "configd iter 5 pattern value";
+	xmlDataOut		list;
+	mach_msg_type_number_t	listCnt = 0;
+	union {
+		mach_msg_header_t	hdr;
+		uint8_t			buf[256];	/* header + trailer */
+	} nmsg;
+
+	kr = bootstrap_look_up(bootstrap_port, SERVICE, &server);
+	if (kr != KERN_SUCCESS) {
+		printf("CONFIGD-PATTERN-FAIL: bootstrap_look_up: 0x%x\n",
+		    (unsigned)kr);
+		return 1;
+	}
+
+	sessionA = open_session(server, "patterntest-watcher");
+	if (sessionA == MACH_PORT_NULL)
+		return 1;
+	sessionB = open_session(server, "patterntest-writer");
+	if (sessionB == MACH_PORT_NULL)
+		return 1;
+
+	/* session A watches the regex pattern. */
+	kr = notifyadd(sessionA, (uint8_t *)pattern,
+	    (mach_msg_type_number_t)strlen(pattern), 1, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-PATTERN-FAIL: notifyadd(regex) kr=0x%x "
+		    "status=%d\n", (unsigned)kr, status);
+		return 1;
+	}
+
+	/* A notification port: hand configd a send right, keep the
+	 * receive right to listen on. */
+	kr = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE,
+	    &notify_port);
+	if (kr != KERN_SUCCESS) {
+		printf("CONFIGD-PATTERN-FAIL: mach_port_allocate: 0x%x\n",
+		    (unsigned)kr);
+		return 1;
+	}
+	kr = mach_port_insert_right(mach_task_self(), notify_port,
+	    notify_port, MACH_MSG_TYPE_MAKE_SEND);
+	if (kr != KERN_SUCCESS) {
+		printf("CONFIGD-PATTERN-FAIL: insert_right: 0x%x\n",
+		    (unsigned)kr);
+		return 1;
+	}
+	kr = notifyviaport(sessionA, notify_port, 0, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-PATTERN-FAIL: notifyviaport kr=0x%x "
+		    "status=%d\n", (unsigned)kr, status);
+		return 1;
+	}
+
+	/* session B changes a key that matches the pattern. */
+	if (set_key(sessionB, matchKey, val) != 0)
+		return 1;
+
+	/* configd must have messaged session A's notification port. */
+	memset(&nmsg, 0, sizeof(nmsg));
+	kr = mach_msg(&nmsg.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0,
+	    sizeof(nmsg), notify_port, 5000, MACH_PORT_NULL);
+	if (kr != MACH_MSG_SUCCESS) {
+		printf("CONFIGD-PATTERN-FAIL: no notification for matching "
+		    "key (mach_msg: 0x%x)\n", (unsigned)kr);
+		return 1;
+	}
+
+	/* notifychanges must report the matching key. */
+	kr = notifychanges(sessionA, list, &listCnt, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-PATTERN-FAIL: notifychanges kr=0x%x "
+		    "status=%d\n", (unsigned)kr, status);
+		return 1;
+	}
+	if (!change_list_has(list, listCnt, matchKey)) {
+		printf("CONFIGD-PATTERN-FAIL: changed-key list (%u bytes) "
+		    "does not contain matching key '%s'\n",
+		    (unsigned)listCnt, matchKey);
+		return 1;
+	}
+
+	/* session B changes a key that does NOT match the pattern. */
+	if (set_key(sessionB, missKey, val) != 0)
+		return 1;
+
+	/* configd must NOT message the notification port for it. */
+	memset(&nmsg, 0, sizeof(nmsg));
+	kr = mach_msg(&nmsg.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0,
+	    sizeof(nmsg), notify_port, 500, MACH_PORT_NULL);
+	if (kr != MACH_RCV_TIMED_OUT) {
+		printf("CONFIGD-PATTERN-FAIL: unexpected notification for "
+		    "non-matching key (mach_msg: 0x%x)\n", (unsigned)kr);
+		return 1;
+	}
+
+	/* ...and notifychanges must report nothing pending. */
+	listCnt = 0;
+	kr = notifychanges(sessionA, list, &listCnt, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-PATTERN-FAIL: notifychanges(2) kr=0x%x "
+		    "status=%d\n", (unsigned)kr, status);
+		return 1;
+	}
+	if (listCnt != 0) {
+		printf("CONFIGD-PATTERN-FAIL: non-matching key registered a "
+		    "change (%u bytes pending)\n", (unsigned)listCnt);
+		return 1;
+	}
+
+	printf("CONFIGD-PATTERN-OK: configd regex pattern watch round-trip "
+	    "(matching key notified, non-matching key ignored)\n");
+	return 0;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -417,6 +417,18 @@ expect {
     "CONFIGD-NOTIFY-OK" { puts "\nOK: configd change notifications work" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: CONFIGD-PATTERN marker not seen"
+        exit 1
+    }
+    "CONFIGD-PATTERN-FAIL" {
+        puts "\nFAIL: configd regex pattern watch failed"
+        exit 1
+    }
+    "CONFIGD-PATTERN-OK" { puts "\nOK: configd regex pattern watches work" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## configd iter 5 — regex pattern watches

Builds on iter 4 (merged PR #16, change notifications + per-session ports). Completes the SCDynamicStore notification model with POSIX-regex pattern watches — the `isRegex` half of `notifyadd`/`notifyremove`.

### What changed
- `notifyadd` / `notifyremove` with `isRegex` set now register a **pattern watch** instead of returning `kSCStatusFailed`.
- `config_session.c` compiles each pattern with `regcomp(REG_EXTENDED)`, anchoring it to a full-key match (`^...$`) the way Apple's `pattern.c` does. The compiled `regex_t` is heap-allocated so the per-session pattern array can be `realloc`'d freely; `regfree` runs on session close.
- `session_key_changed` runs every changed key through each watching session's compiled patterns (alongside the explicit-key check), so a key matching a pattern triggers the same change-notification fan-out.

### Tests
- **`patterntest`** (new) — a session watches `patterntest:[0-9]+` plus a notification port; a second session changes a matching key (`patterntest:42`) and a non-matching key (`patterntest:nodigits`). configd must notify for the match only: the matching change arrives via both the notification message and `notifychanges`; the non-matching change produces neither. Gates the new `CONFIGD-PATTERN` marker.
- **`configd --selftest`** extended with an in-process regex-watch check.

### Verification
Built configd against real Mach and ran `configd --selftest` → `CONFIGD-SELFTEST-OK: in-process config.defs round-trip + change notification + notify port + regex watch works`. Separately verified the anchoring + match/non-match (`^`/`$` anchors reject prefixed/suffixed keys; `[0-9]+` rejects non-digit keys). All sources compile clean under `WARNS=6`. The cross-process pattern path is exercised by this PR's CI boot test.

Still stubbed for a later iteration: `configlist`, `notifyset`, the multi-get/set variants, `notifyviafd`, `snapshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)