### PR TITLE
feat(libSystemConfiguration): SCPreferences iter 2 — path accessors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1176,6 +1176,22 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scprefstest" \
     || { echo "FAIL: scprefstest not built"; exit 1; }
 echo "==> scprefstest built"
 
+# scpathtest — libSystemConfiguration SCPreferences path-accessor test
+# client. Exercises SCPreferencesPathSetValue / PathGetValue /
+# PathRemoveValue (nested '/'-separated paths). run.sh runs it and
+# checks for the SC-PATH-OK marker.
+echo "==> building scpathtest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scpathtest" \
+   "$ROOT/src/libSystemConfiguration/scpathtest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scpathtest" \
+    || { echo "FAIL: scpathtest not built"; exit 1; }
+echo "==> scpathtest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -558,4 +558,14 @@ if [ ! -x "$scprefstest" ]; then
 fi
 "$scprefstest" || true	# marker (SC-PREFS-OK/FAIL) gates in boot-test.sh
 
+# SC-PATH — SCPreferences path accessors: set a dictionary at a nested
+# '/'-separated path, read it (and an intermediate level) back, commit,
+# re-open to confirm it persisted, then remove.
+scpathtest=/usr/tests/freebsd-launchd-mach/scpathtest
+if [ ! -x "$scpathtest" ]; then
+    echo "SC-PATH-FAIL: $scpathtest missing"
+    exit 1
+fi
+"$scpathtest" || true	# marker (SC-PATH-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/SCPreferences.c
+++ b/src/libSystemConfiguration/SCPreferences.c
@@ -486,3 +486,296 @@ SCPreferencesCommitChanges(SCPreferencesRef prefs)
 	_SCErrorSet(kSCStatusOK);
 	return TRUE;
 }
