### PR TITLE
feat(libSystemConfiguration): SCNetworkConfiguration iter 3 — SCNetworkService + SCNetworkProtocol

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1261,6 +1261,23 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scnetiftest" \
     || { echo "FAIL: scnetiftest not built"; exit 1; }
 echo "==> scnetiftest built"
 
+# scnetsvctest — libSystemConfiguration SCNetworkConfiguration iter 3
+# test client. Creates an SCNetworkService on the e1000 interface,
+# names it, attaches + configures an IPv4 SCNetworkProtocol, commits,
+# reopens and confirms it persisted, then tears it down. run.sh runs
+# it and checks for the SC-NETSVC-OK marker.
+echo "==> building scnetsvctest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scnetsvctest" \
+   "$ROOT/src/libSystemConfiguration/scnetsvctest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scnetsvctest" \
+    || { echo "FAIL: scnetsvctest not built"; exit 1; }
+echo "==> scnetsvctest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -607,4 +607,14 @@ if [ ! -x "$scnetiftest" ]; then
 fi
 "$scnetiftest" || true	# marker (SC-NETIF-OK/FAIL) gates in boot-test.sh
 
+# SC-NETSVC — SCNetworkConfiguration service + protocol: create a
+# network service on the e1000 interface, name it, attach + configure
+# an IPv4 protocol, commit, reopen and confirm it all persisted.
+scnetsvctest=/usr/tests/freebsd-launchd-mach/scnetsvctest
+if [ ! -x "$scnetsvctest" ]; then
+    echo "SC-NETSVC-FAIL: $scnetsvctest missing"
+    exit 1
+fi
+"$scnetsvctest" || true	# marker (SC-NETSVC-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/Makefile
+++ b/src/libSystemConfiguration/Makefile
@@ -22,6 +22,7 @@ SHLIB_MAJOR=	1
 
 SRCS=		SCD.c SCDynamicStore.c SCNotify.c SCDMultiple.c SCPreferences.c
 SRCS+=		SCNetworkConfigurationInternal.c SCNetworkInterface.c
+SRCS+=		SCNetworkProtocol.c SCNetworkService.c
 
 # configUser.c — MIG-generated config.defs client stubs (same file
 # configd's test clients link). config_wire.c — configd's shared

--- a/src/libSystemConfiguration/SCNetworkConfigurationInternal.c
+++ b/src/libSystemConfiguration/SCNetworkConfigurationInternal.c
@@ -10,6 +10,8 @@
  * plist, so they match Apple's exactly.
  */
 
+#include "SCNetworkConfigurationInternal.h"
+
 #include <CoreFoundation/CoreFoundation.h>
 #include <SystemConfiguration/SCNetworkConfiguration.h>
 
@@ -35,3 +37,17 @@ const CFStringRef kSCNetworkProtocolTypeIPv4		= CFSTR("IPv4");
 const CFStringRef kSCNetworkProtocolTypeIPv6		= CFSTR("IPv6");
 const CFStringRef kSCNetworkProtocolTypeProxies		= CFSTR("Proxies");
 const CFStringRef kSCNetworkProtocolTypeSMB		= CFSTR("SMB");
+
+
+CFStringRef
+__SCNetworkServiceEntityPath(CFStringRef serviceID, CFStringRef entity)
+{
+	if (entity == NULL) {
+		return CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@/%@"),
+						kSCPrefNetworkServices,
+						serviceID);
+	}
+	return CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@/%@/%@"),
+					kSCPrefNetworkServices,
+					serviceID, entity);
+}

--- a/src/libSystemConfiguration/SCNetworkConfigurationInternal.h
+++ b/src/libSystemConfiguration/SCNetworkConfigurationInternal.h
@@ -16,51 +16,160 @@
 #include <SystemConfiguration/SCPreferences.h>
 
 /*
- * The SCNetworkInterface object. A CoreFoundation runtime type — the
- * leading CFRuntimeBase is filled in by _CFRuntimeCreateInstance(), and
- * CFRetain() / CFRelease() drive its lifetime.
- *
- * A leaf (hardware) interface is the common case: SCNetworkInterfaceCopy
- * All builds one per enumerated BSD interface. `interface` is non-NULL
- * only for a layered interface (PPP-over-modem, VLAN, ...) — deferred to
- * a later iteration. `prefs` / `serviceID` are set when the interface
- * is bound to a stored network service (the SCNetworkService iteration).
+ * Reserved preferences-plist keys. The network configuration lives in
+ * the preferences plist under /NetworkServices/<serviceID>, each
+ * service dict carrying an "Interface" entity, a "UserDefinedName", and
+ * one sub-dict per configured protocol. A "__INACTIVE__" key marks a
+ * service or protocol disabled.
+ */
+#define kSCResvInactive			CFSTR("__INACTIVE__")
+#define kSCPrefNetworkServices		CFSTR("NetworkServices")
+#define kSCEntNetInterface		CFSTR("Interface")
+#define kSCPropUserDefinedName		CFSTR("UserDefinedName")
+#define kSCPropNetInterfaceType		CFSTR("Type")
+#define kSCPropNetInterfaceDeviceName	CFSTR("DeviceName")
+#define kSCPropNetInterfaceHardware	CFSTR("Hardware")
+
+
+#pragma mark -
+#pragma mark SCNetworkInterface
+
+/*
+ * The SCNetworkInterface object — see SCNetworkInterface.c. A leaf
+ * (hardware) interface is the common case; `interface` is non-NULL only
+ * for a layered interface. `prefs` / `serviceID` are set when the
+ * interface is bound to a stored network service.
  */
 typedef struct __SCNetworkInterface {
 	CFRuntimeBase		cfBase;
 
-	/* interface identity */
 	CFStringRef		interface_type;		/* kSCNetworkInterfaceType* */
 	CFStringRef		entity_device;		/* BSD name, e.g. "en0" */
 
-	/* display names */
 	CFStringRef		name;			/* non-localized */
 	CFStringRef		localized_name;		/* localized */
 
-	/* link-layer (hardware) address */
-	CFDataRef		address;		/* raw bytes */
+	CFDataRef		address;		/* raw link-layer bytes */
 	CFStringRef		addressString;		/* "xx:xx:..." */
 	Boolean			builtin;
 
-	/* layering — non-NULL only for a layered interface */
-	SCNetworkInterfaceRef	interface;
+	SCNetworkInterfaceRef	interface;		/* layered-on, or NULL */
 
-	/* preferences entity bookkeeping (the SCNetworkService iteration) */
 	SCPreferencesRef	prefs;			/* bound prefs, or NULL */
 	CFStringRef		serviceID;		/* bound service, or NULL */
 	CFStringRef		entity_type;		/* prefs entity "Type" */
 	CFStringRef		entity_subtype;		/* prefs entity "SubType" */
 
-	/* what can be layered / configured on this interface */
 	CFArrayRef		supported_interface_types;
 	CFArrayRef		supported_protocol_types;
 } SCNetworkInterfacePrivate, *SCNetworkInterfacePrivateRef;
 
+
+#pragma mark -
+#pragma mark SCNetworkService
+
 /*
- * SCNetworkInterface.c — allocate a bare SCNetworkInterface (every field
- * NULL / FALSE). Returns a retained instance, or NULL with SCError() set.
+ * The SCNetworkService object — see SCNetworkService.c. A network
+ * service binds an interface to the protocols configured on it; it is
+ * persisted at /NetworkServices/<serviceID> in the preferences plist.
  */
+typedef struct __SCNetworkService {
+	CFRuntimeBase		cfBase;
+
+	CFStringRef		serviceID;
+	SCNetworkInterfaceRef	interface;	/* lazily reconstructed */
+	SCPreferencesRef	prefs;
+	CFStringRef		name;		/* cached UserDefinedName */
+} SCNetworkServicePrivate, *SCNetworkServicePrivateRef;
+
+
+#pragma mark -
+#pragma mark SCNetworkProtocol
+
+/*
+ * The SCNetworkProtocol object — see SCNetworkProtocol.c. One protocol
+ * (IPv4, IPv6, DNS, Proxies, SMB) configured on a network service;
+ * persisted at /NetworkServices/<serviceID>/<entityID>.
+ */
+typedef struct __SCNetworkProtocol {
+	CFRuntimeBase		cfBase;
+
+	CFStringRef		entityID;	/* the protocol type */
+	SCNetworkServiceRef	service;
+} SCNetworkProtocolPrivate, *SCNetworkProtocolPrivateRef;
+
+
+#pragma mark -
+#pragma mark Type checks
+
+static inline Boolean
+isA_SCNetworkInterface(SCNetworkInterfaceRef interface)
+{
+	return ((interface != NULL) &&
+		(CFGetTypeID(interface) == SCNetworkInterfaceGetTypeID()));
+}
+
+static inline Boolean
+isA_SCNetworkService(SCNetworkServiceRef service)
+{
+	return ((service != NULL) &&
+		(CFGetTypeID(service) == SCNetworkServiceGetTypeID()));
+}
+
+static inline Boolean
+isA_SCNetworkProtocol(SCNetworkProtocolRef protocol)
+{
+	return ((protocol != NULL) &&
+		(CFGetTypeID(protocol) == SCNetworkProtocolGetTypeID()));
+}
+
+
+#pragma mark -
+#pragma mark Internal helpers
+
+/* SCNetworkInterface.c — allocate a bare interface (all fields NULL). */
 SCNetworkInterfacePrivateRef
