### PR TITLE
feat(configd): iter 6 — configlist key listing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1028,6 +1028,20 @@ cc -I"$CONFIGD_MIG" -I"$ROOT/src/configd" \
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/patterntest" \
     || { echo "FAIL: patterntest not built"; exit 1; }
 
+# listtest — configd iter 6 key-listing test client. Stores keys and
+# exercises configlist (prefix / empty-key / regex queries). run.sh
+# runs it and checks for the CONFIGD-LIST-OK marker.
+echo "==> building listtest"
+cc -I"$CONFIGD_MIG" -I"$ROOT/src/configd" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/listtest" \
+   "$ROOT/src/configd/listtest.c" "$CONFIGD_MIG/configUser.c" \
+   -llaunch -lsystem_kernel
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/listtest" \
+    || { echo "FAIL: listtest not built"; exit 1; }
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -488,4 +488,13 @@ if [ ! -x "$patterntest" ]; then
 fi
 "$patterntest" || true	# marker (CONFIGD-PATTERN-OK/FAIL) gates in boot-test.sh
 
+# CONFIGD-LIST — configd key listing: store keys and query them back
+# with configlist by prefix, by empty key (all), and by POSIX regex.
+listtest=/usr/tests/freebsd-launchd-mach/listtest
+if [ ! -x "$listtest" ]; then
+    echo "CONFIGD-LIST-FAIL: $listtest missing"
+    exit 1
+fi
+"$listtest" || true	# marker (CONFIGD-LIST-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/configd/config_session.c
+++ b/src/configd/config_session.c
@@ -357,21 +357,46 @@ session_watch_remove(mach_port_t port, const void *key, size_t klen)
 }
 
 int
