### PR TITLE
feat(libSystemConfiguration): SCNetworkConfiguration iter 2 — SCNetworkInterface

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1243,6 +1243,24 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scplinktest" \
     || { echo "FAIL: scplinktest not built"; exit 1; }
 echo "==> scplinktest built"
 
+# scnetiftest — libSystemConfiguration SCNetworkConfiguration iter 2
+# test client. Exercises SCNetworkInterfaceCopyAll + the interface
+# accessors: the QEMU guest boots with one e1000 NIC, so the
+# enumeration must report an Ethernet interface with a hardware
+# address and exclude loopback. run.sh runs it and checks for the
+# SC-NETIF-OK marker.
+echo "==> building scnetiftest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scnetiftest" \
+   "$ROOT/src/libSystemConfiguration/scnetiftest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scnetiftest" \
+    || { echo "FAIL: scnetiftest not built"; exit 1; }
+echo "==> scnetiftest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -597,4 +597,14 @@ if [ ! -x "$scplinktest" ]; then
 fi
 "$scplinktest" || true	# marker (SC-PLINK-OK/FAIL) gates in boot-test.sh
 
+# SC-NETIF — SCNetworkConfiguration interface enumeration: list the
+# network interfaces and confirm the e1000 NIC is reported as an
+# Ethernet interface with a hardware address, loopback excluded.
+scnetiftest=/usr/tests/freebsd-launchd-mach/scnetiftest
+if [ ! -x "$scnetiftest" ]; then
+    echo "SC-NETIF-FAIL: $scnetiftest missing"
+    exit 1
+fi
+"$scnetiftest" || true	# marker (SC-NETIF-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/Makefile
+++ b/src/libSystemConfiguration/Makefile
@@ -21,6 +21,7 @@ LIB=		SystemConfiguration
 SHLIB_MAJOR=	1
 
 SRCS=		SCD.c SCDynamicStore.c SCNotify.c SCDMultiple.c SCPreferences.c
+SRCS+=		SCNetworkConfigurationInternal.c SCNetworkInterface.c
 
 # configUser.c — MIG-generated config.defs client stubs (same file
 # configd's test clients link). config_wire.c — configd's shared
@@ -68,6 +69,7 @@ LDADD+=		-L${SYSROOT}/usr/lib/system
 .endif
 
 INCS=		SystemConfiguration/SCDynamicStore.h \
+		SystemConfiguration/SCNetworkConfiguration.h \
 		SystemConfiguration/SCPreferences.h \
 		SystemConfiguration/SystemConfiguration.h
 INCSDIR=	${PREFIX}/include/SystemConfiguration

--- a/src/libSystemConfiguration/SCNetworkConfigurationInternal.c
+++ b/src/libSystemConfiguration/SCNetworkConfigurationInternal.c
@@ -1,0 +1,37 @@
+/*
+ * SCNetworkConfigurationInternal.c — definitions shared across the
+ * SCNetworkConfiguration sources (freebsd-launchd-mach port).
+ *
+ * This file defines the kSCNetworkInterfaceType* and kSCNetworkProtocol
+ * Type* constant CFStrings. Apple spreads these across SCNetworkInterface.c
+ * and SCNetworkProtocol.c; collecting them here keeps every constant in
+ * one translation unit as the object families land iteration by
+ * iteration. The string values are the ones written into the preferences
+ * plist, so they match Apple's exactly.
+ */
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <SystemConfiguration/SCNetworkConfiguration.h>
+
+const CFStringRef kSCNetworkInterfaceType6to4		= CFSTR("6to4");
+const CFStringRef kSCNetworkInterfaceTypeBluetooth	= CFSTR("Bluetooth");
+const CFStringRef kSCNetworkInterfaceTypeBond		= CFSTR("Bond");
+const CFStringRef kSCNetworkInterfaceTypeBridge		= CFSTR("Bridge");
+const CFStringRef kSCNetworkInterfaceTypeEthernet	= CFSTR("Ethernet");
+const CFStringRef kSCNetworkInterfaceTypeFireWire	= CFSTR("FireWire");
+const CFStringRef kSCNetworkInterfaceTypeIEEE80211	= CFSTR("IEEE80211");
+const CFStringRef kSCNetworkInterfaceTypeIPSec		= CFSTR("IPSec");
+const CFStringRef kSCNetworkInterfaceTypeL2TP		= CFSTR("L2TP");
+const CFStringRef kSCNetworkInterfaceTypeLoopback	= CFSTR("Loopback");
+const CFStringRef kSCNetworkInterfaceTypeModem		= CFSTR("Modem");
+const CFStringRef kSCNetworkInterfaceTypePPP		= CFSTR("PPP");
+const CFStringRef kSCNetworkInterfaceTypeSerial		= CFSTR("Serial");
+const CFStringRef kSCNetworkInterfaceTypeVLAN		= CFSTR("VLAN");
+const CFStringRef kSCNetworkInterfaceTypeWWAN		= CFSTR("WWAN");
+const CFStringRef kSCNetworkInterfaceTypeIPv4		= CFSTR("IPv4");
+
+const CFStringRef kSCNetworkProtocolTypeDNS		= CFSTR("DNS");
+const CFStringRef kSCNetworkProtocolTypeIPv4		= CFSTR("IPv4");
+const CFStringRef kSCNetworkProtocolTypeIPv6		= CFSTR("IPv6");
+const CFStringRef kSCNetworkProtocolTypeProxies		= CFSTR("Proxies");
+const CFStringRef kSCNetworkProtocolTypeSMB		= CFSTR("SMB");

