### PR TITLE
feat(libSystemConfiguration): SCPreferences iter 4 — change notifications

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1208,6 +1208,23 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/sclocktest" \
     || { echo "FAIL: sclocktest not built"; exit 1; }
 echo "==> sclocktest built"
 
+# scprefsnotifytest — libSystemConfiguration SCPreferences change-
+# notification test client. One session watches a preferences file on
+# a dispatch queue, another commits a change, and the callback must
+# fire. run.sh runs it and checks for the SC-PNOTIFY-OK marker.
+echo "==> building scprefsnotifytest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scprefsnotifytest" \
+   "$ROOT/src/libSystemConfiguration/scprefsnotifytest.c" \
+   -lSystemConfiguration -lCoreFoundation -ldispatch -lBlocksRuntime \
+   -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scprefsnotifytest" \
+    || { echo "FAIL: scprefsnotifytest not built"; exit 1; }
+echo "==> scprefsnotifytest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -577,4 +577,14 @@ if [ ! -x "$sclocktest" ]; then
 fi
 "$sclocktest" || true	# marker (SC-LOCK-OK/FAIL) gates in boot-test.sh
 
+# SC-PNOTIFY — SCPreferences change notifications: one session watches a
+# preferences file on a dispatch queue, another commits a change, and
+# the watcher's callback must fire.
+scprefsnotifytest=/usr/tests/freebsd-launchd-mach/scprefsnotifytest
+if [ ! -x "$scprefsnotifytest" ]; then
+    echo "SC-PNOTIFY-FAIL: $scprefsnotifytest missing"
+    exit 1
+fi
+"$scprefsnotifytest" || true	# marker (SC-PNOTIFY-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/SCDynamicStore.c
+++ b/src/libSystemConfiguration/SCDynamicStore.c
@@ -471,6 +471,37 @@ SCDynamicStoreRemoveValue(SCDynamicStoreRef store, CFStringRef key)
 	return TRUE;
 }
 
+Boolean
+SCDynamicStoreNotifyValue(SCDynamicStoreRef store, CFStringRef key)
+{
+	SCDynamicStorePrivateRef	storePrivate	= (SCDynamicStorePrivateRef)store;
+	CFDataRef			keyData;
+	int				sc_status	= kSCStatusFailed;
+	kern_return_t			kr;
+
+	keyData = __SCStorePrepare(store, key);
+	if (keyData == NULL) {
+		return FALSE;
+	}
+
+	/* confignotify posts a change for the key without altering it */
+	kr = confignotify(storePrivate->server,
+			  (uint8_t *)CFDataGetBytePtr(keyData),
+			  (mach_msg_type_number_t)CFDataGetLength(keyData),
+			  &sc_status);
+	CFRelease(keyData);
+
+	if (kr != KERN_SUCCESS) {
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+	if (sc_status != kSCStatusOK) {
+		_SCErrorSet(sc_status);
+		return FALSE;
+	}
+	return TRUE;
+}
+
 CFArrayRef
 SCDynamicStoreCopyKeyList(SCDynamicStoreRef store, CFStringRef pattern)
 {

--- a/src/libSystemConfiguration/SCPreferences.c
+++ b/src/libSystemConfiguration/SCPreferences.c
@@ -56,7 +56,15 @@ typedef struct __SCPreferences {
 	Boolean			locked;		/* this session holds the lock */
 	int			lockFD;		/* O_EXLOCK descriptor, or -1 */
 	char			*lockPath;	/* lock file path (malloc'd) */
+
+	/* change-notification delivery */
+	SCPreferencesCallBack	rlsFunction;	/* the client callout */
+	SCPreferencesContext	rlsContext;	/* the callout's context */
+	SCDynamicStoreRef	notifyStore;	/* internal store, or NULL */
 } SCPreferencesPrivate, *SCPreferencesPrivateRef;
+
+/* SCPreferencesCommitChanges posts a change here once the file is written */
+static void	__SCPreferencesPostCommit(SCPreferencesRef prefs);
 
 
 #pragma mark -
@@ -87,6 +95,15 @@ __SCPreferencesDeallocate(CFTypeRef cf)
 	}
 	if (prefsPrivate->lockPath != NULL) {
 		free(prefsPrivate->lockPath);
+	}
+	if (prefsPrivate->notifyStore != NULL) {
+		/* tear the internal change-notification store down */
+		(void) SCDynamicStoreSetDispatchQueue(prefsPrivate->notifyStore,
+						      NULL);
+		CFRelease(prefsPrivate->notifyStore);
+	}
+	if (prefsPrivate->rlsContext.release != NULL) {
+		prefsPrivate->rlsContext.release(prefsPrivate->rlsContext.info);
 	}
 }
 
