### PR TITLE
feat(libSystemConfiguration): SCNetworkConfiguration iter 1 — SCPreferences path links

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1225,6 +1225,24 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scprefsnotifytest" \
     || { echo "FAIL: scprefsnotifytest not built"; exit 1; }
 echo "==> scprefsnotifytest built"
 
+# scplinktest — libSystemConfiguration SCNetworkConfiguration iter 1
+# test client. Exercises the SCPreferences path link accessors that
+# SCNetworkConfiguration is built on: SCPreferencesPathCreateUnique
+# Child, SCPreferencesPathSet/GetLink, and __LINK__ resolution (leaf
+# and mid-path) by SCPreferencesPathGetValue. run.sh runs it and checks
+# for the SC-PLINK-OK marker.
+echo "==> building scplinktest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scplinktest" \
+   "$ROOT/src/libSystemConfiguration/scplinktest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scplinktest" \
+    || { echo "FAIL: scplinktest not built"; exit 1; }
+echo "==> scplinktest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -587,4 +587,14 @@ if [ ! -x "$scprefsnotifytest" ]; then
 fi
 "$scprefsnotifytest" || true	# marker (SC-PNOTIFY-OK/FAIL) gates in boot-test.sh
 
+# SC-PLINK — SCPreferences path links (the SCNetworkConfiguration
+# prerequisite): create a unique child entry, store + read a __LINK__,
+# resolve a path through the link, and confirm the link persists.
+scplinktest=/usr/tests/freebsd-launchd-mach/scplinktest
+if [ ! -x "$scplinktest" ]; then
+    echo "SC-PLINK-FAIL: $scplinktest missing"
+    exit 1
+fi
+"$scplinktest" || true	# marker (SC-PLINK-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/SCD.c
+++ b/src/libSystemConfiguration/SCD.c
@@ -85,6 +85,8 @@ SCErrorString(int status)
 		return "Configuration daemon not (no longer) available";
 	case kSCStatusNotifierActive :
 		return "Notifier is currently active";
+	case kSCStatusMaxLink :
+		return "Maximum link count exceeded";
 	case kSCStatusNoPrefsSession :
 		return "Preferences session not active";
 	case kSCStatusPrefsBusy :

--- a/src/libSystemConfiguration/SCInternal.h
+++ b/src/libSystemConfiguration/SCInternal.h
@@ -37,9 +37,11 @@
 
 /*
  * SCPreferences status codes — likewise client-side, absent from
- * config_types.h. Guarded the same way.
+ * config_types.h. Guarded the same way. kSCStatusMaxLink is reported by
+ * the SCPreferencesPath* link walker when a __LINK__ chain loops.
  */
 #ifndef kSCStatusNoPrefsSession
+#define kSCStatusMaxLink	3006
 #define kSCStatusNoPrefsSession	5001
 #define kSCStatusPrefsBusy	5002
 #define kSCStatusNoConfigFile	5003

--- a/src/libSystemConfiguration/SCPreferences.c
+++ b/src/libSystemConfiguration/SCPreferences.c
@@ -644,6 +644,16 @@ SCPreferencesCommitChanges(SCPreferencesRef prefs)
 #pragma mark Path-based access
 
 /*
+ * A path component whose dictionary holds the reserved kSCResvLink key
+ * is a link: the value of that key is another '/'-separated path, and
+ * walking into the component continues from there instead. This is how
+ * SCNetworkSet entries reference the SCNetworkService dictionaries they
+ * are made of. MAXLINKS bounds a chain so a cycle cannot spin forever.
+ */
+#define	kSCResvLink	CFSTR("__LINK__")
+#define	MAXLINKS	8
+
+/*
  * Split a '/'-rooted path into its non-empty components. Returns a
  * retained CFArray of CFString (caller releases), or NULL.
  */
@@ -694,7 +704,8 @@ normalizePath(CFStringRef path)
 }
 
 /*
- * Walk `path` through the nested preferences dictionaries; on success
+ * Walk `path` through the nested preferences dictionaries, following
+ * any kSCResvLink indirection met at a non-final component; on success
  * *entity is the dictionary found there (owned by the session).
  */
 static Boolean