-__SCNetworkInterfaceCreatePrivate	(CFAllocatorRef			allocator);
+__SCNetworkInterfaceCreatePrivate	(CFAllocatorRef		allocator);
+
+/*
+ * SCNetworkInterface.c — the interface <-> preferences-entity bridge.
+ * __SCNetworkInterfaceCopyInterfaceEntity serializes an interface into
+ * the dictionary stored at a service's "Interface" path; _SCNetworkInter
+ * faceCreateWithEntity rebuilds an interface from that dictionary.
+ */
+CFDictionaryRef
+__SCNetworkInterfaceCopyInterfaceEntity	(SCNetworkInterfaceRef	interface);
+
+SCNetworkInterfaceRef
+_SCNetworkInterfaceCreateWithEntity	(CFAllocatorRef		allocator,
+					 CFDictionaryRef	entity,
+					 SCNetworkServiceRef	service);
+
+/* SCNetworkService.c — allocate a service object. */
+SCNetworkServicePrivateRef
+__SCNetworkServiceCreatePrivate		(CFAllocatorRef		allocator,
+					 SCPreferencesRef	prefs,
+					 CFStringRef		serviceID,
+					 SCNetworkInterfaceRef	interface);
+
+/* SCNetworkProtocol.c — allocate a protocol object. */
+SCNetworkProtocolPrivateRef
+__SCNetworkProtocolCreatePrivate	(CFAllocatorRef		allocator,
+					 CFStringRef		entityID,
+					 SCNetworkServiceRef	service);
+
+/* SCNetworkProtocol.c — TRUE iff `protocolType` is a known protocol. */
+Boolean
+__SCNetworkProtocolIsValidType		(CFStringRef		protocolType);
+
+/*
+ * SCNetworkConfigurationInternal.c — build a preferences path for a
+ * network service or one of its entities: entity NULL gives
+ * "/NetworkServices/<serviceID>", otherwise
+ * "/NetworkServices/<serviceID>/<entity>". Caller releases.
+ */
+CFStringRef
+__SCNetworkServiceEntityPath		(CFStringRef		serviceID,
+					 CFStringRef		entity);
 
 #endif	/* _SCNETWORKCONFIGURATIONINTERNAL_H */

--- a/src/libSystemConfiguration/SCNetworkInterface.c
+++ b/src/libSystemConfiguration/SCNetworkInterface.c
@@ -140,12 +140,7 @@ SCNetworkInterfaceGetTypeID(void)
 	return __kSCNetworkInterfaceTypeID;
 }
 
-static Boolean
-isA_SCNetworkInterface(SCNetworkInterfaceRef interface)
-{
-	return ((interface != NULL) &&
-		(CFGetTypeID(interface) == SCNetworkInterfaceGetTypeID()));
-}
+/* isA_SCNetworkInterface() is a shared inline in the internal header. */
 
 SCNetworkInterfacePrivateRef
 __SCNetworkInterfaceCreatePrivate(CFAllocatorRef allocator)
@@ -273,6 +268,20 @@ __SCNetworkInterfaceLocalizedName(CFStringRef type)
 	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
 }
 