@@ -218,6 +235,9 @@ __SCPreferencesCreatePrivate(CFAllocatorRef allocator)
 	prefsPrivate->locked	= FALSE;
 	prefsPrivate->lockFD	= -1;
 	prefsPrivate->lockPath	= NULL;
+	prefsPrivate->rlsFunction = NULL;
+	memset(&prefsPrivate->rlsContext, 0, sizeof(prefsPrivate->rlsContext));
+	prefsPrivate->notifyStore = NULL;
 	return prefsPrivate;
 }
 
@@ -582,6 +602,7 @@ SCPreferencesCommitChanges(SCPreferencesRef prefs)
 	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
 	Boolean			wasLocked;
 	Boolean			ok;
+	int			status;
 
 	if (!isA_SCPreferences(prefs)) {
 		_SCErrorSet(kSCStatusNoPrefsSession);
@@ -604,13 +625,17 @@ SCPreferencesCommitChanges(SCPreferencesRef prefs)
 	}
 
 	ok = __SCPreferencesWriteFile(prefs);
+	status = SCError();		/* the write's status */
+
+	if (ok) {
+		/* post a change notification — best effort */
+		__SCPreferencesPostCommit(prefs);
+	}
 
 	if (!wasLocked) {
-		int	status	= SCError();	/* preserve across the unlock */
-
 		(void) SCPreferencesUnlock(prefs);
-		_SCErrorSet(status);
 	}
+	_SCErrorSet(status);		/* restore the write's status */
 	return ok;
 }
 
@@ -905,4 +930,192 @@ SCPreferencesPathRemoveValue(SCPreferencesRef prefs, CFStringRef path)
 		return FALSE;
 	}
 	return setPath(prefs, path, NULL);
