### PR TITLE
feat(libSystemConfiguration): SCPreferences iter 3 — the preferences lock

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1192,6 +1192,22 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scpathtest" \
     || { echo "FAIL: scpathtest not built"; exit 1; }
 echo "==> scpathtest built"
 
+# sclocktest — libSystemConfiguration SCPreferences lock test client.
+# Exercises SCPreferencesLock / SCPreferencesUnlock contention between
+# two sessions, plus commit's internal auto-lock. run.sh runs it and
+# checks for the SC-LOCK-OK marker.
+echo "==> building sclocktest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/sclocktest" \
+   "$ROOT/src/libSystemConfiguration/sclocktest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/sclocktest" \
+    || { echo "FAIL: sclocktest not built"; exit 1; }
+echo "==> sclocktest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -568,4 +568,13 @@ if [ ! -x "$scpathtest" ]; then
 fi
 "$scpathtest" || true	# marker (SC-PATH-OK/FAIL) gates in boot-test.sh
 
+# SC-LOCK — SCPreferences lock: two sessions on one preferences file
+# contend for the exclusive lock; commit takes the lock itself.
+sclocktest=/usr/tests/freebsd-launchd-mach/sclocktest
+if [ ! -x "$sclocktest" ]; then
+    echo "SC-LOCK-FAIL: $sclocktest missing"
+    exit 1
+fi
+"$sclocktest" || true	# marker (SC-LOCK-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/SCD.c
+++ b/src/libSystemConfiguration/SCD.c
@@ -95,6 +95,10 @@ SCErrorString(int status)
 		return "Write attempted on stale version of object";
 	case kSCStatusAccessError :
 		return "Permission denied";
+	case kSCStatusLocked :
+		return "Preferences update currently in progress";
+	case kSCStatusNeedLock :
+		return "Lock not held";
 	default :
 		return "Unknown error";
 	}

--- a/src/libSystemConfiguration/SCInternal.h
+++ b/src/libSystemConfiguration/SCInternal.h
@@ -45,6 +45,8 @@
 #define kSCStatusNoConfigFile	5003
 #define kSCStatusStale		5005
 #define kSCStatusAccessError	5006
+#define kSCStatusLocked		5007
+#define kSCStatusNeedLock	5008
 #endif
 
 /* Notification delivery status (SCNotify.c). */

--- a/src/libSystemConfiguration/SCPreferences.c
+++ b/src/libSystemConfiguration/SCPreferences.c
@@ -21,6 +21,7 @@
 #include "SCInternal.h"
 #include <SystemConfiguration/SCPreferences.h>
 
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <pthread.h>
@@ -51,6 +52,10 @@ typedef struct __SCPreferences {
 	CFMutableDictionaryRef	prefs;		/* the in-memory preferences */
 	Boolean			accessed;	/* prefs loaded from the file */
 	Boolean			changed;	/* prefs edited since the load */
+
+	Boolean			locked;		/* this session holds the lock */
+	int			lockFD;		/* O_EXLOCK descriptor, or -1 */
+	char			*lockPath;	/* lock file path (malloc'd) */
 } SCPreferencesPrivate, *SCPreferencesPrivateRef;
 
 
@@ -75,6 +80,13 @@ __SCPreferencesDeallocate(CFTypeRef cf)
 	}
 	if (prefsPrivate->path != NULL) {
 		free(prefsPrivate->path);
+	}
+	if (prefsPrivate->lockFD != -1) {
+		/* closing the descriptor releases any held O_EXLOCK lock */
+		(void) close(prefsPrivate->lockFD);
+	}
+	if (prefsPrivate->lockPath != NULL) {
+		free(prefsPrivate->lockPath);
 	}
 }
 
@@ -203,6 +215,9 @@ __SCPreferencesCreatePrivate(CFAllocatorRef allocator)
 	prefsPrivate->prefs	= NULL;
 	prefsPrivate->accessed	= FALSE;
 	prefsPrivate->changed	= FALSE;
+	prefsPrivate->locked	= FALSE;
+	prefsPrivate->lockFD	= -1;
+	prefsPrivate->lockPath	= NULL;
 	return prefsPrivate;
 }
 
@@ -403,8 +418,98 @@ SCPreferencesCopyKeyList(SCPreferencesRef prefs)
 #pragma mark -
 #pragma mark Commit
 