--- a/src/libSystemConfiguration/SCNetworkConfigurationInternal.h
+++ b/src/libSystemConfiguration/SCNetworkConfigurationInternal.h
@@ -1,0 +1,66 @@
+/*
+ * SCNetworkConfigurationInternal.h — private definitions shared by the
+ * SCNetworkConfiguration sources (freebsd-launchd-mach port of Apple's
+ * SystemConfiguration.fproj SCNetworkConfigurationInternal.h).
+ *
+ * Not installed.
+ */
+
+#ifndef _SCNETWORKCONFIGURATIONINTERNAL_H
+#define _SCNETWORKCONFIGURATIONINTERNAL_H
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreFoundation/CFRuntime.h>
+
+#include <SystemConfiguration/SCNetworkConfiguration.h>
+#include <SystemConfiguration/SCPreferences.h>
+
+/*
+ * The SCNetworkInterface object. A CoreFoundation runtime type — the
+ * leading CFRuntimeBase is filled in by _CFRuntimeCreateInstance(), and
+ * CFRetain() / CFRelease() drive its lifetime.
+ *
+ * A leaf (hardware) interface is the common case: SCNetworkInterfaceCopy
+ * All builds one per enumerated BSD interface. `interface` is non-NULL
+ * only for a layered interface (PPP-over-modem, VLAN, ...) — deferred to
+ * a later iteration. `prefs` / `serviceID` are set when the interface
+ * is bound to a stored network service (the SCNetworkService iteration).
+ */
+typedef struct __SCNetworkInterface {
+	CFRuntimeBase		cfBase;
+
+	/* interface identity */
+	CFStringRef		interface_type;		/* kSCNetworkInterfaceType* */
+	CFStringRef		entity_device;		/* BSD name, e.g. "en0" */
+
+	/* display names */
+	CFStringRef		name;			/* non-localized */
+	CFStringRef		localized_name;		/* localized */
+
+	/* link-layer (hardware) address */
+	CFDataRef		address;		/* raw bytes */
+	CFStringRef		addressString;		/* "xx:xx:..." */
+	Boolean			builtin;
+
+	/* layering — non-NULL only for a layered interface */
+	SCNetworkInterfaceRef	interface;
+
+	/* preferences entity bookkeeping (the SCNetworkService iteration) */
+	SCPreferencesRef	prefs;			/* bound prefs, or NULL */
+	CFStringRef		serviceID;		/* bound service, or NULL */
+	CFStringRef		entity_type;		/* prefs entity "Type" */
+	CFStringRef		entity_subtype;		/* prefs entity "SubType" */
+
+	/* what can be layered / configured on this interface */
+	CFArrayRef		supported_interface_types;
+	CFArrayRef		supported_protocol_types;
+} SCNetworkInterfacePrivate, *SCNetworkInterfacePrivateRef;
+
+/*
+ * SCNetworkInterface.c — allocate a bare SCNetworkInterface (every field
+ * NULL / FALSE). Returns a retained instance, or NULL with SCError() set.
+ */
+SCNetworkInterfacePrivateRef
+__SCNetworkInterfaceCreatePrivate	(CFAllocatorRef			allocator);
+
+#endif	/* _SCNETWORKCONFIGURATIONINTERNAL_H */