+config_pattern_anchor(const void *pat, size_t plen, char *buf, size_t bufsz)
+{
+	const char	*p = pat;
+	size_t		need;
+	size_t		off = 0;
+	int		lead;
+	int		trail;
+
+	/* prepend '^' unless the pattern is already anchored at the start */
+	lead = (plen == 0 || p[0] != '^');
+	/* append '$' unless it already ends in an unescaped '$' */
+	trail = (plen == 0 || p[plen - 1] != '$' ||
+	    (plen >= 2 && p[plen - 2] == '\\'));
+
+	need = plen + (size_t)(lead ? 1 : 0) + (size_t)(trail ? 1 : 0) + 1;
+	if (need > bufsz)
+		return -1;
+
+	if (lead)
+		buf[off++] = '^';
+	memcpy(buf + off, p, plen);
+	off += plen;
+	if (trail)
+		buf[off++] = '$';
+	buf[off] = '\0';
+	return 0;
+}
+
+int
 session_pattern_add(mach_port_t port, const void *pat, size_t plen)
 {
 	struct session	*s = session_find(port);
-	const char	*p = pat;
 	struct pattern	*entry;
 	regex_t		*preg;
 	void		*scopy;
 	char		buf[CONFIG_DATA_MAX + 3];	/* ^ + pattern + $ + NUL */
-	size_t		off = 0;
 	size_t		i;
 
 	if (s == NULL)
 		return kSCStatusNoStoreSession;
-	if (plen > CONFIG_DATA_MAX)
-		return kSCStatusInvalidArgument;
 
 	/* Already watching this exact pattern — idempotent success. */
 	for (i = 0; i < s->n_patterns; i++) {
@@ -380,19 +405,9 @@ session_pattern_add(mach_port_t port, const void *pat, size_t plen)
 			return kSCStatusOK;
 	}
 
-	/*
-	 * Anchor the expression to a full-key match: prepend '^' unless
-	 * it is already there, append '$' unless the pattern already
-	 * ends in an unescaped '$' (mirrors Apple's pattern.c).
-	 */
-	if (plen == 0 || p[0] != '^')
-		buf[off++] = '^';
-	memcpy(buf + off, p, plen);
-	off += plen;
-	if (plen == 0 || p[plen - 1] != '$' ||
-	    (plen >= 2 && p[plen - 2] == '\\'))
-		buf[off++] = '$';
-	buf[off] = '\0';
+	/* Anchor the expression to a full-key match, ready for regcomp(). */
+	if (config_pattern_anchor(pat, plen, buf, sizeof(buf)) != 0)
+		return kSCStatusInvalidArgument;
 
 	if (s->n_patterns == s->patterns_cap) {
 		size_t		ncap = (s->patterns_cap != 0)

--- a/src/configd/config_session.h
+++ b/src/configd/config_session.h
@@ -107,6 +107,17 @@ int session_pattern_add(mach_port_t port, const void *pat, size_t plen);
 int session_pattern_remove(mach_port_t port, const void *pat, size_t plen);
 
 /*
+ * config_pattern_anchor — write the anchored, NUL-terminated form of a
+ * raw SCDynamicStore pattern into buf (capacity bufsz): '^' is prepended
+ * and '$' appended unless the pattern is already bounded, so a compiled
+ * regex matches a whole key (mirrors Apple's pattern.c). The result is
+ * ready for regcomp(). Returns 0, or -1 if bufsz is too small. Shared by
+ * the pattern-watch path and configlist's isRegex query.
+ */
+int config_pattern_anchor(const void *pat, size_t plen, char *buf,
+    size_t bufsz);
+
+/*
  * session_drain_changes — copy the session's pending changed-key list
  * into `buf` (capacity `cap`) and clear it. The list is encoded as a
  * run of records, each a uint32 little-endian key length followed by

--- a/src/configd/config_store.c
+++ b/src/configd/config_store.c
@@ -119,3 +119,19 @@ store_remove(const void *key, size_t klen)
 	entries[idx] = entries[--n_entries];
 	return 0;
 }
+
+size_t
+store_count(void)
+{
+	return n_entries;
+}
+
+int
+store_key_at(size_t idx, const void **key, size_t *klen)
+{
+	if (idx >= n_entries)
+		return -1;
+	*key = entries[idx].key;
+	*klen = entries[idx].klen;
+	return 0;
+}

--- a/src/configd/config_store.h
+++ b/src/configd/config_store.h
@@ -38,4 +38,17 @@ int store_get(const void *key, size_t klen, const void **val, size_t *vlen);
  */
 int store_remove(const void *key, size_t klen);
 
+/*
+ * store_count — number of keys currently in the store.
+ *
+ * store_key_at — borrow the key at index idx (0 <= idx < store_count()).
+ * On success *key / *klen point at the stored key (borrowed — valid
+ * only until the next store mutation) and 0 is returned; returns -1 if
+ * idx is out of range. Together they let configlist enumerate the
+ * store. Indices are not stable across a store_remove (which compacts),
+ * so a walk must not mutate the store mid-iteration.
+ */
+size_t store_count(void);
+int store_key_at(size_t idx, const void **key, size_t *klen);
+
 #endif /* _CONFIG_STORE_H */

--- a/src/configd/configd.c
+++ b/src/configd/configd.c
@@ -26,7 +26,8 @@
  *     notification port, and drain the keys that changed. configset /
  *     configremove / confignotify fan a change out to every watching
  *     session.
- * configlist, the multi-get/set variants and snapshot remain stubs.
+ *   - configlist (iter 6) lists store keys by prefix or POSIX regex.
+ * notifyset, the multi-get/set variants and snapshot remain stubs.
  *
  * config.defs carries the key/value payloads INLINE in bounded arrays
  * — out-of-line Mach data is broken cross-process in this port's
@@ -45,6 +46,7 @@
 #include <servers/bootstrap.h>
 
 #include <pthread.h>
+#include <regex.h>			/* regcomp / regexec — configlist isRegex */
 #include <signal.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -96,6 +98,28 @@ clog(const char *fmt, ...)
 }
 
 /*
+ * keylist_append — append one [uint32 little-endian length][bytes]
+ * record to `buf` at offset *off (capacity cap), advancing *off.
+ * Returns 0, or -1 if the record would not fit. configlist emits its
+ * key list in this encoding — the same one session_drain_changes uses
+ * for notifychanges.
+ */
+static int
+keylist_append(uint8_t *buf, size_t cap, size_t *off,
+    const void *rec, size_t rlen)
+{
+	uint32_t l32 = (uint32_t)rlen;
+
+	if (*off + sizeof(l32) + rlen > cap)
+		return -1;
+	memcpy(buf + *off, &l32, sizeof(l32));
+	*off += sizeof(l32);
+	memcpy(buf + *off, rec, rlen);
+	*off += rlen;
+	return 0;
+}
+
+/*
  * MIG routine handlers — config_server() dispatches to these. An
  * xmlData / xmlDataOut argument is an inline byte buffer (config.defs
  * carries the payloads inline); the matching mach_msg_type_number_t
@@ -131,14 +155,74 @@ _configopen(mach_port_t server, xmlData name, mach_msg_type_number_t nameCnt,
 	return KERN_SUCCESS;
 }
 
+/*
+ * configlist (SCDynamicStoreCopyKeyList) — return the store keys that
+ * match `key`: with isRegex set, the keys matching `key` as a POSIX
+ * regex; otherwise the keys prefixed by `key` (an empty `key` lists
+ * every key). The result is the keylist_append [len][bytes] encoding.
+ */
 kern_return_t
 _configlist(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
     int isRegex, xmlDataOut list, mach_msg_type_number_t *listCnt,
     int *status)
 {
-	(void)server; (void)key; (void)keyCnt; (void)isRegex; (void)list;
+	size_t	count, i, off = 0;
+	regex_t	re;
+	int	have_re = 0;
+
+	(void)server;
 	*listCnt = 0;
-	*status = kSCStatusFailed;
+
+	if (isRegex != 0) {
+		char buf[CONFIG_DATA_MAX + 3];	/* ^ + pattern + $ + NUL */
+
+		if (config_pattern_anchor(key, keyCnt, buf, sizeof(buf)) != 0 ||
+		    regcomp(&re, buf, REG_EXTENDED) != 0) {
+			*status = kSCStatusInvalidArgument;
+			return KERN_SUCCESS;
+		}
+		have_re = 1;
+	}
+
+	count = store_count();
+	for (i = 0; i < count; i++) {
+		const void	*skey;
+		size_t		sklen;
+		int		match;
+
+		if (store_key_at(i, &skey, &sklen) != 0)
+			continue;
+
+		if (isRegex != 0) {
+			char keystr[CONFIG_DATA_MAX + 1];	/* NUL-term */
+
+			if (sklen >= sizeof(keystr))
+				continue;	/* key too long to match */
+			memcpy(keystr, skey, sklen);
+			keystr[sklen] = '\0';
+			match = (regexec(&re, keystr, 0, NULL, 0) == 0);
+		} else {
+			/* prefix match; an empty key matches every key */
+			match = (keyCnt == 0) ||
+			    (sklen >= keyCnt &&
+			     memcmp(skey, key, keyCnt) == 0);
+		}
+
+		if (match && keylist_append(list, CONFIG_DATA_MAX, &off,
+		    skey, sklen) != 0) {
+			/* the packed list overflowed the inline reply */
+			if (have_re)
+				regfree(&re);
+			*listCnt = 0;
+			*status = kSCStatusFailed;
+			return KERN_SUCCESS;
+		}
+	}
+
+	if (have_re)
+		regfree(&re);
+	*listCnt = (mach_msg_type_number_t)off;
+	*status = kSCStatusOK;
 	return KERN_SUCCESS;
 }
 
@@ -491,12 +575,39 @@ extern kern_return_t configset(mach_port_t, xmlData,
 extern kern_return_t configget(mach_port_t, xmlData,
     mach_msg_type_number_t, xmlDataOut, mach_msg_type_number_t *,
     int *, int *);
+extern kern_return_t configlist(mach_port_t, xmlData,
+    mach_msg_type_number_t, int, xmlDataOut, mach_msg_type_number_t *,
+    int *);
 extern kern_return_t notifyadd(mach_port_t, xmlData,
     mach_msg_type_number_t, int, int *);
 extern kern_return_t notifyviaport(mach_port_t, mach_port_t,
     mach_msg_id_t, int *);
 extern kern_return_t notifychanges(mach_port_t, xmlDataOut,
     mach_msg_type_number_t *, int *);
+
+/*
+ * selftest_list_has — 1 if the keylist_append-encoded [len][bytes]
+ * list `list` (of `len` bytes) contains a record equal to want/wlen.
+ */
+static int
+selftest_list_has(const uint8_t *list, mach_msg_type_number_t len,
+    const void *want, size_t wlen)
+{
+	size_t off = 0;
+
+	while (off + sizeof(uint32_t) <= (size_t)len) {
+		uint32_t reclen;
+
+		memcpy(&reclen, list + off, sizeof(reclen));
+		off += sizeof(reclen);
+		if (off + reclen > (size_t)len)
+			break;
+		if (reclen == wlen && memcmp(list + off, want, wlen) == 0)
+			return 1;
+		off += reclen;
+	}
+	return 0;
+}
 
 static mach_port_t selftest_pset;
 
@@ -735,8 +846,26 @@ run_selftest(void)
 		}
 	}
 