+}
+
+
+#pragma mark -
+#pragma mark Change notifications
+
+/*
+ * The SCDynamicStore key a commit posts on / a watcher watches. It is
+ * derived from the preferences file path so every session for the same
+ * file agrees on it.
+ */
+static CFStringRef
+__SCPreferencesCommitKey(SCPreferencesRef prefs)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	char			buf[PATH_MAX + 32];
+
+	(void) snprintf(buf, sizeof(buf), "SCPreferences:commit:%s",
+			prefsPrivate->path);
+	return CFStringCreateWithCString(NULL, buf, kCFStringEncodingUTF8);
+}
+
+/*
+ * Internal SCDynamicStore callback — a change on the commit key means
+ * the preferences were committed. Runs on the caller's dispatch queue.
+ */
+static void
+prefsNotify(SCDynamicStoreRef store, CFArrayRef changedKeys, void *info)
+{
+	SCPreferencesRef	prefs		= (SCPreferencesRef)info;
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	SCPreferencesCallBack	callout;
+	void			*context_info;
+
+	(void)store;
+	(void)changedKeys;	/* the only watched key is our commit key */
+
+	callout      = prefsPrivate->rlsFunction;
+	context_info = prefsPrivate->rlsContext.info;
+	if (callout != NULL) {
+		(*callout)(prefs, kSCPreferencesNotificationCommit,
+			   context_info);
+	}
+}
+
+Boolean
+SCPreferencesSetCallback(SCPreferencesRef	prefs,
+			 SCPreferencesCallBack	callout,
+			 SCPreferencesContext	*context)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+
+	/* release any previous callback context */
+	if (prefsPrivate->rlsContext.release != NULL) {
+		prefsPrivate->rlsContext.release(prefsPrivate->rlsContext.info);
+	}
+
+	prefsPrivate->rlsFunction = callout;
+	memset(&prefsPrivate->rlsContext, 0, sizeof(prefsPrivate->rlsContext));
+	if (context != NULL) {
+		memcpy(&prefsPrivate->rlsContext, context,
+		       sizeof(SCPreferencesContext));
+		if (context->retain != NULL) {
+			prefsPrivate->rlsContext.info =
+				(void *)context->retain(context->info);
+		}
+	}
+	return TRUE;
+}
+
+Boolean
+SCPreferencesSetDispatchQueue(SCPreferencesRef prefs, dispatch_queue_t queue)
+{
+	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
+	SCDynamicStoreContext	storeContext;
+	SCDynamicStoreRef	store;
+	CFStringRef		storeName;
+	CFStringRef		commitKey;
+	CFArrayRef		watchKeys;
+	Boolean			ok;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+
+	if (queue == NULL) {
+		/* unschedule */
+		if (prefsPrivate->notifyStore == NULL) {
+			_SCErrorSet(kSCStatusInvalidArgument);
+			return FALSE;
+		}
+		(void) SCDynamicStoreSetDispatchQueue(prefsPrivate->notifyStore,
+						      NULL);
+		CFRelease(prefsPrivate->notifyStore);
+		prefsPrivate->notifyStore = NULL;
+		return TRUE;
+	}
+
+	if (prefsPrivate->notifyStore != NULL) {
+		/* already scheduled */
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	/*
+	 * Watch our commit key on an internal SCDynamicStore session. The
+	 * context does not retain `prefs`: the SCPreferences object owns
+	 * the store and tears it down in its finalizer (after which the
+	 * store delivers no further callouts).
+	 */
+	memset(&storeContext, 0, sizeof(storeContext));
+	storeContext.info = (void *)prefs;
+
+	storeName = CFStringCreateWithCString(NULL, "SCPreferences",
+					      kCFStringEncodingUTF8);
+	store = SCDynamicStoreCreate(NULL, storeName, prefsNotify,
+				     &storeContext);
+	if (storeName != NULL) {
+		CFRelease(storeName);
+	}
+	if (store == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+
+	commitKey = __SCPreferencesCommitKey(prefs);
+	if (commitKey == NULL) {
+		CFRelease(store);
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+	watchKeys = CFArrayCreate(NULL, (const void **)&commitKey, 1,
+				  &kCFTypeArrayCallBacks);
+	ok = (watchKeys != NULL) &&
+	     SCDynamicStoreSetNotificationKeys(store, watchKeys, NULL);
+	if (watchKeys != NULL) {
+		CFRelease(watchKeys);
+	}
+	CFRelease(commitKey);
+	if (!ok) {
+		CFRelease(store);
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+
+	if (!SCDynamicStoreSetDispatchQueue(store, queue)) {
+		CFRelease(store);
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+
+	prefsPrivate->notifyStore = store;
+	return TRUE;
+}
+
+/*
+ * Post a change on the commit key so watching sessions are notified.
+ * Best effort: if configd is unreachable the commit still succeeded.
+ */
+static void
+__SCPreferencesPostCommit(SCPreferencesRef prefs)
+{
+	SCDynamicStoreRef	store;
+	CFStringRef		storeName;
+	CFStringRef		commitKey;
+
+	storeName = CFStringCreateWithCString(NULL, "SCPreferences",
+					      kCFStringEncodingUTF8);
+	store = SCDynamicStoreCreate(NULL, storeName, NULL, NULL);
+	if (storeName != NULL) {
+		CFRelease(storeName);
+	}
+	if (store == NULL) {
+		return;
+	}
+
+	commitKey = __SCPreferencesCommitKey(prefs);
+	if (commitKey != NULL) {
+		(void) SCDynamicStoreNotifyValue(store, commitKey);
+		CFRelease(commitKey);
+	}
+	CFRelease(store);
 }

--- a/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
@@ -207,6 +207,15 @@ SCDynamicStoreRemoveValue	(SCDynamicStoreRef		store,
 				 CFStringRef			key);
 
 /*!
+	@function SCDynamicStoreNotifyValue
+	@discussion Posts a change notification for a key without altering
+		its value — sessions watching the key are notified.
+ */
+Boolean
+SCDynamicStoreNotifyValue	(SCDynamicStoreRef		store,
+				 CFStringRef			key);
+
+/*!
 	@function SCDynamicStoreSetNotificationKeys
 	@discussion Specifies the keys and key patterns the session wants
 		change notifications for. Replaces any previous set.

--- a/src/libSystemConfiguration/SystemConfiguration/SCPreferences.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCPreferences.h
@@ -33,6 +33,7 @@
 #define _SCPREFERENCES_H
 
 #include <sys/cdefs.h>
+#include <dispatch/dispatch.h>
 #include <CoreFoundation/CoreFoundation.h>
 
 /*!
@@ -41,6 +42,37 @@
 		type (see SCPreferencesGetTypeID()) — release with CFRelease().
  */
 typedef const struct __SCPreferences *	SCPreferencesRef;
+
+/*!
+	@enum SCPreferencesNotification
+	@discussion The kinds of change an SCPreferencesCallBack reports.
+ */
+typedef CFOptionFlags	SCPreferencesNotification;
+enum {
+	kSCPreferencesNotificationCommit	= 1<<0,	/* prefs committed */
+	kSCPreferencesNotificationApply		= 1<<1	/* prefs should apply */
+};
+
+/*!
+	@typedef SCPreferencesContext
+	@discussion Client-supplied data + callbacks for an SCPreferences
+		callback.
+ */
+typedef struct {
+	CFIndex		version;
+	void *		info;
+	const void *	(*retain)(const void *info);
+	void		(*release)(const void *info);
+	CFStringRef	(*copyDescription)(const void *info);
+} SCPreferencesContext;
+
+/*!
+	@typedef SCPreferencesCallBack
+	@discussion Invoked when the watched preferences change.
+ */
+typedef void (*SCPreferencesCallBack)(SCPreferencesRef		prefs,
+				      SCPreferencesNotification	notificationType,
+				      void *			info);
 
 __BEGIN_DECLS
 
@@ -160,6 +192,25 @@ SCPreferencesPathSetValue	(SCPreferencesRef		prefs,
 Boolean
 SCPreferencesPathRemoveValue	(SCPreferencesRef		prefs,
 				 CFStringRef			path);
+
+/*!
+	@function SCPreferencesSetCallback
+	@discussion Sets the callback invoked when the preferences change.
+ */
+Boolean
+SCPreferencesSetCallback	(SCPreferencesRef		prefs,
+				 SCPreferencesCallBack		callout,
+				 SCPreferencesContext		*context);
+
+/*!
+	@function SCPreferencesSetDispatchQueue
+	@discussion Schedules change-notification delivery onto a dispatch
+		queue: the SCPreferencesCallBack runs on `queue` when the
+		preferences are committed. Pass NULL to unschedule.
+ */
+Boolean
+SCPreferencesSetDispatchQueue	(SCPreferencesRef		prefs,
+				 dispatch_queue_t		queue);
 
 __END_DECLS
 

--- a/src/libSystemConfiguration/scprefsnotifytest.c
+++ b/src/libSystemConfiguration/scprefsnotifytest.c
@@ -1,0 +1,138 @@
+/*
+ * scprefsnotifytest.c — libSystemConfiguration SCPreferences change-
+ * notification test client.
+ *
+ * Exercises SCPreferencesSetCallback + SCPreferencesSetDispatchQueue:
+ * one session watches a preferences file on a dispatch queue, another
+ * commits a change to it, and the watcher's callback must fire. This
+ * crosses SCPreferences -> SCDynamicStore -> configd and back. run.sh
+ * runs it and boot-test.sh gates on the SC-PNOTIFY-OK / SC-PNOTIFY-FAIL
+ * marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <dispatch/dispatch.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define	SCPN_ID		"scprefsnotifytest.plist"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-PNOTIFY-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+/* shared between main and the notification callback */
+struct result {
+	dispatch_semaphore_t	sem;
+	int			committed;	/* commit notification seen */
+};
+
+/* runs on the dispatch queue when the watched preferences change */
+static void
+prefs_cb(SCPreferencesRef prefs, SCPreferencesNotification type, void *info)
+{
+	struct result	*r	= info;
+
+	(void)prefs;
+	if ((type & kSCPreferencesNotificationCommit) != 0) {
+		r->committed = 1;
+	}
+	dispatch_semaphore_signal(r->sem);
+}
+
+int
+main(void)
+{
+	SCPreferencesRef	watcher	= NULL;
+	SCPreferencesRef	writer	= NULL;
+	SCPreferencesContext	ctx;
+	struct result		r;
+	CFStringRef		watcherName, writerName, prefsID;
+	CFStringRef		key, value;
+	dispatch_queue_t	queue;
+	dispatch_semaphore_t	sem;
+	int			rc	= 1;
+
+	printf("scprefsnotifytest: SCPreferences change notifications\n");
+	fflush(stdout);
+
+	watcherName	= mkstr("scprefsnotifytest-watcher");
+	writerName	= mkstr("scprefsnotifytest-writer");
+	prefsID		= mkstr(SCPN_ID);
+	key		= mkstr("notifykey");
+	value		= mkstr("notifyvalue");
+	sem		= dispatch_semaphore_create(0);
+
+	r.sem		= sem;
+	r.committed	= 0;
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.info = &r;
+
+	watcher = SCPreferencesCreate(NULL, watcherName, prefsID);
+	writer  = SCPreferencesCreate(NULL, writerName, prefsID);
+	if ((watcher == NULL) || (writer == NULL)) {
+		fail("SCPreferencesCreate failed");
+		goto out;
+	}
+
+	/* the watcher takes a callback on a dispatch queue */
+	if (!SCPreferencesSetCallback(watcher, prefs_cb, &ctx)) {
+		fail("SCPreferencesSetCallback failed");
+		goto out;
+	}
+	queue = dispatch_queue_create("scprefsnotifytest", NULL);
+	if (!SCPreferencesSetDispatchQueue(watcher, queue)) {
+		fail("SCPreferencesSetDispatchQueue failed");
+		goto out;
+	}
+	printf("  watcher: callback scheduled\n");
+
+	/* the writer commits a change */
+	if (!SCPreferencesSetValue(writer, key, value) ||
+	    !SCPreferencesCommitChanges(writer)) {
+		fail("writer SetValue/CommitChanges failed");
+		goto out;
+	}
+	printf("  writer: committed a change — waiting for the callback\n");
+
+	/* wait up to 5s for the watcher's callback */
+	if (dispatch_semaphore_wait(sem,
+		dispatch_time(DISPATCH_TIME_NOW,
+			      (int64_t)5 * 1000 * 1000 * 1000)) != 0) {
+		fail("no SCPreferences callback within 5s");
+		goto out;
+	}
+	if (!r.committed) {
+		fail("callback fired without kSCPreferencesNotificationCommit");
+		goto out;
+	}
+	printf("  watcher: commit notification delivered\n");
+
+	(void) SCPreferencesSetDispatchQueue(watcher, NULL);
+
+	printf("SC-PNOTIFY-OK: SCPreferences change notifications work\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (watcher != NULL) CFRelease(watcher);
+	if (writer != NULL)  CFRelease(writer);
+	CFRelease(watcherName);
+	CFRelease(writerName);
+	CFRelease(prefsID);
+	CFRelease(key);
+	CFRelease(value);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -537,6 +537,18 @@ expect {
     "SC-LOCK-OK" { puts "\nOK: SCPreferences lock works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-PNOTIFY marker not seen"
+        exit 1
+    }
+    "SC-PNOTIFY-FAIL" {
+        puts "\nFAIL: SCPreferences change-notification delivery failed"
+        exit 1
+    }
+    "SC-PNOTIFY-OK" { puts "\nOK: SCPreferences change notifications work" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

Fourth iteration of **SCPreferences** — change notifications: a session watching a preferences file is told when it is committed.

## New API

| Function | Notes |
|----------|-------|
| `SCPreferencesSetCallback(prefs, callout, context)` | the change callback |
| `SCPreferencesSetDispatchQueue(prefs, queue)` | deliver the callback onto a dispatch queue; `NULL` unschedules |
| `SCDynamicStoreNotifyValue(store, key)` | post a change for a key without altering it (→ configd's `confignotify`); previously missing from the SCDynamicStore client |

Plus the types `SCPreferencesContext`, `SCPreferencesCallBack`, `SCPreferencesNotification`.

## How it works

SCPreferences notifications ride an **internal SCDynamicStore session**. A commit key is derived from the preferences file path; `SCPreferencesCommitChanges` posts a change on it (`SCDynamicStoreNotifyValue`) once the file is written, and `SCPreferencesSetDispatchQueue` opens an internal SCDynamicStore that watches that key and runs the `SCPreferencesCallBack` on the caller's queue.

The internal store's callback context does **not** retain the SCPreferences object (no reference cycle); the finalizer tears the store down, after which SCDynamicStore delivers no further callouts (a cancelled store skips queued callouts via its notify-status check).

## Test

New `scprefsnotifytest` crosses SCPreferences → SCDynamicStore → configd and back: a watcher on a dispatch queue, a writer that commits, the callback must fire. Gated by a new `SC-PNOTIFY` boot marker.

## Verified

All library sources syntax-checked clean under `-Wall`.

This is the last of the three SCPreferences round-out pieces (after the path accessors and the lock); SCPreferences is now a complete component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)