### PR TITLE
feat(libSystemConfiguration): iter 3 — SCDynamicStoreCreateRunLoopSource

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1126,6 +1126,24 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scnotifytest" \
     || { echo "FAIL: scnotifytest not built"; exit 1; }
 echo "==> scnotifytest built"
 
+# scrltest — libSystemConfiguration iter 3 run-loop-source test client.
+# One session watches a key and adds a SCDynamicStoreCreateRunLoopSource
+# to its run loop; another writes the key; running the run loop must
+# fire the callback. run.sh runs it and checks for the SC-RUNLOOP-OK
+# marker.
+echo "==> building scrltest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scrltest" \
+   "$ROOT/src/libSystemConfiguration/scrltest.c" \
+   -lSystemConfiguration -lCoreFoundation -ldispatch -lBlocksRuntime \
+   -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scrltest" \
+    || { echo "FAIL: scrltest not built"; exit 1; }
+echo "==> scrltest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -528,4 +528,15 @@ if [ ! -x "$scnotifytest" ]; then
 fi
 "$scnotifytest" || true	# marker (SC-NOTIFY-OK/FAIL) gates in boot-test.sh
 
+# SC-RUNLOOP — SCDynamicStore run-loop-source notifications: a session
+# watches a key via SCDynamicStoreCreateRunLoopSource added to its run
+# loop, another writes the key, and running the run loop must fire the
+# callback with the changed key.
+scrltest=/usr/tests/freebsd-launchd-mach/scrltest
+if [ ! -x "$scrltest" ]; then
+    echo "SC-RUNLOOP-FAIL: $scrltest missing"
+    exit 1
+fi
+"$scrltest" || true	# marker (SC-RUNLOOP-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/SCDynamicStore.c
+++ b/src/libSystemConfiguration/SCDynamicStore.c
@@ -41,6 +41,18 @@ __SCDynamicStoreDeallocate(CFTypeRef cf)
 	__SCDynamicStoreNotifyCancel((SCDynamicStoreRef)cf);
 
 	/*
+	 * Drop the run-loop source. The notification thread is already
+	 * stopped (it held a store reference, so we could not get here
+	 * while it ran), hence the source is fully unscheduled and
+	 * invalidating it calls no further callbacks.
+	 */
+	if (storePrivate->rls != NULL) {
+		CFRunLoopSourceInvalidate(storePrivate->rls);
+		CFRelease(storePrivate->rls);
+		storePrivate->rls = NULL;
+	}
+
+	/*
 	 * Drop our send right to the per-session port. configd has
 	 * MACH_NOTIFY_NO_SENDERS armed on it, so this closes the
 	 * session server-side.
@@ -129,8 +141,11 @@ __SCDynamicStoreCreatePrivate(CFAllocatorRef		allocator,
 	storePrivate->server	= MACH_PORT_NULL;
 	storePrivate->notifyStatus	= NotifierNotRegistered;
 	storePrivate->notifyPort	= MACH_PORT_NULL;
-	storePrivate->dispatchQueue	= NULL;
 	storePrivate->notifyStop	= 0;
+	storePrivate->dispatchQueue	= NULL;
+	storePrivate->rls		= NULL;
+	storePrivate->rlsRunLoop	= NULL;
+	storePrivate->rlsScheduled	= 0;
 	storePrivate->rlsFunction = callout;
 	memset(&storePrivate->rlsContext, 0, sizeof(storePrivate->rlsContext));
 	if (context != NULL) {

--- a/src/libSystemConfiguration/SCInternal.h
+++ b/src/libSystemConfiguration/SCInternal.h
@@ -38,7 +38,8 @@
 /* Notification delivery status (SCNotify.c). */
 enum {
 	NotifierNotRegistered = 0,
-	Using_NotifierInformViaDispatch
+	Using_NotifierInformViaDispatch,
+	Using_NotifierInformViaRunLoop
 };
 
 /*
@@ -73,9 +74,16 @@ typedef struct __SCDynamicStore {
 	 */
 	int			notifyStatus;	/* Notifier* enum above */
 	mach_port_t		notifyPort;	/* receive right configd notifies */
-	dispatch_queue_t	dispatchQueue;	/* caller's callout queue (retained) */
 	pthread_t		notifyThread;	/* raw mach_msg receive loop */
 	volatile int		notifyStop;	/* asks notifyThread to exit */
