### PR TITLE
feat(libSystemConfiguration): SCPreferences iter 1 — read/edit/commit

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1160,6 +1160,22 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scmultitest" \
     || { echo "FAIL: scmultitest not built"; exit 1; }
 echo "==> scmultitest built"
 
+# scprefstest — libSystemConfiguration SCPreferences test client.
+# Exercises the SCPreferences read / edit / commit cycle: set values,
+# commit, re-open and confirm they persisted, list keys, remove. run.sh
+# runs it and checks for the SC-PREFS-OK marker.
+echo "==> building scprefstest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scprefstest" \
+   "$ROOT/src/libSystemConfiguration/scprefstest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scprefstest" \
+    || { echo "FAIL: scprefstest not built"; exit 1; }
+echo "==> scprefstest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -549,4 +549,13 @@ if [ ! -x "$scmultitest" ]; then
 fi
 "$scmultitest" || true	# marker (SC-MULTI-OK/FAIL) gates in boot-test.sh
 
+# SC-PREFS — SCPreferences read/edit/commit: open a preferences file,
+# set values, commit, re-open and confirm they persisted, then remove.
+scprefstest=/usr/tests/freebsd-launchd-mach/scprefstest
+if [ ! -x "$scprefstest" ]; then
+    echo "SC-PREFS-FAIL: $scprefstest missing"
+    exit 1
+fi
+"$scprefstest" || true	# marker (SC-PREFS-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/Makefile
+++ b/src/libSystemConfiguration/Makefile
@@ -20,7 +20,7 @@
 LIB=		SystemConfiguration
 SHLIB_MAJOR=	1
 
-SRCS=		SCD.c SCDynamicStore.c SCNotify.c SCDMultiple.c
+SRCS=		SCD.c SCDynamicStore.c SCNotify.c SCDMultiple.c SCPreferences.c
 
 # configUser.c — MIG-generated config.defs client stubs (same file
 # configd's test clients link). config_wire.c — configd's shared
@@ -68,6 +68,7 @@ LDADD+=		-L${SYSROOT}/usr/lib/system
 .endif
 
 INCS=		SystemConfiguration/SCDynamicStore.h \
+		SystemConfiguration/SCPreferences.h \
 		SystemConfiguration/SystemConfiguration.h
 INCSDIR=	${PREFIX}/include/SystemConfiguration
 LIBDIR=		${PREFIX}/lib/system

--- a/src/libSystemConfiguration/SCD.c
+++ b/src/libSystemConfiguration/SCD.c
@@ -85,6 +85,16 @@ SCErrorString(int status)
 		return "Configuration daemon not (no longer) available";
 	case kSCStatusNotifierActive :
 		return "Notifier is currently active";
+	case kSCStatusNoPrefsSession :
+		return "Preferences session not active";
+	case kSCStatusPrefsBusy :
+		return "Preferences update currently in progress";
+	case kSCStatusNoConfigFile :
+		return "Configuration file not found";
+	case kSCStatusStale :
+		return "Write attempted on stale version of object";
+	case kSCStatusAccessError :
+		return "Permission denied";
 	default :
 		return "Unknown error";
 	}

--- a/src/libSystemConfiguration/SCInternal.h
+++ b/src/libSystemConfiguration/SCInternal.h
@@ -35,6 +35,18 @@
 #define kSCStatusNoStoreServer	2002
 #endif
 