--- a/src/libSystemConfiguration/SCNetworkInterface.c
+++ b/src/libSystemConfiguration/SCNetworkInterface.c
@@ -1,0 +1,444 @@
+/*
+ * SCNetworkInterface.c — the SCNetworkInterface object (freebsd-launchd-
+ * mach port of Apple's SystemConfiguration.fproj SCNetworkInterface.c).
+ *
+ * An SCNetworkInterface is a CoreFoundation-typed handle to a network
+ * interface — its type (Ethernet, Wi-Fi, ...), BSD name, hardware (MAC)
+ * address, and the protocols that can be configured on it.
+ *
+ * Apple's SCNetworkInterface.c enumerates the hardware by walking the
+ * IORegistry (IONetworkInterface nodes, USB / PCI / Thunderbolt device
+ * matching) — there is no IOKit on FreeBSD, so SCNetworkInterfaceCopyAll
+ * here is a native reimplementation over getifaddrs(3): each AF_LINK
+ * record is one interface, and its sockaddr_dl carries the link-layer
+ * type and address. Layered (virtual) interfaces — Bond / Bridge / VLAN
+ * and the PPP family — are a later iteration; iter 2 covers the leaf
+ * hardware interfaces and their accessors.
+ */
+
+#include "SCNetworkConfigurationInternal.h"
+#include "SCInternal.h"
+
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <net/if_types.h>
+#include <pthread.h>
+#include <string.h>
+#include <sys/socket.h>
+
+
+#pragma mark -
+#pragma mark CoreFoundation runtime type
+
+static CFTypeID	__kSCNetworkInterfaceTypeID	= _kCFRuntimeNotATypeID;
+
+/* NULL-safe CFEqual: both NULL is equal, one NULL is not. */
+static Boolean
+__cfEqual(CFTypeRef a, CFTypeRef b)
+{
+	if (a == b) {
+		return TRUE;
+	}
+	if ((a == NULL) || (b == NULL)) {
+		return FALSE;
+	}
+	return CFEqual(a, b);
+}
+
+static void
+__SCNetworkInterfaceDeallocate(CFTypeRef cf)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)cf;
+
+	if (ip->interface_type != NULL)		CFRelease(ip->interface_type);
+	if (ip->entity_device != NULL)		CFRelease(ip->entity_device);
+	if (ip->name != NULL)			CFRelease(ip->name);
+	if (ip->localized_name != NULL)		CFRelease(ip->localized_name);
+	if (ip->address != NULL)		CFRelease(ip->address);
+	if (ip->addressString != NULL)		CFRelease(ip->addressString);
+	if (ip->interface != NULL)		CFRelease(ip->interface);
+	if (ip->prefs != NULL)			CFRelease(ip->prefs);
+	if (ip->serviceID != NULL)		CFRelease(ip->serviceID);
+	if (ip->entity_type != NULL)		CFRelease(ip->entity_type);
+	if (ip->entity_subtype != NULL)		CFRelease(ip->entity_subtype);
+	if (ip->supported_interface_types != NULL)
+		CFRelease(ip->supported_interface_types);
+	if (ip->supported_protocol_types != NULL)
+		CFRelease(ip->supported_protocol_types);
+}
+
+/*
+ * Two interfaces are equal iff they are the same type, the same BSD
+ * device, and the same layering — so an SCNetworkInterface read back
+ * from a service compares equal to the enumerated hardware interface.
+ */
+static Boolean
+__SCNetworkInterfaceEqual(CFTypeRef cf1, CFTypeRef cf2)
+{
+	SCNetworkInterfacePrivateRef	if1	= (SCNetworkInterfacePrivateRef)cf1;
+	SCNetworkInterfacePrivateRef	if2	= (SCNetworkInterfacePrivateRef)cf2;
+
+	if (if1 == if2) {
+		return TRUE;
+	}
+	if (!__cfEqual(if1->interface_type, if2->interface_type)) {
+		return FALSE;
+	}
+	if (!__cfEqual(if1->entity_device, if2->entity_device)) {
+		return FALSE;
+	}
+	if (!__cfEqual(if1->interface, if2->interface)) {
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static CFHashCode
+__SCNetworkInterfaceHash(CFTypeRef cf)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)cf;
+
+	return (ip->entity_device != NULL) ? CFHash(ip->entity_device) : 0;
+}
+
+static CFStringRef
+__SCNetworkInterfaceCopyDescription(CFTypeRef cf)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)cf;
+
+	return CFStringCreateWithFormat(NULL, NULL,
+			CFSTR("<SCNetworkInterface %@ (%@)>"),
+			(ip->entity_device != NULL)
+				? ip->entity_device : CFSTR("?"),
+			(ip->interface_type != NULL)
+				? ip->interface_type : CFSTR("?"));
+}
+
+static const CFRuntimeClass __SCNetworkInterfaceClass = {
+	.version	= 0,
+	.className	= "SCNetworkInterface",
+	.finalize	= __SCNetworkInterfaceDeallocate,
+	.equal		= __SCNetworkInterfaceEqual,
+	.hash		= __SCNetworkInterfaceHash,
+	.copyDebugDesc	= __SCNetworkInterfaceCopyDescription,
+};
+
+static void
+__SCNetworkInterfaceClassInitialize(void)
+{
+	__kSCNetworkInterfaceTypeID =
+		_CFRuntimeRegisterClass(&__SCNetworkInterfaceClass);
+}
+
+CFTypeID
+SCNetworkInterfaceGetTypeID(void)
+{
+	static pthread_once_t	once	= PTHREAD_ONCE_INIT;
+
+	(void) pthread_once(&once, __SCNetworkInterfaceClassInitialize);
+	return __kSCNetworkInterfaceTypeID;
+}
+
+static Boolean
+isA_SCNetworkInterface(SCNetworkInterfaceRef interface)
+{
+	return ((interface != NULL) &&
+		(CFGetTypeID(interface) == SCNetworkInterfaceGetTypeID()));
+}
+
+SCNetworkInterfacePrivateRef
+__SCNetworkInterfaceCreatePrivate(CFAllocatorRef allocator)
+{
+	SCNetworkInterfacePrivateRef	ip;
+	CFIndex				extra;
+
+	extra = sizeof(SCNetworkInterfacePrivate) - sizeof(CFRuntimeBase);
+	ip = (SCNetworkInterfacePrivateRef)
+	     _CFRuntimeCreateInstance(allocator,
+				      SCNetworkInterfaceGetTypeID(),
+				      extra, NULL);
+	if (ip == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+
+	ip->interface_type		= NULL;
+	ip->entity_device		= NULL;
+	ip->name			= NULL;
+	ip->localized_name		= NULL;
+	ip->address			= NULL;
+	ip->addressString		= NULL;
+	ip->builtin			= FALSE;
+	ip->interface			= NULL;
+	ip->prefs			= NULL;
+	ip->serviceID			= NULL;
+	ip->entity_type			= NULL;
+	ip->entity_subtype		= NULL;
+	ip->supported_interface_types	= NULL;
+	ip->supported_protocol_types	= NULL;
+	return ip;
+}
+
+
+#pragma mark -
+#pragma mark Hardware enumeration (getifaddrs)
+
+/*
+ * BSD-name prefixes of the pseudo / virtual interfaces the kernel
+ * exposes alongside real hardware. SCNetworkInterfaceCopyAll skips
+ * them; the layered (Bond / Bridge / VLAN) interfaces are modelled
+ * separately in a later iteration. "wlan" is deliberately absent — a
+ * FreeBSD Wi-Fi interface is a wlanN clone and is a real interface.
+ */
+static const char * const __virtualInterfacePrefixes[] = {
+	"lo", "bridge", "vlan", "tap", "tun", "gif", "gre", "epair",
+	"pflog", "pfsync", "ipfw", "stf", "faith", "enc", "ng", "ovpn",
+	"wg", "ipsec", "disc", "vmnet",
+};
+
+static Boolean
+__SCNetworkInterfaceIsVirtual(const char *name)
+{
+	size_t	i;
+
+	for (i = 0; i < (sizeof(__virtualInterfacePrefixes) /
+			 sizeof(__virtualInterfacePrefixes[0])); i++) {
+		const char	*prefix	= __virtualInterfacePrefixes[i];
+
+		if (strncmp(name, prefix, strlen(prefix)) == 0) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+/*
+ * Map a BSD interface to an SCNetworkInterface type, or NULL if it is
+ * not a kind iter 2 models. FreeBSD presents 802.11 with Ethernet
+ * framing, so a wlanN clone reports IFT_ETHER — the name prefix is the
+ * reliable Wi-Fi tell.
+ */
+static CFStringRef
+__SCNetworkInterfaceTypeForLink(const char *name, int sdl_type)
+{
+	if (strncmp(name, "wlan", 4) == 0) {
+		return kSCNetworkInterfaceTypeIEEE80211;
+	}
+	switch (sdl_type) {
+	case IFT_ETHER :
+		return kSCNetworkInterfaceTypeEthernet;
+	case IFT_IEEE80211 :
+		return kSCNetworkInterfaceTypeIEEE80211;
+	case IFT_IEEE1394 :
+		return kSCNetworkInterfaceTypeFireWire;
+	default :
+		return NULL;
+	}
+}
+
+/* "xx:xx:xx:xx:xx:xx" for a link-layer address (lowercase hex). */
+static CFStringRef
+__SCNetworkInterfaceAddressString(const uint8_t *bytes, int len)
+{
+	CFMutableStringRef	s;
+	int			i;
+
+	if ((bytes == NULL) || (len <= 0)) {
+		return NULL;
+	}
+	s = CFStringCreateMutable(NULL, 0);
+	for (i = 0; i < len; i++) {
+		CFStringAppendFormat(s, NULL, CFSTR("%s%02x"),
+				     (i == 0) ? "" : ":", bytes[i]);
+	}
+	return s;
+}
+
+/* a human-readable name for an interface type */
+static CFStringRef
+__SCNetworkInterfaceLocalizedName(CFStringRef type)
+{
+	const char	*s	= "Network";
+
+	if (CFEqual(type, kSCNetworkInterfaceTypeEthernet)) {
+		s = "Ethernet";
+	} else if (CFEqual(type, kSCNetworkInterfaceTypeIEEE80211)) {
+		s = "Wi-Fi";
+	} else if (CFEqual(type, kSCNetworkInterfaceTypeFireWire)) {
+		s = "FireWire";
+	} else if (CFEqual(type, kSCNetworkInterfaceTypeLoopback)) {
+		s = "Loopback";
+	}
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+/* build an interface object from one getifaddrs AF_LINK record */
+static SCNetworkInterfaceRef
+__SCNetworkInterfaceCreateForLink(const char *name,
+				  const struct sockaddr_dl *sdl)
+{
+	CFStringRef			type;
+	SCNetworkInterfacePrivateRef	ip;
+	const void			*protos[5];
+
+	type = __SCNetworkInterfaceTypeForLink(name, sdl->sdl_type);
+	if (type == NULL) {
+		/* not a hardware interface kind iter 2 models */
+		return NULL;
+	}
+
+	ip = __SCNetworkInterfaceCreatePrivate(NULL);
+	if (ip == NULL) {
+		return NULL;
+	}
+
+	ip->interface_type = (CFStringRef)CFRetain(type);
+	ip->entity_device  = CFStringCreateWithCString(NULL, name,
+						       kCFStringEncodingUTF8);
+	ip->builtin        = TRUE;
+
+	/* link-layer (hardware) address */
+	if (sdl->sdl_alen > 0) {
+		const uint8_t	*lladdr	= (const uint8_t *)LLADDR(sdl);
+
+		ip->address       = CFDataCreate(NULL, lladdr, sdl->sdl_alen);
+		ip->addressString = __SCNetworkInterfaceAddressString(lladdr,
+							       sdl->sdl_alen);
+	}
+
+	/* display names */
+	ip->localized_name = __SCNetworkInterfaceLocalizedName(type);
+	ip->name           = (CFStringRef)CFRetain(ip->localized_name);
+
+	/* the protocols configurable on a hardware interface */
+	protos[0] = kSCNetworkProtocolTypeIPv4;
+	protos[1] = kSCNetworkProtocolTypeIPv6;
+	protos[2] = kSCNetworkProtocolTypeDNS;
+	protos[3] = kSCNetworkProtocolTypeProxies;
+	protos[4] = kSCNetworkProtocolTypeSMB;
+	ip->supported_protocol_types =
+		CFArrayCreate(NULL, protos, 5, &kCFTypeArrayCallBacks);
+
+	return (SCNetworkInterfaceRef)ip;
+}
+
+CFArrayRef
+SCNetworkInterfaceCopyAll(void)
+{
+	CFMutableArrayRef	all;
+	struct ifaddrs		*ifap	= NULL;
+	struct ifaddrs		*ifa;
+
+	all = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	if (all == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+	if (getifaddrs(&ifap) != 0) {
+		/* nothing visible — an empty list is still a valid answer */
+		return all;
+	}
+
+	for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
+		struct sockaddr_dl	*sdl;
+		SCNetworkInterfaceRef	interface;
+
+		/* one AF_LINK record carries the link-layer info per device */
+		if ((ifa->ifa_addr == NULL) ||
+		    (ifa->ifa_addr->sa_family != AF_LINK)) {
+			continue;
+		}
+		if ((ifa->ifa_flags & IFF_LOOPBACK) != 0) {
+			continue;
+		}
+		if (__SCNetworkInterfaceIsVirtual(ifa->ifa_name)) {
+			continue;
+		}
+
+		sdl = (struct sockaddr_dl *)(void *)ifa->ifa_addr;
+		interface = __SCNetworkInterfaceCreateForLink(ifa->ifa_name,
+							      sdl);
+		if (interface != NULL) {
+			CFArrayAppendValue(all, interface);
+			CFRelease(interface);
+		}
+	}
+
+	freeifaddrs(ifap);
+	return all;
+}
+
+
+#pragma mark -
+#pragma mark Accessors
+
+CFStringRef
+SCNetworkInterfaceGetBSDName(SCNetworkInterfaceRef interface)
+{
+	if (!isA_SCNetworkInterface(interface)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)interface)->entity_device;
+}
+
+CFStringRef
+SCNetworkInterfaceGetInterfaceType(SCNetworkInterfaceRef interface)
+{
+	if (!isA_SCNetworkInterface(interface)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)interface)->interface_type;
+}
+
+CFStringRef
+SCNetworkInterfaceGetHardwareAddressString(SCNetworkInterfaceRef interface)
+{
+	if (!isA_SCNetworkInterface(interface)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)interface)->addressString;
+}
+
+CFStringRef
+SCNetworkInterfaceGetLocalizedDisplayName(SCNetworkInterfaceRef interface)
+{
+	if (!isA_SCNetworkInterface(interface)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)interface)->localized_name;
+}
+
+SCNetworkInterfaceRef
+SCNetworkInterfaceGetInterface(SCNetworkInterfaceRef interface)
+{
+	if (!isA_SCNetworkInterface(interface)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)interface)->interface;
+}
+
+CFArrayRef
+SCNetworkInterfaceGetSupportedInterfaceTypes(SCNetworkInterfaceRef interface)
+{
+	if (!isA_SCNetworkInterface(interface)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)interface)->supported_interface_types;
+}
+
+CFArrayRef
+SCNetworkInterfaceGetSupportedProtocolTypes(SCNetworkInterfaceRef interface)
+{
+	if (!isA_SCNetworkInterface(interface)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)interface)->supported_protocol_types;
+}