+
+	/* SCDynamicStoreSetDispatchQueue delivery */
+	dispatch_queue_t	dispatchQueue;	/* caller's callout queue (retained) */
+
+	/* SCDynamicStoreCreateRunLoopSource delivery */
+	CFRunLoopSourceRef	rls;		/* the v0 source (store-owned) */
+	CFRunLoopRef		rlsRunLoop;	/* run loop to wake on a change */
+	int			rlsScheduled;	/* CFRunLoopAddSource refcount */
 } SCDynamicStorePrivate, *SCDynamicStorePrivateRef;
 
 /* TRUE iff obj is a live SCDynamicStore. */

--- a/src/libSystemConfiguration/SCNotify.c
+++ b/src/libSystemConfiguration/SCNotify.c
@@ -264,7 +264,7 @@ __SCDynamicStoreDeliverChanges(SCDynamicStoreRef store)
 	}
 
 	if ((callout != NULL) &&
-	    (storePrivate->notifyStatus == Using_NotifierInformViaDispatch)) {
+	    (storePrivate->notifyStatus != NotifierNotRegistered)) {
 		(*callout)(store, changedKeys, info);
 	}
 
@@ -323,21 +323,95 @@ __sc_notify_thread(void *arg)
 			break;			/* port gone / unexpected error */
 		}
 
-		/* a notification arrived — deliver on the caller's queue */
-		CFRetain(store);
-		dispatch_async_f(storePrivate->dispatchQueue,
-				 (void *)store, __sc_deliver);
+		/* a notification arrived — hand it to the active delivery */
+		if (storePrivate->notifyStatus == Using_NotifierInformViaDispatch) {
+			CFRetain(store);
+			dispatch_async_f(storePrivate->dispatchQueue,
+					 (void *)store, __sc_deliver);
+		} else if (storePrivate->notifyStatus == Using_NotifierInformViaRunLoop) {
+			/* signal the run-loop source and wake its run loop */
+			CFRunLoopSourceSignal(storePrivate->rls);
+			if (storePrivate->rlsRunLoop != NULL) {
+				CFRunLoopWakeUp(storePrivate->rlsRunLoop);
+			}
+		}
 	}
 
 	return NULL;