+#pragma mark -
+#pragma mark Lock
+
 Boolean
-SCPreferencesCommitChanges(SCPreferencesRef prefs)
+SCPreferencesLock(SCPreferencesRef prefs, Boolean wait)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	size_t			len;
+	int			oflag;
+	int			fd;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+	if (prefsPrivate->locked) {
+		_SCErrorSet(kSCStatusLocked);
+		return FALSE;
+	}
+
+	/* the lock file sits beside the preferences file as "<path>-lock" */
+	if (prefsPrivate->lockPath == NULL) {
+		len = strlen(prefsPrivate->path) + sizeof("-lock");
+		prefsPrivate->lockPath = malloc(len);
+		if (prefsPrivate->lockPath == NULL) {
+			_SCErrorSet(kSCStatusFailed);
+			return FALSE;
+		}
+		(void) snprintf(prefsPrivate->lockPath, len, "%s-lock",
+				prefsPrivate->path);
+	}
+	__SCPreferencesMakeParents(prefsPrivate->lockPath);
+
+	/*
+	 * O_EXLOCK takes an exclusive advisory lock as part of the open;
+	 * the lock is released when the descriptor is closed. With
+	 * O_NONBLOCK a non-waiting request fails with EWOULDBLOCK if the
+	 * lock is already held.
+	 */
+	oflag = O_WRONLY | O_CREAT | O_EXLOCK;
+	if (!wait) {
+		oflag |= O_NONBLOCK;
+	}
+	fd = open(prefsPrivate->lockPath, oflag, 0644);
+	if (fd == -1) {
+		_SCErrorSet((errno == EWOULDBLOCK)
+				? kSCStatusPrefsBusy : kSCStatusFailed);
+		return FALSE;
+	}
+
+	prefsPrivate->lockFD = fd;
+	prefsPrivate->locked = TRUE;
+	_SCErrorSet(kSCStatusOK);
+	return TRUE;
+}
+
+Boolean
+SCPreferencesUnlock(SCPreferencesRef prefs)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+	if (!prefsPrivate->locked) {
+		_SCErrorSet(kSCStatusNeedLock);
+		return FALSE;
+	}
+
+	if (prefsPrivate->lockFD != -1) {
+		/* closing the descriptor releases the O_EXLOCK lock */
+		(void) close(prefsPrivate->lockFD);
+		prefsPrivate->lockFD = -1;
+	}
+	prefsPrivate->locked = FALSE;
+	_SCErrorSet(kSCStatusOK);
+	return TRUE;
+}
+
+
+#pragma mark -
+#pragma mark Commit
+
+/*
+ * Write the in-memory preferences out to the file: serialize, write a
+ * sibling "-new" file, and rename it over the target so the file is
+ * replaced atomically. Returns TRUE with SCError() OK, or FALSE with
+ * SCError() set.
+ */
+static Boolean
+__SCPreferencesWriteFile(SCPreferencesRef prefs)
 {
 	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
 	CFDataRef		xmlData;
@@ -414,18 +519,6 @@ SCPreferencesCommitChanges(SCPreferencesRef prefs)
 	CFIndex			off;
 	int			fd;
 
-	if (!isA_SCPreferences(prefs)) {
-		_SCErrorSet(kSCStatusNoPrefsSession);
-		return FALSE;
-	}
-	__SCPreferencesAccess(prefs);
-
-	if (!prefsPrivate->changed) {
-		/* nothing to write */
-		_SCErrorSet(kSCStatusOK);
-		return TRUE;
-	}
-
 	xmlData = CFPropertyListCreateData(NULL, prefsPrivate->prefs,
 					   kCFPropertyListXMLFormat_v1_0, 0, NULL);
 	if (xmlData == NULL) {
@@ -433,10 +526,6 @@ SCPreferencesCommitChanges(SCPreferencesRef prefs)
 		return FALSE;
 	}
 
-	/*
-	 * Write to a sibling "-new" file and rename it over the target so
-	 * the preferences file is replaced atomically.
-	 */
 	__SCPreferencesMakeParents(prefsPrivate->path);
 	if (snprintf(newPath, sizeof(newPath), "%s-new",
 		     prefsPrivate->path) >= (int)sizeof(newPath)) {
@@ -485,6 +574,44 @@ SCPreferencesCommitChanges(SCPreferencesRef prefs)
 	prefsPrivate->changed = FALSE;
 	_SCErrorSet(kSCStatusOK);
 	return TRUE;
+}
+
+Boolean
+SCPreferencesCommitChanges(SCPreferencesRef prefs)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	Boolean			wasLocked;
+	Boolean			ok;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+	__SCPreferencesAccess(prefs);
+
+	if (!prefsPrivate->changed) {
+		/* nothing to write */
+		_SCErrorSet(kSCStatusOK);
+		return TRUE;
+	}
+
+	/* hold the preferences lock for the duration of the write */
+	wasLocked = prefsPrivate->locked;
+	if (!wasLocked) {
+		if (!SCPreferencesLock(prefs, TRUE)) {
+			return FALSE;	/* SCError() set by SCPreferencesLock */
+		}
+	}
+
+	ok = __SCPreferencesWriteFile(prefs);
+
+	if (!wasLocked) {
+		int	status	= SCError();	/* preserve across the unlock */
+
+		(void) SCPreferencesUnlock(prefs);
+		_SCErrorSet(status);
+	}
+	return ok;
 }
 
 