--- a/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2004-2022 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/*
+ * SCNetworkConfiguration.h — the SCNetworkConfiguration API.
+ *
+ * freebsd-launchd-mach port: a trimmed port of Apple's
+ * SystemConfiguration.framework SCNetworkConfiguration.h. The
+ * SCNetworkConfiguration API is the CoreFoundation-typed object model
+ * for the persistent network configuration — interfaces, the protocols
+ * (IPv4, IPv6, DNS, Proxies) layered on them, the services that bind an
+ * interface to its protocols, and the sets ("locations") that group
+ * services. Everything but SCNetworkInterface is persisted through the
+ * SCPreferences path accessors.
+ *
+ * The port lands one object family per iteration:
+ *   iter 2 — SCNetworkInterface (this is what is declared so far);
+ *   iter 3 — SCNetworkProtocol + SCNetworkService;
+ *   iter 4 — SCNetworkSet;
+ *   iter 5 — the virtual (Bond / Bridge / VLAN) interfaces.
+ * The SCNetworkService / Protocol / Set function declarations are added
+ * to this header as those iterations land.
+ */
+
+#ifndef _SCNETWORKCONFIGURATION_H
+#define _SCNETWORKCONFIGURATION_H
+
+#include <sys/cdefs.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+/*!
+	@typedef SCNetworkInterfaceRef
+	@discussion Handle to a network interface (e.g. "en0"). A
+		CoreFoundation type — see SCNetworkInterfaceGetTypeID().
+ */
+typedef const struct __SCNetworkInterface *	SCNetworkInterfaceRef;
+
+/*!
+	@typedef SCNetworkProtocolRef
+	@discussion Handle to the configuration of one protocol (IPv4,
+		IPv6, DNS, Proxies, SMB) on a network service.
+ */
+typedef const struct __SCNetworkProtocol *	SCNetworkProtocolRef;
+
+/*!
+	@typedef SCNetworkServiceRef
+	@discussion Handle to a network service — an interface together
+		with the protocols configured on it.
+ */
+typedef const struct __SCNetworkService *	SCNetworkServiceRef;
+
+/*!
+	@typedef SCNetworkSetRef
+	@discussion Handle to a network set ("location") — an ordered
+		collection of network services.
+ */
+typedef const struct __SCNetworkSet *		SCNetworkSetRef;
+
+/*
+ * Network interface types. The string values are the ones stored in the
+ * preferences plist, so they must match Apple's exactly.
+ */
+extern const CFStringRef kSCNetworkInterfaceType6to4;
+extern const CFStringRef kSCNetworkInterfaceTypeBluetooth;
+extern const CFStringRef kSCNetworkInterfaceTypeBond;
+extern const CFStringRef kSCNetworkInterfaceTypeBridge;
+extern const CFStringRef kSCNetworkInterfaceTypeEthernet;
+extern const CFStringRef kSCNetworkInterfaceTypeFireWire;
+extern const CFStringRef kSCNetworkInterfaceTypeIEEE80211;	/* Wi-Fi */
+extern const CFStringRef kSCNetworkInterfaceTypeIPSec;
+extern const CFStringRef kSCNetworkInterfaceTypeL2TP;
+extern const CFStringRef kSCNetworkInterfaceTypeLoopback;
+extern const CFStringRef kSCNetworkInterfaceTypeModem;
+extern const CFStringRef kSCNetworkInterfaceTypePPP;
+extern const CFStringRef kSCNetworkInterfaceTypeSerial;
+extern const CFStringRef kSCNetworkInterfaceTypeVLAN;
+extern const CFStringRef kSCNetworkInterfaceTypeWWAN;
+extern const CFStringRef kSCNetworkInterfaceTypeIPv4;
+
+/*
+ * Network protocol types — the protocols that can be layered on a
+ * service. Also the preferences-plist entity names.
+ */
+extern const CFStringRef kSCNetworkProtocolTypeDNS;
+extern const CFStringRef kSCNetworkProtocolTypeIPv4;
+extern const CFStringRef kSCNetworkProtocolTypeIPv6;
+extern const CFStringRef kSCNetworkProtocolTypeProxies;
+extern const CFStringRef kSCNetworkProtocolTypeSMB;
+
+__BEGIN_DECLS
+
+/* --------------------------------------------------------------------
+ * SCNetworkInterface
+ * ------------------------------------------------------------------ */
+
+/*!
+	@function SCNetworkInterfaceGetTypeID
+	@discussion Returns the CoreFoundation type identifier of all
+		SCNetworkInterface instances.
+ */
+CFTypeID
+SCNetworkInterfaceGetTypeID		(void);
+
+/*!
+	@function SCNetworkInterfaceCopyAll
+	@discussion Returns every network-capable interface on the system.
+	@result a CFArray of SCNetworkInterfaceRef (caller releases).
+ */
+CFArrayRef
+SCNetworkInterfaceCopyAll		(void);
+
+/*!
+	@function SCNetworkInterfaceGetBSDName
+	@discussion Returns the BSD name (e.g. "en0") of the interface, or
+		NULL if it has none. Owned by the interface.
+ */
+CFStringRef
+SCNetworkInterfaceGetBSDName		(SCNetworkInterfaceRef		interface);
+
+/*!
+	@function SCNetworkInterfaceGetInterfaceType
+	@discussion Returns the interface type — one of the
+		kSCNetworkInterfaceType* constants. Owned by the interface.
+ */
+CFStringRef
+SCNetworkInterfaceGetInterfaceType	(SCNetworkInterfaceRef		interface);
+
+/*!
+	@function SCNetworkInterfaceGetHardwareAddressString
+	@discussion Returns the link-layer (MAC) address as a displayable
+		"xx:xx:xx:xx:xx:xx" string, or NULL. Owned by the interface.
+ */
+CFStringRef
+SCNetworkInterfaceGetHardwareAddressString
+					(SCNetworkInterfaceRef		interface);
+
+/*!
+	@function SCNetworkInterfaceGetLocalizedDisplayName
+	@discussion Returns a human-readable name (e.g. "Ethernet",
+		"Wi-Fi") for the interface, or NULL. Owned by the interface.
+ */
+CFStringRef
+SCNetworkInterfaceGetLocalizedDisplayName
+					(SCNetworkInterfaceRef		interface);
+
+/*!
+	@function SCNetworkInterfaceGetInterface
+	@discussion For a layered interface, returns the interface it is
+		built on; NULL for a leaf (hardware) interface.
+ */
+SCNetworkInterfaceRef
+SCNetworkInterfaceGetInterface		(SCNetworkInterfaceRef		interface);
+
+/*!
+	@function SCNetworkInterfaceGetSupportedInterfaceTypes
+	@discussion Returns the interface types that can be layered on top
+		of this interface, or NULL if none. Owned by the interface.
+ */
+CFArrayRef
+SCNetworkInterfaceGetSupportedInterfaceTypes
+					(SCNetworkInterfaceRef		interface);
+
+/*!
+	@function SCNetworkInterfaceGetSupportedProtocolTypes
+	@discussion Returns the protocol types that can be configured on
+		this interface, or NULL if none. Owned by the interface.
+ */
+CFArrayRef
+SCNetworkInterfaceGetSupportedProtocolTypes
+					(SCNetworkInterfaceRef		interface);
+
+__END_DECLS
+
+#endif	/* _SCNETWORKCONFIGURATION_H */