+}
+
+/*
+ * Start the notification receive thread. notifyStatus and any
+ * delivery-mode fields must already be set. Returns TRUE, or FALSE
+ * with SCError() set and the registration unwound.
+ */
+static Boolean
+__sc_notify_start(SCDynamicStoreRef store)
+{
+	SCDynamicStorePrivateRef	storePrivate	= (SCDynamicStorePrivateRef)store;
+	mach_port_t			mp;
+	int				err;
+
+	mp = __SCDynamicStoreAddNotificationPort(store);
+	if (mp == MACH_PORT_NULL) {
+		return FALSE;		/* SCError already set */
+	}
+	storePrivate->notifyPort = mp;
+	storePrivate->notifyStop = 0;
+
+	/* the receive thread holds a reference to the store */
+	CFRetain(store);
+
+	err = pthread_create(&storePrivate->notifyThread, NULL,
+			     __sc_notify_thread, (void *)store);
+	if (err != 0) {
+		int	sc_status;
+
+		CFRelease(store);
+		if (storePrivate->server != MACH_PORT_NULL) {
+			(void) notifycancel(storePrivate->server, &sc_status);
+		}
+		(void) mach_port_mod_refs(mach_task_self(), mp,
+					  MACH_PORT_RIGHT_RECEIVE, -1);
+		storePrivate->notifyPort = MACH_PORT_NULL;
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+	return TRUE;
+}
+
+/*
+ * Stop the receive thread and tear the notification port down. Drops
+ * the receive thread's store reference last; callers must not touch
+ * storePrivate after this returns.
+ */
+static void
+__sc_notify_stop(SCDynamicStoreRef store)
+{
+	SCDynamicStorePrivateRef	storePrivate	= (SCDynamicStorePrivateRef)store;
+	int				sc_status;
+
+	storePrivate->notifyStop = 1;
+	(void) pthread_join(storePrivate->notifyThread, NULL);
+
+	if (storePrivate->server != MACH_PORT_NULL) {
+		(void) notifycancel(storePrivate->server, &sc_status);
+	}
+	if (storePrivate->notifyPort != MACH_PORT_NULL) {
+		(void) mach_port_mod_refs(mach_task_self(),
+					  storePrivate->notifyPort,
+					  MACH_PORT_RIGHT_RECEIVE, -1);
+		storePrivate->notifyPort = MACH_PORT_NULL;
+	}
+
+	/* release the receive thread's store reference */
+	CFRelease(store);
 }
 
 Boolean
 SCDynamicStoreSetDispatchQueue(SCDynamicStoreRef store, dispatch_queue_t queue)
 {
 	SCDynamicStorePrivateRef	storePrivate	= (SCDynamicStorePrivateRef)store;
-	mach_port_t			mp;
-	int				err;
 
 	if (!isA_SCDynamicStore(store)) {
 		_SCErrorSet(kSCStatusNoStoreSession);
@@ -364,41 +438,16 @@ SCDynamicStoreSetDispatchQueue(SCDynamicStoreRef store, dispatch_queue_t queue)
 		return FALSE;
 	}
 
-	/* register a notification port with configd */
-	mp = __SCDynamicStoreAddNotificationPort(store);
-	if (mp == MACH_PORT_NULL) {
-		return FALSE;		/* SCError already set */
-	}
-
-	storePrivate->notifyPort	= mp;
-	storePrivate->dispatchQueue	= queue;
+	storePrivate->dispatchQueue = queue;
 	dispatch_retain(queue);
-	storePrivate->notifyStop	= 0;
-	storePrivate->notifyStatus	= Using_NotifierInformViaDispatch;
+	storePrivate->notifyStatus = Using_NotifierInformViaDispatch;
 
-	/* the receive thread holds a reference to the store */
-	CFRetain(store);
-
-	err = pthread_create(&storePrivate->notifyThread, NULL,
-			     __sc_notify_thread, (void *)store);
-	if (err != 0) {
-		/* unwind the registration */
-		int	sc_status;
-
-		CFRelease(store);
+	if (!__sc_notify_start(store)) {
 		dispatch_release(queue);
 		storePrivate->dispatchQueue = NULL;
 		storePrivate->notifyStatus  = NotifierNotRegistered;
-		if (storePrivate->server != MACH_PORT_NULL) {
-			(void) notifycancel(storePrivate->server, &sc_status);
-		}
-		(void) mach_port_mod_refs(mach_task_self(), mp,
-					  MACH_PORT_RIGHT_RECEIVE, -1);
-		storePrivate->notifyPort = MACH_PORT_NULL;
-		_SCErrorSet(kSCStatusFailed);
 		return FALSE;
 	}
-
 	return TRUE;
 }
 
@@ -406,41 +455,136 @@ void
 __SCDynamicStoreNotifyCancel(SCDynamicStoreRef store)
 {
 	SCDynamicStorePrivateRef	storePrivate	= (SCDynamicStorePrivateRef)store;
-	int				sc_status;
+	dispatch_queue_t		queue;
 
+	/* this is the dispatch-queue teardown; the run-loop source path
+	   tears down through rlsCancel */
 	if (storePrivate->notifyStatus != Using_NotifierInformViaDispatch) {
 		return;
 	}
 
-	/* stop the receive loop and wait for the thread to exit */
-	storePrivate->notifyStop = 1;
-	(void) pthread_join(storePrivate->notifyThread, NULL);
+	queue = storePrivate->dispatchQueue;
+	storePrivate->dispatchQueue = NULL;
+	storePrivate->notifyStatus  = NotifierNotRegistered;
 
-	/* ask configd to stop notifying this session */
-	if (storePrivate->server != MACH_PORT_NULL) {
-		(void) notifycancel(storePrivate->server, &sc_status);
+	__sc_notify_stop(store);	/* last — drops the store reference */
+
+	if (queue != NULL) {
+		dispatch_release(queue);
+	}
+}
+
+
+#pragma mark -
+#pragma mark Run-loop-source delivery
+
+/* CFRunLoopSource perform — runs the callout on the run loop thread */
+static void
+rlsPerform(void *info)
+{
+	__SCDynamicStoreDeliverChanges((SCDynamicStoreRef)info);
+}
+
+/*
+ * CFRunLoopSource schedule — called when the source is added to a run
+ * loop. On the first run loop it registers the notification port and
+ * starts the receive thread.
+ */
+static void
+rlsSchedule(void *info, CFRunLoopRef rl, CFRunLoopMode mode)
+{
+	SCDynamicStoreRef		store		= (SCDynamicStoreRef)info;
+	SCDynamicStorePrivateRef	storePrivate	= (SCDynamicStorePrivateRef)store;
+
+	(void)mode;
+
+	/* the receive thread wakes this run loop on a change. If the
+	   source is added to several run loops only the last is woken
+	   explicitly; CFRunLoopSourceSignal still marks it for them all. */
+	storePrivate->rlsRunLoop = rl;
+
+	if (storePrivate->rlsScheduled == 0) {
+		if (storePrivate->server == MACH_PORT_NULL) {
+			return;
+		}
+		storePrivate->notifyStatus = Using_NotifierInformViaRunLoop;
+		if (!__sc_notify_start(store)) {
+			storePrivate->notifyStatus = NotifierNotRegistered;
+			return;
+		}
+	}
+	storePrivate->rlsScheduled++;
+}
+
+/*
+ * CFRunLoopSource cancel — called when the source is removed from a
+ * run loop (or invalidated). Stops notifications once the source is no
+ * longer scheduled anywhere.
+ */
+static void
+rlsCancel(void *info, CFRunLoopRef rl, CFRunLoopMode mode)
+{
+	SCDynamicStoreRef		store		= (SCDynamicStoreRef)info;
+	SCDynamicStorePrivateRef	storePrivate	= (SCDynamicStorePrivateRef)store;
+
+	(void)rl;
+	(void)mode;
+
+	if (storePrivate->rlsScheduled == 0) {
+		return;
+	}
+	storePrivate->rlsScheduled--;
+	if (storePrivate->rlsScheduled > 0) {
+		return;
+	}
+	if (storePrivate->notifyStatus == Using_NotifierInformViaRunLoop) {
+		storePrivate->notifyStatus = NotifierNotRegistered;
+		storePrivate->rlsRunLoop   = NULL;
+		__sc_notify_stop(store);	/* last — drops the store reference */
+	}
+}
+
+CFRunLoopSourceRef
+SCDynamicStoreCreateRunLoopSource(CFAllocatorRef	allocator,
+				  SCDynamicStoreRef	store,
+				  CFIndex		order)
+{
+	SCDynamicStorePrivateRef	storePrivate	= (SCDynamicStorePrivateRef)store;
+	CFRunLoopSourceContext		context		= {
+		.version	= 0,
+		.info		= (void *)store,
+		/*
+		 * No retain/release on info: the store owns the source via
+		 * storePrivate->rls, so a retaining context would form a
+		 * reference cycle.
+		 */
+		.schedule	= rlsSchedule,
+		.cancel		= rlsCancel,
+		.perform	= rlsPerform,
+	};
+
+	if (!isA_SCDynamicStore(store)) {
+		_SCErrorSet(kSCStatusNoStoreSession);
+		return NULL;
+	}
+	if (storePrivate->server == MACH_PORT_NULL) {
+		_SCErrorSet(kSCStatusNoStoreServer);
+		return NULL;
 	}
 
-	/* drop the notification port's receive right */
-	if (storePrivate->notifyPort != MACH_PORT_NULL) {
-		(void) mach_port_mod_refs(mach_task_self(),
-					  storePrivate->notifyPort,
-					  MACH_PORT_RIGHT_RECEIVE, -1);
-		storePrivate->notifyPort = MACH_PORT_NULL;
+	/* one source per session — hand back the existing one, retained */
+	if (storePrivate->rls != NULL) {
+		CFRetain(storePrivate->rls);
+		return storePrivate->rls;
 	}
 
-	if (storePrivate->dispatchQueue != NULL) {
-		dispatch_release(storePrivate->dispatchQueue);
-		storePrivate->dispatchQueue = NULL;
+	storePrivate->rls = CFRunLoopSourceCreate(allocator, order, &context);
+	if (storePrivate->rls == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
 	}
 
-	storePrivate->notifyStatus = NotifierNotRegistered;
-
-	/*
-	 * Release the receive thread's store reference. Any callout still
-	 * queued on the caller's queue holds its own reference (taken
-	 * before dispatch_async_f), so the store stays alive until those
-	 * drain.
-	 */
-	CFRelease(store);
+	/* one reference for storePrivate->rls, one returned to the caller */
+	CFRetain(storePrivate->rls);
+	return storePrivate->rls;
 }

--- a/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
@@ -204,6 +204,19 @@ SCDynamicStoreSetDispatchQueue	(SCDynamicStoreRef		store,
 				 dispatch_queue_t		queue);
 
 /*!
+	@function SCDynamicStoreCreateRunLoopSource
+	@discussion Creates a CFRunLoopSource for the session. Once added
+		to a run loop with CFRunLoopAddSource(), the SCDynamicStore
+		CallBack passed to SCDynamicStoreCreate() runs on that run
+		loop whenever a watched key changes.
+	@result a CFRunLoopSource (caller releases), or NULL on error.
+ */
+CFRunLoopSourceRef
+SCDynamicStoreCreateRunLoopSource (CFAllocatorRef		allocator,
+				   SCDynamicStoreRef		store,
+				   CFIndex			order);
+
+/*!
 	@function SCError
 	@discussion Returns the most recent status/error code, as a
 		kSCStatus* value, for the calling thread.

--- a/src/libSystemConfiguration/scrltest.c
+++ b/src/libSystemConfiguration/scrltest.c
@@ -1,0 +1,147 @@
+/*
+ * scrltest.c — libSystemConfiguration iter 3 run-loop-source test
+ * client.
+ *
+ * Exercises the run-loop notification path: one session watches a key
+ * and adds an SCDynamicStoreCreateRunLoopSource() to the current run
+ * loop; a second session writes that key; running the run loop must
+ * deliver the SCDynamicStoreCallBack with the changed key. run.sh runs
+ * it and boot-test.sh gates on the SC-RUNLOOP-OK / SC-RUNLOOP-FAIL
+ * marker.
+ */
+
+#include <SystemConfiguration/SCDynamicStore.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define	SCR_KEY		"scrltest:watched"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-RUNLOOP-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+/* shared between main and the notification callback */
+struct result {
+	CFStringRef	expect;		/* the key we expect to change */
+	int		matched;	/* set when expect is seen */
+};
+
+/* runs on the run loop thread when a watched key changes */
+static void
+notify_cb(SCDynamicStoreRef store, CFArrayRef changedKeys, void *info)
+{
+	struct result	*r	= info;
+	CFRange		range;
+
+	(void)store;
+	range = CFRangeMake(0, CFArrayGetCount(changedKeys));
+	if (CFArrayContainsValue(changedKeys, range, r->expect)) {
+		r->matched = 1;
+	}
+}
+
+int
+main(void)
+{
+	SCDynamicStoreRef	watcher	= NULL;
+	SCDynamicStoreRef	writer	= NULL;
+	SCDynamicStoreContext	ctx;
+	struct result		r;
+	CFStringRef		watcherName, writerName;
+	CFStringRef		key, value;
+	CFArrayRef		watchKeys;
+	CFRunLoopSourceRef	rls	= NULL;
+	int			rc	= 1;
+
+	printf("scrltest: SCDynamicStore run-loop-source notifications\n");
+	fflush(stdout);
+
+	watcherName	= mkstr("scrltest-watcher");
+	writerName	= mkstr("scrltest-writer");
+	key		= mkstr(SCR_KEY);
+	value		= mkstr("changed");
+
+	r.expect	= key;
+	r.matched	= 0;
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.info = &r;
+
+	/* the watcher session carries the change callback */
+	watcher = SCDynamicStoreCreate(NULL, watcherName, notify_cb, &ctx);
+	if (watcher == NULL) {
+		fail("SCDynamicStoreCreate(watcher) failed");
+		goto out;
+	}
+	writer = SCDynamicStoreCreate(NULL, writerName, NULL, NULL);
+	if (writer == NULL) {
+		fail("SCDynamicStoreCreate(writer) failed");
+		goto out;
+	}
+
+	/* watch one explicit key */
+	watchKeys = CFArrayCreate(NULL, (const void **)&key, 1,
+				  &kCFTypeArrayCallBacks);
+	if (!SCDynamicStoreSetNotificationKeys(watcher, watchKeys, NULL)) {
+		fail("SCDynamicStoreSetNotificationKeys failed");
+		CFRelease(watchKeys);
+		goto out;
+	}
+	CFRelease(watchKeys);
+	printf("  SetNotificationKeys: watching %s\n", SCR_KEY);
+
+	/* create a run loop source and add it to this thread's run loop */
+	rls = SCDynamicStoreCreateRunLoopSource(NULL, watcher, 0);
+	if (rls == NULL) {
+		fail("SCDynamicStoreCreateRunLoopSource failed");
+		goto out;
+	}
+	CFRunLoopAddSource(CFRunLoopGetCurrent(), rls, kCFRunLoopDefaultMode);
+	printf("  CreateRunLoopSource: source scheduled\n");
+
+	/* the writer session changes the watched key */
+	if (!SCDynamicStoreSetValue(writer, key, value)) {
+		fail("SCDynamicStoreSetValue(writer) failed");
+		goto out;
+	}
+	printf("  writer set %s — running the run loop\n", SCR_KEY);
+
+	/* run the run loop up to 5s; it returns once the source fires */
+	(void) CFRunLoopRunInMode(kCFRunLoopDefaultMode, 5.0, TRUE);
+
+	if (!r.matched) {
+		fail("no run-loop callback with the watched key within 5s");
+		goto out;
+	}
+	printf("  run-loop callback fired with the watched key\n");
+
+	/* tear the source back down */
+	CFRunLoopRemoveSource(CFRunLoopGetCurrent(), rls, kCFRunLoopDefaultMode);
+	CFRunLoopSourceInvalidate(rls);
+	printf("  source removed + invalidated\n");
+
+	printf("SC-RUNLOOP-OK: SCDynamicStore run-loop notifications work\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (rls != NULL)     CFRelease(rls);
+	if (watcher != NULL) CFRelease(watcher);
+	if (writer != NULL)  CFRelease(writer);
+	CFRelease(watcherName);
+	CFRelease(writerName);
+	CFRelease(key);
+	CFRelease(value);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -477,6 +477,18 @@ expect {
     "SC-NOTIFY-OK" { puts "\nOK: SCDynamicStore change notifications work" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-RUNLOOP marker not seen"
+        exit 1
+    }
+    "SC-RUNLOOP-FAIL" {
+        puts "\nFAIL: SCDynamicStore run-loop-source notifications failed"
+        exit 1
+    }
+    "SC-RUNLOOP-OK" { puts "\nOK: SCDynamicStore run-loop notifications work" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

Third iteration of the SystemConfiguration client framework — the **run-loop-integrated notification path**, completing the `SCDynamicStore` notification API alongside iter 2's dispatch-queue path (PR #22).

## New API

`SCDynamicStoreCreateRunLoopSource(allocator, store, order)` — returns a `CFRunLoopSource`; once added to a run loop with `CFRunLoopAddSource()`, the `SCDynamicStoreCallBack` runs on that run loop whenever a watched key changes.

## How it's built

Apple builds this on **CFMachPort**, which this repo's `libCoreFoundation` does not compile. Instead the source is a **version-0 `CFRunLoopSource`** driven by the same raw `mach_msg` receive thread iter 2 introduced:

- the receive thread's notification handler now branches on delivery mode — `dispatch_async_f` for `SetDispatchQueue`, or `CFRunLoopSourceSignal` + `CFRunLoopWakeUp` for the run-loop source;
- the source's `schedule` / `cancel` callbacks start / stop that thread (reference-counted across multiple `CFRunLoopAddSource` calls);
- `perform` drains the changes and runs the callout on the run loop thread.

The receive-thread start/stop is factored into `__sc_notify_start` / `__sc_notify_stop`, shared by both delivery paths. The v0 source's context does **not** retain the store (the store owns the source via `storePrivate->rls` — a retaining context would cycle); the object finalizer invalidates and releases the source.

## Test

New `scrltest` — a session watches a key through a run-loop source, another writes it, and running the run loop must fire the callback. Gated by a new `SC-RUNLOOP` boot marker.

## Verified

- All five library sources syntax-checked clean under `-Wall` against stub headers matching the verified Mach / CoreFoundation / dispatch signatures.
- The repo survey confirmed `CFRunLoopSource` v0 + `CFRunLoopSourceSignal` / `CFRunLoopWakeUp` are real (CFRunLoop is kqueue-backed and fully built); the receive thread uses the raw-`mach_msg`-loop pattern proven by `notifytest` and hwregd.

## Notification API now complete

dispatch-queue (iter 2) + run-loop source (iter 3). Deferred: `CopyMultiple` / `SetMultiple`, session reconnect, then SCPreferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)