--- a/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
@@ -87,7 +87,9 @@ enum {
 	kSCStatusPrefsBusy		= 5002,	/* preferences update in progress */
 	kSCStatusNoConfigFile		= 5003,	/* no configuration file */
 	kSCStatusStale			= 5005,	/* write attempted on stale prefs */
-	kSCStatusAccessError		= 5006	/* permission/authorization failure */
+	kSCStatusAccessError		= 5006,	/* permission/authorization failure */
+	kSCStatusLocked			= 5007,	/* preferences already locked */
+	kSCStatusNeedLock		= 5008	/* preferences not locked */
 };
 #endif	/* !_CONFIG_TYPES_H */
 

--- a/src/libSystemConfiguration/SystemConfiguration/SCPreferences.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCPreferences.h
@@ -114,6 +114,26 @@ Boolean
 SCPreferencesCommitChanges	(SCPreferencesRef		prefs);
 
 /*!
+	@function SCPreferencesLock
+	@discussion Takes exclusive access to the preferences. With
+		`wait` TRUE the call blocks until the lock is available;
+		with FALSE it fails immediately (kSCStatusPrefsBusy) if the
+		lock is held. SCPreferencesCommitChanges takes the lock
+		itself if the caller has not.
+ */
+Boolean
+SCPreferencesLock		(SCPreferencesRef		prefs,
+				 Boolean			wait);
+
+/*!
+	@function SCPreferencesUnlock
+	@discussion Releases the exclusive access taken by
+		SCPreferencesLock.
+ */
+Boolean
+SCPreferencesUnlock		(SCPreferencesRef		prefs);
+
+/*!
 	@function SCPreferencesPathGetValue
 	@discussion Returns the dictionary at a '/'-separated path within
 		the preferences. The dictionary is owned by the session.

--- a/src/libSystemConfiguration/sclocktest.c
+++ b/src/libSystemConfiguration/sclocktest.c
@@ -1,0 +1,120 @@
+/*
+ * sclocktest.c — libSystemConfiguration SCPreferences lock test client.
+ *
+ * Exercises SCPreferencesLock / SCPreferencesUnlock: two sessions on
+ * the same preferences file contend for the exclusive lock, a session
+ * cannot double-lock or unlock when it holds nothing, and
+ * SCPreferencesCommitChanges takes the lock itself. run.sh runs it and
+ * boot-test.sh gates on the SC-LOCK-OK / SC-LOCK-FAIL marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+#define	SCL_ID	"sclocktest.plist"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-LOCK-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+int
+main(void)
+{
+	SCPreferencesRef	a	= NULL;
+	SCPreferencesRef	b	= NULL;
+	CFStringRef		name, prefsID, key, value;
+	int			rc	= 1;
+
+	printf("sclocktest: SCPreferences lock\n");
+	fflush(stdout);
+
+	name	= mkstr("sclocktest");
+	prefsID	= mkstr(SCL_ID);
+	key	= mkstr("lockkey");
+	value	= mkstr("lockvalue");
+
+	a = SCPreferencesCreate(NULL, name, prefsID);
+	b = SCPreferencesCreate(NULL, name, prefsID);
+	if ((a == NULL) || (b == NULL)) {
+		fail("SCPreferencesCreate failed");
+		goto out;
+	}
+
+	/* session A takes the lock */
+	if (!SCPreferencesLock(a, TRUE)) {
+		fail("SCPreferencesLock(a) failed");
+		goto out;
+	}
+	printf("  Lock(a): acquired\n");
+
+	/* A cannot lock twice */
+	if (SCPreferencesLock(a, TRUE) || (SCError() != kSCStatusLocked)) {
+		fail("double Lock(a) did not report kSCStatusLocked");
+		goto out;
+	}
+
+	/* B's non-blocking lock must fail while A holds it */
+	if (SCPreferencesLock(b, FALSE) || (SCError() != kSCStatusPrefsBusy)) {
+		fail("Lock(b) did not report kSCStatusPrefsBusy");
+		goto out;
+	}
+	printf("  Lock(b): correctly refused while A holds the lock\n");
+
+	/* A releases */
+	if (!SCPreferencesUnlock(a)) {
+		fail("SCPreferencesUnlock(a) failed");
+		goto out;
+	}
+	/* A cannot unlock again */
+	if (SCPreferencesUnlock(a) || (SCError() != kSCStatusNeedLock)) {
+		fail("double Unlock(a) did not report kSCStatusNeedLock");
+		goto out;
+	}
+
+	/* now B can take it */
+	if (!SCPreferencesLock(b, FALSE)) {
+		fail("Lock(b) failed after A released");
+		goto out;
+	}
+	if (!SCPreferencesUnlock(b)) {
+		fail("SCPreferencesUnlock(b) failed");
+		goto out;
+	}
+	printf("  Lock(b): acquired + released after A unlocked\n");
+
+	/* SCPreferencesCommitChanges takes the lock itself */
+	if (!SCPreferencesSetValue(a, key, value)) {
+		fail("SCPreferencesSetValue failed");
+		goto out;
+	}
+	if (!SCPreferencesCommitChanges(a)) {
+		fail("SCPreferencesCommitChanges (auto-lock) failed");
+		printf("  SCError: %s\n", SCErrorString(SCError()));
+		goto out;
+	}
+	printf("  CommitChanges: auto-locked write OK\n");
+
+	printf("SC-LOCK-OK: SCPreferences lock works\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (a != NULL) CFRelease(a);
+	if (b != NULL) CFRelease(b);
+	CFRelease(name);
+	CFRelease(prefsID);
+	CFRelease(key);
+	CFRelease(value);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -525,6 +525,18 @@ expect {
     "SC-PATH-OK" { puts "\nOK: SCPreferences path accessors work" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-LOCK marker not seen"
+        exit 1
+    }
+    "SC-LOCK-FAIL" {
+        puts "\nFAIL: SCPreferences lock failed"
+        exit 1
+    }
+    "SC-LOCK-OK" { puts "\nOK: SCPreferences lock works" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

Third iteration of **SCPreferences** — `SCPreferencesLock` / `SCPreferencesUnlock`, exclusive access to the preferences file.

## New API

- `SCPreferencesLock(prefs, wait)` — take the exclusive lock; with `wait` FALSE it fails immediately (`kSCStatusPrefsBusy`) if the lock is held.
- `SCPreferencesUnlock(prefs)` — release it.

## How it works

The lock is an **`O_EXLOCK` advisory lock** on a sibling `<path>-lock` file (the lock is released when the descriptor closes) — the same mechanism Apple uses, minus the SCDynamicStore fallback for filesystems without `O_EXLOCK` and the stale-signature recheck.

`SCPreferencesCommitChanges` now takes the lock itself for the duration of the write if the caller has not (its file-write body is factored into `__SCPreferencesWriteFile`).

## Other changes

- Adds `kSCStatusLocked` / `kSCStatusNeedLock` (public enum, `SCInternal.h` guards, `SCErrorString`).
- The SCPreferences object gains `locked` / `lockFD` / `lockPath`; the finalizer releases a held lock.

## Test

New `sclocktest` — two sessions contend for the lock (the non-blocking loser gets `kSCStatusPrefsBusy`), double-lock reports `kSCStatusLocked`, unlock-without-lock reports `kSCStatusNeedLock`, and a plain `CommitChanges` auto-locks. (`O_EXLOCK` locks conflict between separate `open()`s even in one process, so the two-session contention is exercised in a single test binary.) Gated by a new `SC-LOCK` boot marker.

## Verified

All library sources syntax-checked clean under `-Wall`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)