@@ -703,7 +714,10 @@ getPath(SCPreferencesRef prefs, CFStringRef path, CFDictionaryRef *entity)
 	SCPreferencesPrivateRef	prefsPrivate	= (SCPreferencesPrivateRef)prefs;
 	CFMutableArrayRef	elements;
 	CFIndex			i;
+	CFStringRef		link;
 	CFIndex			n;
+	CFIndex			nLinks		= 0;
+	Boolean			ok		= FALSE;
 	CFTypeRef		value		= NULL;
 
 	elements = normalizePath(path);
@@ -712,13 +726,14 @@ getPath(SCPreferencesRef prefs, CFStringRef path, CFDictionaryRef *entity)
 		return FALSE;
 	}
 
+    restart :
 	n = CFArrayGetCount(elements);
 	if (n < 1) {
 		/* the root path — the whole preferences dictionary */
 		__SCPreferencesAccess(prefs);
 		*entity = prefsPrivate->prefs;
-		CFRelease(elements);
-		return TRUE;
+		ok = TRUE;
+		goto done;
 	}
 
 	for (i = 0; i < n; i++) {
@@ -733,14 +748,44 @@ getPath(SCPreferencesRef prefs, CFStringRef path, CFDictionaryRef *entity)
 		if ((value == NULL) ||
 		    (CFGetTypeID(value) != CFDictionaryGetTypeID())) {
 			_SCErrorSet(kSCStatusNoKey);
+			goto done;
+		}
+
+		/*
+		 * If this is not the last component and the dictionary
+		 * here is a link, splice the link target's components in
+		 * front of the components still to walk and start over.
+		 */
+		if ((i < n - 1) &&
+		    CFDictionaryGetValueIfPresent((CFDictionaryRef)value,
+						  kSCResvLink,
+						  (const void **)&link)) {
+			CFMutableArrayRef	linkElements;
+
+			if (++nLinks > MAXLINKS) {
+				/* a link chain that loops back on itself */
+				_SCErrorSet(kSCStatusMaxLink);
+				goto done;
+			}
+			linkElements = normalizePath(link);
+			if (linkElements == NULL) {
+				_SCErrorSet(kSCStatusNoKey);
+				goto done;
+			}
+			CFArrayAppendArray(linkElements, elements,
+					   CFRangeMake(i + 1, n - i - 1));
 			CFRelease(elements);
-			return FALSE;
+			elements = linkElements;
+			goto restart;
 		}
 	}
 
 	*entity = (CFDictionaryRef)value;
+	ok = TRUE;
+
+    done :
 	CFRelease(elements);
-	return TRUE;
+	return ok;
 }
 
 /*
@@ -757,10 +802,12 @@ setPath(SCPreferencesRef prefs, CFStringRef path, CFDictionaryRef entity)
 	CFMutableArrayRef	elements;
 	CFMutableArrayRef	nodes		= NULL;
 	CFStringRef		element;
+	CFStringRef		link;
 	CFTypeRef		node		= NULL;
 	CFTypeRef		newEntity	= NULL;
 	CFIndex			i;
 	CFIndex			n;
+	CFIndex			nLinks		= 0;
 	Boolean			ok		= FALSE;
 
 	if ((entity != NULL) &&
@@ -775,6 +822,7 @@ setPath(SCPreferencesRef prefs, CFStringRef path, CFDictionaryRef entity)
 		return FALSE;
 	}
 
+    restart :
 	n = CFArrayGetCount(elements);
 	if (n < 1) {
 		/* the root path — replace the whole preferences dictionary */
@@ -792,8 +840,8 @@ setPath(SCPreferencesRef prefs, CFStringRef path, CFDictionaryRef entity)
 				CFDictionaryCreateMutableCopy(NULL, 0, entity);
 		}
 		prefsPrivate->changed = TRUE;
-		CFRelease(elements);
-		return TRUE;
+		ok = TRUE;
+		goto done;
 	}
 
 	/* collect the existing dictionary at each parent level */
