### PR TITLE
feat(configd): iter 7 — batch routines (notifyset, multi-get/set)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1042,6 +1042,22 @@ cc -I"$CONFIGD_MIG" -I"$ROOT/src/configd" \
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/listtest" \
     || { echo "FAIL: listtest not built"; exit 1; }
 
+# multitest — configd iter 7 batch-routine test client. Exercises
+# configset_m / configget_m / notifyset; links config_wire.c for the
+# key-list / key-value payload encodings. run.sh runs it and checks
+# for the CONFIGD-MULTI-OK marker.
+echo "==> building multitest"
+cc -I"$CONFIGD_MIG" -I"$ROOT/src/configd" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/multitest" \
+   "$ROOT/src/configd/multitest.c" "$ROOT/src/configd/config_wire.c" \
+   "$CONFIGD_MIG/configUser.c" \
+   -llaunch -lsystem_kernel
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/multitest" \
+    || { echo "FAIL: multitest not built"; exit 1; }
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -497,4 +497,14 @@ if [ ! -x "$listtest" ]; then
 fi
 "$listtest" || true	# marker (CONFIGD-LIST-OK/FAIL) gates in boot-test.sh
 
+# CONFIGD-MULTI — configd batch routines: set/remove several keys with
+# configset_m, fetch several with configget_m (by key and by regex),
+# and replace a session's whole watch set with notifyset.
+multitest=/usr/tests/freebsd-launchd-mach/multitest
+if [ ! -x "$multitest" ]; then
+    echo "CONFIGD-MULTI-FAIL: $multitest missing"
+    exit 1
+fi
+"$multitest" || true	# marker (CONFIGD-MULTI-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/configd/Makefile
+++ b/src/configd/Makefile
@@ -9,7 +9,9 @@
 # backing configopen / configget / configset / configremove. iter 4
 # adds config_session.c — per-session ports, key watches and the
 # change-notification fan-out backing notifyadd / notifyviaport /
-# notifychanges.
+# notifychanges. iter 7 adds config_wire.c — the key-list / key-value
+# byte encodings the batch routines (notifyset / configget_m /
+# configset_m) carry in their inline payloads.
 #
 # Build:   cd src/configd && make SYSROOT=/path/to/rootfs MIGOUT=...
 # Install: make DESTDIR=/path/to/rootfs install
@@ -17,7 +19,7 @@
 PROG=		configd
 MAN=
 
-SRCS=		configd.c config_store.c config_session.c
+SRCS=		configd.c config_store.c config_session.c config_wire.c
 
 # configServer.c — MIG-generated server demux for config.defs.
 # configUser.c — MIG-generated client stubs, linked for the in-process

--- a/src/configd/config_session.c
+++ b/src/configd/config_session.c
@@ -11,6 +11,7 @@
 
 #include "config_session.h"
 #include "config_types.h"		/* kSCStatus*, CONFIG_DATA_MAX */
+#include "config_wire.h"		/* wire_keylist_put — notifychanges encoding */
 
 #include <mach/notify.h>		/* MACH_NOTIFY_NO_SENDERS */
 
@@ -357,6 +358,28 @@ session_watch_remove(mach_port_t port, const void *key, size_t klen)
 }
 
 int