+/*
+ * SCPreferences status codes — likewise client-side, absent from
+ * config_types.h. Guarded the same way.
+ */
+#ifndef kSCStatusNoPrefsSession
+#define kSCStatusNoPrefsSession	5001
+#define kSCStatusPrefsBusy	5002
+#define kSCStatusNoConfigFile	5003
+#define kSCStatusStale		5005
+#define kSCStatusAccessError	5006
+#endif
+
 /* Notification delivery status (SCNotify.c). */
 enum {
 	NotifierNotRegistered = 0,

--- a/src/libSystemConfiguration/SCPreferences.c
+++ b/src/libSystemConfiguration/SCPreferences.c
@@ -1,0 +1,488 @@
+/*
+ * SCPreferences.c — the SCPreferences client API (freebsd-launchd-mach
+ * port of Apple's SystemConfiguration.fproj SCPOpen.c / SCPGet.c /
+ * SCPSet.c / SCPRemove.c / SCPList.c / SCPCommit.c).
+ *
+ * SCPreferences is the persistent counterpart of SCDynamicStore: a
+ * property-list file (the system network configuration lives in one)
+ * read into memory, edited, then committed back. An SCPreferencesRef
+ * is a CoreFoundation runtime type holding the in-memory dictionary;
+ * the file is read lazily on first access and written back by
+ * SCPreferencesCommitChanges.
+ *
+ * iter 1 is the synchronous read / edit / commit cycle. Apple also
+ * routes privileged writes through SCHelper and guards the file with
+ * SCPreferencesLock; this repo has no helper and runs its daemons as
+ * root, so iter 1 reads and writes the file directly. The preferences
+ * lock, change notifications, SCPreferencesApplyChanges and the path-
+ * based accessors are later iterations.
+ */
+
+#include "SCInternal.h"
+#include <SystemConfiguration/SCPreferences.h>
+
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define	PREFS_DEFAULT_DIR	"/Library/Preferences/SystemConfiguration"
+#define	PREFS_DEFAULT_CONFIG	"preferences.plist"
+
+/* refuse to load a "preferences file" larger than this — treat as corrupt */
+#define	SCP_MAX_PREFS_SIZE	(1 << 20)
+
+
+/*
+ * The SCPreferences session object. A CoreFoundation runtime type.
+ */
+typedef struct __SCPreferences {
+	CFRuntimeBase		cfBase;
+
+	CFStringRef		name;		/* caller's session label */
+	CFStringRef		prefsID;	/* caller's preferences id */
+	char			*path;		/* resolved file path (malloc'd) */
+
+	CFMutableDictionaryRef	prefs;		/* the in-memory preferences */
+	Boolean			accessed;	/* prefs loaded from the file */
+	Boolean			changed;	/* prefs edited since the load */
+} SCPreferencesPrivate, *SCPreferencesPrivateRef;
+
+
+#pragma mark -
+#pragma mark CoreFoundation runtime type
+
+static CFTypeID		__kSCPreferencesTypeID	= _kCFRuntimeNotATypeID;
+
+static void
+__SCPreferencesDeallocate(CFTypeRef cf)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)cf;
+
+	if (prefsPrivate->name != NULL) {
+		CFRelease(prefsPrivate->name);
+	}
+	if (prefsPrivate->prefsID != NULL) {
+		CFRelease(prefsPrivate->prefsID);
+	}
+	if (prefsPrivate->prefs != NULL) {
+		CFRelease(prefsPrivate->prefs);
+	}
+	if (prefsPrivate->path != NULL) {
+		free(prefsPrivate->path);
+	}
+}
+
+static CFStringRef
+__SCPreferencesCopyDescription(CFTypeRef cf)
+{
+	(void)cf;
+	return CFStringCreateWithCString(NULL, "<SCPreferences>",
+					 kCFStringEncodingASCII);
+}
+
+static const CFRuntimeClass __SCPreferencesClass = {
+	.version	= 0,
+	.className	= "SCPreferences",
+	.finalize	= __SCPreferencesDeallocate,
+	.copyDebugDesc	= __SCPreferencesCopyDescription,
+};
+
+static void
+__SCPreferencesClassInitialize(void)
+{
+	__kSCPreferencesTypeID = _CFRuntimeRegisterClass(&__SCPreferencesClass);
+}
+
+CFTypeID
+SCPreferencesGetTypeID(void)
+{
+	static pthread_once_t	once	= PTHREAD_ONCE_INIT;
+
+	(void) pthread_once(&once, __SCPreferencesClassInitialize);
+	return __kSCPreferencesTypeID;
+}
+
+static Boolean
+isA_SCPreferences(SCPreferencesRef prefs)
+{
+	return ((prefs != NULL) &&
+		(CFGetTypeID(prefs) == SCPreferencesGetTypeID()));
+}
+
+
+#pragma mark -
+#pragma mark Session establishment
+
+/*
+ * Resolve a prefsID to a file path (malloc'd, caller frees). NULL is
+ * the default preferences file; a prefsID containing a '/' is taken
+ * as a path; a bare name resolves within the default directory.
+ */
+static char *
+__SCPreferencesPath(CFStringRef prefsID)
+{
+	char	idbuf[PATH_MAX];
+	char	pathbuf[PATH_MAX];
+
+	if (prefsID == NULL) {
+		return strdup(PREFS_DEFAULT_DIR "/" PREFS_DEFAULT_CONFIG);
+	}
+
+	if (!CFStringGetCString(prefsID, idbuf, sizeof(idbuf),
+				kCFStringEncodingUTF8)) {
+		return NULL;
+	}
+
+	if (strchr(idbuf, '/') != NULL) {
+		/* a path — use it as given */
+		return strdup(idbuf);
+	}
+
+	/* a bare name — resolve within the default directory */
+	if (snprintf(pathbuf, sizeof(pathbuf), "%s/%s",
+		     PREFS_DEFAULT_DIR, idbuf) >= (int)sizeof(pathbuf)) {
+		return NULL;
+	}
+	return strdup(pathbuf);
+}
+
+/* create the directories leading up to `path` (best effort) */
+static void
+__SCPreferencesMakeParents(const char *path)
+{
+	char	dir[PATH_MAX];
+	char	*slash;
+	size_t	i;
+
+	if (strlen(path) >= sizeof(dir)) {
+		return;
+	}
+	strcpy(dir, path);
+
+	slash = strrchr(dir, '/');
+	if ((slash == NULL) || (slash == dir)) {
+		return;			/* no directory part */
+	}
+	*slash = '\0';
+
+	for (i = 1; dir[i] != '\0'; i++) {
+		if (dir[i] == '/') {
+			dir[i] = '\0';
+			(void) mkdir(dir, 0755);
+			dir[i] = '/';
+		}
+	}
+	(void) mkdir(dir, 0755);
+}
+
+static SCPreferencesPrivateRef
+__SCPreferencesCreatePrivate(CFAllocatorRef allocator)
+{
+	SCPreferencesPrivateRef	prefsPrivate;
+	CFIndex			extra;
+
+	extra = sizeof(SCPreferencesPrivate) - sizeof(CFRuntimeBase);
+	prefsPrivate = (SCPreferencesPrivateRef)
+		       _CFRuntimeCreateInstance(allocator,
+						SCPreferencesGetTypeID(),
+						extra, NULL);
+	if (prefsPrivate == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+
+	prefsPrivate->name	= NULL;
+	prefsPrivate->prefsID	= NULL;
+	prefsPrivate->path	= NULL;
+	prefsPrivate->prefs	= NULL;
+	prefsPrivate->accessed	= FALSE;
+	prefsPrivate->changed	= FALSE;
+	return prefsPrivate;
+}
+
+SCPreferencesRef
+SCPreferencesCreate(CFAllocatorRef	allocator,
+		    CFStringRef		name,
+		    CFStringRef		prefsID)
+{
+	SCPreferencesPrivateRef	prefsPrivate;
+
+	prefsPrivate = __SCPreferencesCreatePrivate(allocator);
+	if (prefsPrivate == NULL) {
+		return NULL;
+	}
+
+	if (name != NULL) {
+		prefsPrivate->name = CFStringCreateCopy(allocator, name);
+	}
+	if (prefsID != NULL) {
+		prefsPrivate->prefsID = CFStringCreateCopy(allocator, prefsID);
+	}
+
+	prefsPrivate->path = __SCPreferencesPath(prefsID);
+	if (prefsPrivate->path == NULL) {
+		CFRelease(prefsPrivate);
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+
+	_SCErrorSet(kSCStatusOK);
+	return (SCPreferencesRef)prefsPrivate;
+}
+
+/*
+ * Lazily read the preferences file into memory on first access. A
+ * missing, empty or corrupt file simply yields an empty dictionary —
+ * the caller "starts fresh".
+ */
+static void
+__SCPreferencesAccess(SCPreferencesRef prefs)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	int			fd;
+	struct stat		sb;
+
+	if (prefsPrivate->accessed) {
+		return;
+	}
+
+	fd = open(prefsPrivate->path, O_RDONLY);
+	if (fd != -1) {
+		if ((fstat(fd, &sb) == 0) &&
+		    (sb.st_size > 0) &&
+		    (sb.st_size <= SCP_MAX_PREFS_SIZE)) {
+			uint8_t	*buf	= malloc((size_t)sb.st_size);
+
+			if ((buf != NULL) &&
+			    (read(fd, buf, (size_t)sb.st_size) ==
+				(ssize_t)sb.st_size)) {
+				CFDataRef		data;
+				CFPropertyListRef	plist	= NULL;
+				CFErrorRef		error	= NULL;
+
+				data = CFDataCreateWithBytesNoCopy(NULL, buf,
+								   (CFIndex)sb.st_size,
+								   kCFAllocatorNull);
+				if (data != NULL) {
+					plist = CFPropertyListCreateWithData(
+							NULL, data,
+							kCFPropertyListImmutable,
+							NULL, &error);
+				}
+				if ((plist != NULL) &&
+				    (CFGetTypeID(plist) == CFDictionaryGetTypeID())) {
+					prefsPrivate->prefs =
+						CFDictionaryCreateMutableCopy(
+							NULL, 0,
+							(CFDictionaryRef)plist);
+				}
+				if (plist != NULL) CFRelease(plist);
+				if (error != NULL) CFRelease(error);
+				if (data != NULL)  CFRelease(data);
+			}
+			if (buf != NULL) {
+				free(buf);
+			}
+		}
+		(void) close(fd);
+	}
+
+	if (prefsPrivate->prefs == NULL) {
+		/* missing / empty / corrupt file — start fresh */
+		prefsPrivate->prefs =
+			CFDictionaryCreateMutable(NULL, 0,
+						  &kCFTypeDictionaryKeyCallBacks,
+						  &kCFTypeDictionaryValueCallBacks);
+	}
+	prefsPrivate->accessed = TRUE;
+}
+
+
+#pragma mark -
+#pragma mark Preferences access
+
+CFPropertyListRef
+SCPreferencesGetValue(SCPreferencesRef prefs, CFStringRef key)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	CFPropertyListRef	value;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return NULL;
+	}
+	__SCPreferencesAccess(prefs);
+
+	value = CFDictionaryGetValue(prefsPrivate->prefs, key);
+	_SCErrorSet((value != NULL) ? kSCStatusOK : kSCStatusNoKey);
+	return value;
+}
+
+Boolean
+SCPreferencesSetValue(SCPreferencesRef	prefs,
+		      CFStringRef	key,
+		      CFPropertyListRef	value)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+	if ((key == NULL) || (value == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	__SCPreferencesAccess(prefs);
+
+	CFDictionarySetValue(prefsPrivate->prefs, key, value);
+	prefsPrivate->changed = TRUE;
+	return TRUE;
+}
+
+Boolean
+SCPreferencesRemoveValue(SCPreferencesRef prefs, CFStringRef key)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+	if (key == NULL) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	__SCPreferencesAccess(prefs);
+
+	CFDictionaryRemoveValue(prefsPrivate->prefs, key);
+	prefsPrivate->changed = TRUE;
+	return TRUE;
+}
+
+CFArrayRef
+SCPreferencesCopyKeyList(SCPreferencesRef prefs)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	CFArrayRef		keys;
+	CFIndex			n;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return NULL;
+	}
+	__SCPreferencesAccess(prefs);
+
+	n = CFDictionaryGetCount(prefsPrivate->prefs);
+	if (n > 0) {
+		const void	**keyValues;
+
+		keyValues = malloc((size_t)n * sizeof(*keyValues));
+		if (keyValues == NULL) {
+			_SCErrorSet(kSCStatusFailed);
+			return NULL;
+		}
+		CFDictionaryGetKeysAndValues(prefsPrivate->prefs, keyValues, NULL);
+		keys = CFArrayCreate(NULL, keyValues, n, &kCFTypeArrayCallBacks);
+		free(keyValues);
+	} else {
+		keys = CFArrayCreate(NULL, NULL, 0, &kCFTypeArrayCallBacks);
+	}
+
+	_SCErrorSet(kSCStatusOK);
+	return keys;
+}
+
+
+#pragma mark -
+#pragma mark Commit
+
+Boolean
+SCPreferencesCommitChanges(SCPreferencesRef prefs)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	CFDataRef		xmlData;
+	char			newPath[PATH_MAX];
+	const uint8_t		*bytes;
+	CFIndex			len;
+	CFIndex			off;
+	int			fd;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+	__SCPreferencesAccess(prefs);
+
+	if (!prefsPrivate->changed) {
+		/* nothing to write */
+		_SCErrorSet(kSCStatusOK);
+		return TRUE;
+	}
+
+	xmlData = CFPropertyListCreateData(NULL, prefsPrivate->prefs,
+					   kCFPropertyListXMLFormat_v1_0, 0, NULL);
+	if (xmlData == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+
+	/*
+	 * Write to a sibling "-new" file and rename it over the target so
+	 * the preferences file is replaced atomically.
+	 */
+	__SCPreferencesMakeParents(prefsPrivate->path);
+	if (snprintf(newPath, sizeof(newPath), "%s-new",
+		     prefsPrivate->path) >= (int)sizeof(newPath)) {
+		CFRelease(xmlData);
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+
+	fd = open(newPath, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (fd == -1) {
+		CFRelease(xmlData);
+		_SCErrorSet(kSCStatusAccessError);
+		return FALSE;
+	}
+
+	bytes = CFDataGetBytePtr(xmlData);
+	len   = CFDataGetLength(xmlData);
+	off   = 0;
+	while (off < len) {
+		ssize_t	w;
+
+		w = write(fd, bytes + off, (size_t)(len - off));
+		if (w <= 0) {
+			(void) close(fd);
+			(void) unlink(newPath);
+			CFRelease(xmlData);
+			_SCErrorSet(kSCStatusFailed);
+			return FALSE;
+		}
+		off += w;
+	}
+	CFRelease(xmlData);
+
+	if (close(fd) == -1) {
+		(void) unlink(newPath);
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+
+	if (rename(newPath, prefsPrivate->path) == -1) {
+		(void) unlink(newPath);
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+
+	prefsPrivate->changed = FALSE;
+	_SCErrorSet(kSCStatusOK);
+	return TRUE;
+}

--- a/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
@@ -82,7 +82,12 @@ enum {
 	kSCStatusKeyExists		= 1005,	/* key already defined */
 	kSCStatusNoStoreSession		= 2001,	/* no open store session */
 	kSCStatusNoStoreServer		= 2002,	/* configd not (no longer) available */
-	kSCStatusNotifierActive		= 2003	/* notifier already active */
+	kSCStatusNotifierActive		= 2003,	/* notifier already active */
+	kSCStatusNoPrefsSession		= 5001,	/* no open preferences session */
+	kSCStatusPrefsBusy		= 5002,	/* preferences update in progress */
+	kSCStatusNoConfigFile		= 5003,	/* no configuration file */
+	kSCStatusStale			= 5005,	/* write attempted on stale prefs */
+	kSCStatusAccessError		= 5006	/* permission/authorization failure */
 };
 #endif	/* !_CONFIG_TYPES_H */
 

--- a/src/libSystemConfiguration/SystemConfiguration/SCPreferences.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCPreferences.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2000-2022 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/*
+ * SCPreferences.h — the SCPreferences client API.
+ *
+ * freebsd-launchd-mach port: a trimmed port of Apple's
+ * SystemConfiguration.framework SCPreferences.h. SCPreferences is the
+ * persistent counterpart of SCDynamicStore — a property-list file
+ * (the system network configuration lives in one) read into memory,
+ * edited, and committed back.
+ *
+ * iter 1 covers the synchronous read / edit / commit cycle: create a
+ * session, get / set / remove values and list keys, then commit the
+ * changes back to the file. The preferences lock, change notifications
+ * (SCPreferencesSetCallback), SCPreferencesApplyChanges and the path-
+ * based accessors are later iterations.
+ */
+
+#ifndef _SCPREFERENCES_H
+#define _SCPREFERENCES_H
+
+#include <sys/cdefs.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+/*!
+	@typedef SCPreferencesRef
+	@discussion Handle to an open preferences session. A CoreFoundation
+		type (see SCPreferencesGetTypeID()) — release with CFRelease().
+ */
+typedef const struct __SCPreferences *	SCPreferencesRef;
+
+__BEGIN_DECLS
+
+/*!
+	@function SCPreferencesGetTypeID
+	@discussion Returns the CoreFoundation type identifier of all
+		SCPreferences instances.
+ */
+CFTypeID
+SCPreferencesGetTypeID		(void);
+
+/*!
+	@function SCPreferencesCreate
+	@discussion Opens a session to the named preferences file.
+	@param allocator the CFAllocator to use, or NULL.
+	@param name      a label identifying the calling process.
+	@param prefsID   the preferences file: NULL for the default
+		(/Library/Preferences/SystemConfiguration/preferences.plist),
+		a name resolved within that directory, or a path containing
+		a '/' used as-is.
+	@result a new session handle (the file is read lazily on first
+		access), or NULL on error (see SCError()).
+ */
+SCPreferencesRef
+SCPreferencesCreate		(CFAllocatorRef			allocator,
+				 CFStringRef			name,
+				 CFStringRef			prefsID);
+
+/*!
+	@function SCPreferencesGetValue
+	@discussion Returns the value for a top-level preferences key.
+		The value is owned by the session — do not release it, and
+		do not use it past the next change to the session.
+ */
+CFPropertyListRef
+SCPreferencesGetValue		(SCPreferencesRef		prefs,
+				 CFStringRef			key);
+
+/*!
+	@function SCPreferencesSetValue
+	@discussion Sets the value for a top-level preferences key. The
+		change is in memory until SCPreferencesCommitChanges().
+ */
+Boolean
+SCPreferencesSetValue		(SCPreferencesRef		prefs,
+				 CFStringRef			key,
+				 CFPropertyListRef		value);
+
+/*!
+	@function SCPreferencesRemoveValue
+	@discussion Removes a top-level preferences key.
+ */
+Boolean
+SCPreferencesRemoveValue	(SCPreferencesRef		prefs,
+				 CFStringRef			key);
+
+/*!
+	@function SCPreferencesCopyKeyList
+	@discussion Returns the top-level preferences keys.
+	@result a CFArray of CFString keys (caller releases).
+ */
+CFArrayRef
+SCPreferencesCopyKeyList	(SCPreferencesRef		prefs);
+
+/*!
+	@function SCPreferencesCommitChanges
+	@discussion Writes any in-memory changes back to the preferences
+		file.
+ */
+Boolean
+SCPreferencesCommitChanges	(SCPreferencesRef		prefs);
+
+__END_DECLS
+
+#endif	/* _SCPREFERENCES_H */

--- a/src/libSystemConfiguration/SystemConfiguration/SystemConfiguration.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SystemConfiguration.h
@@ -17,8 +17,8 @@
  * SystemConfiguration.h — umbrella header for the SystemConfiguration
  * client framework (freebsd-launchd-mach port).
  *
- * iter 1 exposes only the SCDynamicStore API. The schema-definition
- * keys, SCPreferences, and the network-configuration APIs are later
+ * Exposes the SCDynamicStore and SCPreferences APIs. The schema-
+ * definition keys and the network-configuration APIs are later
  * iterations and will be added here as they land.
  */
 
@@ -26,5 +26,6 @@
 #define _SYSTEMCONFIGURATION_H
 
 #include <SystemConfiguration/SCDynamicStore.h>
+#include <SystemConfiguration/SCPreferences.h>
 
 #endif	/* _SYSTEMCONFIGURATION_H */

--- a/src/libSystemConfiguration/scprefstest.c
+++ b/src/libSystemConfiguration/scprefstest.c
@@ -1,0 +1,167 @@
+/*
+ * scprefstest.c — libSystemConfiguration SCPreferences iter 1 test
+ * client.
+ *
+ * Exercises the SCPreferences read / edit / commit cycle: open a
+ * preferences session, set values, commit, then re-open and confirm
+ * the values persisted; list keys; remove a key, commit, and confirm
+ * the removal persisted. run.sh runs it and boot-test.sh gates on the
+ * SC-PREFS-OK / SC-PREFS-FAIL marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+#define	SCP_ID		"scprefstest.plist"
+#define	SCP_KEY1	"key1"
+#define	SCP_KEY2	"key2"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-PREFS-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+int
+main(void)
+{
+	SCPreferencesRef	prefs	= NULL;
+	CFStringRef		name, prefsID;
+	CFStringRef		key1, key2, value1;
+	CFMutableDictionaryRef	value2	= NULL;
+	CFPropertyListRef	got;
+	CFArrayRef		keys;
+	int			rc	= 1;
+
+	printf("scprefstest: SCPreferences read/edit/commit\n");
+	fflush(stdout);
+
+	name	= mkstr("scprefstest");
+	prefsID	= mkstr(SCP_ID);
+	key1	= mkstr(SCP_KEY1);
+	key2	= mkstr(SCP_KEY2);
+	value1	= mkstr("value-1");
+
+	value2 = CFDictionaryCreateMutable(NULL, 0,
+					   &kCFTypeDictionaryKeyCallBacks,
+					   &kCFTypeDictionaryValueCallBacks);
+	{
+		CFStringRef	dk = mkstr("inner");
+		CFStringRef	dv = mkstr("inner-value");
+		CFDictionarySetValue(value2, dk, dv);
+		CFRelease(dk);
+		CFRelease(dv);
+	}
+
+	/* open a session, set two values, commit */
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate failed");
+		goto out;
+	}
+	if (!SCPreferencesSetValue(prefs, key1, value1) ||
+	    !SCPreferencesSetValue(prefs, key2, value2)) {
+		fail("SCPreferencesSetValue failed");
+		goto out;
+	}
+	if (!SCPreferencesCommitChanges(prefs)) {
+		fail("SCPreferencesCommitChanges failed");
+		printf("  SCError: %s\n", SCErrorString(SCError()));
+		goto out;
+	}
+	CFRelease(prefs);
+	prefs = NULL;
+	printf("  Create/SetValue/CommitChanges: 2 keys written\n");
+
+	/* re-open and confirm the values persisted */
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate (reopen) failed");
+		goto out;
+	}
+	got = SCPreferencesGetValue(prefs, key1);
+	if ((got == NULL) || !CFEqual(got, value1)) {
+		fail("key1 did not persist");
+		goto out;
+	}
+	got = SCPreferencesGetValue(prefs, key2);
+	if ((got == NULL) || !CFEqual(got, value2)) {
+		fail("key2 (dictionary) did not persist");
+		goto out;
+	}
+	printf("  reopen/GetValue: both values persisted\n");
+
+	/* CopyKeyList must list both keys */
+	keys = SCPreferencesCopyKeyList(prefs);
+	if (keys == NULL) {
+		fail("SCPreferencesCopyKeyList returned NULL");
+		goto out;
+	}
+	{
+		CFRange	range = CFRangeMake(0, CFArrayGetCount(keys));
+
+		if (!CFArrayContainsValue(keys, range, key1) ||
+		    !CFArrayContainsValue(keys, range, key2)) {
+			fail("CopyKeyList missing a key");
+			CFRelease(keys);
+			goto out;
+		}
+	}
+	CFRelease(keys);
+	printf("  CopyKeyList: both keys listed\n");
+
+	/* remove key1, commit */
+	if (!SCPreferencesRemoveValue(prefs, key1)) {
+		fail("SCPreferencesRemoveValue failed");
+		goto out;
+	}
+	if (!SCPreferencesCommitChanges(prefs)) {
+		fail("SCPreferencesCommitChanges (after remove) failed");
+		goto out;
+	}
+	CFRelease(prefs);
+	prefs = NULL;
+
+	/* re-open: key1 gone, key2 still there */
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate (reopen 2) failed");
+		goto out;
+	}
+	if (SCPreferencesGetValue(prefs, key1) != NULL) {
+		fail("key1 still present after remove + commit");
+		goto out;
+	}
+	if (SCError() != kSCStatusNoKey) {
+		fail("GetValue of removed key did not report kSCStatusNoKey");
+		goto out;
+	}
+	if (SCPreferencesGetValue(prefs, key2) == NULL) {
+		fail("key2 lost after removing key1");
+		goto out;
+	}
+	printf("  RemoveValue: removal persisted, other key kept\n");
+
+	printf("SC-PREFS-OK: SCPreferences read/edit/commit works\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (prefs != NULL) CFRelease(prefs);
+	CFRelease(name);
+	CFRelease(prefsID);
+	CFRelease(key1);
+	CFRelease(key2);
+	CFRelease(value1);
+	CFRelease(value2);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -501,6 +501,18 @@ expect {
     "SC-MULTI-OK" { puts "\nOK: SCDynamicStore batch get/set works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-PREFS marker not seen"
+        exit 1
+    }
+    "SC-PREFS-FAIL" {
+        puts "\nFAIL: SCPreferences read/edit/commit failed"
+        exit 1
+    }
+    "SC-PREFS-OK" { puts "\nOK: SCPreferences read/edit/commit works" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

First iteration of **SCPreferences** — the persistent counterpart of `SCDynamicStore`. SCPreferences reads a property-list file into memory (the system network configuration lives in one), lets a client edit it, and commits it back. It ships in the same framework as `SCDynamicStore`, so it lands in `libSystemConfiguration`.

## New API (`SystemConfiguration/SCPreferences.h`)

- `SCPreferencesCreate(allocator, name, prefsID)` / `SCPreferencesGetTypeID`
- `SCPreferencesGetValue` / `SetValue` / `RemoveValue` / `CopyKeyList`
- `SCPreferencesCommitChanges`

## How it works

An `SCPreferencesRef` is a CoreFoundation runtime type holding the in-memory dictionary. The file is read **lazily** on first access (a missing / empty / corrupt file just starts fresh) and written back by `CommitChanges` via a `-new` sibling file `rename`d over the target for atomicity. `prefsID` resolves to a path: `NULL` → the default `/Library/Preferences/SystemConfiguration/preferences.plist`, a bare name → within that directory, a path with a `/` → used as-is.

Apple routes privileged writes through `SCHelper` and guards the file with `SCPreferencesLock`; this repo has no helper and runs its daemons as root, so iter 1 reads and writes the file directly. **Deferred to later iterations:** the preferences lock, change notifications (`SCPreferencesSetCallback`), `SCPreferencesApplyChanges`, and the path-based accessors (`SCPreferencesPathGetValue`, …).

## Other changes

- Adds the SCPreferences `kSCStatus` codes (`kSCStatusNoPrefsSession`, `kSCStatusNoConfigFile`, …) to the public enum, the `SCInternal.h` guards, and `SCErrorString`.
- New `scprefstest` — set / commit / reopen / persistence / list / remove — gated by a new `SC-PREFS` boot marker.

## Verified

All library sources syntax-checked clean under `-Wall` against stub headers matching the verified CoreFoundation signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)