+/* the protocol types configurable on a hardware network interface */
+static CFArrayRef
+__SCNetworkInterfaceCopyProtocolTypes(void)
+{
+	const void	*protos[5];
+
+	protos[0] = kSCNetworkProtocolTypeIPv4;
+	protos[1] = kSCNetworkProtocolTypeIPv6;
+	protos[2] = kSCNetworkProtocolTypeDNS;
+	protos[3] = kSCNetworkProtocolTypeProxies;
+	protos[4] = kSCNetworkProtocolTypeSMB;
+	return CFArrayCreate(NULL, protos, 5, &kCFTypeArrayCallBacks);
+}
+
 /* build an interface object from one getifaddrs AF_LINK record */
 static SCNetworkInterfaceRef
 __SCNetworkInterfaceCreateForLink(const char *name,
@@ -280,7 +289,6 @@ __SCNetworkInterfaceCreateForLink(const char *name,
 {
 	CFStringRef			type;
 	SCNetworkInterfacePrivateRef	ip;
-	const void			*protos[5];
 
 	type = __SCNetworkInterfaceTypeForLink(name, sdl->sdl_type);
 	if (type == NULL) {
@@ -312,13 +320,7 @@ __SCNetworkInterfaceCreateForLink(const char *name,
 	ip->name           = (CFStringRef)CFRetain(ip->localized_name);
 
 	/* the protocols configurable on a hardware interface */
-	protos[0] = kSCNetworkProtocolTypeIPv4;
-	protos[1] = kSCNetworkProtocolTypeIPv6;
-	protos[2] = kSCNetworkProtocolTypeDNS;
-	protos[3] = kSCNetworkProtocolTypeProxies;
-	protos[4] = kSCNetworkProtocolTypeSMB;
-	ip->supported_protocol_types =
-		CFArrayCreate(NULL, protos, 5, &kCFTypeArrayCallBacks);
+	ip->supported_protocol_types = __SCNetworkInterfaceCopyProtocolTypes();
 
 	return (SCNetworkInterfaceRef)ip;
 }
@@ -441,4 +443,98 @@ SCNetworkInterfaceGetSupportedProtocolTypes(SCNetworkInterfaceRef interface)
 		return NULL;
 	}
 	return ((SCNetworkInterfacePrivateRef)interface)->supported_protocol_types;
+}
+
+
+#pragma mark -
+#pragma mark Preferences entity bridge
+
+/*
+ * Serialize an interface into the dictionary stored at a service's
+ * "Interface" path. A hardware interface needs only its type and BSD
+ * device name; the localized name is kept so a removed interface still
+ * has a readable label. (Apple's entity also carries IORegistry detail
+ * — irrelevant without IOKit.)
+ */
+CFDictionaryRef
+__SCNetworkInterfaceCopyInterfaceEntity(SCNetworkInterfaceRef interface)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)interface;
+	CFMutableDictionaryRef		entity;
+
+	entity = CFDictionaryCreateMutable(NULL, 0,
+					   &kCFTypeDictionaryKeyCallBacks,
+					   &kCFTypeDictionaryValueCallBacks);
+	if (ip->interface_type != NULL) {
+		CFDictionarySetValue(entity, kSCPropNetInterfaceType,
+				     ip->interface_type);
+		CFDictionarySetValue(entity, kSCPropNetInterfaceHardware,
+				     ip->interface_type);
+	}
+	if (ip->entity_device != NULL) {
+		CFDictionarySetValue(entity, kSCPropNetInterfaceDeviceName,
+				     ip->entity_device);
+	}
+	if (ip->localized_name != NULL) {
+		CFDictionarySetValue(entity, kSCPropUserDefinedName,
+				     ip->localized_name);
+	}
+	return entity;
+}
+
+/*
+ * Rebuild an interface from the dictionary stored at a service's
+ * "Interface" path. The reconstructed interface has no hardware address
+ * (the entity does not store one — it is matched live against the
+ * enumerated hardware). `service`, when non-NULL, binds the interface
+ * to its preferences session.
+ */
+SCNetworkInterfaceRef
+_SCNetworkInterfaceCreateWithEntity(CFAllocatorRef allocator,
+				    CFDictionaryRef entity,
+				    SCNetworkServiceRef service)
+{
+	SCNetworkInterfacePrivateRef	ip;
+	CFStringRef			type;
+	CFStringRef			device;
+
+	if ((entity == NULL) ||
+	    (CFGetTypeID(entity) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	type   = CFDictionaryGetValue(entity, kSCPropNetInterfaceType);
+	device = CFDictionaryGetValue(entity, kSCPropNetInterfaceDeviceName);
+
+	ip = __SCNetworkInterfaceCreatePrivate(allocator);
+	if (ip == NULL) {
+		return NULL;
+	}
+
+	if ((type != NULL) && (CFGetTypeID(type) == CFStringGetTypeID())) {
+		ip->interface_type = (CFStringRef)CFRetain(type);
+	} else {
+		ip->interface_type =
+			(CFStringRef)CFRetain(kSCNetworkInterfaceTypeEthernet);
+	}
+	if ((device != NULL) && (CFGetTypeID(device) == CFStringGetTypeID())) {
+		ip->entity_device = (CFStringRef)CFRetain(device);
+	}
+	ip->builtin		= TRUE;
+	ip->localized_name	= __SCNetworkInterfaceLocalizedName(ip->interface_type);
+	ip->name		= (CFStringRef)CFRetain(ip->localized_name);
+	ip->supported_protocol_types = __SCNetworkInterfaceCopyProtocolTypes();
+
+	if (service != NULL) {
+		SCNetworkServicePrivateRef	sp =
+			(SCNetworkServicePrivateRef)service;
+
+		if (sp->prefs != NULL) {
+			ip->prefs = (SCPreferencesRef)CFRetain(sp->prefs);
+		}
+		if (sp->serviceID != NULL) {
+			ip->serviceID = (CFStringRef)CFRetain(sp->serviceID);
+		}
+	}
+	return (SCNetworkInterfaceRef)ip;
 }

--- a/src/libSystemConfiguration/SCNetworkProtocol.c
+++ b/src/libSystemConfiguration/SCNetworkProtocol.c
@@ -1,0 +1,308 @@
+/*
+ * SCNetworkProtocol.c — the SCNetworkProtocol object (freebsd-launchd-
+ * mach port of Apple's SystemConfiguration.fproj SCNetworkProtocol.c).
+ *
+ * An SCNetworkProtocol is one protocol (IPv4, IPv6, DNS, Proxies, SMB)
+ * configured on a network service. It is a thin handle: the protocol's
+ * configuration lives in the preferences plist at
+ * /NetworkServices/<serviceID>/<protocolType>, and a reserved
+ * "__INACTIVE__" key in that dictionary marks the protocol disabled.
+ */
+
+#include "SCNetworkConfigurationInternal.h"
+#include "SCInternal.h"
+
+#include <pthread.h>
+
+
+#pragma mark -
+#pragma mark CoreFoundation runtime type
+
+static CFTypeID	__kSCNetworkProtocolTypeID	= _kCFRuntimeNotATypeID;
+
+static void
+__SCNetworkProtocolDeallocate(CFTypeRef cf)
+{
+	SCNetworkProtocolPrivateRef	pp	= (SCNetworkProtocolPrivateRef)cf;
+
+	if (pp->entityID != NULL)	CFRelease(pp->entityID);
+	if (pp->service != NULL)	CFRelease(pp->service);
+}
+
+static Boolean
+__SCNetworkProtocolEqual(CFTypeRef cf1, CFTypeRef cf2)
+{
+	SCNetworkProtocolPrivateRef	p1	= (SCNetworkProtocolPrivateRef)cf1;
+	SCNetworkProtocolPrivateRef	p2	= (SCNetworkProtocolPrivateRef)cf2;
+
+	if (p1 == p2) {
+		return TRUE;
+	}
+	if (!CFEqual(p1->entityID, p2->entityID)) {
+		return FALSE;	/* a different protocol type */
+	}
+	if (p1->service == p2->service) {
+		return TRUE;
+	}
+	return ((p1->service != NULL) && (p2->service != NULL) &&
+		CFEqual(p1->service, p2->service));
+}
+
+static CFHashCode
+__SCNetworkProtocolHash(CFTypeRef cf)
+{
+	return CFHash(((SCNetworkProtocolPrivateRef)cf)->entityID);
+}
+
+static CFStringRef
+__SCNetworkProtocolCopyDescription(CFTypeRef cf)
+{
+	SCNetworkProtocolPrivateRef	pp	= (SCNetworkProtocolPrivateRef)cf;
+
+	return CFStringCreateWithFormat(NULL, NULL,
+			CFSTR("<SCNetworkProtocol %@>"), pp->entityID);
+}
+
+static const CFRuntimeClass __SCNetworkProtocolClass = {
+	.version	= 0,
+	.className	= "SCNetworkProtocol",
+	.finalize	= __SCNetworkProtocolDeallocate,
+	.equal		= __SCNetworkProtocolEqual,
+	.hash		= __SCNetworkProtocolHash,
+	.copyDebugDesc	= __SCNetworkProtocolCopyDescription,
+};
+
+static void
+__SCNetworkProtocolClassInitialize(void)
+{
+	__kSCNetworkProtocolTypeID =
+		_CFRuntimeRegisterClass(&__SCNetworkProtocolClass);
+}
+
+CFTypeID
+SCNetworkProtocolGetTypeID(void)
+{
+	static pthread_once_t	once	= PTHREAD_ONCE_INIT;
+
+	(void) pthread_once(&once, __SCNetworkProtocolClassInitialize);
+	return __kSCNetworkProtocolTypeID;
+}
+
+SCNetworkProtocolPrivateRef
+__SCNetworkProtocolCreatePrivate(CFAllocatorRef		allocator,
+				 CFStringRef		entityID,
+				 SCNetworkServiceRef	service)
+{
+	SCNetworkProtocolPrivateRef	pp;
+	CFIndex				extra;
+
+	extra = sizeof(SCNetworkProtocolPrivate) - sizeof(CFRuntimeBase);
+	pp = (SCNetworkProtocolPrivateRef)
+	     _CFRuntimeCreateInstance(allocator,
+				      SCNetworkProtocolGetTypeID(),
+				      extra, NULL);
+	if (pp == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+	pp->entityID = CFStringCreateCopy(NULL, entityID);
+	pp->service  = (SCNetworkServiceRef)CFRetain(service);
+	return pp;
+}
+
+Boolean
+__SCNetworkProtocolIsValidType(CFStringRef protocolType)
+{
+	static const CFStringRef * const	valid[] = {
+		&kSCNetworkProtocolTypeDNS,
+		&kSCNetworkProtocolTypeIPv4,
+		&kSCNetworkProtocolTypeIPv6,
+		&kSCNetworkProtocolTypeProxies,
+		&kSCNetworkProtocolTypeSMB,
+	};
+	size_t	i;
+
+	if ((protocolType == NULL) ||
+	    (CFGetTypeID(protocolType) != CFStringGetTypeID())) {
+		return FALSE;
+	}
+	for (i = 0; i < (sizeof(valid) / sizeof(valid[0])); i++) {
+		if (CFEqual(protocolType, *valid[i])) {
+			return TRUE;
+		}
+	}
+	/* a user-defined protocol type (e.g. com.example.myProtocol) */
+	return (CFStringFind(protocolType, CFSTR("."), 0).location
+		!= kCFNotFound);
+}
+
+
+#pragma mark -
+#pragma mark Accessors
+
+/* the preferences path of this protocol's configuration entity */
+static CFStringRef
+__protocolPath(SCNetworkProtocolPrivateRef pp)
+{
+	SCNetworkServicePrivateRef	sp =
+		(SCNetworkServicePrivateRef)pp->service;
+
+	return __SCNetworkServiceEntityPath(sp->serviceID, pp->entityID);
+}
+
+CFStringRef
+SCNetworkProtocolGetProtocolType(SCNetworkProtocolRef protocol)
+{
+	if (!isA_SCNetworkProtocol(protocol)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkProtocolPrivateRef)protocol)->entityID;
+}
+
+CFDictionaryRef
+SCNetworkProtocolGetConfiguration(SCNetworkProtocolRef protocol)
+{
+	SCNetworkProtocolPrivateRef	pp	= (SCNetworkProtocolPrivateRef)protocol;
+	SCNetworkServicePrivateRef	sp;
+	CFDictionaryRef			config;
+	CFStringRef			path;
+
+	if (!isA_SCNetworkProtocol(protocol)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	sp     = (SCNetworkServicePrivateRef)pp->service;
+	path   = __protocolPath(pp);
+	config = SCPreferencesPathGetValue(sp->prefs, path);
+	CFRelease(path);
+
+	if ((config == NULL) ||
+	    (CFGetTypeID(config) != CFDictionaryGetTypeID())) {
+		return NULL;
+	}
+	/* an empty entity — or one holding only the disabled marker — has
+	 * no configuration to report */
+	if (CFDictionaryGetCount(config) == 0) {
+		return NULL;
+	}
+	if ((CFDictionaryGetCount(config) == 1) &&
+	    CFDictionaryContainsKey(config, kSCResvInactive)) {
+		return NULL;
+	}
+	return config;
+}
+
+Boolean
+SCNetworkProtocolSetConfiguration(SCNetworkProtocolRef protocol,
+				  CFDictionaryRef config)
+{
+	SCNetworkProtocolPrivateRef	pp	= (SCNetworkProtocolPrivateRef)protocol;
+	SCNetworkServicePrivateRef	sp;
+	CFDictionaryRef			cur;
+	CFMutableDictionaryRef		newConfig;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCNetworkProtocol(protocol)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((config != NULL) &&
+	    (CFGetTypeID(config) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	sp   = (SCNetworkServicePrivateRef)pp->service;
+	path = __protocolPath(pp);
+
+	/* the new configuration preserves the current enabled state */
+	cur = SCPreferencesPathGetValue(sp->prefs, path);
+	if ((cur != NULL) && (CFGetTypeID(cur) != CFDictionaryGetTypeID())) {
+		cur = NULL;
+	}
+	if (config != NULL) {
+		newConfig = CFDictionaryCreateMutableCopy(NULL, 0, config);
+	} else {
+		newConfig = CFDictionaryCreateMutable(NULL, 0,
+					&kCFTypeDictionaryKeyCallBacks,
+					&kCFTypeDictionaryValueCallBacks);
+	}
+	if ((cur != NULL) &&
+	    CFDictionaryContainsKey(cur, kSCResvInactive)) {
+		CFDictionarySetValue(newConfig, kSCResvInactive,
+				     kCFBooleanTrue);
+	} else {
+		CFDictionaryRemoveValue(newConfig, kSCResvInactive);
+	}
+
+	ok = SCPreferencesPathSetValue(sp->prefs, path, newConfig);
+	CFRelease(newConfig);
+	CFRelease(path);
+	return ok;
+}
+
+Boolean
+SCNetworkProtocolGetEnabled(SCNetworkProtocolRef protocol)
+{
+	SCNetworkProtocolPrivateRef	pp	= (SCNetworkProtocolPrivateRef)protocol;
+	SCNetworkServicePrivateRef	sp;
+	CFDictionaryRef			config;
+	CFStringRef			path;
+	Boolean				enabled;
+
+	if (!isA_SCNetworkProtocol(protocol)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	sp      = (SCNetworkServicePrivateRef)pp->service;
+	path    = __protocolPath(pp);
+	config  = SCPreferencesPathGetValue(sp->prefs, path);
+	enabled = !((config != NULL) &&
+		    (CFGetTypeID(config) == CFDictionaryGetTypeID()) &&
+		    CFDictionaryContainsKey(config, kSCResvInactive));
+	CFRelease(path);
+	return enabled;
+}
+
+Boolean
+SCNetworkProtocolSetEnabled(SCNetworkProtocolRef protocol, Boolean enabled)
+{
+	SCNetworkProtocolPrivateRef	pp	= (SCNetworkProtocolPrivateRef)protocol;
+	SCNetworkServicePrivateRef	sp;
+	CFDictionaryRef			cur;
+	CFMutableDictionaryRef		newConfig;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCNetworkProtocol(protocol)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	sp   = (SCNetworkServicePrivateRef)pp->service;
+	path = __protocolPath(pp);
+
+	cur = SCPreferencesPathGetValue(sp->prefs, path);
+	if ((cur != NULL) && (CFGetTypeID(cur) != CFDictionaryGetTypeID())) {
+		cur = NULL;
+	}
+	if (cur != NULL) {
+		newConfig = CFDictionaryCreateMutableCopy(NULL, 0, cur);
+	} else {
+		newConfig = CFDictionaryCreateMutable(NULL, 0,
+					&kCFTypeDictionaryKeyCallBacks,
+					&kCFTypeDictionaryValueCallBacks);
+	}
+	if (enabled) {
+		CFDictionaryRemoveValue(newConfig, kSCResvInactive);
+	} else {
+		CFDictionarySetValue(newConfig, kSCResvInactive,
+				     kCFBooleanTrue);
+	}
+
+	ok = SCPreferencesPathSetValue(sp->prefs, path, newConfig);
+	CFRelease(newConfig);
+	CFRelease(path);
+	return ok;
+}

--- a/src/libSystemConfiguration/SCNetworkService.c
+++ b/src/libSystemConfiguration/SCNetworkService.c
@@ -1,0 +1,612 @@
+/*
+ * SCNetworkService.c — the SCNetworkService object (freebsd-launchd-mach
+ * port of Apple's SystemConfiguration.fproj SCNetworkService.c).
+ *
+ * A network service binds a network interface to the protocols (IPv4,
+ * IPv6, DNS, Proxies, ...) configured on it. It is persisted in the
+ * preferences plist at /NetworkServices/<serviceID>: a dictionary whose
+ * "Interface" entity describes the interface, "UserDefinedName" holds
+ * the service name, and each remaining sub-dictionary is one protocol
+ * entity.
+ *
+ * Apple's SCNetworkService.c additionally seeds interface-type-specific
+ * configuration templates (PPP/Modem/Bluetooth), routes privileged
+ * writes through SCHelper, and tracks set membership. The port keeps
+ * the core CRUD: create / copy / list a service, name it, read its
+ * interface, attach and remove protocols.
+ */
+
+#include "SCNetworkConfigurationInternal.h"
+#include "SCInternal.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+
+
+#pragma mark -
+#pragma mark CoreFoundation runtime type
+
+static CFTypeID	__kSCNetworkServiceTypeID	= _kCFRuntimeNotATypeID;
+
+static void
+__SCNetworkServiceDeallocate(CFTypeRef cf)
+{
+	SCNetworkServicePrivateRef	sp	= (SCNetworkServicePrivateRef)cf;
+
+	if (sp->serviceID != NULL)	CFRelease(sp->serviceID);
+	if (sp->interface != NULL)	CFRelease(sp->interface);
+	if (sp->prefs != NULL)		CFRelease(sp->prefs);
+	if (sp->name != NULL)		CFRelease(sp->name);
+}
+
+static Boolean
+__SCNetworkServiceEqual(CFTypeRef cf1, CFTypeRef cf2)
+{
+	SCNetworkServicePrivateRef	s1	= (SCNetworkServicePrivateRef)cf1;
+	SCNetworkServicePrivateRef	s2	= (SCNetworkServicePrivateRef)cf2;
+
+	if (s1 == s2) {
+		return TRUE;
+	}
+	return CFEqual(s1->serviceID, s2->serviceID);
+}
+
+static CFHashCode
+__SCNetworkServiceHash(CFTypeRef cf)
+{
+	return CFHash(((SCNetworkServicePrivateRef)cf)->serviceID);
+}
+
+static CFStringRef
+__SCNetworkServiceCopyDescription(CFTypeRef cf)
+{
+	SCNetworkServicePrivateRef	sp	= (SCNetworkServicePrivateRef)cf;
+
+	return CFStringCreateWithFormat(NULL, NULL,
+			CFSTR("<SCNetworkService %@>"), sp->serviceID);
+}
+
+static const CFRuntimeClass __SCNetworkServiceClass = {
+	.version	= 0,
+	.className	= "SCNetworkService",
+	.finalize	= __SCNetworkServiceDeallocate,
+	.equal		= __SCNetworkServiceEqual,
+	.hash		= __SCNetworkServiceHash,
+	.copyDebugDesc	= __SCNetworkServiceCopyDescription,
+};
+
+static void
+__SCNetworkServiceClassInitialize(void)
+{
+	__kSCNetworkServiceTypeID =
+		_CFRuntimeRegisterClass(&__SCNetworkServiceClass);
+}
+
+CFTypeID
+SCNetworkServiceGetTypeID(void)
+{
+	static pthread_once_t	once	= PTHREAD_ONCE_INIT;
+
+	(void) pthread_once(&once, __SCNetworkServiceClassInitialize);
+	return __kSCNetworkServiceTypeID;
+}
+
+SCNetworkServicePrivateRef
+__SCNetworkServiceCreatePrivate(CFAllocatorRef		allocator,
+				SCPreferencesRef	prefs,
+				CFStringRef		serviceID,
+				SCNetworkInterfaceRef	interface)
+{
+	SCNetworkServicePrivateRef	sp;
+	CFIndex				extra;
+
+	extra = sizeof(SCNetworkServicePrivate) - sizeof(CFRuntimeBase);
+	sp = (SCNetworkServicePrivateRef)
+	     _CFRuntimeCreateInstance(allocator,
+				      SCNetworkServiceGetTypeID(),
+				      extra, NULL);
+	if (sp == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+	sp->serviceID = CFStringCreateCopy(NULL, serviceID);
+	sp->interface = (interface != NULL)
+			? (SCNetworkInterfaceRef)CFRetain(interface) : NULL;
+	sp->prefs     = (prefs != NULL)
+			? (SCPreferencesRef)CFRetain(prefs) : NULL;
+	sp->name      = NULL;
+	return sp;
+}
+
+
+#pragma mark -
+#pragma mark Helpers
+
+/*
+ * Copy the keys and values of `dict` into caller-freed arrays; both
+ * returned arrays must be free()d. Returns the count, or 0 (with the
+ * arrays left NULL) for an empty or non-dictionary argument.
+ */
+static CFIndex
+__copyDictEntries(CFDictionaryRef dict, const void ***keys,
+		  const void ***vals)
+{
+	CFIndex	n;
+
+	*keys = NULL;
+	*vals = NULL;
+	if ((dict == NULL) ||
+	    (CFGetTypeID(dict) != CFDictionaryGetTypeID())) {
+		return 0;
+	}
+	n = CFDictionaryGetCount(dict);
+	if (n <= 0) {
+		return 0;
+	}
+	*keys = (const void **)malloc((size_t)n * sizeof(void *));
+	*vals = (const void **)malloc((size_t)n * sizeof(void *));
+	CFDictionaryGetKeysAndValues(dict, *keys, *vals);
+	return n;
+}
+
+/* the service's "Interface" entity dictionary, or NULL */
+static CFDictionaryRef
+__serviceInterfaceEntity(SCNetworkServicePrivateRef sp)
+{
+	CFDictionaryRef	entity;
+	CFStringRef	path;
+
+	path   = __SCNetworkServiceEntityPath(sp->serviceID, kSCEntNetInterface);
+	entity = SCPreferencesPathGetValue(sp->prefs, path);
+	CFRelease(path);
+	if ((entity != NULL) &&
+	    (CFGetTypeID(entity) == CFDictionaryGetTypeID())) {
+		return entity;
+	}
+	return NULL;
+}
+
+
+#pragma mark -
+#pragma mark SCNetworkService APIs
+
+SCNetworkServiceRef
+SCNetworkServiceCreate(SCPreferencesRef prefs, SCNetworkInterfaceRef interface)
+{
+	CFArrayRef			components;
+	CFDictionaryRef			entity;
+	CFStringRef			name;
+	CFStringRef			path;
+	CFStringRef			prefix;
+	CFStringRef			serviceID;
+	SCNetworkServicePrivateRef	sp;
+
+	if (!isA_SCNetworkInterface(interface)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	/* only interfaces that support a protocol may back a service */
+	if (SCNetworkInterfaceGetSupportedProtocolTypes(interface) == NULL) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	/* mint a unique /NetworkServices/<serviceID> entry — the prefix
+	 * passed to SCPreferencesPathCreateUniqueChild must be a rooted
+	 * path, not the bare "NetworkServices" preferences key */
+	prefix = CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@"),
+					  kSCPrefNetworkServices);
+	path = SCPreferencesPathCreateUniqueChild(prefs, prefix);
+	CFRelease(prefix);
+	if (path == NULL) {
+		return NULL;
+	}
+	components = CFStringCreateArrayBySeparatingStrings(NULL, path,
+							    CFSTR("/"));
+	CFRelease(path);
+	/* path "/NetworkServices/<id>" splits to ["", "NetworkServices", id] */
+	if ((components == NULL) || (CFArrayGetCount(components) < 3)) {
+		if (components != NULL) CFRelease(components);
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+	serviceID = CFArrayGetValueAtIndex(components, 2);
+
+	sp = __SCNetworkServiceCreatePrivate(NULL, prefs, serviceID, interface);
+	CFRelease(components);
+	if (sp == NULL) {
+		return NULL;
+	}
+
+	/* store the interface entity at /NetworkServices/<id>/Interface */
+	path   = __SCNetworkServiceEntityPath(sp->serviceID, kSCEntNetInterface);
+	entity = __SCNetworkInterfaceCopyInterfaceEntity(interface);
+	if (!SCPreferencesPathSetValue(sp->prefs, path, entity)) {
+		CFRelease(entity);
+		CFRelease(path);
+		CFRelease(sp);
+		return NULL;
+	}
+	CFRelease(entity);
+	CFRelease(path);
+
+	/* seed the service name from the interface's display name */
+	name = SCNetworkServiceGetName((SCNetworkServiceRef)sp);
+	if (name != NULL) {
+		(void) SCNetworkServiceSetName((SCNetworkServiceRef)sp, name);
+	}
+
+	return (SCNetworkServiceRef)sp;
+}
+
+SCNetworkServiceRef
+SCNetworkServiceCopy(SCPreferencesRef prefs, CFStringRef serviceID)
+{
+	SCNetworkServicePrivateRef	sp;
+
+	if ((serviceID == NULL) ||
+	    (CFGetTypeID(serviceID) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	sp = __SCNetworkServiceCreatePrivate(NULL, prefs, serviceID, NULL);
+	if (sp == NULL) {
+		return NULL;
+	}
+	/* a service must have an interface entity to exist */
+	if (__serviceInterfaceEntity(sp) == NULL) {
+		CFRelease(sp);
+		_SCErrorSet(kSCStatusNoKey);
+		return NULL;
+	}
+	return (SCNetworkServiceRef)sp;
+}
+
+CFArrayRef
+SCNetworkServiceCopyAll(SCPreferencesRef prefs)
+{
+	CFMutableArrayRef	array;
+	const void		**keys;
+	const void		**vals;
+	CFIndex			i, n;
+	CFStringRef		path;
+	CFDictionaryRef		services;
+
+	path     = CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@"),
+					    kSCPrefNetworkServices);
+	services = SCPreferencesPathGetValue(prefs, path);
+	CFRelease(path);
+
+	if ((services != NULL) &&
+	    (CFGetTypeID(services) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+
+	array = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	n     = __copyDictEntries(services, &keys, &vals);
+	for (i = 0; i < n; i++) {
+		SCNetworkServicePrivateRef	sp;
+		CFDictionaryRef			entity;
+
+		if (CFGetTypeID(vals[i]) != CFDictionaryGetTypeID()) {
+			continue;
+		}
+		/* a service must carry an "Interface" entity */
+		entity = CFDictionaryGetValue((CFDictionaryRef)vals[i],
+					      kSCEntNetInterface);
+		if ((entity == NULL) ||
+		    (CFGetTypeID(entity) != CFDictionaryGetTypeID())) {
+			continue;
+		}
+		sp = __SCNetworkServiceCreatePrivate(NULL, prefs,
+						     (CFStringRef)keys[i], NULL);
+		if (sp != NULL) {
+			CFArrayAppendValue(array, sp);
+			CFRelease(sp);
+		}
+	}
+	if (keys != NULL)	free(keys);
+	if (vals != NULL)	free(vals);
+	return array;
+}
+
+CFStringRef
+SCNetworkServiceGetServiceID(SCNetworkServiceRef service)
+{
+	if (!isA_SCNetworkService(service)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkServicePrivateRef)service)->serviceID;
+}
+
+SCNetworkInterfaceRef
+SCNetworkServiceGetInterface(SCNetworkServiceRef service)
+{
+	SCNetworkServicePrivateRef	sp	= (SCNetworkServicePrivateRef)service;
+
+	if (!isA_SCNetworkService(service) || (sp->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	if (sp->interface == NULL) {
+		CFDictionaryRef	entity = __serviceInterfaceEntity(sp);
+
+		if (entity != NULL) {
+			sp->interface = _SCNetworkInterfaceCreateWithEntity(
+						NULL, entity, service);
+		}
+	}
+	return sp->interface;
+}
+
+CFStringRef
+SCNetworkServiceGetName(SCNetworkServiceRef service)
+{
+	SCNetworkServicePrivateRef	sp	= (SCNetworkServicePrivateRef)service;
+	SCNetworkInterfaceRef		interface;
+	CFDictionaryRef			entity;
+	CFStringRef			name;
+	CFStringRef			path;
+
+	if (!isA_SCNetworkService(service) || (sp->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	if (sp->name != NULL) {
+		return sp->name;
+	}
+
+	/* a stored UserDefinedName wins */
+	path   = __SCNetworkServiceEntityPath(sp->serviceID, NULL);
+	entity = SCPreferencesPathGetValue(sp->prefs, path);
+	CFRelease(path);
+	if ((entity != NULL) &&
+	    (CFGetTypeID(entity) == CFDictionaryGetTypeID())) {
+		name = CFDictionaryGetValue(entity, kSCPropUserDefinedName);
+		if ((name != NULL) &&
+		    (CFGetTypeID(name) == CFStringGetTypeID())) {
+			sp->name = (CFStringRef)CFRetain(name);
+			return sp->name;
+		}
+	}
+
+	/* otherwise fall back to the interface's display name */
+	interface = SCNetworkServiceGetInterface(service);
+	if (interface != NULL) {
+		return SCNetworkInterfaceGetLocalizedDisplayName(interface);
+	}
+	return NULL;
+}
+
+Boolean
+SCNetworkServiceSetName(SCNetworkServiceRef service, CFStringRef name)
+{
+	SCNetworkServicePrivateRef	sp	= (SCNetworkServicePrivateRef)service;
+	CFDictionaryRef			entity;
+	CFMutableDictionaryRef		newEntity;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCNetworkService(service) || (sp->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((name != NULL) &&
+	    (CFGetTypeID(name) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	path   = __SCNetworkServiceEntityPath(sp->serviceID, NULL);
+	entity = SCPreferencesPathGetValue(sp->prefs, path);
+	if ((entity != NULL) &&
+	    (CFGetTypeID(entity) == CFDictionaryGetTypeID())) {
+		newEntity = CFDictionaryCreateMutableCopy(NULL, 0, entity);
+	} else {
+		newEntity = CFDictionaryCreateMutable(NULL, 0,
+					&kCFTypeDictionaryKeyCallBacks,
+					&kCFTypeDictionaryValueCallBacks);
+	}
+	if (name != NULL) {
+		CFDictionarySetValue(newEntity, kSCPropUserDefinedName, name);
+	} else {
+		CFDictionaryRemoveValue(newEntity, kSCPropUserDefinedName);
+	}
+
+	ok = SCPreferencesPathSetValue(sp->prefs, path, newEntity);
+	CFRelease(newEntity);
+	CFRelease(path);
+
+	if (ok) {
+		if (sp->name != NULL) {
+			CFRelease(sp->name);
+		}
+		sp->name = (name != NULL) ? CFStringCreateCopy(NULL, name)
+					  : NULL;
+	}
+	return ok;
+}
+
+Boolean
+SCNetworkServiceRemove(SCNetworkServiceRef service)
+{
+	SCNetworkServicePrivateRef	sp	= (SCNetworkServicePrivateRef)service;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCNetworkService(service) || (sp->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	/* set membership is removed by the SCNetworkSet iteration */
+	path = __SCNetworkServiceEntityPath(sp->serviceID, NULL);
+	ok   = SCPreferencesPathRemoveValue(sp->prefs, path);
+	CFRelease(path);
+	return ok;
+}
+
+
+#pragma mark -
+#pragma mark Protocols on a service
+
+SCNetworkProtocolRef
+SCNetworkServiceCopyProtocol(SCNetworkServiceRef service,
+			     CFStringRef protocolType)
+{
+	SCNetworkServicePrivateRef	sp	= (SCNetworkServicePrivateRef)service;
+	CFDictionaryRef			entity;
+	CFDictionaryRef			service_entity;
+	CFStringRef			path;
+
+	if (!isA_SCNetworkService(service) || (sp->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	if ((protocolType == NULL) ||
+	    (CFGetTypeID(protocolType) != CFStringGetTypeID()) ||
+	    CFEqual(protocolType, kSCEntNetInterface)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	path           = __SCNetworkServiceEntityPath(sp->serviceID, NULL);
+	service_entity = SCPreferencesPathGetValue(sp->prefs, path);
+	CFRelease(path);
+	if ((service_entity == NULL) ||
+	    (CFGetTypeID(service_entity) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+
+	entity = CFDictionaryGetValue(service_entity, protocolType);
+	if ((entity == NULL) ||
+	    (CFGetTypeID(entity) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusNoKey);
+		return NULL;
+	}
+	return (SCNetworkProtocolRef)
+		__SCNetworkProtocolCreatePrivate(NULL, protocolType, service);
+}
+
+CFArrayRef
+SCNetworkServiceCopyProtocols(SCNetworkServiceRef service)
+{
+	SCNetworkServicePrivateRef	sp	= (SCNetworkServicePrivateRef)service;
+	CFMutableArrayRef		array;
+	const void			**keys;
+	const void			**vals;
+	CFIndex				i, n;
+	CFStringRef			path;
+	CFDictionaryRef			service_entity;
+
+	if (!isA_SCNetworkService(service) || (sp->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	path           = __SCNetworkServiceEntityPath(sp->serviceID, NULL);
+	service_entity = SCPreferencesPathGetValue(sp->prefs, path);
+	CFRelease(path);
+	if ((service_entity == NULL) ||
+	    (CFGetTypeID(service_entity) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+
+	array = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	n     = __copyDictEntries(service_entity, &keys, &vals);
+	for (i = 0; i < n; i++) {
+		SCNetworkProtocolPrivateRef	pp;
+
+		/* a protocol entity is a dictionary that is not "Interface" */
+		if (CFGetTypeID(vals[i]) != CFDictionaryGetTypeID()) {
+			continue;
+		}
+		if (CFEqual((CFStringRef)keys[i], kSCEntNetInterface)) {
+			continue;
+		}
+		pp = __SCNetworkProtocolCreatePrivate(NULL,
+						      (CFStringRef)keys[i],
+						      service);
+		if (pp != NULL) {
+			CFArrayAppendValue(array, pp);
+			CFRelease(pp);
+		}
+	}
+	if (keys != NULL)	free(keys);
+	if (vals != NULL)	free(vals);
+	return array;
+}
+
+Boolean
+SCNetworkServiceAddProtocolType(SCNetworkServiceRef service,
+				CFStringRef protocolType)
+{
+	SCNetworkServicePrivateRef	sp	= (SCNetworkServicePrivateRef)service;
+	CFDictionaryRef			entity;
+	CFDictionaryRef			newEntity;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCNetworkService(service) || (sp->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!__SCNetworkProtocolIsValidType(protocolType)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	path   = __SCNetworkServiceEntityPath(sp->serviceID, protocolType);
+	entity = SCPreferencesPathGetValue(sp->prefs, path);
+	if (entity != NULL) {
+		/* the protocol is already configured */
+		_SCErrorSet(kSCStatusKeyExists);
+		CFRelease(path);
+		return FALSE;
+	}
+
+	/* a fresh, empty protocol entity — configure it via the protocol */
+	newEntity = CFDictionaryCreate(NULL, NULL, NULL, 0,
+				       &kCFTypeDictionaryKeyCallBacks,
+				       &kCFTypeDictionaryValueCallBacks);
+	ok = SCPreferencesPathSetValue(sp->prefs, path, newEntity);
+	CFRelease(newEntity);
+	CFRelease(path);
+	return ok;
+}
+
+Boolean
+SCNetworkServiceRemoveProtocolType(SCNetworkServiceRef service,
+				   CFStringRef protocolType)
+{
+	SCNetworkServicePrivateRef	sp	= (SCNetworkServicePrivateRef)service;
+	CFDictionaryRef			entity;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCNetworkService(service) || (sp->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!__SCNetworkProtocolIsValidType(protocolType)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	path   = __SCNetworkServiceEntityPath(sp->serviceID, protocolType);
+	entity = SCPreferencesPathGetValue(sp->prefs, path);
+	if (entity == NULL) {
+		/* the protocol is not configured */
+		_SCErrorSet(kSCStatusNoKey);
+		CFRelease(path);
+		return FALSE;
+	}
+
+	ok = SCPreferencesPathRemoveValue(sp->prefs, path);
+	CFRelease(path);
+	return ok;
+}

--- a/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
@@ -39,6 +39,7 @@
 
 #include <sys/cdefs.h>
 #include <CoreFoundation/CoreFoundation.h>
+#include <SystemConfiguration/SCPreferences.h>
 
 /*!
 	@typedef SCNetworkInterfaceRef
@@ -180,6 +181,169 @@ SCNetworkInterfaceGetSupportedInterfaceTypes
 CFArrayRef
 SCNetworkInterfaceGetSupportedProtocolTypes
 					(SCNetworkInterfaceRef		interface);
+
+/* --------------------------------------------------------------------
+ * SCNetworkProtocol
+ * ------------------------------------------------------------------ */
+
+/*!
+	@function SCNetworkProtocolGetTypeID
+	@discussion Returns the CoreFoundation type identifier of all
+		SCNetworkProtocol instances.
+ */
+CFTypeID
+SCNetworkProtocolGetTypeID		(void);
+
+/*!
+	@function SCNetworkProtocolGetProtocolType
+	@discussion Returns the protocol type — one of the
+		kSCNetworkProtocolType* constants. Owned by the protocol.
+ */
+CFStringRef
+SCNetworkProtocolGetProtocolType	(SCNetworkProtocolRef		protocol);
+
+/*!
+	@function SCNetworkProtocolGetConfiguration
+	@discussion Returns the protocol's configuration dictionary, or
+		NULL if it has none. Owned by the protocol.
+ */
+CFDictionaryRef
+SCNetworkProtocolGetConfiguration	(SCNetworkProtocolRef		protocol);
+
+/*!
+	@function SCNetworkProtocolSetConfiguration
+	@discussion Stores the protocol's configuration dictionary. The
+		protocol's enabled/disabled state is preserved.
+ */
+Boolean
+SCNetworkProtocolSetConfiguration	(SCNetworkProtocolRef		protocol,
+					 CFDictionaryRef		config);
+
+/*!
+	@function SCNetworkProtocolGetEnabled
+	@discussion Returns whether the protocol is enabled.
+ */
+Boolean
+SCNetworkProtocolGetEnabled		(SCNetworkProtocolRef		protocol);
+
+/*!
+	@function SCNetworkProtocolSetEnabled
+	@discussion Enables or disables the protocol.
+ */
+Boolean
+SCNetworkProtocolSetEnabled		(SCNetworkProtocolRef		protocol,
+					 Boolean			enabled);
+
+/* --------------------------------------------------------------------
+ * SCNetworkService
+ * ------------------------------------------------------------------ */
+
+/*!
+	@function SCNetworkServiceGetTypeID
+	@discussion Returns the CoreFoundation type identifier of all
+		SCNetworkService instances.
+ */
+CFTypeID
+SCNetworkServiceGetTypeID		(void);
+
+/*!
+	@function SCNetworkServiceCreate
+	@discussion Creates a new network service bound to `interface`,
+		stored in `prefs`. Release the returned value.
+ */
+SCNetworkServiceRef
+SCNetworkServiceCreate			(SCPreferencesRef		prefs,
+					 SCNetworkInterfaceRef		interface);
+
+/*!
+	@function SCNetworkServiceCopy
+	@discussion Returns the existing network service `serviceID` in
+		`prefs`, or NULL. Release the returned value.
+ */
+SCNetworkServiceRef
+SCNetworkServiceCopy			(SCPreferencesRef		prefs,
+					 CFStringRef			serviceID);
+
+/*!
+	@function SCNetworkServiceCopyAll
+	@discussion Returns every network service stored in `prefs`.
+	@result a CFArray of SCNetworkServiceRef (caller releases).
+ */
+CFArrayRef
+SCNetworkServiceCopyAll			(SCPreferencesRef		prefs);
+
+/*!
+	@function SCNetworkServiceGetServiceID
+	@discussion Returns the service's identifier. Owned by the service.
+ */
+CFStringRef
+SCNetworkServiceGetServiceID		(SCNetworkServiceRef		service);
+
+/*!
+	@function SCNetworkServiceGetName
+	@discussion Returns the service's name — the stored name, or the
+		associated interface's name if none has been set.
+ */
+CFStringRef
+SCNetworkServiceGetName			(SCNetworkServiceRef		service);
+
+/*!
+	@function SCNetworkServiceSetName
+	@discussion Sets the service's name.
+ */
+Boolean
+SCNetworkServiceSetName			(SCNetworkServiceRef		service,
+					 CFStringRef			name);
+
+/*!
+	@function SCNetworkServiceGetInterface
+	@discussion Returns the interface the service is bound to. Owned
+		by the service.
+ */
+SCNetworkInterfaceRef
+SCNetworkServiceGetInterface		(SCNetworkServiceRef		service);
+
+/*!
+	@function SCNetworkServiceRemove
+	@discussion Removes the service from the preferences.
+ */
+Boolean
+SCNetworkServiceRemove			(SCNetworkServiceRef		service);
+
+/*!
+	@function SCNetworkServiceCopyProtocol
+	@discussion Returns the service's configured protocol of type
+		`protocolType`, or NULL. Release the returned value.
+ */
+SCNetworkProtocolRef
+SCNetworkServiceCopyProtocol		(SCNetworkServiceRef		service,
+					 CFStringRef			protocolType);
+
+/*!
+	@function SCNetworkServiceCopyProtocols
+	@discussion Returns every protocol configured on the service.
+	@result a CFArray of SCNetworkProtocolRef (caller releases).
+ */
+CFArrayRef
+SCNetworkServiceCopyProtocols		(SCNetworkServiceRef		service);
+
+/*!
+	@function SCNetworkServiceAddProtocolType
+	@discussion Adds an (empty) protocol of type `protocolType` to the
+		service; configure it via SCNetworkProtocolSetConfiguration.
+ */
+Boolean
+SCNetworkServiceAddProtocolType		(SCNetworkServiceRef		service,
+					 CFStringRef			protocolType);
+
+/*!
+	@function SCNetworkServiceRemoveProtocolType
+	@discussion Removes the protocol of type `protocolType` from the
+		service.
+ */
+Boolean
+SCNetworkServiceRemoveProtocolType	(SCNetworkServiceRef		service,
+					 CFStringRef			protocolType);
 
 __END_DECLS
 

--- a/src/libSystemConfiguration/scnetsvctest.c
+++ b/src/libSystemConfiguration/scnetsvctest.c
@@ -1,0 +1,279 @@
+/*
+ * scnetsvctest.c — libSystemConfiguration SCNetworkConfiguration iter 3
+ * test client: SCNetworkService + SCNetworkProtocol.
+ *
+ * Creates a network service bound to the guest's e1000 interface,
+ * names it, attaches an IPv4 protocol and configures it, commits, then
+ * reopens the preferences and confirms the service, its name, its
+ * interface and its protocol configuration all persisted — and finally
+ * removes the protocol and the service.
+ *
+ * run.sh runs it and boot-test.sh gates on the SC-NETSVC-OK / -FAIL
+ * marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+#define	SCT_ID	"scnetsvctest.plist"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-NETSVC-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+/* the first Ethernet interface from SCNetworkInterfaceCopyAll, or NULL */
+static SCNetworkInterfaceRef
+first_ethernet(CFArrayRef all)
+{
+	CFIndex	i, n;
+
+	n = CFArrayGetCount(all);
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	iface;
+
+		iface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(all, i);
+		if (CFEqual(SCNetworkInterfaceGetInterfaceType(iface),
+			    kSCNetworkInterfaceTypeEthernet)) {
+			return iface;
+		}
+	}
+	return NULL;
+}
+
+int
+main(void)
+{
+	SCPreferencesRef	prefs	= NULL;
+	CFArrayRef		all	= NULL;
+	CFArrayRef		protos	= NULL;
+	CFArrayRef		all2	= NULL;
+	SCNetworkInterfaceRef	iface;
+	SCNetworkServiceRef	svc	= NULL;
+	SCNetworkServiceRef	svc2	= NULL;
+	SCNetworkProtocolRef	proto	= NULL;
+	SCNetworkProtocolRef	proto2	= NULL;
+	CFMutableDictionaryRef	config	= NULL;
+	CFStringRef		name, prefsID, wantName;
+	CFStringRef		savedID	= NULL;
+	CFStringRef		origBSD	= NULL;
+	CFStringRef		method, dhcp;
+	int			rc	= 1;
+
+	printf("scnetsvctest: SCNetworkService + SCNetworkProtocol\n");
+	fflush(stdout);
+
+	name	 = mkstr("scnetsvctest");
+	prefsID	 = mkstr(SCT_ID);
+	wantName = mkstr("Test Service");
+	method	 = mkstr("Method");
+	dhcp	 = mkstr("DHCP");
+
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate failed");
+		goto out;
+	}
+
+	all = SCNetworkInterfaceCopyAll();
+	iface = (all != NULL) ? first_ethernet(all) : NULL;
+	if (iface == NULL) {
+		fail("no Ethernet interface to build a service on");
+		goto out;
+	}
+	origBSD = CFStringCreateCopy(NULL, SCNetworkInterfaceGetBSDName(iface));
+
+	/* create a service bound to the interface */
+	svc = SCNetworkServiceCreate(prefs, iface);
+	if (svc == NULL) {
+		fail("SCNetworkServiceCreate failed");
+		goto out;
+	}
+	savedID = CFStringCreateCopy(NULL, SCNetworkServiceGetServiceID(svc));
+	if (savedID == NULL) {
+		fail("SCNetworkServiceGetServiceID returned NULL");
+		goto out;
+	}
+
+	/* a fresh service is named after its interface */
+	if (SCNetworkServiceGetName(svc) == NULL) {
+		fail("a new service has no default name");
+		goto out;
+	}
+	if (!SCNetworkServiceSetName(svc, wantName) ||
+	    !CFEqual(SCNetworkServiceGetName(svc), wantName)) {
+		fail("SCNetworkServiceSetName did not round-trip");
+		goto out;
+	}
+	printf("  ServiceCreate/SetName: service named\n");
+
+	/* the service reports the interface it was created on */
+	iface = SCNetworkServiceGetInterface(svc);
+	if ((iface == NULL) ||
+	    !CFEqual(SCNetworkInterfaceGetBSDName(iface), origBSD)) {
+		fail("SCNetworkServiceGetInterface mismatch");
+		goto out;
+	}
+
+	/* attach an IPv4 protocol */
+	if (!SCNetworkServiceAddProtocolType(svc, kSCNetworkProtocolTypeIPv4)) {
+		fail("SCNetworkServiceAddProtocolType(IPv4) failed");
+		goto out;
+	}
+	if (SCNetworkServiceAddProtocolType(svc, kSCNetworkProtocolTypeIPv4)) {
+		fail("adding a duplicate protocol type was allowed");
+		goto out;
+	}
+
+	proto = SCNetworkServiceCopyProtocol(svc, kSCNetworkProtocolTypeIPv4);
+	if ((proto == NULL) ||
+	    !CFEqual(SCNetworkProtocolGetProtocolType(proto),
+		     kSCNetworkProtocolTypeIPv4)) {
+		fail("SCNetworkServiceCopyProtocol(IPv4) failed");
+		goto out;
+	}
+
+	/* configure + enable/disable the protocol */
+	config = CFDictionaryCreateMutable(NULL, 0,
+					   &kCFTypeDictionaryKeyCallBacks,
+					   &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(config, method, dhcp);
+	if (!SCNetworkProtocolSetConfiguration(proto, config)) {
+		fail("SCNetworkProtocolSetConfiguration failed");
+		goto out;
+	}
+	{
+		CFDictionaryRef	got = SCNetworkProtocolGetConfiguration(proto);
+		CFTypeRef	v   = (got != NULL)
+				      ? CFDictionaryGetValue(got, method) : NULL;
+
+		if ((v == NULL) || !CFEqual(v, dhcp)) {
+			fail("protocol configuration did not round-trip");
+			goto out;
+		}
+	}
+	if (!SCNetworkProtocolGetEnabled(proto)) {
+		fail("a new protocol is not enabled");
+		goto out;
+	}
+	if (!SCNetworkProtocolSetEnabled(proto, FALSE) ||
+	    SCNetworkProtocolGetEnabled(proto)) {
+		fail("SCNetworkProtocolSetEnabled(FALSE) did not take");
+		goto out;
+	}
+	if (!SCNetworkProtocolSetEnabled(proto, TRUE) ||
+	    !SCNetworkProtocolGetEnabled(proto)) {
+		fail("SCNetworkProtocolSetEnabled(TRUE) did not take");
+		goto out;
+	}
+
+	protos = SCNetworkServiceCopyProtocols(svc);
+	if ((protos == NULL) || (CFArrayGetCount(protos) != 1)) {
+		fail("SCNetworkServiceCopyProtocols count wrong");
+		goto out;
+	}
+	printf("  AddProtocolType/Protocol*: IPv4 protocol configured\n");
+
+	/* commit, reopen, confirm the service persisted */
+	if (!SCPreferencesCommitChanges(prefs)) {
+		fail("SCPreferencesCommitChanges failed");
+		goto out;
+	}
+	CFRelease(prefs);
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate (reopen) failed");
+		goto out;
+	}
+
+	svc2 = SCNetworkServiceCopy(prefs, savedID);
+	if (svc2 == NULL) {
+		fail("SCNetworkServiceCopy after reopen failed");
+		goto out;
+	}
+	if (!CFEqual(SCNetworkServiceGetName(svc2), wantName)) {
+		fail("service name did not persist");
+		goto out;
+	}
+	iface = SCNetworkServiceGetInterface(svc2);
+	if ((iface == NULL) ||
+	    !CFEqual(SCNetworkInterfaceGetBSDName(iface), origBSD)) {
+		fail("service interface did not persist");
+		goto out;
+	}
+	proto2 = SCNetworkServiceCopyProtocol(svc2, kSCNetworkProtocolTypeIPv4);
+	if (proto2 == NULL) {
+		fail("protocol did not persist");
+		goto out;
+	}
+	{
+		CFDictionaryRef	got = SCNetworkProtocolGetConfiguration(proto2);
+		CFTypeRef	v   = (got != NULL)
+				      ? CFDictionaryGetValue(got, method) : NULL;
+
+		if ((v == NULL) || !CFEqual(v, dhcp)) {
+			fail("protocol configuration did not persist");
+			goto out;
+		}
+	}
+	all2 = SCNetworkServiceCopyAll(prefs);
+	if ((all2 == NULL) || (CFArrayGetCount(all2) < 1)) {
+		fail("SCNetworkServiceCopyAll did not list the service");
+		goto out;
+	}
+	printf("  CommitChanges/reopen: service persisted\n");
+
+	/* remove the protocol, then the service */
+	if (!SCNetworkServiceRemoveProtocolType(svc2,
+						kSCNetworkProtocolTypeIPv4)) {
+		fail("SCNetworkServiceRemoveProtocolType failed");
+		goto out;
+	}
+	if (SCNetworkServiceCopyProtocol(svc2,
+					 kSCNetworkProtocolTypeIPv4) != NULL) {
+		fail("protocol still present after removal");
+		goto out;
+	}
+	if (!SCNetworkServiceRemove(svc2)) {
+		fail("SCNetworkServiceRemove failed");
+		goto out;
+	}
+	if (SCNetworkServiceCopy(prefs, savedID) != NULL) {
+		fail("service still present after removal");
+		goto out;
+	}
+	printf("  RemoveProtocolType/ServiceRemove: torn down\n");
+
+	printf("SC-NETSVC-OK: SCNetworkService + SCNetworkProtocol work\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (config != NULL)	CFRelease(config);
+	if (proto != NULL)	CFRelease(proto);
+	if (proto2 != NULL)	CFRelease(proto2);
+	if (protos != NULL)	CFRelease(protos);
+	if (svc != NULL)	CFRelease(svc);
+	if (svc2 != NULL)	CFRelease(svc2);
+	if (all != NULL)	CFRelease(all);
+	if (all2 != NULL)	CFRelease(all2);
+	if (prefs != NULL)	CFRelease(prefs);
+	if (savedID != NULL)	CFRelease(savedID);
+	if (origBSD != NULL)	CFRelease(origBSD);
+	CFRelease(name);
+	CFRelease(prefsID);
+	CFRelease(wantName);
+	CFRelease(method);
+	CFRelease(dhcp);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -574,6 +574,18 @@ expect {
     "SC-NETIF-OK" { puts "\nOK: SCNetworkInterface enumeration works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-NETSVC marker not seen"
+        exit 1
+    }
+    "SC-NETSVC-FAIL" {
+        puts "\nFAIL: SCNetworkService / SCNetworkProtocol failed"
+        exit 1
+    }
+    "SC-NETSVC-OK" { puts "\nOK: SCNetworkService + SCNetworkProtocol work" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## SCNetworkConfiguration iter 3 — SCNetworkService + SCNetworkProtocol

Third iteration of the **SCNetworkConfiguration** port: the `SCNetworkService` and `SCNetworkProtocol` objects. A network service binds an interface to the protocols configured on it; it is persisted in the preferences plist at `/NetworkServices/<serviceID>` — a dictionary carrying an `Interface` entity, a `UserDefinedName`, and one sub-dictionary per protocol.

### Changes

- **`SCNetworkProtocol.c`** — the protocol object: `GetProtocolType`, `Get/SetConfiguration`, `Get/SetEnabled`. A protocol's configuration is the dictionary at `/NetworkServices/<id>/<type>`; a reserved `__INACTIVE__` key marks it disabled, and `SetConfiguration` preserves that state.
- **`SCNetworkService.c`** — the service object: `Create` (mints a unique `/NetworkServices/<id>` via `SCPreferencesPathCreateUniqueChild` and stores the interface entity), `Copy` / `CopyAll`, `GetServiceID`, `Get/SetName`, `GetInterface`, `Remove`, and the protocol attach/detach calls `Add/RemoveProtocolType` / `CopyProtocol(s)`.
- **`SCNetworkInterface.c`** — the interface ⇄ preferences-entity bridge: `__SCNetworkInterfaceCopyInterfaceEntity` serializes an interface into a service's `Interface` dictionary; `_SCNetworkInterfaceCreateWithEntity` rebuilds one from it (so `SCNetworkServiceGetInterface` works after a reopen).
- **`SCNetworkConfigurationInternal.{c,h}`** — the Service / Protocol private structs, the reserved-key macros, `isA_*` checks, and a shared `__SCNetworkServiceEntityPath()` path builder.

Apple's `SCNetworkService.c` additionally seeds interface-type templates (PPP/Modem) and routes writes through SCHelper; the port keeps the core CRUD.

### Test

New **`scnetsvctest`** (`SC-NETSVC` marker) creates a service on the e1000 interface, names it, attaches and configures an IPv4 protocol (with enable/disable round-trips), commits, reopens the preferences to confirm the service / name / interface / protocol config all persisted, then removes the protocol and the service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)