@@ -822,6 +870,34 @@ setPath(SCPreferencesRef prefs, CFStringRef path, CFDictionaryRef entity)
 		if (CFGetTypeID(node) != CFDictionaryGetTypeID()) {
 			_SCErrorSet(kSCStatusNoKey);
 			goto done;
+		}
+
+		/*
+		 * If this parent is a link, splice the link target's
+		 * components in front of those still to walk, drop the
+		 * collected nodes and start the collection over.
+		 */
+		if (CFDictionaryGetValueIfPresent((CFDictionaryRef)node,
+						  kSCResvLink,
+						  (const void **)&link)) {
+			CFMutableArrayRef	linkElements;
+
+			if (++nLinks > MAXLINKS) {
+				_SCErrorSet(kSCStatusMaxLink);
+				goto done;
+			}
+			linkElements = normalizePath(link);
+			if (linkElements == NULL) {
+				_SCErrorSet(kSCStatusNoKey);
+				goto done;
+			}
+			CFArrayAppendArray(linkElements, elements,
+					   CFRangeMake(i + 1, n - i - 1));
+			CFRelease(elements);
+			elements = linkElements;
+			CFRelease(nodes);
+			nodes = NULL;
+			goto restart;
 		}
 	}
 
@@ -889,6 +965,7 @@ CFDictionaryRef
 SCPreferencesPathGetValue(SCPreferencesRef prefs, CFStringRef path)
 {
 	CFDictionaryRef	entity	= NULL;
+	CFStringRef	link;
 
 	if (!isA_SCPreferences(prefs)) {
 		_SCErrorSet(kSCStatusNoPrefsSession);
@@ -896,6 +973,15 @@ SCPreferencesPathGetValue(SCPreferencesRef prefs, CFStringRef path)
 	}
 	if (!getPath(prefs, path, &entity)) {
 		return NULL;
+	}
+	/* if the entity at the path is itself a link, follow it */
+	if ((entity != NULL) &&
+	    (CFGetTypeID(entity) == CFDictionaryGetTypeID()) &&
+	    CFDictionaryGetValueIfPresent(entity, kSCResvLink,
+					  (const void **)&link)) {
+		if (!getPath(prefs, link, &entity)) {
+			return NULL;
+		}
 	}
 	return entity;
 }
@@ -930,6 +1016,128 @@ SCPreferencesPathRemoveValue(SCPreferencesRef prefs, CFStringRef path)
 		return FALSE;
 	}
 	return setPath(prefs, path, NULL);