+	/*
+	 * configlist: list every store key and confirm both keys this
+	 * selftest stored (the explicit key and the pattern-matched key)
+	 * appear in the result.
+	 */
+	gotCnt = 0;
+	kr = configlist(session, empty, 0, 0, got, &gotCnt, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		clog("selftest: configlist kr=0x%x status=%d", (unsigned)kr,
+		    status);
+		return 1;
+	}
+	if (!selftest_list_has(got, gotCnt, key, sizeof(key) - 1) ||
+	    !selftest_list_has(got, gotCnt, patkey, sizeof(patkey) - 1)) {
+		clog("selftest: configlist is missing a stored key");
+		return 1;
+	}
+
 	clog("CONFIGD-SELFTEST-OK: in-process config.defs round-trip + "
-	    "change notification + notify port + regex watch works");
+	    "change notification + notify port + regex watch + list works");
 	return 0;
 }
 

--- a/src/configd/listtest.c
+++ b/src/configd/listtest.c
@@ -1,0 +1,190 @@
+/*
+ * listtest — configd key-listing test client (configd iter 6).
+ *
+ * Opens a configd session, stores a handful of keys under a known
+ * prefix plus one key outside it, then exercises configlist
+ * (SCDynamicStoreCopyKeyList) three ways:
+ *   - a prefix query ("listtest:")  -> the prefixed keys only;
+ *   - an empty-key query            -> every key in the store;
+ *   - a POSIX-regex query           -> the keys matching the pattern.
+ * Each result must contain the keys it should and omit the ones it
+ * should not. Prints CONFIGD-LIST-OK on success — the CI boot test
+ * (run.sh / boot-test.sh) matches that marker.
+ *
+ * Speaks config.defs directly via the MIG user stub configUser.c, the
+ * same way configtest / notifytest / patterntest do.
+ */
+
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"		/* MIG user stubs + xmlData; pulls config_types.h */
+
+#define SERVICE		"com.apple.SystemConfiguration.configd"
+
+static const char *KEY_ALPHA	= "listtest:alpha";
+static const char *KEY_BETA	= "listtest:beta";
+static const char *KEY_GAMMA	= "listtest:gamma";
+static const char *KEY_OUTSIDE	= "outsidelist:key";
+
+/* Open a configd session on `server`; returns the session port or NULL. */
+static mach_port_t
+open_session(mach_port_t server, const char *name)
+{
+	mach_port_t	session = MACH_PORT_NULL;
+	int		status = -1;
+	kern_return_t	kr;
+
+	kr = configopen(server, (uint8_t *)name,
+	    (mach_msg_type_number_t)strlen(name), (uint8_t *)"", 0,
+	    &session, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-LIST-FAIL: configopen(%s) kr=0x%x status=%d\n",
+		    name, (unsigned)kr, status);
+		return MACH_PORT_NULL;
+	}
+	return session;
+}
+
+/* Store `key`=`val`. Returns 0 on success. */
+static int
+set_key(mach_port_t session, const char *key, const char *val)
+{
+	kern_return_t	kr;
+	int		status = -1;
+	int		newInstance = 0;
+
+	kr = configset(session, (uint8_t *)key,
+	    (mach_msg_type_number_t)strlen(key), (uint8_t *)val,
+	    (mach_msg_type_number_t)strlen(val), 0, &newInstance, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-LIST-FAIL: configset(%s) kr=0x%x status=%d\n",
+		    key, (unsigned)kr, status);
+		return -1;
+	}
+	return 0;
+}
+
+/*
+ * list_has — walk the [uint32 little-endian length][key bytes] records
+ * configlist returns; 1 if `key` is among them.
+ */
+static int
+list_has(const uint8_t *list, size_t len, const char *key)
+{
+	size_t klen = strlen(key);
+	size_t off = 0;
+
+	while (off + sizeof(uint32_t) <= len) {
+		uint32_t reclen;
+
+		memcpy(&reclen, list + off, sizeof(reclen));
+		off += sizeof(reclen);
+		if (off + reclen > len)
+			break;		/* truncated record */
+		if (reclen == klen && memcmp(list + off, key, klen) == 0)
+			return 1;
+		off += reclen;
+	}
+	return 0;
+}
+
+/* Run a configlist query; returns 0 and fills list/listCnt on success. */
+static int
+list_keys(mach_port_t session, const char *key, int isRegex,
+    uint8_t *list, mach_msg_type_number_t *listCnt)
+{
+	kern_return_t	kr;
+	int		status = -1;
+
+	*listCnt = 0;
+	kr = configlist(session, (uint8_t *)key,
+	    (mach_msg_type_number_t)strlen(key), isRegex, list, listCnt,
+	    &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-LIST-FAIL: configlist(%s,isRegex=%d) kr=0x%x "
+		    "status=%d\n", key, isRegex, (unsigned)kr, status);
+		return -1;
+	}
+	return 0;
+}
+
+int
+main(void)
+{
+	mach_port_t		server = MACH_PORT_NULL;
+	mach_port_t		session = MACH_PORT_NULL;
+	kern_return_t		kr;
+	const char		*val = "configd iter 6 list value";
+	xmlDataOut		list;
+	mach_msg_type_number_t	listCnt = 0;
+
+	kr = bootstrap_look_up(bootstrap_port, SERVICE, &server);
+	if (kr != KERN_SUCCESS) {
+		printf("CONFIGD-LIST-FAIL: bootstrap_look_up: 0x%x\n",
+		    (unsigned)kr);
+		return 1;
+	}
+
+	session = open_session(server, "listtest");
+	if (session == MACH_PORT_NULL)
+		return 1;
+
+	/* Three keys under a known prefix, plus one outside it. */
+	if (set_key(session, KEY_ALPHA, val) != 0 ||
+	    set_key(session, KEY_BETA, val) != 0 ||
+	    set_key(session, KEY_GAMMA, val) != 0 ||
+	    set_key(session, KEY_OUTSIDE, val) != 0)
+		return 1;
+
+	/* Prefix query: the three "listtest:" keys, not the outside one. */
+	if (list_keys(session, "listtest:", 0, list, &listCnt) != 0)
+		return 1;
+	if (!list_has(list, listCnt, KEY_ALPHA) ||
+	    !list_has(list, listCnt, KEY_BETA) ||
+	    !list_has(list, listCnt, KEY_GAMMA)) {
+		printf("CONFIGD-LIST-FAIL: prefix query missing a "
+		    "\"listtest:\" key\n");
+		return 1;
+	}
+	if (list_has(list, listCnt, KEY_OUTSIDE)) {
+		printf("CONFIGD-LIST-FAIL: prefix query returned the "
+		    "non-prefixed key '%s'\n", KEY_OUTSIDE);
+		return 1;
+	}
+
+	/* Empty-key query: every key, including the outside one. */
+	if (list_keys(session, "", 0, list, &listCnt) != 0)
+		return 1;
+	if (!list_has(list, listCnt, KEY_ALPHA) ||
+	    !list_has(list, listCnt, KEY_GAMMA) ||
+	    !list_has(list, listCnt, KEY_OUTSIDE)) {
+		printf("CONFIGD-LIST-FAIL: empty-key query missing a "
+		    "stored key\n");
+		return 1;
+	}
+
+	/* Regex query: only the keys matching the pattern. */
+	if (list_keys(session, "listtest:(alpha|beta)", 1, list, &listCnt) != 0)
+		return 1;
+	if (!list_has(list, listCnt, KEY_ALPHA) ||
+	    !list_has(list, listCnt, KEY_BETA)) {
+		printf("CONFIGD-LIST-FAIL: regex query missing a "
+		    "matching key\n");
+		return 1;
+	}
+	if (list_has(list, listCnt, KEY_GAMMA) ||
+	    list_has(list, listCnt, KEY_OUTSIDE)) {
+		printf("CONFIGD-LIST-FAIL: regex query returned a "
+		    "non-matching key\n");
+		return 1;
+	}
+
+	printf("CONFIGD-LIST-OK: configd key listing round-trip "
+	    "(prefix / all / regex queries)\n");
+	return 0;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -429,6 +429,18 @@ expect {
     "CONFIGD-PATTERN-OK" { puts "\nOK: configd regex pattern watches work" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: CONFIGD-LIST marker not seen"
+        exit 1
+    }
+    "CONFIGD-LIST-FAIL" {
+        puts "\nFAIL: configd key listing failed"
+        exit 1
+    }
+    "CONFIGD-LIST-OK" { puts "\nOK: configd key listing works" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## configd iter 6 — configlist key listing

Builds on iter 5 (merged PR #17). Implements `configlist` — `SCDynamicStoreCopyKeyList` — the SCDynamicStore key-enumeration routine, previously a stub.

### What changed
- **`_configlist`** is now real. With `isRegex` clear it returns the store keys **prefixed by** the request key (an empty key lists every key); with `isRegex` set it returns the keys matching the request key as an **anchored POSIX regex**.
- **`config_store`** gains `store_count` / `store_key_at` to enumerate the store.
- The regex anchoring (`^…$`) is factored out of the pattern-watch path into a shared **`config_pattern_anchor`** helper, used by both `session_pattern_add` and `configlist`.
- The key list crosses the wire in the same `[uint32 len][key bytes]` record encoding `notifychanges` already uses.

### Tests
- **`listtest`** (new) — stores three keys under a known prefix plus one key outside it, then checks: the prefix query returns the prefixed keys only, the empty-key query returns every stored key, and a regex query (`listtest:(alpha|beta)`) returns just the matching keys.
- **`configd --selftest`** gains a `configlist` check.

### Verification
Built configd against real Mach and ran `configd --selftest` → `CONFIGD-SELFTEST-OK: in-process config.defs round-trip + change notification + notify port + regex watch + list works`. All sources compile clean under `WARNS=6`. The cross-process listing path is exercised by this PR's CI boot test (`CONFIGD-LIST` marker).

Still stubbed for a later iteration: `notifyset`, the multi-get/set variants (`configget_m`/`configset_m`), `notifyviafd`, `snapshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)