### PR TITLE
feat(libSystemConfiguration): iter 4 — SCDynamicStore batch get/set

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1144,6 +1144,22 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scrltest" \
     || { echo "FAIL: scrltest not built"; exit 1; }
 echo "==> scrltest built"
 
+# scmultitest — libSystemConfiguration iter 4 batch get/set test client.
+# Exercises SCDynamicStoreSetMultiple / SCDynamicStoreCopyMultiple
+# against the live configd. run.sh runs it and checks for the
+# SC-MULTI-OK marker.
+echo "==> building scmultitest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scmultitest" \
+   "$ROOT/src/libSystemConfiguration/scmultitest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scmultitest" \
+    || { echo "FAIL: scmultitest not built"; exit 1; }
+echo "==> scmultitest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -539,4 +539,14 @@ if [ ! -x "$scrltest" ]; then
 fi
 "$scrltest" || true	# marker (SC-RUNLOOP-OK/FAIL) gates in boot-test.sh
 
+# SC-MULTI — SCDynamicStore batch get/set: SCDynamicStoreSetMultiple
+# sets several keys in one call, SCDynamicStoreCopyMultiple fetches
+# them back by key and by pattern, then one is removed.
+scmultitest=/usr/tests/freebsd-launchd-mach/scmultitest
+if [ ! -x "$scmultitest" ]; then
+    echo "SC-MULTI-FAIL: $scmultitest missing"
+    exit 1
+fi
+"$scmultitest" || true	# marker (SC-MULTI-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/Makefile
+++ b/src/libSystemConfiguration/Makefile
@@ -20,7 +20,7 @@
 LIB=		SystemConfiguration
 SHLIB_MAJOR=	1
 
-SRCS=		SCD.c SCDynamicStore.c SCNotify.c
+SRCS=		SCD.c SCDynamicStore.c SCNotify.c SCDMultiple.c
 
 # configUser.c — MIG-generated config.defs client stubs (same file
 # configd's test clients link). config_wire.c — configd's shared

--- a/src/libSystemConfiguration/SCD.c
+++ b/src/libSystemConfiguration/SCD.c
@@ -20,6 +20,7 @@
  */
 
 #include "SCInternal.h"
+#include "config_wire.h"		/* wire_keylist_put — _SCEncodeKeyList */
 
 #include <pthread.h>
 #include <stdlib.h>
@@ -176,4 +177,47 @@ _SCUnserialize(const void *bytes, CFIndex len)
 	}
 
 	return obj;
+}
+
+int
+_SCEncodeKeyList(CFArrayRef array, uint8_t *buf, size_t cap, size_t *outLen)
+{
+	CFIndex	i;
+	CFIndex	n;
+	size_t	off	= 0;
+
+	*outLen = 0;
+	if (array == NULL) {
+		return 0;
+	}
+	if (CFGetTypeID(array) != CFArrayGetTypeID()) {
+		return -1;
+	}
+
+	n = CFArrayGetCount(array);
+	for (i = 0; i < n; i++) {
+		CFStringRef	key	= CFArrayGetValueAtIndex(array, i);
+		CFDataRef	keyData;
+		int		rc;
+
+		if ((key == NULL) || (CFGetTypeID(key) != CFStringGetTypeID())) {
+			return -1;
+		}
+		keyData = CFStringCreateExternalRepresentation(NULL, key,
+							       kCFStringEncodingUTF8,
+							       0);
+		if (keyData == NULL) {
+			return -1;
+		}
+		rc = wire_keylist_put(buf, cap, &off,
+				      CFDataGetBytePtr(keyData),
+				      (size_t)CFDataGetLength(keyData));
+		CFRelease(keyData);
+		if (rc != 0) {
+			return -1;
+		}
+	}
+
+	*outLen = off;
+	return 0;
 }