+}
+
+/*
+ * Return the link target if the dictionary at `path` is a link, else
+ * NULL. Unlike SCPreferencesPathGetValue this does not follow the link
+ * — it reports the raw kSCResvLink value.
+ */
+CFStringRef
+SCPreferencesPathGetLink(SCPreferencesRef prefs, CFStringRef path)
+{
+	CFDictionaryRef	entity	= NULL;
+	CFStringRef	link;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return NULL;
+	}
+	if (!getPath(prefs, path, &entity)) {
+		return NULL;
+	}
+	if ((entity != NULL) &&
+	    (CFGetTypeID(entity) == CFDictionaryGetTypeID()) &&
+	    CFDictionaryGetValueIfPresent(entity, kSCResvLink,
+					  (const void **)&link)) {
+		return link;
+	}
+	return NULL;
+}
+
+/*
+ * Store a link at `path`: a one-entry dictionary { kSCResvLink = link }.
+ * The link target must already exist (so a session never links into
+ * nothing); subsequent walks through `path` continue from `link`.
+ */
+Boolean
+SCPreferencesPathSetLink(SCPreferencesRef prefs,
+			 CFStringRef	  path,
+			 CFStringRef	  link)
+{
+	CFMutableDictionaryRef	dict;
+	CFDictionaryRef		entity	= NULL;
+	Boolean			ok;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return FALSE;
+	}
+	if ((link == NULL) ||
+	    (CFGetTypeID(link) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	/* the link target must resolve */
+	if (!getPath(prefs, link, &entity)) {
+		return FALSE;
+	}
+
+	dict = CFDictionaryCreateMutable(NULL, 0,
+					 &kCFTypeDictionaryKeyCallBacks,
+					 &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(dict, kSCResvLink, link);
+	ok = setPath(prefs, path, dict);
+	CFRelease(dict);
+	return ok;
+}
+
+/*
+ * Create a uniquely-named empty child dictionary under `prefix` and
+ * return its full '/'-separated path (caller releases). The child name
+ * is a fresh UUID, so SCNetworkServiceCreate / SCNetworkSetCreate can
+ * mint a never-colliding entry. `prefix` need not exist yet, but it
+ * must not itself be a link.
+ */
+CFStringRef
+SCPreferencesPathCreateUniqueChild(SCPreferencesRef prefs, CFStringRef prefix)
+{
+	CFStringRef	child;
+	CFDictionaryRef	entity	= NULL;
+	CFDictionaryRef	newDict;
+	CFStringRef	newPath	= NULL;
+	CFUUIDRef	uuid;
+
+	if (!isA_SCPreferences(prefs)) {
+		_SCErrorSet(kSCStatusNoPrefsSession);
+		return NULL;
+	}
+	if ((prefix == NULL) ||
+	    (CFGetTypeID(prefix) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	if (getPath(prefs, prefix, &entity)) {
+		/* the prefix exists — it must not be a link */
+		if ((entity != NULL) &&
+		    (CFGetTypeID(entity) == CFDictionaryGetTypeID()) &&
+		    CFDictionaryContainsKey(entity, kSCResvLink)) {
+			_SCErrorSet(kSCStatusFailed);
+			return NULL;
+		}
+	} else if (SCError() != kSCStatusNoKey) {
+		/* any error other than "the prefix is not present yet" */
+		return NULL;
+	}
+
+	uuid	= CFUUIDCreate(NULL);
+	child	= CFUUIDCreateString(NULL, uuid);
+	CFRelease(uuid);
+	newPath	= CFStringCreateWithFormat(NULL, NULL, CFSTR("%@/%@"),
+					   prefix, child);
+	CFRelease(child);
+
+	/* store a fresh, empty dictionary at the unique child path */
+	newDict = CFDictionaryCreate(NULL, NULL, NULL, 0,
+				     &kCFTypeDictionaryKeyCallBacks,
+				     &kCFTypeDictionaryValueCallBacks);
+	if (!setPath(prefs, newPath, newDict)) {
+		CFRelease(newPath);
+		newPath = NULL;
+	}
+	CFRelease(newDict);
+	return newPath;
 }
 
 

--- a/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCDynamicStore.h
@@ -83,6 +83,7 @@ enum {
 	kSCStatusNoStoreSession		= 2001,	/* no open store session */
 	kSCStatusNoStoreServer		= 2002,	/* configd not (no longer) available */
 	kSCStatusNotifierActive		= 2003,	/* notifier already active */
+	kSCStatusMaxLink		= 3006,	/* maximum link count exceeded */
 	kSCStatusNoPrefsSession		= 5001,	/* no open preferences session */
 	kSCStatusPrefsBusy		= 5002,	/* preferences update in progress */
 	kSCStatusNoConfigFile		= 5003,	/* no configuration file */

--- a/src/libSystemConfiguration/SystemConfiguration/SCPreferences.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCPreferences.h
@@ -194,6 +194,39 @@ SCPreferencesPathRemoveValue	(SCPreferencesRef		prefs,
 				 CFStringRef			path);
 
 /*!
+	@function SCPreferencesPathCreateUniqueChild
+	@discussion Creates a uniquely-named empty child dictionary under
+		`prefix` and returns its full '/'-separated path (caller
+		releases). The child name is a fresh UUID, so a new entry
+		never collides with an existing one.
+ */
+CFStringRef
+SCPreferencesPathCreateUniqueChild
+				(SCPreferencesRef		prefs,
+				 CFStringRef			prefix);
+
+/*!
+	@function SCPreferencesPathGetLink
+	@discussion Returns the link target if the dictionary at `path` is
+		a link, or NULL. Unlike SCPreferencesPathGetValue this does
+		not follow the link.
+ */
+CFStringRef
+SCPreferencesPathGetLink	(SCPreferencesRef		prefs,
+				 CFStringRef			path);
+
+/*!
+	@function SCPreferencesPathSetLink
+	@discussion Stores a link at `path` pointing at `link`; subsequent
+		path walks through `path` continue from `link`. The link
+		target must already exist.
+ */
+Boolean
+SCPreferencesPathSetLink	(SCPreferencesRef		prefs,
+				 CFStringRef			path,
+				 CFStringRef			link);
+
+/*!
 	@function SCPreferencesSetCallback
 	@discussion Sets the callback invoked when the preferences change.
  */

--- a/src/libSystemConfiguration/scplinktest.c
+++ b/src/libSystemConfiguration/scplinktest.c
@@ -1,0 +1,256 @@
+/*
+ * scplinktest.c — libSystemConfiguration SCNetworkConfiguration iter 1
+ * test client: the SCPreferences path link / unique-child accessors.
+ *
+ * These are the SCPreferences pieces SCNetworkConfiguration is built on
+ * — SCNetworkServiceCreate mints entries with SCPreferencesPathCreate
+ * UniqueChild, and SCNetworkSet references its services through
+ * __LINK__ dictionaries. This client exercises:
+ *
+ *   - SCPreferencesPathCreateUniqueChild: a fresh empty child entry;
+ *   - SCPreferencesPathSetLink / GetLink: store + read a raw link;
+ *   - SCPreferencesPathGetValue through a link, both at the leaf and
+ *     mid-path (a component walked *through*);
+ *   - commit / reopen: the link survives a round-trip to the file;
+ *   - SetLink rejects a dangling target;
+ *   - a __LINK__ cycle is caught with kSCStatusMaxLink.
+ *
+ * run.sh runs it and boot-test.sh gates on the SC-PLINK-OK / -FAIL
+ * marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+#define	SCT_ID		"scplinktest.plist"
+#define	SCT_PREFIX	"/NetworkServices"
+#define	SCT_LINK	"/Sets/set1/Network/Service/link0"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-PLINK-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+/* a single-entry dictionary { key: value } */
+static CFDictionaryRef
+mkdict1(const char *key, const char *value)
+{
+	CFStringRef		k	= mkstr(key);
+	CFStringRef		v	= mkstr(value);
+	CFDictionaryRef		d;
+	const void		*kk[1]	= { k };
+	const void		*vv[1]	= { v };
+
+	d = CFDictionaryCreate(NULL, kk, vv, 1,
+			       &kCFTypeDictionaryKeyCallBacks,
+			       &kCFTypeDictionaryValueCallBacks);
+	CFRelease(k);
+	CFRelease(v);
+	return d;
+}
+
+/* TRUE iff dict[key] is the string `want` */
+static Boolean
+dict_has(CFDictionaryRef dict, const char *key, const char *want)
+{
+	CFStringRef	k	= mkstr(key);
+	CFStringRef	w	= mkstr(want);
+	CFTypeRef	v;
+	Boolean		ok;
+
+	v  = (dict != NULL) ? CFDictionaryGetValue(dict, k) : NULL;
+	ok = (v != NULL) && CFEqual(v, w);
+	CFRelease(k);
+	CFRelease(w);
+	return ok;
+}
+
+int
+main(void)
+{
+	SCPreferencesRef	prefs	= NULL;
+	CFStringRef		name, prefsID;
+	CFStringRef		prefix, linkPath, ipv4Path = NULL;
+	CFStringRef		child	= NULL;
+	CFStringRef		gotLink;
+	CFDictionaryRef		svc	= NULL, ipv4 = NULL, got;
+	int			rc	= 1;
+
+	printf("scplinktest: SCPreferences path links + unique child\n");
+	fflush(stdout);
+
+	name	 = mkstr("scplinktest");
+	prefsID	 = mkstr(SCT_ID);
+	prefix	 = mkstr(SCT_PREFIX);
+	linkPath = mkstr(SCT_LINK);
+	svc	 = mkdict1("UserDefinedName", "TestService");
+	ipv4	 = mkdict1("Method", "DHCP");
+
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate failed");
+		goto out;
+	}
+
+	/* a fresh, uniquely-named child entry under /NetworkServices */
+	child = SCPreferencesPathCreateUniqueChild(prefs, prefix);
+	if (child == NULL) {
+		fail("SCPreferencesPathCreateUniqueChild returned NULL");
+		goto out;
+	}
+	if (!CFStringHasPrefix(child, prefix)) {
+		fail("unique child path not rooted at the prefix");
+		goto out;
+	}
+	got = SCPreferencesPathGetValue(prefs, child);
+	if ((got == NULL) || (CFDictionaryGetCount(got) != 0)) {
+		fail("unique child is not an empty dictionary");
+		goto out;
+	}
+	printf("  PathCreateUniqueChild: created an entry\n");
+
+	/* give the entry some content + a nested IPv4 sub-entity */
+	if (!SCPreferencesPathSetValue(prefs, child, svc)) {
+		fail("SCPreferencesPathSetValue (child) failed");
+		goto out;
+	}
+	ipv4Path = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@/IPv4"),
+					    child);
+	if (!SCPreferencesPathSetValue(prefs, ipv4Path, ipv4)) {
+		fail("SCPreferencesPathSetValue (child/IPv4) failed");
+		goto out;
+	}
+
+	/* link a Sets path at the service entry */
+	if (!SCPreferencesPathSetLink(prefs, linkPath, child)) {
+		fail("SCPreferencesPathSetLink failed");
+		goto out;
+	}
+	gotLink = SCPreferencesPathGetLink(prefs, linkPath);
+	if ((gotLink == NULL) || !CFEqual(gotLink, child)) {
+		fail("SCPreferencesPathGetLink did not round-trip");
+		goto out;
+	}
+	printf("  PathSetLink/GetLink: link round-trips\n");
+
+	/* GetValue at the link path follows the link to the target */
+	got = SCPreferencesPathGetValue(prefs, linkPath);
+	if (!dict_has(got, "UserDefinedName", "TestService")) {
+		fail("GetValue did not follow the leaf link");
+		goto out;
+	}
+
+	/* GetValue *through* the link resolves a mid-path component */
+	{
+		CFStringRef	deep;
+
+		deep = CFStringCreateWithFormat(NULL, NULL,
+						CFSTR("%@/IPv4"), linkPath);
+		got  = SCPreferencesPathGetValue(prefs, deep);
+		CFRelease(deep);
+		if (!dict_has(got, "Method", "DHCP")) {
+			fail("GetValue did not follow a mid-path link");
+			goto out;
+		}
+	}
+	printf("  PathGetValue: leaf + mid-path link resolution OK\n");
+
+	/* commit, re-open, confirm the link persisted */
+	if (!SCPreferencesCommitChanges(prefs)) {
+		fail("SCPreferencesCommitChanges failed");
+		goto out;
+	}
+	CFRelease(prefs);
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate (reopen) failed");
+		goto out;
+	}
+	gotLink = SCPreferencesPathGetLink(prefs, linkPath);
+	if ((gotLink == NULL) || !CFEqual(gotLink, child)) {
+		fail("link did not persist across commit/reopen");
+		goto out;
+	}
+	{
+		CFStringRef	deep;
+
+		deep = CFStringCreateWithFormat(NULL, NULL,
+						CFSTR("%@/IPv4"), linkPath);
+		got  = SCPreferencesPathGetValue(prefs, deep);
+		CFRelease(deep);
+		if (!dict_has(got, "Method", "DHCP")) {
+			fail("linked content did not persist");
+			goto out;
+		}
+	}
+	printf("  CommitChanges/reopen: link persisted\n");
+
+	/* SetLink must reject a dangling target */
+	{
+		CFStringRef	bad	= mkstr("/no/such/target");
+		CFStringRef	badAt	= mkstr("/bad/link");
+		Boolean		ok	= SCPreferencesPathSetLink(prefs,
+							badAt, bad);
+		CFRelease(bad);
+		CFRelease(badAt);
+		if (ok) {
+			fail("SetLink accepted a dangling target");
+			goto out;
+		}
+	}
+
+	/* a __LINK__ cycle must be caught with kSCStatusMaxLink */
+	{
+		CFStringRef	pa	= mkstr("/cyc/a");
+		CFStringRef	pb	= mkstr("/cyc/b");
+		CFStringRef	probe	= mkstr("/cyc/a/x");
+		CFDictionaryRef	la	= mkdict1("__LINK__", "/cyc/b");
+		CFDictionaryRef	lb	= mkdict1("__LINK__", "/cyc/a");
+		Boolean		set;
+
+		set = SCPreferencesPathSetValue(prefs, pa, la) &&
+		      SCPreferencesPathSetValue(prefs, pb, lb);
+		got = set ? SCPreferencesPathGetValue(prefs, probe) : NULL;
+		CFRelease(pa);
+		CFRelease(pb);
+		CFRelease(probe);
+		CFRelease(la);
+		CFRelease(lb);
+		if (!set) {
+			fail("could not stage the link cycle");
+			goto out;
+		}
+		/* walking the cycle must fail with the link-count error */
+		if ((got != NULL) || (SCError() != kSCStatusMaxLink)) {
+			fail("link cycle not caught with kSCStatusMaxLink");
+			goto out;
+		}
+	}
+	printf("  link cycle caught (kSCStatusMaxLink); dangling link rejected\n");
+
+	printf("SC-PLINK-OK: SCPreferences path links work\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (prefs != NULL)	CFRelease(prefs);
+	if (child != NULL)	CFRelease(child);
+	if (ipv4Path != NULL)	CFRelease(ipv4Path);
+	if (svc != NULL)	CFRelease(svc);
+	if (ipv4 != NULL)	CFRelease(ipv4);
+	CFRelease(name);
+	CFRelease(prefsID);
+	CFRelease(prefix);
+	CFRelease(linkPath);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -549,6 +549,18 @@ expect {
     "SC-PNOTIFY-OK" { puts "\nOK: SCPreferences change notifications work" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-PLINK marker not seen"
+        exit 1
+    }
+    "SC-PLINK-FAIL" {
+        puts "\nFAIL: SCPreferences path links failed"
+        exit 1
+    }
+    "SC-PLINK-OK" { puts "\nOK: SCPreferences path links work" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## SCNetworkConfiguration iter 1 — the SCPreferences prerequisite

First iteration of the **SCNetworkConfiguration** port (full port, scoped into 5 iterations). SCNetworkConfiguration's CF-typed network-service / interface / protocol / set model is layered on the SCPreferences `/`-separated path accessors:

- `SCNetworkServiceCreate` / `SCNetworkSetCreate` mint entries with `SCPreferencesPathCreateUniqueChild`;
- an `SCNetworkSet` references its services through `__LINK__` indirection.

Both pieces were listed *REMAINING* in SCPreferences iter 3 but never landed (iter 4 did notifications instead). This iteration completes them.

### Changes — ported from Apple's `SCPPath.c`

- `getPath` / `setPath` now follow a `kSCResvLink` (`"__LINK__"`) dictionary met at a **non-final** path component: the link target's components are spliced in front of the components still to walk and the walk restarts. A `MAXLINKS` (8) bound catches a link chain that loops back on itself → `kSCStatusMaxLink` (3006), added to the public `kSCStatus` enum, the `SCInternal.h` guarded defines, and `SCErrorString`.
- `SCPreferencesPathGetValue` follows a link at the **leaf** too.
- **`SCPreferencesPathCreateUniqueChild`** — a fresh UUID-named empty child entry under a prefix.
- **`SCPreferencesPathGetLink` / `SCPreferencesPathSetLink`** — read / store a raw link.

### Test

New `scplinktest` (`SC-PLINK` boot marker) exercises: unique-child creation, link `Set`/`Get` round-trip, link resolution at the leaf and mid-path, commit/reopen persistence, a rejected dangling link, and a `__LINK__` cycle caught with `kSCStatusMaxLink`. Wired into `build.sh`, `run.sh`, and `boot-test.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)