+
+
+#pragma mark -
+#pragma mark Path-based access
+
+/*
+ * Split a '/'-rooted path into its non-empty components. Returns a
+ * retained CFArray of CFString (caller releases), or NULL.
+ */
+static CFMutableArrayRef
+normalizePath(CFStringRef path)
+{
+	CFStringRef		slash;
+	CFArrayRef		split;
+	CFMutableArrayRef	elements;
+	CFIndex			n;
+
+	if ((path == NULL) || (CFGetTypeID(path) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	slash = CFStringCreateWithCString(NULL, "/", kCFStringEncodingUTF8);
+	if (slash == NULL) {
+		return NULL;
+	}
+	if (!CFStringHasPrefix(path, slash)) {
+		/* a path must be rooted at "/" */
+		CFRelease(slash);
+		return NULL;
+	}
+
+	split = CFStringCreateArrayBySeparatingStrings(NULL, path, slash);
+	CFRelease(slash);
+	if (split == NULL) {
+		return NULL;
+	}
+	elements = CFArrayCreateMutableCopy(NULL, 0, split);
+	CFRelease(split);
+	if (elements == NULL) {
+		return NULL;
+	}
+
+	/* drop the empty components the leading/trailing/doubled "/" leave */
+	n = CFArrayGetCount(elements);
+	while (n-- > 0) {
+		CFStringRef	element = CFArrayGetValueAtIndex(elements, n);
+
+		if (CFStringGetLength(element) == 0) {
+			CFArrayRemoveValueAtIndex(elements, n);
+		}
+	}
+	return elements;
+}
+
+/*
+ * Walk `path` through the nested preferences dictionaries; on success
+ * *entity is the dictionary found there (owned by the session).
+ */
+static Boolean
+getPath(SCPreferencesRef prefs, CFStringRef path, CFDictionaryRef *entity)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	CFMutableArrayRef	elements;
+	CFIndex			i;
+	CFIndex			n;
+	CFTypeRef		value		= NULL;
+
+	elements = normalizePath(path);
+	if (elements == NULL) {
+		_SCErrorSet(kSCStatusNoKey);
+		return FALSE;
+	}
+
+	n = CFArrayGetCount(elements);
+	if (n < 1) {
+		/* the root path — the whole preferences dictionary */
+		__SCPreferencesAccess(prefs);
+		*entity = prefsPrivate->prefs;
+		CFRelease(elements);
+		return TRUE;
+	}
+
+	for (i = 0; i < n; i++) {
+		CFStringRef	element = CFArrayGetValueAtIndex(elements, i);
+
+		if (i == 0) {
+			value = SCPreferencesGetValue(prefs, element);
+		} else {
+			value = CFDictionaryGetValue((CFDictionaryRef)value,
+						     element);
+		}
+		if ((value == NULL) ||
+		    (CFGetTypeID(value) != CFDictionaryGetTypeID())) {
+			_SCErrorSet(kSCStatusNoKey);
+			CFRelease(elements);
+			return FALSE;
+		}
+	}
+
+	*entity = (CFDictionaryRef)value;
+	CFRelease(elements);
+	return TRUE;
+}
+
+/*
+ * Store `entity` at `path` (NULL removes). Apple's algorithm: collect
+ * the existing dictionary at each parent level, then rebuild the
+ * affected dictionaries bottom-up — each level a mutable copy of the
+ * old one with the child replaced — and set the rebuilt top level back
+ * with SCPreferencesSetValue. Empty parents are pruned on removal.
+ */
+static Boolean
+setPath(SCPreferencesRef prefs, CFStringRef path, CFDictionaryRef entity)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	CFMutableArrayRef	elements;
+	CFMutableArrayRef	nodes		= NULL;
+	CFStringRef		element;
+	CFTypeRef		node		= NULL;
+	CFTypeRef		newEntity	= NULL;
+	CFIndex			i;
+	CFIndex			n;
+	Boolean			ok		= FALSE;
+
+	if ((entity != NULL) &&
+	    (CFGetTypeID(entity) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	elements = normalizePath(path);
+	if (elements == NULL) {
+		_SCErrorSet(kSCStatusNoKey);
+		return FALSE;
+	}
+
+	n = CFArrayGetCount(elements);
+	if (n < 1) {
+		/* the root path — replace the whole preferences dictionary */
+		__SCPreferencesAccess(prefs);
+		if (prefsPrivate->prefs != NULL) {
+			CFRelease(prefsPrivate->prefs);
+		}
+		if (entity == NULL) {
+			prefsPrivate->prefs =
+				CFDictionaryCreateMutable(NULL, 0,
+					&kCFTypeDictionaryKeyCallBacks,
+					&kCFTypeDictionaryValueCallBacks);
+		} else {
+			prefsPrivate->prefs =
+				CFDictionaryCreateMutableCopy(NULL, 0, entity);
+		}
+		prefsPrivate->changed = TRUE;
+		CFRelease(elements);
+		return TRUE;
+	}
+
+	/* collect the existing dictionary at each parent level */
+	nodes = CFArrayCreateMutable(NULL, n - 1, &kCFTypeArrayCallBacks);
+	for (i = 0; i < n - 1; i++) {
+		element = CFArrayGetValueAtIndex(elements, i);
+		if (i == 0) {
+			node = SCPreferencesGetValue(prefs, element);
+		} else {
+			node = CFDictionaryGetValue((CFDictionaryRef)node,
+						    element);
+		}
+		if (node != NULL) {
+			CFArrayAppendValue(nodes, node);
+		} else {
+			/* a missing parent — synthesize an empty dictionary */
+			CFDictionaryRef	empty;
+
+			empty = CFDictionaryCreate(NULL, NULL, NULL, 0,
+					&kCFTypeDictionaryKeyCallBacks,
+					&kCFTypeDictionaryValueCallBacks);
+			CFArrayAppendValue(nodes, empty);
+			node = empty;
+			CFRelease(empty);
+		}
+		if (CFGetTypeID(node) != CFDictionaryGetTypeID()) {
+			_SCErrorSet(kSCStatusNoKey);
+			goto done;
+		}
+	}
+
+	/* the leaf must not overwrite a non-dictionary component */
+	element = CFArrayGetValueAtIndex(elements, n - 1);
+	if (n > 1) {
+		node = CFArrayGetValueAtIndex(nodes, n - 2);
+		node = CFDictionaryGetValue((CFDictionaryRef)node, element);
+	} else {
+		node = SCPreferencesGetValue(prefs, element);
+	}
+	if ((node != NULL) &&
+	    (CFGetTypeID(node) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		goto done;
+	}
+
+	/* rebuild the affected dictionaries bottom-up */
+	if (entity != NULL) {
+		newEntity = CFRetain(entity);
+	}
+	for (i = n - 1; i >= 0; i--) {
+		element = CFArrayGetValueAtIndex(elements, i);
+		if (i == 0) {
+			if (newEntity != NULL) {
+				ok = SCPreferencesSetValue(prefs, element,
+							   newEntity);
+			} else {
+				ok = SCPreferencesRemoveValue(prefs, element);
+			}
+		} else {
+			CFMutableDictionaryRef	newNode;
+
+			node    = CFArrayGetValueAtIndex(nodes, i - 1);
+			newNode = CFDictionaryCreateMutableCopy(NULL, 0,
+					(CFDictionaryRef)node);
+			if (newEntity != NULL) {
+				CFDictionarySetValue(newNode, element,
+						     newEntity);
+				CFRelease(newEntity);
+			} else {
+				CFDictionaryRemoveValue(newNode, element);
+				if (CFDictionaryGetCount(newNode) == 0) {
+					/* prune the now-empty parent */
+					CFRelease(newNode);
+					newNode = NULL;
+				}
+			}
+			newEntity = newNode;
+		}
+	}
+	if (newEntity != NULL) {
+		CFRelease(newEntity);
+	}
+
+    done :
+	if (nodes != NULL) {
+		CFRelease(nodes);
+	}
+	CFRelease(elements);
+	return ok;
+}
+
+CFDictionaryRef
+SCPreferencesPathGetValue(SCPreferencesRef prefs, CFStringRef path)
+{
+	CFDictionaryRef	entity	= NULL;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return NULL;
+	}
+	if (!getPath(prefs, path, &entity)) {
+		return NULL;
+	}
+	return entity;
+}
+
+Boolean
+SCPreferencesPathSetValue(SCPreferencesRef	prefs,
+			  CFStringRef		path,
+			  CFDictionaryRef	value)
+{
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+	if (value == NULL) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	return setPath(prefs, path, value);
+}
+
+Boolean
+SCPreferencesPathRemoveValue(SCPreferencesRef prefs, CFStringRef path)
+{
+	CFDictionaryRef	entity	= NULL;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+	if (!getPath(prefs, path, &entity)) {
+		/* nothing at that path to remove */
+		return FALSE;
+	}
+	return setPath(prefs, path, NULL);
+}

--- a/src/libSystemConfiguration/SystemConfiguration/SCPreferences.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCPreferences.h
@@ -113,6 +113,34 @@ SCPreferencesCopyKeyList	(SCPreferencesRef		prefs);
 Boolean
 SCPreferencesCommitChanges	(SCPreferencesRef		prefs);
 
+/*!
+	@function SCPreferencesPathGetValue
+	@discussion Returns the dictionary at a '/'-separated path within
+		the preferences. The dictionary is owned by the session.
+ */
+CFDictionaryRef
+SCPreferencesPathGetValue	(SCPreferencesRef		prefs,
+				 CFStringRef			path);
+
+/*!
+	@function SCPreferencesPathSetValue
+	@discussion Stores a dictionary at a '/'-separated path, creating
+		any intermediate dictionaries.
+ */
+Boolean
+SCPreferencesPathSetValue	(SCPreferencesRef		prefs,
+				 CFStringRef			path,
+				 CFDictionaryRef		value);
+
+/*!
+	@function SCPreferencesPathRemoveValue
+	@discussion Removes the dictionary at a '/'-separated path; any
+		intermediate dictionaries left empty are pruned.
+ */
+Boolean
+SCPreferencesPathRemoveValue	(SCPreferencesRef		prefs,
+				 CFStringRef			path);
+
 __END_DECLS
 
 #endif	/* _SCPREFERENCES_H */

--- a/src/libSystemConfiguration/scpathtest.c
+++ b/src/libSystemConfiguration/scpathtest.c
@@ -1,0 +1,141 @@
+/*
+ * scpathtest.c — libSystemConfiguration SCPreferences iter 2 path-
+ * accessor test client.
+ *
+ * Exercises the '/'-separated path accessors: set a dictionary at a
+ * nested path (creating the intermediate dictionaries), read it back
+ * (and read an intermediate level), commit, re-open and confirm it
+ * persisted, then remove it. run.sh runs it and boot-test.sh gates on
+ * the SC-PATH-OK / SC-PATH-FAIL marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+#define	SCT_ID		"scpathtest.plist"
+#define	SCT_PATH	"/net/service"
+#define	SCT_PARENT	"/net"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-PATH-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+int
+main(void)
+{
+	SCPreferencesRef	prefs	= NULL;
+	CFStringRef		name, prefsID;
+	CFStringRef		path, parent, leafKey, leafValue, childKey;
+	CFMutableDictionaryRef	entity	= NULL;
+	CFDictionaryRef		got;
+	int			rc	= 1;
+
+	printf("scpathtest: SCPreferences path accessors\n");
+	fflush(stdout);
+
+	name		= mkstr("scpathtest");
+	prefsID		= mkstr(SCT_ID);
+	path		= mkstr(SCT_PATH);
+	parent		= mkstr(SCT_PARENT);
+	leafKey		= mkstr("leaf");
+	leafValue	= mkstr("leaf-value");
+	childKey	= mkstr("service");
+
+	entity = CFDictionaryCreateMutable(NULL, 0,
+					   &kCFTypeDictionaryKeyCallBacks,
+					   &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(entity, leafKey, leafValue);
+
+	/* set a dictionary at a nested path */
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate failed");
+		goto out;
+	}
+	if (!SCPreferencesPathSetValue(prefs, path, entity)) {
+		fail("SCPreferencesPathSetValue failed");
+		goto out;
+	}
+	printf("  PathSetValue: %s created\n", SCT_PATH);
+
+	/* read it back */
+	got = SCPreferencesPathGetValue(prefs, path);
+	if (got == NULL) {
+		fail("SCPreferencesPathGetValue returned NULL");
+		goto out;
+	}
+	{
+		CFTypeRef	v = CFDictionaryGetValue(got, leafKey);
+
+		if ((v == NULL) || !CFEqual(v, leafValue)) {
+			fail("path entity did not round-trip");
+			goto out;
+		}
+	}
+
+	/* the intermediate level must hold the child */
+	got = SCPreferencesPathGetValue(prefs, parent);
+	if ((got == NULL) ||
+	    (CFDictionaryGetValue(got, childKey) == NULL)) {
+		fail("intermediate path missing the child dictionary");
+		goto out;
+	}
+	printf("  PathGetValue: nested + intermediate read OK\n");
+
+	/* commit, re-open, confirm it persisted */
+	if (!SCPreferencesCommitChanges(prefs)) {
+		fail("SCPreferencesCommitChanges failed");
+		goto out;
+	}
+	CFRelease(prefs);
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate (reopen) failed");
+		goto out;
+	}
+	got = SCPreferencesPathGetValue(prefs, path);
+	if ((got == NULL) ||
+	    !CFEqual(CFDictionaryGetValue(got, leafKey), leafValue)) {
+		fail("path entity did not persist");
+		goto out;
+	}
+	printf("  CommitChanges/reopen: path persisted\n");
+
+	/* remove it */
+	if (!SCPreferencesPathRemoveValue(prefs, path)) {
+		fail("SCPreferencesPathRemoveValue failed");
+		goto out;
+	}
+	if (SCPreferencesPathGetValue(prefs, path) != NULL) {
+		fail("path still present after remove");
+		goto out;
+	}
+	printf("  PathRemoveValue: path removed\n");
+
+	printf("SC-PATH-OK: SCPreferences path accessors work\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (prefs != NULL) CFRelease(prefs);
+	if (entity != NULL) CFRelease(entity);
+	CFRelease(name);
+	CFRelease(prefsID);
+	CFRelease(path);
+	CFRelease(parent);
+	CFRelease(leafKey);
+	CFRelease(leafValue);
+	CFRelease(childKey);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -513,6 +513,18 @@ expect {
     "SC-PREFS-OK" { puts "\nOK: SCPreferences read/edit/commit works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-PATH marker not seen"
+        exit 1
+    }
+    "SC-PATH-FAIL" {
+        puts "\nFAIL: SCPreferences path accessors failed"
+        exit 1
+    }
+    "SC-PATH-OK" { puts "\nOK: SCPreferences path accessors work" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

Second iteration of **SCPreferences** — the `/`-separated **path accessors**, the form `SCNetworkConfiguration` is built on.

## New API

| Function | Notes |
|----------|-------|
| `SCPreferencesPathGetValue(prefs, path)` | the dictionary at a nested path |
| `SCPreferencesPathSetValue(prefs, path, value)` | store a dictionary at a path, creating the intermediate dictionaries |
| `SCPreferencesPathRemoveValue(prefs, path)` | remove it; empty parents are pruned |

## How it works

Added to `SCPreferences.c`:
- `normalizePath` splits a `/`-rooted path into its non-empty components;
- `getPath` walks them through the nested dictionaries;
- `setPath` ports Apple's bottom-up rebuild — collect the existing dictionary at each parent level, then rebuild the affected dictionaries from the leaf up (each a mutable copy with the child replaced) and set the rebuilt top level back via `SCPreferencesSetValue`.

Apple's paths also support a `__LINK__` indirection (a path component linking to another path) chased by `getPath`/`setPath`; that — and `SCPreferencesPathCreateUniqueChild` — are a later iteration. iter 2 is plain nested-dictionary paths.

## Test

New `scpathtest` — set at a nested path, read back (nested + intermediate level), commit / reopen / persistence, and remove. Gated by a new `SC-PATH` boot marker.

## Verified

All library sources syntax-checked clean under `-Wall` against stub headers matching the verified CoreFoundation signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)