--- a/src/libSystemConfiguration/SCDMultiple.c
+++ b/src/libSystemConfiguration/SCDMultiple.c
@@ -1,0 +1,238 @@
+/*
+ * SCDMultiple.c — the SCDynamicStore batch store calls
+ * (freebsd-launchd-mach port of Apple's SystemConfiguration.fproj
+ * SCDGet.c SCDynamicStoreCopyMultiple + SCDSet.c
+ * SCDynamicStoreSetMultiple).
+ *
+ * One MIG round trip moves several keys at once: configget_m fetches
+ * the values for a set of keys (and pattern-matched keys); configset_m
+ * sets, removes and notifies several keys together.
+ *
+ * Apple serializes each batch argument as a property list; this port
+ * carries them in configd's length-prefixed wire encodings instead
+ * (config_wire.h) — a key list for the get keys / patterns / removes /
+ * notifies, and a key/value map for the values to fetch or set. Values
+ * inside the map are still XML-plist blobs (the SCD.c form).
+ */
+
+#include "SCInternal.h"
+#include "config_wire.h"
+
+
+#pragma mark -
+#pragma mark Key/value-map encoding
+
+/* CFDictionaryApplyFunction context for encode_kvmap() */
+struct kvmap_encode_ctx {
+	uint8_t	*buf;
+	size_t	cap;
+	size_t	off;
+	int	err;
+};
+
+/* encode one key (CFString) / value (CFPropertyList) pair into the map */
+static void
+kvmap_encode_one(const void *key, const void *value, void *context)
+{
+	struct kvmap_encode_ctx	*ctx	= context;
+	CFDataRef		keyData;
+	CFDataRef		valueData;
+
+	if (ctx->err) {
+		return;
+	}
+	if ((key == NULL) || (CFGetTypeID(key) != CFStringGetTypeID())) {
+		ctx->err = 1;
+		return;
+	}
+
+	keyData = CFStringCreateExternalRepresentation(NULL, (CFStringRef)key,
+						       kCFStringEncodingUTF8, 0);
+	if (keyData == NULL) {
+		ctx->err = 1;
+		return;
+	}
+	valueData = _SCSerialize((CFPropertyListRef)value);
+	if (valueData == NULL) {
+		CFRelease(keyData);
+		ctx->err = 1;
+		return;
+	}
+
+	if (wire_kvmap_put(ctx->buf, ctx->cap, &ctx->off,
+			   CFDataGetBytePtr(keyData),
+			   (size_t)CFDataGetLength(keyData),
+			   CFDataGetBytePtr(valueData),
+			   (size_t)CFDataGetLength(valueData)) != 0) {
+		ctx->err = 1;
+	}
+
+	CFRelease(keyData);
+	CFRelease(valueData);
+}
+
+/*
+ * Encode a CFDictionary of CFString -> CFPropertyList into configd's
+ * wire key/value-map form. Returns 0 with the byte count in *outLen,
+ * or -1 on a bad element / buffer overflow.
+ */
+static int
+encode_kvmap(CFDictionaryRef dict, uint8_t *buf, size_t cap, size_t *outLen)
+{
+	struct kvmap_encode_ctx	ctx;
+
+	*outLen = 0;
+	if (dict == NULL) {
+		return 0;
+	}
+	if (CFGetTypeID(dict) != CFDictionaryGetTypeID()) {
+		return -1;
+	}
+
+	ctx.buf = buf;
+	ctx.cap = cap;
+	ctx.off = 0;
+	ctx.err = 0;
+	CFDictionaryApplyFunction(dict, kvmap_encode_one, &ctx);
+	if (ctx.err) {
+		return -1;
+	}
+
+	*outLen = ctx.off;
+	return 0;
+}
+
+
+#pragma mark -
+#pragma mark Batch store access
+
+CFDictionaryRef
+SCDynamicStoreCopyMultiple(SCDynamicStoreRef	store,
+			   CFArrayRef		keys,
+			   CFArrayRef		patterns)
+{
+	SCDynamicStorePrivateRef	storePrivate	= (SCDynamicStorePrivateRef)store;
+	uint8_t				keyBuf[CONFIG_DATA_MAX];
+	uint8_t				patternBuf[CONFIG_DATA_MAX];
+	size_t				keyLen		= 0;
+	size_t				patternLen	= 0;
+	xmlDataOut			reply;
+	mach_msg_type_number_t		replyLen	= 0;
+	int				sc_status	= kSCStatusFailed;
+	kern_return_t			kr;
+	CFMutableDictionaryRef		result;
+	const uint8_t			*cur;
+	const uint8_t			*end;
+	const void			*keyBytes;
+	const void			*valueBytes;
+	size_t				kl;
+	size_t				vl;
+
+	if (!isA_SCDynamicStore(store)) {
+		_SCErrorSet(kSCStatusNoStoreSession);
+		return NULL;
+	}
+	if (storePrivate->server == MACH_PORT_NULL) {
+		_SCErrorSet(kSCStatusNoStoreServer);
+		return NULL;
+	}
+
+	if ((_SCEncodeKeyList(keys, keyBuf, sizeof(keyBuf), &keyLen) != 0) ||
+	    (_SCEncodeKeyList(patterns, patternBuf, sizeof(patternBuf),
+			      &patternLen) != 0)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	kr = configget_m(storePrivate->server,
+			 keyBuf, (mach_msg_type_number_t)keyLen,
+			 patternBuf, (mach_msg_type_number_t)patternLen,
+			 reply, &replyLen,
+			 &sc_status);
+	if (kr != KERN_SUCCESS) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+	if (sc_status != kSCStatusOK) {
+		_SCErrorSet(sc_status);
+		return NULL;
+	}
+
+	result = CFDictionaryCreateMutable(NULL, 0,
+					   &kCFTypeDictionaryKeyCallBacks,
+					   &kCFTypeDictionaryValueCallBacks);
+	if (result == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+
+	/* the reply is a key/value map; each value is an XML-plist blob */
+	cur = reply;
+	end = reply + replyLen;
+	while (wire_kvmap_next(&cur, end, &keyBytes, &kl, &valueBytes, &vl)) {
+		CFStringRef		key;
+		CFPropertyListRef	value;
+
+		key   = CFStringCreateWithBytes(NULL, keyBytes, (CFIndex)kl,
+						kCFStringEncodingUTF8, FALSE);
+		value = _SCUnserialize(valueBytes, (CFIndex)vl);
+		if ((key != NULL) && (value != NULL)) {
+			CFDictionarySetValue(result, key, value);
+		}
+		if (key != NULL)   CFRelease(key);
+		if (value != NULL) CFRelease(value);
+	}
+
+	_SCErrorSet(kSCStatusOK);
+	return result;
+}
+
+Boolean
+SCDynamicStoreSetMultiple(SCDynamicStoreRef	store,
+			  CFDictionaryRef	keysToSet,
+			  CFArrayRef		keysToRemove,
+			  CFArrayRef		keysToNotify)
+{
+	SCDynamicStorePrivateRef	storePrivate	= (SCDynamicStorePrivateRef)store;
+	uint8_t				setBuf[CONFIG_DATA_MAX];
+	uint8_t				removeBuf[CONFIG_DATA_MAX];
+	uint8_t				notifyBuf[CONFIG_DATA_MAX];
+	size_t				setLen		= 0;
+	size_t				removeLen	= 0;
+	size_t				notifyLen	= 0;
+	int				sc_status	= kSCStatusFailed;
+	kern_return_t			kr;
+
+	if (!isA_SCDynamicStore(store)) {
+		_SCErrorSet(kSCStatusNoStoreSession);
+		return FALSE;
+	}
+	if (storePrivate->server == MACH_PORT_NULL) {
+		_SCErrorSet(kSCStatusNoStoreServer);
+		return FALSE;
+	}
+
+	if ((encode_kvmap(keysToSet, setBuf, sizeof(setBuf), &setLen) != 0) ||
+	    (_SCEncodeKeyList(keysToRemove, removeBuf, sizeof(removeBuf),
+			      &removeLen) != 0) ||
+	    (_SCEncodeKeyList(keysToNotify, notifyBuf, sizeof(notifyBuf),
+			      &notifyLen) != 0)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	kr = configset_m(storePrivate->server,
+			 setBuf, (mach_msg_type_number_t)setLen,
+			 removeBuf, (mach_msg_type_number_t)removeLen,
+			 notifyBuf, (mach_msg_type_number_t)notifyLen,
+			 &sc_status);
+	if (kr != KERN_SUCCESS) {
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+	if (sc_status != kSCStatusOK) {
+		_SCErrorSet(sc_status);
+		return FALSE;
+	}
+	return TRUE;
+}

--- a/src/libSystemConfiguration/SCInternal.h
+++ b/src/libSystemConfiguration/SCInternal.h
@@ -123,6 +123,15 @@ CFDataRef		_SCSerialize(CFPropertyListRef obj);
 CFDataRef		_SCSerializeString(CFStringRef str);
 CFPropertyListRef	_SCUnserialize(const void *bytes, CFIndex len);
 
+/*
+ * SCD.c — encode a CFArray of CFString keys into configd's wire
+ * key-list form ([uint32 LE len][bytes] records). Returns 0 with the
+ * byte count in *outLen, or -1 on a bad element / buffer overflow.
+ * Shared by the notification watch-set and the multi-get key list.
+ */
+int	_SCEncodeKeyList(CFArrayRef array, uint8_t *buf, size_t cap,
+			 size_t *outLen);
+
 /* configd's inline config.defs payload bound (config_types.h). */
 #ifndef CONFIG_DATA_MAX
 #define CONFIG_DATA_MAX		8192

--- a/src/libSystemConfiguration/SCNotify.c
+++ b/src/libSystemConfiguration/SCNotify.c
@@ -32,55 +32,6 @@
 #pragma mark -
 #pragma mark Watch set / changed-key list
 
-/*
- * Encode a CFArray of CFString keys into configd's wire key-list form
- * ([uint32 LE len][bytes] records). Writes into buf (capacity cap) and
- * stores the byte count in *outLen. Returns 0, or -1 on a bad array
- * element or if the records do not fit.
- */
-static int
-encode_keylist(CFArrayRef array, uint8_t *buf, size_t cap, size_t *outLen)
-{
-	CFIndex	i;
-	CFIndex	n;
-	size_t	off	= 0;
-
-	*outLen = 0;
-	if (array == NULL) {
-		return 0;
-	}
-	if (CFGetTypeID(array) != CFArrayGetTypeID()) {
-		return -1;
-	}
-
-	n = CFArrayGetCount(array);
-	for (i = 0; i < n; i++) {
-		CFStringRef	key	= CFArrayGetValueAtIndex(array, i);
-		CFDataRef	keyData;
-		int		rc;
-
-		if ((key == NULL) || (CFGetTypeID(key) != CFStringGetTypeID())) {
-			return -1;
-		}
-		keyData = CFStringCreateExternalRepresentation(NULL, key,
-							       kCFStringEncodingUTF8,
-							       0);
-		if (keyData == NULL) {
-			return -1;
-		}
-		rc = wire_keylist_put(buf, cap, &off,
-				      CFDataGetBytePtr(keyData),
-				      (size_t)CFDataGetLength(keyData));
-		CFRelease(keyData);
-		if (rc != 0) {
-			return -1;
-		}
-	}
-
-	*outLen = off;
-	return 0;
-}
-
 Boolean
 SCDynamicStoreSetNotificationKeys(SCDynamicStoreRef	store,
 				  CFArrayRef		keys,
@@ -103,8 +54,8 @@ SCDynamicStoreSetNotificationKeys(SCDynamicStoreRef	store,
 		return FALSE;
 	}
 
-	if ((encode_keylist(keys, keyBuf, sizeof(keyBuf), &keyLen) != 0) ||
-	    (encode_keylist(patterns, patternBuf, sizeof(patternBuf), &patternLen) != 0)) {
+	if ((_SCEncodeKeyList(keys, keyBuf, sizeof(keyBuf), &keyLen) != 0) ||
+	    (_SCEncodeKeyList(patterns, patternBuf, sizeof(patternBuf), &patternLen) != 0)) {
 		_SCErrorSet(kSCStatusInvalidArgument);
 		return FALSE;
 	}

--- a/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
@@ -135,6 +135,34 @@ SCDynamicStoreCopyKeyList	(SCDynamicStoreRef		store,
 				 CFStringRef			pattern);
 
 /*!
+	@function SCDynamicStoreCopyMultiple
+	@discussion Fetches the values for several keys in one call.
+	@param keys     a CFArray of CFString keys to fetch, or NULL.
+	@param patterns a CFArray of CFString POSIX-regex patterns whose
+		matching keys are also fetched, or NULL.
+	@result a CFDictionary of key -> value (caller releases), or NULL.
+ */
+CFDictionaryRef
+SCDynamicStoreCopyMultiple	(SCDynamicStoreRef		store,
+				 CFArrayRef			keys,
+				 CFArrayRef			patterns);
+
+/*!
+	@function SCDynamicStoreSetMultiple
+	@discussion Sets, removes and posts notifications for several keys
+		in one call.
+	@param keysToSet     a CFDictionary of key -> value to set, or NULL.
+	@param keysToRemove  a CFArray of CFString keys to remove, or NULL.
+	@param keysToNotify  a CFArray of CFString keys to flag changed
+		without altering their value, or NULL.
+ */
+Boolean
+SCDynamicStoreSetMultiple	(SCDynamicStoreRef		store,
+				 CFDictionaryRef		keysToSet,
+				 CFArrayRef			keysToRemove,
+				 CFArrayRef			keysToNotify);
+
+/*!
 	@function SCDynamicStoreCopyValue
 	@discussion Fetches the value associated with a key.
 	@result the value (caller releases), or NULL if no such key.

--- a/src/libSystemConfiguration/scmultitest.c
+++ b/src/libSystemConfiguration/scmultitest.c
@@ -1,0 +1,154 @@
+/*
+ * scmultitest.c — libSystemConfiguration iter 4 batch get/set test
+ * client.
+ *
+ * Exercises the batch store calls: SCDynamicStoreSetMultiple sets two
+ * keys in one call; SCDynamicStoreCopyMultiple fetches them back by
+ * key and by pattern; SCDynamicStoreSetMultiple then removes one. All
+ * against the live configd. run.sh runs it and boot-test.sh gates on
+ * the SC-MULTI-OK / SC-MULTI-FAIL marker.
+ */
+
+#include <SystemConfiguration/SCDynamicStore.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+#define	SCM_KEY_A	"scmultitest:a"
+#define	SCM_KEY_B	"scmultitest:b"
+#define	SCM_PATTERN	"scmultitest:.*"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-MULTI-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+int
+main(void)
+{
+	SCDynamicStoreRef	store	= NULL;
+	CFStringRef		name;
+	CFStringRef		keyA, keyB, valueA, valueB, pattern;
+	CFMutableDictionaryRef	toSet	= NULL;
+	CFMutableArrayRef	getKeys	= NULL;
+	CFMutableArrayRef	patterns = NULL;
+	CFMutableArrayRef	toRemove = NULL;
+	CFDictionaryRef		got	= NULL;
+	int			rc	= 1;
+
+	printf("scmultitest: SCDynamicStore batch get/set\n");
+	fflush(stdout);
+
+	name	= mkstr("scmultitest");
+	keyA	= mkstr(SCM_KEY_A);
+	keyB	= mkstr(SCM_KEY_B);
+	valueA	= mkstr("value-a");
+	valueB	= mkstr("value-b");
+	pattern	= mkstr(SCM_PATTERN);
+
+	store = SCDynamicStoreCreate(NULL, name, NULL, NULL);
+	if (store == NULL) {
+		fail("SCDynamicStoreCreate failed");
+		goto out;
+	}
+
+	/* SetMultiple — set two keys in one call */
+	toSet = CFDictionaryCreateMutable(NULL, 0,
+					  &kCFTypeDictionaryKeyCallBacks,
+					  &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(toSet, keyA, valueA);
+	CFDictionarySetValue(toSet, keyB, valueB);
+	if (!SCDynamicStoreSetMultiple(store, toSet, NULL, NULL)) {
+		fail("SCDynamicStoreSetMultiple(set) failed");
+		goto out;
+	}
+	printf("  SetMultiple: set 2 keys\n");
+
+	/* CopyMultiple by key */
+	getKeys = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	CFArrayAppendValue(getKeys, keyA);
+	CFArrayAppendValue(getKeys, keyB);
+	got = SCDynamicStoreCopyMultiple(store, getKeys, NULL);
+	if (got == NULL) {
+		fail("SCDynamicStoreCopyMultiple(keys) returned NULL");
+		goto out;
+	}
+	{
+		CFTypeRef	gotA	= CFDictionaryGetValue(got, keyA);
+		CFTypeRef	gotB	= CFDictionaryGetValue(got, keyB);
+
+		if ((gotA == NULL) || (gotB == NULL) ||
+		    !CFEqual(gotA, valueA) || !CFEqual(gotB, valueB)) {
+			fail("CopyMultiple(keys) returned wrong values");
+			goto out;
+		}
+	}
+	CFRelease(got);
+	got = NULL;
+	printf("  CopyMultiple: fetched 2 keys by key\n");
+
+	/* CopyMultiple by pattern */
+	patterns = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	CFArrayAppendValue(patterns, pattern);
+	got = SCDynamicStoreCopyMultiple(store, NULL, patterns);
+	if ((got == NULL) ||
+	    (CFDictionaryGetValue(got, keyA) == NULL) ||
+	    (CFDictionaryGetValue(got, keyB) == NULL)) {
+		fail("CopyMultiple(pattern) missing a matched key");
+		goto out;
+	}
+	CFRelease(got);
+	got = NULL;
+	printf("  CopyMultiple: fetched keys by pattern\n");
+
+	/* SetMultiple — remove one key */
+	toRemove = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	CFArrayAppendValue(toRemove, keyA);
+	if (!SCDynamicStoreSetMultiple(store, NULL, toRemove, NULL)) {
+		fail("SCDynamicStoreSetMultiple(remove) failed");
+		goto out;
+	}
+	got = SCDynamicStoreCopyMultiple(store, getKeys, NULL);
+	if (got == NULL) {
+		fail("CopyMultiple after remove returned NULL");
+		goto out;
+	}
+	if (CFDictionaryGetValue(got, keyA) != NULL) {
+		fail("removed key still present");
+		goto out;
+	}
+	if (CFDictionaryGetValue(got, keyB) == NULL) {
+		fail("CopyMultiple dropped the key that was kept");
+		goto out;
+	}
+	CFRelease(got);
+	got = NULL;
+	printf("  SetMultiple: removed a key\n");
+
+	printf("SC-MULTI-OK: SCDynamicStore batch get/set works\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (got != NULL)      CFRelease(got);
+	if (store != NULL)    CFRelease(store);
+	if (toSet != NULL)    CFRelease(toSet);
+	if (getKeys != NULL)  CFRelease(getKeys);
+	if (patterns != NULL) CFRelease(patterns);
+	if (toRemove != NULL) CFRelease(toRemove);
+	CFRelease(name);
+	CFRelease(keyA);
+	CFRelease(keyB);
+	CFRelease(valueA);
+	CFRelease(valueB);
+	CFRelease(pattern);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -489,6 +489,18 @@ expect {
     "SC-RUNLOOP-OK" { puts "\nOK: SCDynamicStore run-loop notifications work" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-MULTI marker not seen"
+        exit 1
+    }
+    "SC-MULTI-FAIL" {
+        puts "\nFAIL: SCDynamicStore batch get/set failed"
+        exit 1
+    }
+    "SC-MULTI-OK" { puts "\nOK: SCDynamicStore batch get/set works" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

Fourth iteration of the SystemConfiguration client framework — the **batch store calls**, completing the `SCDynamicStore` store API.

## New API

| Function | configd routine | Notes |
|----------|-----------------|-------|
| `SCDynamicStoreCopyMultiple(store, keys, patterns)` | `configget_m` | fetch the values for a set of keys (and pattern-matched keys) in one MIG round trip → `CFDictionary` of key→value |
| `SCDynamicStoreSetMultiple(store, keysToSet, keysToRemove, keysToNotify)` | `configset_m` | set, remove and post-notify several keys together |

New `SCDMultiple.c` carries them. Apple serializes each batch argument as a property list; this port uses configd's length-prefixed wire encodings (`config_wire`) — a key list for the get keys / patterns / removes / notifies, and a key/value map for the values (whose entries are still XML-plist blobs).

## Refactor

The `CFArray`-of-keys → wire-key-list encoder is now shared: factored out of `SCNotify.c` into `SCD.c` as `_SCEncodeKeyList` (declared in `SCInternal.h`), used by both the notification watch set and the multi-get key list. `SCDMultiple.c` adds a `CFDictionary` → wire-key/value-map encoder built on `CFDictionaryApplyFunction`.

## Test

New `scmultitest` — exercises set-multiple, copy-multiple by key and by pattern, and remove-multiple against the live configd. Gated by a new `SC-MULTI` boot marker.

## Verified

- `configget_m` / `configset_m` MIG signatures cross-checked against the `mig`-generated stubs; the keylist + kvmap wire contract confirmed against configd's `multitest`.
- All library sources syntax-checked clean under `-Wall` against stub headers matching the verified signatures.

## SCDynamicStore client API now complete

create + get/set/add/remove/list (iter 1), notifications — dispatch queue + run loop (iters 2–3), batch get/set (iter 4). Next: SCPreferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)