--- a/src/libSystemConfiguration/SystemConfiguration/SystemConfiguration.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SystemConfiguration.h
@@ -17,9 +17,10 @@
  * SystemConfiguration.h — umbrella header for the SystemConfiguration
  * client framework (freebsd-launchd-mach port).
  *
- * Exposes the SCDynamicStore and SCPreferences APIs. The schema-
- * definition keys and the network-configuration APIs are later
- * iterations and will be added here as they land.
+ * Exposes the SCDynamicStore, SCPreferences and SCNetworkConfiguration
+ * APIs. The schema-definition keys and the remaining network APIs
+ * (Reachability, Connection) are later iterations and will be added
+ * here as they land.
  */
 
 #ifndef _SYSTEMCONFIGURATION_H
@@ -27,5 +28,6 @@
 
 #include <SystemConfiguration/SCDynamicStore.h>
 #include <SystemConfiguration/SCPreferences.h>
+#include <SystemConfiguration/SCNetworkConfiguration.h>
 
 #endif	/* _SYSTEMCONFIGURATION_H */

--- a/src/libSystemConfiguration/scnetiftest.c
+++ b/src/libSystemConfiguration/scnetiftest.c
@@ -1,0 +1,167 @@
+/*
+ * scnetiftest.c — libSystemConfiguration SCNetworkConfiguration iter 2
+ * test client: SCNetworkInterface hardware enumeration.
+ *
+ * Exercises SCNetworkInterfaceCopyAll and the interface accessors
+ * against the live system. The QEMU guest is booted with one e1000
+ * NIC, so the enumeration must report at least one Ethernet interface
+ * with a hardware address; loopback must be excluded. Every returned
+ * interface must be well-formed (a BSD name, a recognized type, the
+ * IPv4 protocol in its supported set).
+ *
+ * run.sh runs it and boot-test.sh gates on the SC-NETIF-OK / -FAIL
+ * marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+static void
+fail(const char *msg)
+{
+	printf("SC-NETIF-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+/* TRUE iff `array` (of CFString) contains `want` */
+static Boolean
+array_has(CFArrayRef array, CFStringRef want)
+{
+	CFIndex	i, n;
+
+	if (array == NULL) {
+		return FALSE;
+	}
+	n = CFArrayGetCount(array);
+	for (i = 0; i < n; i++) {
+		if (CFEqual(CFArrayGetValueAtIndex(array, i), want)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+/* TRUE iff `s` is one of the recognized interface types */
+static Boolean
+is_known_type(CFStringRef s)
+{
+	return (CFEqual(s, kSCNetworkInterfaceTypeEthernet) ||
+		CFEqual(s, kSCNetworkInterfaceTypeIEEE80211) ||
+		CFEqual(s, kSCNetworkInterfaceTypeFireWire));
+}
+
+int
+main(void)
+{
+	CFArrayRef	all	= NULL;
+	CFStringRef	lo0	= NULL;
+	CFIndex		i, n;
+	int		ethernet = 0;
+	int		rc	= 1;
+
+	printf("scnetiftest: SCNetworkInterface enumeration\n");
+	fflush(stdout);
+
+	lo0 = CFStringCreateWithCString(NULL, "lo0", kCFStringEncodingUTF8);
+
+	/* the type identifier must be stable */
+	if (SCNetworkInterfaceGetTypeID() != SCNetworkInterfaceGetTypeID()) {
+		fail("SCNetworkInterfaceGetTypeID not stable");
+		goto out;
+	}
+
+	all = SCNetworkInterfaceCopyAll();
+	if (all == NULL) {
+		fail("SCNetworkInterfaceCopyAll returned NULL");
+		goto out;
+	}
+	n = CFArrayGetCount(all);
+	printf("  SCNetworkInterfaceCopyAll: %ld interface(s)\n", (long)n);
+	if (n < 1) {
+		fail("no interfaces enumerated (expected the e1000 NIC)");
+		goto out;
+	}
+
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	iface;
+		CFStringRef		bsdName, type, mac, disp;
+
+		iface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(all, i);
+		if (CFGetTypeID(iface) != SCNetworkInterfaceGetTypeID()) {
+			fail("array element is not an SCNetworkInterface");
+			goto out;
+		}
+
+		bsdName = SCNetworkInterfaceGetBSDName(iface);
+		type    = SCNetworkInterfaceGetInterfaceType(iface);
+		if ((bsdName == NULL) || (type == NULL)) {
+			fail("interface missing a BSD name or type");
+			goto out;
+		}
+		if (CFEqual(bsdName, lo0)) {
+			fail("loopback was not excluded from CopyAll");
+			goto out;
+		}
+		if (!is_known_type(type)) {
+			fail("interface has an unrecognized type");
+			goto out;
+		}
+		if (!array_has(SCNetworkInterfaceGetSupportedProtocolTypes(iface),
+			       kSCNetworkProtocolTypeIPv4)) {
+			fail("IPv4 missing from supported protocol types");
+			goto out;
+		}
+		if (SCNetworkInterfaceGetInterface(iface) != NULL) {
+			fail("a hardware interface reported a sub-interface");
+			goto out;
+		}
+
+		mac  = SCNetworkInterfaceGetHardwareAddressString(iface);
+		disp = SCNetworkInterfaceGetLocalizedDisplayName(iface);
+		{
+			char	nbuf[64] = "?";
+
+			CFStringGetCString(bsdName, nbuf, sizeof(nbuf),
+					   kCFStringEncodingUTF8);
+			printf("  %-8s type=%-10s mac=%s\n", nbuf,
+			       CFEqual(type, kSCNetworkInterfaceTypeEthernet)
+				       ? "Ethernet"
+			       : CFEqual(type, kSCNetworkInterfaceTypeIEEE80211)
+				       ? "IEEE80211" : "FireWire",
+			       (mac != NULL) ? "present" : "(none)");
+		}
+
+		if (CFEqual(type, kSCNetworkInterfaceTypeEthernet)) {
+			/* the e1000 NIC: must have a usable MAC + name */
+			if ((mac == NULL) ||
+			    (CFStringGetLength(mac) == 0) ||
+			    (CFStringFind(mac, CFSTR(":"), 0).location
+			     == kCFNotFound)) {
+				fail("Ethernet interface lacks a MAC string");
+				goto out;
+			}
+			if ((disp == NULL) ||
+			    (CFStringGetLength(disp) == 0)) {
+				fail("Ethernet interface lacks a display name");
+				goto out;
+			}
+			ethernet++;
+		}
+	}
+
+	if (ethernet < 1) {
+		fail("no Ethernet interface found (expected the e1000 NIC)");
+		goto out;
+	}
+
+	printf("SC-NETIF-OK: SCNetworkInterface enumeration works\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (all != NULL)	CFRelease(all);
+	if (lo0 != NULL)	CFRelease(lo0);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -74,6 +74,7 @@ eval spawn qemu-system-x86_64 \
     -bios $env(OVMF) \
     $accel_flags \
     -drive file=$img,format=raw,if=virtio \
+    -nic user,model=e1000 \
     -display none -serial stdio \
     -no-reboot
 
@@ -559,6 +560,18 @@ expect {
         exit 1
     }
     "SC-PLINK-OK" { puts "\nOK: SCPreferences path links work" }
+}
+
+expect {
+    timeout {
+        puts "\nFAIL: SC-NETIF marker not seen"
+        exit 1
+    }
+    "SC-NETIF-FAIL" {
+        puts "\nFAIL: SCNetworkInterface enumeration failed"
+        exit 1
+    }
+    "SC-NETIF-OK" { puts "\nOK: SCNetworkInterface enumeration works" }
 }
 
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns


### PR DESCRIPTION
## SCNetworkConfiguration iter 2 — SCNetworkInterface

Second iteration of the **SCNetworkConfiguration** port: the `SCNetworkInterface` object — a CoreFoundation-typed handle to a network interface (type, BSD name, hardware address, configurable protocols).

### FreeBSD-native enumeration

Apple's `SCNetworkInterface.c` (9.7k LOC) enumerates the hardware by walking the IORegistry — `IONetworkInterface` nodes, USB/PCI/Thunderbolt device matching. There is no IOKit on FreeBSD, so **`SCNetworkInterfaceCopyAll` is a native reimplementation over `getifaddrs(3)`**: each `AF_LINK` record is one interface, and its `sockaddr_dl` carries the link-layer type and address.

- Loopback (`IFF_LOOPBACK`) and the pseudo/virtual interfaces (`bridge`, `vlan`, `tap`, `tun`, `gif`, `epair`, …) are skipped.
- A `wlanN` clone — which presents Ethernet framing on FreeBSD — is recognized as Wi-Fi by its name prefix.
- Layered (Bond/Bridge/VLAN) interfaces are deferred to iter 5.

### Changes

- **`SCNetworkConfiguration.h`** — public header: the `SCNetwork*` type forward-decls, the `kSCNetworkInterfaceType*` / `kSCNetworkProtocolType*` constants, and the SCNetworkInterface accessors.
- **`SCNetworkConfigurationInternal.{c,h}`** — the `SCNetworkInterfacePrivate` struct and the shared type-constant definitions.
- **`SCNetworkInterface.c`** — the CFRuntime type (`equal`/`hash` keyed on type + BSD device + layering), the `getifaddrs` enumeration, and the accessors: `GetBSDName` / `GetInterfaceType` / `GetHardwareAddressString` / `GetLocalizedDisplayName` / `GetInterface` / `GetSupported{Interface,Protocol}Types`.

### Test

The QEMU boot test gains a user-mode **e1000 NIC** (`-nic user,model=e1000`) so the guest has a deterministic Ethernet interface. New **`scnetiftest`** (`SC-NETIF` marker) lists the interfaces and confirms the NIC is reported as an Ethernet interface with a hardware address, every interface is well-formed (BSD name, recognized type, IPv4 in its supported protocols), and loopback is excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)