+session_watch_clear(mach_port_t port)
+{
+	struct session *s = session_find(port);
+
+	if (s == NULL)
+		return kSCStatusNoStoreSession;
+
+	/* Drop every watch — both explicit keys and regex patterns. */
+	keylist_free(s->watch, s->n_watch);
+	s->watch = NULL;
+	s->n_watch = 0;
+	s->watch_cap = 0;
+
+	patternlist_free(s->patterns, s->n_patterns);
+	s->patterns = NULL;
+	s->n_patterns = 0;
+	s->patterns_cap = 0;
+
+	return kSCStatusOK;
+}
+
+int
 config_pattern_anchor(const void *pat, size_t plen, char *buf, size_t bufsz)
 {
 	const char	*p = pat;
@@ -469,7 +492,6 @@ ssize_t
 session_drain_changes(mach_port_t port, void *buf, size_t cap)
 {
 	struct session	*s = session_find(port);
-	uint8_t		*p = buf;
 	size_t		i;
 	size_t		off = 0;
 
@@ -477,15 +499,9 @@ session_drain_changes(mach_port_t port, void *buf, size_t cap)
 		return -1;
 
 	for (i = 0; i < s->n_changed; i++) {
-		size_t		klen = s->changed[i].klen;
-		uint32_t	l32 = (uint32_t)klen;
-
-		if (off + sizeof(l32) + klen > cap)
+		if (wire_keylist_put(buf, cap, &off, s->changed[i].key,
+		    s->changed[i].klen) != 0)
 			return -1;	/* would not fit the reply array */
-		memcpy(p + off, &l32, sizeof(l32));
-		off += sizeof(l32);
-		memcpy(p + off, s->changed[i].key, klen);
-		off += klen;
 	}
 
 	/* The client has now seen these — clear the pending list. */

--- a/src/configd/config_session.h
+++ b/src/configd/config_session.h
@@ -95,6 +95,14 @@ int session_watch_add(mach_port_t port, const void *key, size_t klen);
 int session_watch_remove(mach_port_t port, const void *key, size_t klen);
 
 /*
+ * session_watch_clear — drop every watch the session holds, both
+ * explicit keys and regex patterns. notifyset uses this to replace a
+ * session's whole notification key set in one call. Returns a
+ * kSCStatus code.
+ */
+int session_watch_clear(mach_port_t port);
+
+/*
  * session_pattern_add / session_pattern_remove — add or drop a regex
  * watch for the session. The pattern bytes are a POSIX extended regular
  * expression; configd anchors it (^...$) and compiles it. Any store key

--- a/src/configd/config_wire.c
+++ b/src/configd/config_wire.c
@@ -1,0 +1,92 @@
+/*
+ * config_wire.c — key-list and key/value-map byte encodings for
+ * configd's batch routines (configd iter 7). See config_wire.h.
+ */
+
+#include "config_wire.h"
+
+#include <string.h>
+
+int
+wire_keylist_put(uint8_t *buf, size_t cap, size_t *off,
+    const void *key, size_t klen)
+{
+	uint32_t l32 = (uint32_t)klen;
+
+	if (*off + sizeof(l32) + klen > cap)
+		return -1;
+	memcpy(buf + *off, &l32, sizeof(l32));
+	*off += sizeof(l32);
+	memcpy(buf + *off, key, klen);
+	*off += klen;
+	return 0;
+}
+
+int
+wire_keylist_next(const uint8_t **cur, const uint8_t *end,
+    const void **key, size_t *klen)
+{
+	const uint8_t	*p = *cur;
+	uint32_t	l32;
+
+	if ((size_t)(end - p) < sizeof(l32))
+		return 0;
+	memcpy(&l32, p, sizeof(l32));
+	p += sizeof(l32);
+	if ((size_t)(end - p) < l32)
+		return 0;		/* truncated record */
+	*key = p;
+	*klen = l32;
+	*cur = p + l32;
+	return 1;
+}
+
+int
+wire_kvmap_put(uint8_t *buf, size_t cap, size_t *off,
+    const void *key, size_t klen, const void *val, size_t vlen)
+{
+	uint32_t kl = (uint32_t)klen;
+	uint32_t vl = (uint32_t)vlen;
+
+	if (*off + sizeof(kl) + klen + sizeof(vl) + vlen > cap)
+		return -1;
+	memcpy(buf + *off, &kl, sizeof(kl));
+	*off += sizeof(kl);
+	memcpy(buf + *off, key, klen);
+	*off += klen;
+	memcpy(buf + *off, &vl, sizeof(vl));
+	*off += sizeof(vl);
+	memcpy(buf + *off, val, vlen);
+	*off += vlen;
+	return 0;
+}
+
+int
+wire_kvmap_next(const uint8_t **cur, const uint8_t *end,
+    const void **key, size_t *klen, const void **val, size_t *vlen)
+{
+	const uint8_t	*p = *cur;
+	uint32_t	kl;
+	uint32_t	vl;
+
+	if ((size_t)(end - p) < sizeof(kl))
+		return 0;
+	memcpy(&kl, p, sizeof(kl));
+	p += sizeof(kl);
+	if ((size_t)(end - p) < kl)
+		return 0;		/* truncated key */
+	*key = p;
+	*klen = kl;
+	p += kl;
+
+	if ((size_t)(end - p) < sizeof(vl))
+		return 0;
+	memcpy(&vl, p, sizeof(vl));
+	p += sizeof(vl);
+	if ((size_t)(end - p) < vl)
+		return 0;		/* truncated value */
+	*val = p;
+	*vlen = vl;
+	*cur = p + vl;
+	return 1;
+}

--- a/src/configd/config_wire.h
+++ b/src/configd/config_wire.h
@@ -1,0 +1,59 @@
+/*
+ * config_wire.h — the byte encodings configd's batch routines use to
+ * carry a list of keys, or a map of key/value pairs, inside a single
+ * inline config.defs payload (configd iter 7).
+ *
+ * Apple's configd serializes a CFArray / CFDictionary into each batch
+ * argument; this CF-free port packs them as plain length-prefixed
+ * records instead. Two formats, both little-endian:
+ *
+ *   key list   — a run of   [uint32 klen][klen key bytes]
+ *   key/value  — a run of   [uint32 klen][key][uint32 vlen][val bytes]
+ *
+ * The key-list format is the one notifychanges and configlist already
+ * emit; gathering it here lets notifyset / configget_m / configset_m
+ * (and their test clients) share one decoder. Each *_put appends a
+ * record and fails cleanly if the buffer is full; each *_next steps a
+ * cursor and stops at the end or at the first malformed record, so a
+ * truncated or hostile payload can never walk off the buffer.
+ */
+
+#ifndef _CONFIG_WIRE_H
+#define _CONFIG_WIRE_H
+
+#include <sys/types.h>
+#include <stdint.h>
+
+/*
+ * wire_keylist_put — append one [uint32 len][bytes] key record to buf
+ * at offset *off (capacity cap), advancing *off. Returns 0, or -1 if
+ * the record would not fit.
+ */
+int wire_keylist_put(uint8_t *buf, size_t cap, size_t *off,
+    const void *key, size_t klen);
+
+/*
+ * wire_keylist_next — step a cursor through a packed key list. *cur
+ * starts at the buffer; `end` is one past its last byte. Returns 1
+ * with *key / *klen set to the next record (and advances *cur), or 0
+ * at the end or on a truncated record.
+ */
+int wire_keylist_next(const uint8_t **cur, const uint8_t *end,
+    const void **key, size_t *klen);
+
+/*
+ * wire_kvmap_put — append one [uint32 klen][key][uint32 vlen][val]
+ * record. Returns 0, or -1 if it would not fit.
+ */
+int wire_kvmap_put(uint8_t *buf, size_t cap, size_t *off,
+    const void *key, size_t klen, const void *val, size_t vlen);
+
+/*
+ * wire_kvmap_next — step a cursor through a packed key/value map.
+ * Returns 1 with *key / *klen / *val / *vlen set to the next record
+ * (and advances *cur), or 0 at the end or on a truncated record.
+ */
+int wire_kvmap_next(const uint8_t **cur, const uint8_t *end,
+    const void **key, size_t *klen, const void **val, size_t *vlen);
+
+#endif /* !_CONFIG_WIRE_H */

--- a/src/configd/configd.c
+++ b/src/configd/configd.c
@@ -27,7 +27,9 @@
  *     configremove / confignotify fan a change out to every watching
  *     session.
  *   - configlist (iter 6) lists store keys by prefix or POSIX regex.
- * notifyset, the multi-get/set variants and snapshot remain stubs.
+ *   - notifyset / configget_m / configset_m (iter 7) do batch watch
+ *     registration, multi-key fetch and multi-key update.
+ * notifyviafd and snapshot remain stubs (see their handlers).
  *
  * config.defs carries the key/value payloads INLINE in bounded arrays
  * — out-of-line Mach data is broken cross-process in this port's
@@ -59,6 +61,7 @@
 #include "config_types.h"		/* SCD_SERVER, kSCStatus*, CONFIG_DATA_MAX */
 #include "config_store.h"
 #include "config_session.h"
+#include "config_wire.h"	/* keylist / kvmap batch encodings */
 #include "configServer.h"	/* MIG: config_server() demux + _config* protos */
 
 /*
@@ -98,24 +101,25 @@ clog(const char *fmt, ...)
 }
 
 /*
- * keylist_append — append one [uint32 little-endian length][bytes]
- * record to `buf` at offset *off (capacity cap), advancing *off.
- * Returns 0, or -1 if the record would not fit. configlist emits its
- * key list in this encoding — the same one session_drain_changes uses
- * for notifychanges.
+ * kvmap_has — 1 if the wire_kvmap-encoded buffer `buf` (of `len`
+ * bytes) already holds a record for key/klen. configget_m uses it to
+ * keep its reply a set: a key matched by several patterns, or both
+ * requested and matched, is emitted once.
  */
 static int
-keylist_append(uint8_t *buf, size_t cap, size_t *off,
-    const void *rec, size_t rlen)
+kvmap_has(const uint8_t *buf, size_t len, const void *key, size_t klen)
 {
-	uint32_t l32 = (uint32_t)rlen;
+	const uint8_t	*cur = buf;
+	const uint8_t	*end = buf + len;
+	const void	*k;
+	const void	*v;
+	size_t		kl;
+	size_t		vl;
 
-	if (*off + sizeof(l32) + rlen > cap)
-		return -1;
-	memcpy(buf + *off, &l32, sizeof(l32));
-	*off += sizeof(l32);
-	memcpy(buf + *off, rec, rlen);
-	*off += rlen;
+	while (wire_kvmap_next(&cur, end, &k, &kl, &v, &vl)) {
+		if (kl == klen && memcmp(k, key, klen) == 0)
+			return 1;
+	}
 	return 0;
 }
 
@@ -208,7 +212,7 @@ _configlist(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
 			     memcmp(skey, key, keyCnt) == 0);
 		}
 
-		if (match && keylist_append(list, CONFIG_DATA_MAX, &off,
+		if (match && wire_keylist_put(list, CONFIG_DATA_MAX, &off,
 		    skey, sklen) != 0) {
 			/* the packed list overflowed the inline reply */
 			if (have_re)
@@ -334,26 +338,141 @@ _confignotify(mach_port_t server, xmlData key, mach_msg_type_number_t keyCnt,
 	return KERN_SUCCESS;
 }
 
+/*
+ * configget_m (SCDynamicStoreCopyMultiple) — fetch several store
+ * values at once: the values for the requested `keys` that exist,
+ * plus the value of every store key matching one of the `patterns`.
+ * keys and patterns are wire_keylist payloads; the reply `data` is a
+ * wire_kvmap payload. Each key is emitted at most once.
+ */
 kern_return_t
 _configget_m(mach_port_t server, xmlData keys, mach_msg_type_number_t keysCnt,
     xmlData patterns, mach_msg_type_number_t patternsCnt, xmlDataOut data,
     mach_msg_type_number_t *dataCnt, int *status)
 {
-	(void)server; (void)keys; (void)keysCnt;
-	(void)patterns; (void)patternsCnt; (void)data;
+	const uint8_t	*cur, *end;
+	const void	*item;
+	size_t		ilen, off = 0;
+
+	(void)server;
 	*dataCnt = 0;
-	*status = kSCStatusFailed;
+
+	/* Requested explicit keys: emit the value of each that exists. */
+	cur = keys;
+	end = keys + keysCnt;
+	while (wire_keylist_next(&cur, end, &item, &ilen)) {
+		const void	*val;
+		size_t		vlen;
+
+		if (store_get(item, ilen, &val, &vlen) != 0)
+			continue;	/* no such key — skip it */
+		if (kvmap_has(data, off, item, ilen))
+			continue;	/* already emitted */
+		if (wire_kvmap_put(data, CONFIG_DATA_MAX, &off, item, ilen,
+		    val, vlen) != 0) {
+			*dataCnt = 0;
+			*status = kSCStatusFailed;	/* reply overflowed */
+			return KERN_SUCCESS;
+		}
+	}
+
+	/* Pattern keys: emit the value of every store key that matches. */
+	cur = patterns;
+	end = patterns + patternsCnt;
+	while (wire_keylist_next(&cur, end, &item, &ilen)) {
+		char	abuf[CONFIG_DATA_MAX + 3];	/* ^ + pattern + $ + NUL */
+		regex_t	re;
+		size_t	i, count;
+
+		if (config_pattern_anchor(item, ilen, abuf, sizeof(abuf)) != 0 ||
+		    regcomp(&re, abuf, REG_EXTENDED) != 0) {
+			*dataCnt = 0;
+			*status = kSCStatusInvalidArgument;
+			return KERN_SUCCESS;
+		}
+
+		count = store_count();
+		for (i = 0; i < count; i++) {
+			const void	*skey, *val;
+			size_t		sklen, vlen;
+			char		keystr[CONFIG_DATA_MAX + 1];
+
+			if (store_key_at(i, &skey, &sklen) != 0)
+				continue;
+			if (sklen >= sizeof(keystr))
+				continue;	/* too long to match */
+			memcpy(keystr, skey, sklen);
+			keystr[sklen] = '\0';
+			if (regexec(&re, keystr, 0, NULL, 0) != 0)
+				continue;	/* no match */
+			if (kvmap_has(data, off, skey, sklen))
+				continue;	/* already emitted */
+			if (store_get(skey, sklen, &val, &vlen) != 0)
+				continue;
+			if (wire_kvmap_put(data, CONFIG_DATA_MAX, &off, skey,
+			    sklen, val, vlen) != 0) {
+				regfree(&re);
+				*dataCnt = 0;
+				*status = kSCStatusFailed;
+				return KERN_SUCCESS;
+			}
+		}
+		regfree(&re);
+	}
+
+	*dataCnt = (mach_msg_type_number_t)off;
+	*status = kSCStatusOK;
 	return KERN_SUCCESS;
 }
 
+/*
+ * configset_m (SCDynamicStoreSetMultiple) — apply a batch of store
+ * changes in one call: set every key/value pair in `data` (a
+ * wire_kvmap payload), remove every key in `removeData`, and force a
+ * change notification for every key in `notify` (both wire_keylist
+ * payloads). Each set / remove / notify fans out to watching sessions.
+ */
 kern_return_t
 _configset_m(mach_port_t server, xmlData data, mach_msg_type_number_t dataCnt,
     xmlData removeData, mach_msg_type_number_t removeCnt,
     xmlData notify, mach_msg_type_number_t notifyCnt, int *status)
 {
-	(void)server; (void)data; (void)dataCnt;
-	(void)removeData; (void)removeCnt; (void)notify; (void)notifyCnt;
-	*status = kSCStatusFailed;
+	const uint8_t	*cur, *end;
+	const void	*k, *v;
+	size_t		kl, vl;
+
+	(void)server;
+
+	/* Set each key/value pair. */
+	cur = data;
+	end = data + dataCnt;
+	while (wire_kvmap_next(&cur, end, &k, &kl, &v, &vl)) {
+		if (kl == 0)
+			continue;	/* skip an empty key */
+		if (store_set(k, kl, v, vl) != 0) {
+			*status = kSCStatusFailed;
+			return KERN_SUCCESS;
+		}
+		session_key_changed(k, kl);
+	}
+
+	/* Remove each key, notifying watchers of the ones that existed. */
+	cur = removeData;
+	end = removeData + removeCnt;
+	while (wire_keylist_next(&cur, end, &k, &kl)) {
+		if (kl != 0 && store_remove(k, kl) == 0)
+			session_key_changed(k, kl);
+	}
+
+	/* Force a change notification for each notify key. */
+	cur = notify;
+	end = notify + notifyCnt;
+	while (wire_keylist_next(&cur, end, &k, &kl)) {
+		if (kl != 0)
+			session_key_changed(k, kl);
+	}
+
+	*status = kSCStatusOK;
 	return KERN_SUCCESS;
 }
 
@@ -451,25 +570,75 @@ _notifycancel(mach_port_t server, int *status)
 	return KERN_SUCCESS;
 }
 
+/*
+ * notifyset (SCDynamicStoreSetNotificationKeys) — replace the
+ * session's entire notification key set: after this call it watches
+ * exactly the explicit `keys` and the regex `patterns` given (both
+ * wire_keylist payloads).
+ */
 kern_return_t
 _notifyset(mach_port_t server, xmlData keys, mach_msg_type_number_t keysCnt,
     xmlData patterns, mach_msg_type_number_t patternsCnt, int *status)
 {
-	(void)server; (void)keys; (void)keysCnt;
-	(void)patterns; (void)patternsCnt;
-	*status = kSCStatusFailed;
+	const uint8_t	*cur, *end;
+	const void	*item;
+	size_t		ilen;
+	int		rc;
+
+	if (!session_valid(server)) {
+		*status = kSCStatusNoStoreSession;
+		return KERN_SUCCESS;
+	}
+
+	/* Drop the old watch set, then install the new one. */
+	(void)session_watch_clear(server);
+
+	cur = keys;
+	end = keys + keysCnt;
+	while (wire_keylist_next(&cur, end, &item, &ilen)) {
+		rc = session_watch_add(server, item, ilen);
+		if (rc != kSCStatusOK) {
+			*status = rc;
+			return KERN_SUCCESS;
+		}
+	}
+
+	cur = patterns;
+	end = patterns + patternsCnt;
+	while (wire_keylist_next(&cur, end, &item, &ilen)) {
+		rc = session_pattern_add(server, item, ilen);
+		if (rc != kSCStatusOK) {
+			*status = rc;
+			return KERN_SUCCESS;
+		}
+	}
+
+	*status = kSCStatusOK;
 	return KERN_SUCCESS;
 }
 
+/*
+ * notifyviafd (SCDynamicStoreNotifyFileDescriptor) — stubbed. It would
+ * deliver notifications by writing to a client file descriptor passed
+ * as a Mach fileport, but this port has no fileport->fd support; the
+ * Mach-port path (notifyviaport) is the supported notification route.
+ */
 kern_return_t
 _notifyviafd(mach_port_t server, mach_port_t fileport, int identifier,
     int *status)
 {
-	(void)server; (void)fileport; (void)identifier;
+	(void)server; (void)identifier;
+	if (fileport != MACH_PORT_NULL)
+		(void)mach_port_deallocate(mach_task_self(), fileport);
 	*status = kSCStatusFailed;
 	return KERN_SUCCESS;
 }
 
+/*
+ * snapshot — stubbed. Apple's configd writes a debug dump of the whole
+ * store and session table to a file; it is a root-gated diagnostic
+ * with no consumer in this port.
+ */
 kern_return_t
 _snapshot(mach_port_t server, int *status)
 {
@@ -578,6 +747,12 @@ extern kern_return_t configget(mach_port_t, xmlData,
 extern kern_return_t configlist(mach_port_t, xmlData,
     mach_msg_type_number_t, int, xmlDataOut, mach_msg_type_number_t *,
     int *);
+extern kern_return_t configget_m(mach_port_t, xmlData,
+    mach_msg_type_number_t, xmlData, mach_msg_type_number_t, xmlDataOut,
+    mach_msg_type_number_t *, int *);
+extern kern_return_t configset_m(mach_port_t, xmlData,
+    mach_msg_type_number_t, xmlData, mach_msg_type_number_t, xmlData,
+    mach_msg_type_number_t, int *);
 extern kern_return_t notifyadd(mach_port_t, xmlData,
     mach_msg_type_number_t, int, int *);
 extern kern_return_t notifyviaport(mach_port_t, mach_port_t,
@@ -864,8 +1039,73 @@ run_selftest(void)
 		return 1;
 	}
 
+	/*
+	 * configset_m / configget_m: set a key through a batch update,
+	 * fetch it back through a batch query, and confirm the value
+	 * round-trips through the wire_kvmap encoding.
+	 */
+	{
+		uint8_t		mkey[] = "selftest:multi";
+		uint8_t		mval[] = "configd selftest multi value";
+		uint8_t		reqbuf[256];
+		size_t		reqoff;
+		const uint8_t	*cur, *end;
+		const void	*gk, *gv;
+		size_t		gkl, gvl;
+		int		found = 0;
+
+		reqoff = 0;
+		if (wire_kvmap_put(reqbuf, sizeof(reqbuf), &reqoff, mkey,
+		    sizeof(mkey) - 1, mval, sizeof(mval) - 1) != 0) {
+			clog("selftest: configset_m payload build failed");
+			return 1;
+		}
+		kr = configset_m(session, reqbuf, (mach_msg_type_number_t)reqoff,
+		    empty, 0, empty, 0, &status);
+		if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+			clog("selftest: configset_m kr=0x%x status=%d",
+			    (unsigned)kr, status);
+			return 1;
+		}
+
+		reqoff = 0;
+		if (wire_keylist_put(reqbuf, sizeof(reqbuf), &reqoff, mkey,
+		    sizeof(mkey) - 1) != 0) {
+			clog("selftest: configget_m payload build failed");
+			return 1;
+		}
+		gotCnt = 0;
+		kr = configget_m(session, reqbuf,
+		    (mach_msg_type_number_t)reqoff, empty, 0, got, &gotCnt,
+		    &status);
+		if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+			clog("selftest: configget_m kr=0x%x status=%d",
+			    (unsigned)kr, status);
+			return 1;
+		}
+
+		cur = got;
+		end = got + gotCnt;
+		while (wire_kvmap_next(&cur, end, &gk, &gkl, &gv, &gvl)) {
+			if (gkl != sizeof(mkey) - 1 ||
+			    memcmp(gk, mkey, gkl) != 0)
+				continue;
+			found = 1;
+			if (gvl != sizeof(mval) - 1 ||
+			    memcmp(gv, mval, gvl) != 0) {
+				clog("selftest: configget_m value MISMATCH");
+				return 1;
+			}
+		}
+		if (!found) {
+			clog("selftest: configget_m did not return the key");
+			return 1;
+		}
+	}
+
 	clog("CONFIGD-SELFTEST-OK: in-process config.defs round-trip + "
-	    "change notification + notify port + regex watch + list works");
+	    "change notification + notify port + regex watch + list + "
+	    "multi works");
 	return 0;
 }
 

--- a/src/configd/multitest.c
+++ b/src/configd/multitest.c
@@ -1,0 +1,305 @@
+/*
+ * multitest — configd batch-routine test client (configd iter 7).
+ *
+ * Exercises the three batch config.defs routines end to end against a
+ * live configd:
+ *   - configset_m : set two keys and remove two others in one call;
+ *   - configget_m : fetch several values in one call, by explicit key
+ *                   and by regex pattern;
+ *   - notifyset   : replace the session's whole watch set (keys plus
+ *                   patterns) in one call, then confirm a change to a
+ *                   watched key / pattern is reported and a change to
+ *                   an unwatched key is not.
+ * Prints CONFIGD-MULTI-OK on success — the CI boot test (run.sh /
+ * boot-test.sh) matches that marker.
+ *
+ * The batch payloads use the config_wire key-list / key-value
+ * encodings (config_wire.c is linked in); the routines themselves come
+ * from the MIG user stub configUser.c, as in the other test clients.
+ */
+
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"		/* MIG user stubs + xmlData; pulls config_types.h */
+#include "config_wire.h"	/* wire_keylist_* / wire_kvmap_* batch encodings */
+
+#define SERVICE		"com.apple.SystemConfiguration.configd"
+
+/* Open a configd session on `server`; returns the session port or NULL. */
+static mach_port_t
+open_session(mach_port_t server, const char *name)
+{
+	mach_port_t	session = MACH_PORT_NULL;
+	int		status = -1;
+	kern_return_t	kr;
+
+	kr = configopen(server, (uint8_t *)name,
+	    (mach_msg_type_number_t)strlen(name), (uint8_t *)"", 0,
+	    &session, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-MULTI-FAIL: configopen(%s) kr=0x%x status=%d\n",
+		    name, (unsigned)kr, status);
+		return MACH_PORT_NULL;
+	}
+	return session;
+}
+
+/* Store `key`=`val` with a single configset. Returns 0 on success. */
+static int
+set_key(mach_port_t session, const char *key, const char *val)
+{
+	kern_return_t	kr;
+	int		status = -1;
+	int		newInstance = 0;
+
+	kr = configset(session, (uint8_t *)key,
+	    (mach_msg_type_number_t)strlen(key), (uint8_t *)val,
+	    (mach_msg_type_number_t)strlen(val), 0, &newInstance, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-MULTI-FAIL: configset(%s) kr=0x%x status=%d\n",
+		    key, (unsigned)kr, status);
+		return -1;
+	}
+	return 0;
+}
+
+/* Single configget; returns the SCStatus, or -1 on a MIG failure. */
+static int
+get_status(mach_port_t session, const char *key)
+{
+	kern_return_t		kr;
+	int			status = -1;
+	int			newInstance = 0;
+	xmlDataOut		data;
+	mach_msg_type_number_t	dataCnt = 0;
+
+	kr = configget(session, (uint8_t *)key,
+	    (mach_msg_type_number_t)strlen(key), data, &dataCnt,
+	    &newInstance, &status);
+	if (kr != KERN_SUCCESS)
+		return -1;
+	return status;
+}
+
+/* 1 if the wire_kvmap payload holds `key` with value `val`. */
+static int
+kvmap_check(const uint8_t *buf, size_t len, const char *key, const char *val)
+{
+	const uint8_t	*cur = buf;
+	const uint8_t	*end = buf + len;
+	const void	*k, *v;
+	size_t		kl, vl;
+	size_t		klen = strlen(key);
+	size_t		vlen = strlen(val);
+
+	while (wire_kvmap_next(&cur, end, &k, &kl, &v, &vl)) {
+		if (kl == klen && memcmp(k, key, klen) == 0)
+			return vl == vlen && memcmp(v, val, vlen) == 0;
+	}
+	return 0;
+}
+
+/* 1 if the wire_keylist payload contains `key`. */
+static int
+keylist_check(const uint8_t *buf, size_t len, const char *key)
+{
+	const uint8_t	*cur = buf;
+	const uint8_t	*end = buf + len;
+	const void	*k;
+	size_t		kl;
+	size_t		klen = strlen(key);
+
+	while (wire_keylist_next(&cur, end, &k, &kl)) {
+		if (kl == klen && memcmp(k, key, klen) == 0)
+			return 1;
+	}
+	return 0;
+}
+
+int
+main(void)
+{
+	mach_port_t		server = MACH_PORT_NULL;
+	mach_port_t		session = MACH_PORT_NULL;
+	kern_return_t		kr;
+	int			status = -1;
+	uint8_t			req[1024];
+	size_t			off;
+	xmlDataOut		data;
+	mach_msg_type_number_t	dataCnt = 0;
+
+	kr = bootstrap_look_up(bootstrap_port, SERVICE, &server);
+	if (kr != KERN_SUCCESS) {
+		printf("CONFIGD-MULTI-FAIL: bootstrap_look_up: 0x%x\n",
+		    (unsigned)kr);
+		return 1;
+	}
+	session = open_session(server, "multitest");
+	if (session == MACH_PORT_NULL)
+		return 1;
+
+	/* Two keys that configset_m will remove. */
+	if (set_key(session, "multitest:old1", "x") != 0 ||
+	    set_key(session, "multitest:old2", "x") != 0)
+		return 1;
+
+	/*
+	 * configset_m: set multitest:a and multitest:b, remove the two
+	 * "old" keys, in one call (notify list empty).
+	 */
+	off = 0;
+	if (wire_kvmap_put(req, sizeof(req), &off, "multitest:a", 11,
+	    "value-A", 7) != 0 ||
+	    wire_kvmap_put(req, sizeof(req), &off, "multitest:b", 11,
+	    "value-B", 7) != 0) {
+		printf("CONFIGD-MULTI-FAIL: configset_m data build failed\n");
+		return 1;
+	}
+	{
+		uint8_t	rm[256];
+		size_t	rmoff = 0;
+
+		if (wire_keylist_put(rm, sizeof(rm), &rmoff, "multitest:old1",
+		    14) != 0 ||
+		    wire_keylist_put(rm, sizeof(rm), &rmoff, "multitest:old2",
+		    14) != 0) {
+			printf("CONFIGD-MULTI-FAIL: configset_m remove build "
+			    "failed\n");
+			return 1;
+		}
+		kr = configset_m(session, req, (mach_msg_type_number_t)off,
+		    rm, (mach_msg_type_number_t)rmoff, (uint8_t *)"", 0,
+		    &status);
+	}
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-MULTI-FAIL: configset_m kr=0x%x status=%d\n",
+		    (unsigned)kr, status);
+		return 1;
+	}
+
+	/* The two set keys must exist; the two removed keys must not. */
+	if (get_status(session, "multitest:a") != kSCStatusOK ||
+	    get_status(session, "multitest:b") != kSCStatusOK) {
+		printf("CONFIGD-MULTI-FAIL: configset_m did not set a key\n");
+		return 1;
+	}
+	if (get_status(session, "multitest:old1") != kSCStatusNoKey ||
+	    get_status(session, "multitest:old2") != kSCStatusNoKey) {
+		printf("CONFIGD-MULTI-FAIL: configset_m did not remove a "
+		    "key\n");
+		return 1;
+	}
+
+	/*
+	 * configget_m by explicit key: request multitest:a and
+	 * multitest:b; the reply must carry both with their values.
+	 */
+	off = 0;
+	if (wire_keylist_put(req, sizeof(req), &off, "multitest:a", 11) != 0 ||
+	    wire_keylist_put(req, sizeof(req), &off, "multitest:b", 11) != 0) {
+		printf("CONFIGD-MULTI-FAIL: configget_m keys build failed\n");
+		return 1;
+	}
+	dataCnt = 0;
+	kr = configget_m(session, req, (mach_msg_type_number_t)off,
+	    (uint8_t *)"", 0, data, &dataCnt, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-MULTI-FAIL: configget_m(keys) kr=0x%x "
+		    "status=%d\n", (unsigned)kr, status);
+		return 1;
+	}
+	if (!kvmap_check(data, dataCnt, "multitest:a", "value-A") ||
+	    !kvmap_check(data, dataCnt, "multitest:b", "value-B")) {
+		printf("CONFIGD-MULTI-FAIL: configget_m(keys) reply missing "
+		    "a key/value\n");
+		return 1;
+	}
+
+	/*
+	 * configget_m by pattern: a regex matching both keys must return
+	 * both key/value pairs.
+	 */
+	off = 0;
+	if (wire_keylist_put(req, sizeof(req), &off, "multitest:[ab]",
+	    14) != 0) {
+		printf("CONFIGD-MULTI-FAIL: configget_m pattern build "
+		    "failed\n");
+		return 1;
+	}
+	dataCnt = 0;
+	kr = configget_m(session, (uint8_t *)"", 0, req,
+	    (mach_msg_type_number_t)off, data, &dataCnt, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-MULTI-FAIL: configget_m(pattern) kr=0x%x "
+		    "status=%d\n", (unsigned)kr, status);
+		return 1;
+	}
+	if (!kvmap_check(data, dataCnt, "multitest:a", "value-A") ||
+	    !kvmap_check(data, dataCnt, "multitest:b", "value-B")) {
+		printf("CONFIGD-MULTI-FAIL: configget_m(pattern) reply "
+		    "missing a key/value\n");
+		return 1;
+	}
+
+	/*
+	 * notifyset: replace the session's watch set with one explicit
+	 * key and one pattern, then change a watched key, a
+	 * pattern-matched key and an unwatched key.
+	 */
+	off = 0;
+	if (wire_keylist_put(req, sizeof(req), &off, "multitest:a", 11) != 0) {
+		printf("CONFIGD-MULTI-FAIL: notifyset keys build failed\n");
+		return 1;
+	}
+	{
+		uint8_t	pat[256];
+		size_t	patoff = 0;
+
+		if (wire_keylist_put(pat, sizeof(pat), &patoff,
+		    "multitest:c.*", 13) != 0) {
+			printf("CONFIGD-MULTI-FAIL: notifyset patterns build "
+			    "failed\n");
+			return 1;
+		}
+		kr = notifyset(session, req, (mach_msg_type_number_t)off,
+		    pat, (mach_msg_type_number_t)patoff, &status);
+	}
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-MULTI-FAIL: notifyset kr=0x%x status=%d\n",
+		    (unsigned)kr, status);
+		return 1;
+	}
+
+	if (set_key(session, "multitest:a", "value-A2") != 0 ||
+	    set_key(session, "multitest:cZ", "value-C") != 0 ||
+	    set_key(session, "multitest:nomatch", "value-N") != 0)
+		return 1;
+
+	dataCnt = 0;
+	kr = notifychanges(session, data, &dataCnt, &status);
+	if (kr != KERN_SUCCESS || status != kSCStatusOK) {
+		printf("CONFIGD-MULTI-FAIL: notifychanges kr=0x%x status=%d\n",
+		    (unsigned)kr, status);
+		return 1;
+	}
+	if (!keylist_check(data, dataCnt, "multitest:a") ||
+	    !keylist_check(data, dataCnt, "multitest:cZ")) {
+		printf("CONFIGD-MULTI-FAIL: notifyset watch missed a "
+		    "changed key\n");
+		return 1;
+	}
+	if (keylist_check(data, dataCnt, "multitest:nomatch")) {
+		printf("CONFIGD-MULTI-FAIL: notifyset reported an unwatched "
+		    "key\n");
+		return 1;
+	}
+
+	printf("CONFIGD-MULTI-OK: configd batch routines round-trip "
+	    "(configset_m / configget_m / notifyset)\n");
+	return 0;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -441,6 +441,18 @@ expect {
     "CONFIGD-LIST-OK" { puts "\nOK: configd key listing works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: CONFIGD-MULTI marker not seen"
+        exit 1
+    }
+    "CONFIGD-MULTI-FAIL" {
+        puts "\nFAIL: configd batch routines failed"
+        exit 1
+    }
+    "CONFIGD-MULTI-OK" { puts "\nOK: configd batch routines work" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## configd iter 7 — batch routines

Builds on iter 6 (merged PR #18). Implements the three remaining batch `config.defs` routines, completing the SCDynamicStore server's RPC surface that has a real consumer use.

### What changed
- **`notifyset`** (`SCDynamicStoreSetNotificationKeys`) — replaces a session's whole notification key set (explicit keys + regex patterns) in one call.
- **`configget_m`** (`SCDynamicStoreCopyMultiple`) — fetches several store values at once: the requested keys that exist, plus every store key matching a pattern. Each key is emitted at most once.
- **`configset_m`** (`SCDynamicStoreSetMultiple`) — applies a batch of changes in one call: set key/value pairs, remove keys, force-notify keys; each fans out to watching sessions.
- **`config_wire.{c,h}`** (new) — a shared module for the two byte encodings the batch payloads carry: a length-prefixed key list and a length-prefixed key/value map. `session_drain_changes` and `configlist` now emit the key-list form through it; `session_watch_clear` backs `notifyset`.

`notifyviafd` and `snapshot` stay stubbed — `notifyviafd` needs a fileport→fd path this port lacks, and `snapshot` is a root-gated debug dump with no consumer. Both handlers now document that.

### Tests
- **`multitest`** (new) — exercises all three routines cross-process: `configset_m` sets/removes keys, `configget_m` fetches by explicit key and by regex, `notifyset` replaces the watch set and a matching/non-matching change is checked.
- **`configd --selftest`** gains a `configset_m`/`configget_m` round-trip.

### Verification
Built configd against real Mach and ran `configd --selftest` → `CONFIGD-SELFTEST-OK: … round-trip + change notification + notify port + regex watch + list + multi works`. All sources compile clean under `WARNS=6`. The cross-process batch path is exercised by this PR's CI boot test (`CONFIGD-MULTI` marker).

With this, the SCDynamicStore **server** is feature-complete for real use (open/get/set/remove, per-session ports, notifications, notify ports, regex watches, key listing, batch get/set/watch). The remaining work is the CF-typed `SystemConfiguration` **client framework** — a separate, larger effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)