### PR TITLE
feat(libSystemConfiguration): SCNetworkConfiguration iter 4 — SCNetworkSet

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1278,6 +1278,23 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scnetsvctest" \
     || { echo "FAIL: scnetsvctest not built"; exit 1; }
 echo "==> scnetsvctest built"
 
+# scnetsettest — libSystemConfiguration SCNetworkConfiguration iter 4
+# test client. Creates an SCNetworkSet, names it, adds + removes a
+# service, sets a service order, makes the set current, commits,
+# reopens and confirms it persisted. run.sh runs it and checks for the
+# SC-NETSET-OK marker.
+echo "==> building scnetsettest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scnetsettest" \
+   "$ROOT/src/libSystemConfiguration/scnetsettest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scnetsettest" \
+    || { echo "FAIL: scnetsettest not built"; exit 1; }
+echo "==> scnetsettest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -617,4 +617,14 @@ if [ ! -x "$scnetsvctest" ]; then
 fi
 "$scnetsvctest" || true	# marker (SC-NETSVC-OK/FAIL) gates in boot-test.sh
 
+# SC-NETSET — SCNetworkConfiguration set ("location"): create a network
+# set, name it, add/remove a service, set a service order, make it
+# current, commit, reopen and confirm it all persisted.
+scnetsettest=/usr/tests/freebsd-launchd-mach/scnetsettest
+if [ ! -x "$scnetsettest" ]; then
+    echo "SC-NETSET-FAIL: $scnetsettest missing"
+    exit 1
+fi
+"$scnetsettest" || true	# marker (SC-NETSET-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/Makefile
+++ b/src/libSystemConfiguration/Makefile
@@ -22,7 +22,7 @@ SHLIB_MAJOR=	1
 
 SRCS=		SCD.c SCDynamicStore.c SCNotify.c SCDMultiple.c SCPreferences.c
 SRCS+=		SCNetworkConfigurationInternal.c SCNetworkInterface.c
-SRCS+=		SCNetworkProtocol.c SCNetworkService.c
+SRCS+=		SCNetworkProtocol.c SCNetworkService.c SCNetworkSet.c
 
 # configUser.c — MIG-generated config.defs client stubs (same file
 # configd's test clients link). config_wire.c — configd's shared

--- a/src/libSystemConfiguration/SCNetworkConfigurationInternal.h
+++ b/src/libSystemConfiguration/SCNetworkConfigurationInternal.h
@@ -24,8 +24,15 @@
  */
 #define kSCResvInactive			CFSTR("__INACTIVE__")
 #define kSCPrefNetworkServices		CFSTR("NetworkServices")
+#define kSCPrefSets			CFSTR("Sets")
+#define kSCPrefCurrentSet		CFSTR("CurrentSet")
+#define kSCCompNetwork			CFSTR("Network")
+#define kSCCompService			CFSTR("Service")
+#define kSCCompGlobal			CFSTR("Global")
 #define kSCEntNetInterface		CFSTR("Interface")
+#define kSCEntNetIPv4			CFSTR("IPv4")
 #define kSCPropUserDefinedName		CFSTR("UserDefinedName")
+#define kSCPropNetServiceOrder		CFSTR("ServiceOrder")
 #define kSCPropNetInterfaceType		CFSTR("Type")
 #define kSCPropNetInterfaceDeviceName	CFSTR("DeviceName")
 #define kSCPropNetInterfaceHardware	CFSTR("Hardware")
@@ -100,6 +107,24 @@ typedef struct __SCNetworkProtocol {
 
 
 #pragma mark -
+#pragma mark SCNetworkSet
+
+/*
+ * The SCNetworkSet object — see SCNetworkSet.c. A set ("location") is an
+ * ordered collection of network services; persisted at /Sets/<setID> in
+ * the preferences plist, with the active set named by the top-level
+ * "CurrentSet" key.
+ */
+typedef struct __SCNetworkSet {
+	CFRuntimeBase		cfBase;
+
+	CFStringRef		setID;
+	SCPreferencesRef	prefs;
+	CFStringRef		name;		/* cached UserDefinedName */
+} SCNetworkSetPrivate, *SCNetworkSetPrivateRef;
+
+
+#pragma mark -
 #pragma mark Type checks
 
 static inline Boolean
@@ -121,6 +146,13 @@ isA_SCNetworkProtocol(SCNetworkProtocolRef protocol)
 {
 	return ((protocol != NULL) &&
 		(CFGetTypeID(protocol) == SCNetworkProtocolGetTypeID()));
+}
+
+static inline Boolean
+isA_SCNetworkSet(SCNetworkSetRef set)
+{
+	return ((set != NULL) &&
+		(CFGetTypeID(set) == SCNetworkSetGetTypeID()));
 }
 
 
@@ -157,6 +189,12 @@ SCNetworkProtocolPrivateRef
 __SCNetworkProtocolCreatePrivate	(CFAllocatorRef		allocator,
 					 CFStringRef		entityID,
 					 SCNetworkServiceRef	service);
+
+/* SCNetworkSet.c — allocate a set object. */
+SCNetworkSetPrivateRef
+__SCNetworkSetCreatePrivate		(CFAllocatorRef		allocator,
+					 SCPreferencesRef	prefs,
+					 CFStringRef		setID);
 
 /* SCNetworkProtocol.c — TRUE iff `protocolType` is a known protocol. */
 Boolean

--- a/src/libSystemConfiguration/SCNetworkSet.c
+++ b/src/libSystemConfiguration/SCNetworkSet.c
@@ -1,0 +1,622 @@
+/*
+ * SCNetworkSet.c — the SCNetworkSet object (freebsd-launchd-mach port of
+ * Apple's SystemConfiguration.fproj SCNetworkSet.c).
+ *
+ * A network set — a "location" — is an ordered collection of network
+ * services. It is persisted in the preferences plist at /Sets/<setID>;
+ * a service is a member of a set via a __LINK__ entry at
+ * /Sets/<setID>/Network/Service/<serviceID> pointing back at the real
+ * /NetworkServices/<serviceID>. The active set is named by the
+ * top-level "CurrentSet" preferences key.
+ *
+ * Apple's SCNetworkSet.c additionally manages the special "Automatic"
+ * default set, per-interface "deep" configuration, and VPN selection;
+ * the port keeps the core model: create / copy / list a set, name it,
+ * add and remove services, the service order, and the current set.
+ */
+
+#include "SCNetworkConfigurationInternal.h"
+#include "SCInternal.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+
+
+#pragma mark -
+#pragma mark CoreFoundation runtime type
+
+static CFTypeID	__kSCNetworkSetTypeID	= _kCFRuntimeNotATypeID;
+
+static void
+__SCNetworkSetDeallocate(CFTypeRef cf)
+{
+	SCNetworkSetPrivateRef	sp	= (SCNetworkSetPrivateRef)cf;
+
+	if (sp->setID != NULL)	CFRelease(sp->setID);
+	if (sp->prefs != NULL)	CFRelease(sp->prefs);
+	if (sp->name != NULL)	CFRelease(sp->name);
+}
+
+static Boolean
+__SCNetworkSetEqual(CFTypeRef cf1, CFTypeRef cf2)
+{
+	SCNetworkSetPrivateRef	s1	= (SCNetworkSetPrivateRef)cf1;
+	SCNetworkSetPrivateRef	s2	= (SCNetworkSetPrivateRef)cf2;
+
+	if (s1 == s2) {
+		return TRUE;
+	}
+	return CFEqual(s1->setID, s2->setID);
+}
+
+static CFHashCode
+__SCNetworkSetHash(CFTypeRef cf)
+{
+	return CFHash(((SCNetworkSetPrivateRef)cf)->setID);
+}
+
+static CFStringRef
+__SCNetworkSetCopyDescription(CFTypeRef cf)
+{
+	SCNetworkSetPrivateRef	sp	= (SCNetworkSetPrivateRef)cf;
+
+	return CFStringCreateWithFormat(NULL, NULL,
+			CFSTR("<SCNetworkSet %@>"), sp->setID);
+}
+
+static const CFRuntimeClass __SCNetworkSetClass = {
+	.version	= 0,
+	.className	= "SCNetworkSet",
+	.finalize	= __SCNetworkSetDeallocate,
+	.equal		= __SCNetworkSetEqual,
+	.hash		= __SCNetworkSetHash,
+	.copyDebugDesc	= __SCNetworkSetCopyDescription,
+};
+
+static void
+__SCNetworkSetClassInitialize(void)
+{
+	__kSCNetworkSetTypeID = _CFRuntimeRegisterClass(&__SCNetworkSetClass);
+}
+
+CFTypeID
+SCNetworkSetGetTypeID(void)
+{
+	static pthread_once_t	once	= PTHREAD_ONCE_INIT;
+
+	(void) pthread_once(&once, __SCNetworkSetClassInitialize);
+	return __kSCNetworkSetTypeID;
+}
+
+SCNetworkSetPrivateRef
+__SCNetworkSetCreatePrivate(CFAllocatorRef	allocator,
+			    SCPreferencesRef	prefs,
+			    CFStringRef		setID)
+{
+	SCNetworkSetPrivateRef	sp;
+	CFIndex			extra;
+
+	extra = sizeof(SCNetworkSetPrivate) - sizeof(CFRuntimeBase);
+	sp = (SCNetworkSetPrivateRef)
+	     _CFRuntimeCreateInstance(allocator,
+				      SCNetworkSetGetTypeID(),
+				      extra, NULL);
+	if (sp == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+	sp->setID = CFStringCreateCopy(NULL, setID);
+	sp->prefs = (prefs != NULL)
+		    ? (SCPreferencesRef)CFRetain(prefs) : NULL;
+	sp->name  = NULL;
+	return sp;
+}
+
+
+#pragma mark -
+#pragma mark Path helpers
+
+/* "/Sets/<setID>" */
+static CFStringRef
+__setPath(CFStringRef setID)
+{
+	return CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@/%@"),
+					kSCPrefSets, setID);
+}
+
+/*
+ * "/Sets/<setID>/Network/Service" (serviceID NULL) or
+ * "/Sets/<setID>/Network/Service/<serviceID>"
+ */
+static CFStringRef
+__setServicePath(CFStringRef setID, CFStringRef serviceID)
+{
+	if (serviceID == NULL) {
+		return CFStringCreateWithFormat(NULL, NULL,
+				CFSTR("/%@/%@/%@/%@"),
+				kSCPrefSets, setID,
+				kSCCompNetwork, kSCCompService);
+	}
+	return CFStringCreateWithFormat(NULL, NULL,
+			CFSTR("/%@/%@/%@/%@/%@"),
+			kSCPrefSets, setID,
+			kSCCompNetwork, kSCCompService, serviceID);
+}
+
+/* "/Sets/<setID>/Network/Global/IPv4" — holds the service order */
+static CFStringRef
+__setGlobalIPv4Path(CFStringRef setID)
+{
+	return CFStringCreateWithFormat(NULL, NULL,
+			CFSTR("/%@/%@/%@/%@/%@"),
+			kSCPrefSets, setID,
+			kSCCompNetwork, kSCCompGlobal, kSCEntNetIPv4);
+}
+
+/* the __LINK__ target for a service membership: "/NetworkServices/<id>" */
+static CFStringRef
+__netServicePath(CFStringRef serviceID)
+{
+	return CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@/%@"),
+					kSCPrefNetworkServices, serviceID);
+}
+
+/*
+ * Copy the keys of `dict` into a caller-freed array; the array must be
+ * free()d. Returns the count, or 0 (array left NULL) for an empty or
+ * non-dictionary argument.
+ */
+static CFIndex
+__copyDictKeys(CFDictionaryRef dict, const void ***keys)
+{
+	CFIndex	n;
+
+	*keys = NULL;
+	if ((dict == NULL) ||
+	    (CFGetTypeID(dict) != CFDictionaryGetTypeID())) {
+		return 0;
+	}
+	n = CFDictionaryGetCount(dict);
+	if (n <= 0) {
+		return 0;
+	}
+	*keys = (const void **)malloc((size_t)n * sizeof(void *));
+	CFDictionaryGetKeysAndValues(dict, *keys, NULL);
+	return n;
+}
+
+
+#pragma mark -
+#pragma mark SCNetworkSet APIs
+
+SCNetworkSetRef
+SCNetworkSetCreate(SCPreferencesRef prefs)
+{
+	CFArrayRef		components;
+	CFStringRef		path;
+	CFStringRef		prefix;
+	CFStringRef		setID;
+	SCNetworkSetPrivateRef	sp;
+
+	/* mint a unique /Sets/<setID> entry */
+	prefix = CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@"),
+					  kSCPrefSets);
+	path = SCPreferencesPathCreateUniqueChild(prefs, prefix);
+	CFRelease(prefix);
+	if (path == NULL) {
+		return NULL;
+	}
+	components = CFStringCreateArrayBySeparatingStrings(NULL, path,
+							    CFSTR("/"));
+	CFRelease(path);
+	/* "/Sets/<id>" splits to ["", "Sets", id] */
+	if ((components == NULL) || (CFArrayGetCount(components) < 3)) {
+		if (components != NULL) CFRelease(components);
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+	setID = CFArrayGetValueAtIndex(components, 2);
+	sp = __SCNetworkSetCreatePrivate(NULL, prefs, setID);
+	CFRelease(components);
+	return (SCNetworkSetRef)sp;
+}
+
+SCNetworkSetRef
+SCNetworkSetCopy(SCPreferencesRef prefs, CFStringRef setID)
+{
+	CFDictionaryRef		dict;
+	CFStringRef		path;
+	SCNetworkSetPrivateRef	sp;
+
+	if ((setID == NULL) ||
+	    (CFGetTypeID(setID) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	path = __setPath(setID);
+	dict = SCPreferencesPathGetValue(prefs, path);
+	CFRelease(path);
+	if ((dict == NULL) ||
+	    (CFGetTypeID(dict) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusNoKey);
+		return NULL;
+	}
+	sp = __SCNetworkSetCreatePrivate(NULL, prefs, setID);
+	return (SCNetworkSetRef)sp;
+}
+
+CFArrayRef
+SCNetworkSetCopyAll(SCPreferencesRef prefs)
+{
+	CFMutableArrayRef	array;
+	const void		**keys;
+	CFIndex			i, n;
+	CFStringRef		path;
+	CFDictionaryRef		sets;
+
+	path = CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@"),
+					kSCPrefSets);
+	sets = SCPreferencesPathGetValue(prefs, path);
+	CFRelease(path);
+	if ((sets != NULL) &&
+	    (CFGetTypeID(sets) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+
+	array = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	n     = __copyDictKeys(sets, &keys);
+	for (i = 0; i < n; i++) {
+		SCNetworkSetPrivateRef	sp;
+
+		sp = __SCNetworkSetCreatePrivate(NULL, prefs,
+						 (CFStringRef)keys[i]);
+		if (sp != NULL) {
+			CFArrayAppendValue(array, sp);
+			CFRelease(sp);
+		}
+	}
+	if (keys != NULL)	free(keys);
+	return array;
+}
+
+SCNetworkSetRef
+SCNetworkSetCopyCurrent(SCPreferencesRef prefs)
+{
+	CFArrayRef	components;
+	CFStringRef	currentID;
+	SCNetworkSetRef	set	= NULL;
+
+	currentID = SCPreferencesGetValue(prefs, kSCPrefCurrentSet);
+	if ((currentID == NULL) ||
+	    (CFGetTypeID(currentID) != CFStringGetTypeID())) {
+		return NULL;
+	}
+	/* the value is the set's path "/Sets/<setID>" */
+	components = CFStringCreateArrayBySeparatingStrings(NULL, currentID,
+							    CFSTR("/"));
+	if ((components != NULL) && (CFArrayGetCount(components) == 3)) {
+		set = SCNetworkSetCopy(prefs,
+				       CFArrayGetValueAtIndex(components, 2));
+	}
+	if (components != NULL) {
+		CFRelease(components);
+	}
+	return set;
+}
+
+Boolean
+SCNetworkSetSetCurrent(SCNetworkSetRef set)
+{
+	SCNetworkSetPrivateRef	sp	= (SCNetworkSetPrivateRef)set;
+	CFStringRef		path;
+	Boolean			ok;
+
+	if (!isA_SCNetworkSet(set)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	path = __setPath(sp->setID);
+	ok   = SCPreferencesSetValue(sp->prefs, kSCPrefCurrentSet, path);
+	CFRelease(path);
+	return ok;
+}
+
+CFStringRef
+SCNetworkSetGetSetID(SCNetworkSetRef set)
+{
+	if (!isA_SCNetworkSet(set)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkSetPrivateRef)set)->setID;
+}
+
+CFStringRef
+SCNetworkSetGetName(SCNetworkSetRef set)
+{
+	SCNetworkSetPrivateRef	sp	= (SCNetworkSetPrivateRef)set;
+	CFDictionaryRef		dict;
+	CFStringRef		name;
+	CFStringRef		path;
+
+	if (!isA_SCNetworkSet(set)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	if (sp->name != NULL) {
+		return sp->name;
+	}
+	path = __setPath(sp->setID);
+	dict = SCPreferencesPathGetValue(sp->prefs, path);
+	CFRelease(path);
+	if ((dict != NULL) &&
+	    (CFGetTypeID(dict) == CFDictionaryGetTypeID())) {
+		name = CFDictionaryGetValue(dict, kSCPropUserDefinedName);
+		if ((name != NULL) &&
+		    (CFGetTypeID(name) == CFStringGetTypeID())) {
+			sp->name = (CFStringRef)CFRetain(name);
+			return sp->name;
+		}
+	}
+	return NULL;
+}
+
+Boolean
+SCNetworkSetSetName(SCNetworkSetRef set, CFStringRef name)
+{
+	SCNetworkSetPrivateRef	sp	= (SCNetworkSetPrivateRef)set;
+	CFDictionaryRef		dict;
+	CFMutableDictionaryRef	newDict;
+	CFStringRef		path;
+	Boolean			ok;
+
+	if (!isA_SCNetworkSet(set)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((name != NULL) &&
+	    (CFGetTypeID(name) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	path = __setPath(sp->setID);
+	dict = SCPreferencesPathGetValue(sp->prefs, path);
+	if ((dict != NULL) &&
+	    (CFGetTypeID(dict) == CFDictionaryGetTypeID())) {
+		newDict = CFDictionaryCreateMutableCopy(NULL, 0, dict);
+	} else {
+		newDict = CFDictionaryCreateMutable(NULL, 0,
+					&kCFTypeDictionaryKeyCallBacks,
+					&kCFTypeDictionaryValueCallBacks);
+	}
+	if (name != NULL) {
+		CFDictionarySetValue(newDict, kSCPropUserDefinedName, name);
+	} else {
+		CFDictionaryRemoveValue(newDict, kSCPropUserDefinedName);
+	}
+
+	ok = SCPreferencesPathSetValue(sp->prefs, path, newDict);
+	CFRelease(newDict);
+	CFRelease(path);
+
+	if (ok) {
+		if (sp->name != NULL) {
+			CFRelease(sp->name);
+		}
+		sp->name = (name != NULL) ? CFStringCreateCopy(NULL, name)
+					  : NULL;
+	}
+	return ok;
+}
+
+Boolean
+SCNetworkSetRemove(SCNetworkSetRef set)
+{
+	SCNetworkSetPrivateRef	sp	= (SCNetworkSetPrivateRef)set;
+	CFStringRef		currentPath;
+	CFStringRef		path;
+	Boolean			ok;
+
+	if (!isA_SCNetworkSet(set)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	path = __setPath(sp->setID);
+
+	/* the active set may not be removed */
+	currentPath = SCPreferencesGetValue(sp->prefs, kSCPrefCurrentSet);
+	if ((currentPath != NULL) &&
+	    (CFGetTypeID(currentPath) == CFStringGetTypeID()) &&
+	    CFEqual(currentPath, path)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		CFRelease(path);
+		return FALSE;
+	}
+
+	ok = SCPreferencesPathRemoveValue(sp->prefs, path);
+	CFRelease(path);
+	return ok;
+}
+
+
+#pragma mark -
+#pragma mark Services in a set
+
+CFArrayRef
+SCNetworkSetCopyServices(SCNetworkSetRef set)
+{
+	SCNetworkSetPrivateRef	sp	= (SCNetworkSetPrivateRef)set;
+	CFMutableArrayRef	array;
+	CFDictionaryRef		dict;
+	const void		**keys;
+	CFIndex			i, n;
+	CFStringRef		path;
+
+	if (!isA_SCNetworkSet(set)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	path = __setServicePath(sp->setID, NULL);
+	dict = SCPreferencesPathGetValue(sp->prefs, path);
+	CFRelease(path);
+	if ((dict != NULL) &&
+	    (CFGetTypeID(dict) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+
+	array = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	n     = __copyDictKeys(dict, &keys);
+	for (i = 0; i < n; i++) {
+		SCNetworkServiceRef	service;
+
+		/* each membership key is a serviceID; keep it only if the
+		 * referenced service still exists */
+		service = SCNetworkServiceCopy(sp->prefs,
+					       (CFStringRef)keys[i]);
+		if (service != NULL) {
+			CFArrayAppendValue(array, service);
+			CFRelease(service);
+		}
+	}
+	if (keys != NULL)	free(keys);
+	return array;
+}
+
+Boolean
+SCNetworkSetAddService(SCNetworkSetRef set, SCNetworkServiceRef service)
+{
+	SCNetworkSetPrivateRef		sp	= (SCNetworkSetPrivateRef)set;
+	SCNetworkServicePrivateRef	svcp	= (SCNetworkServicePrivateRef)service;
+	CFStringRef			link;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCNetworkSet(set)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!isA_SCNetworkService(service) || (svcp->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	/* link /Sets/<set>/Network/Service/<svc> -> /NetworkServices/<svc> */
+	path = __setServicePath(sp->setID, svcp->serviceID);
+	link = __netServicePath(svcp->serviceID);
+	ok   = SCPreferencesPathSetLink(sp->prefs, path, link);
+	CFRelease(path);
+	CFRelease(link);
+	return ok;
+}
+
+Boolean
+SCNetworkSetRemoveService(SCNetworkSetRef set, SCNetworkServiceRef service)
+{
+	SCNetworkSetPrivateRef		sp	= (SCNetworkSetPrivateRef)set;
+	SCNetworkServicePrivateRef	svcp	= (SCNetworkServicePrivateRef)service;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCNetworkSet(set)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!isA_SCNetworkService(service)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	path = __setServicePath(sp->setID, svcp->serviceID);
+	if (SCPreferencesPathGetLink(sp->prefs, path) == NULL) {
+		/* the service is not a member of this set */
+		_SCErrorSet(kSCStatusNoKey);
+		CFRelease(path);
+		return FALSE;
+	}
+	ok = SCPreferencesPathRemoveValue(sp->prefs, path);
+	CFRelease(path);
+	return ok;
+}
+
+
+#pragma mark -
+#pragma mark Service order
+
+CFArrayRef
+SCNetworkSetGetServiceOrder(SCNetworkSetRef set)
+{
+	SCNetworkSetPrivateRef	sp	= (SCNetworkSetPrivateRef)set;
+	CFDictionaryRef		dict;
+	CFArrayRef		order;
+	CFStringRef		path;
+
+	if (!isA_SCNetworkSet(set)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	path = __setGlobalIPv4Path(sp->setID);
+	dict = SCPreferencesPathGetValue(sp->prefs, path);
+	CFRelease(path);
+	if ((dict == NULL) ||
+	    (CFGetTypeID(dict) != CFDictionaryGetTypeID())) {
+		return NULL;
+	}
+	order = CFDictionaryGetValue(dict, kSCPropNetServiceOrder);
+	if ((order == NULL) ||
+	    (CFGetTypeID(order) != CFArrayGetTypeID())) {
+		return NULL;
+	}
+	return order;
+}
+
+Boolean
+SCNetworkSetSetServiceOrder(SCNetworkSetRef set, CFArrayRef newOrder)
+{
+	SCNetworkSetPrivateRef	sp	= (SCNetworkSetPrivateRef)set;
+	CFDictionaryRef		dict;
+	CFMutableDictionaryRef	newDict;
+	CFIndex			i, n;
+	CFStringRef		path;
+	Boolean			ok;
+
+	if (!isA_SCNetworkSet(set)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((newOrder == NULL) ||
+	    (CFGetTypeID(newOrder) != CFArrayGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	n = CFArrayGetCount(newOrder);
+	for (i = 0; i < n; i++) {
+		CFTypeRef	sid = CFArrayGetValueAtIndex(newOrder, i);
+
+		if (CFGetTypeID(sid) != CFStringGetTypeID()) {
+			_SCErrorSet(kSCStatusInvalidArgument);
+			return FALSE;
+		}
+	}
+
+	path = __setGlobalIPv4Path(sp->setID);
+	dict = SCPreferencesPathGetValue(sp->prefs, path);
+	if ((dict != NULL) &&
+	    (CFGetTypeID(dict) == CFDictionaryGetTypeID())) {
+		newDict = CFDictionaryCreateMutableCopy(NULL, 0, dict);
+	} else {
+		newDict = CFDictionaryCreateMutable(NULL, 0,
+					&kCFTypeDictionaryKeyCallBacks,
+					&kCFTypeDictionaryValueCallBacks);
+	}
+	CFDictionarySetValue(newDict, kSCPropNetServiceOrder, newOrder);
+
+	ok = SCPreferencesPathSetValue(sp->prefs, path, newDict);
+	CFRelease(newDict);
+	CFRelease(path);
+	return ok;
+}

--- a/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
@@ -345,6 +345,128 @@ Boolean
 SCNetworkServiceRemoveProtocolType	(SCNetworkServiceRef		service,
 					 CFStringRef			protocolType);
 
+/* --------------------------------------------------------------------
+ * SCNetworkSet
+ * ------------------------------------------------------------------ */
+
+/*!
+	@function SCNetworkSetGetTypeID
+	@discussion Returns the CoreFoundation type identifier of all
+		SCNetworkSet instances.
+ */
+CFTypeID
+SCNetworkSetGetTypeID			(void);
+
+/*!
+	@function SCNetworkSetCreate
+	@discussion Creates a new, empty network set in `prefs`. Release
+		the returned value.
+ */
+SCNetworkSetRef
+SCNetworkSetCreate			(SCPreferencesRef		prefs);
+
+/*!
+	@function SCNetworkSetCopy
+	@discussion Returns the existing network set `setID` in `prefs`,
+		or NULL. Release the returned value.
+ */
+SCNetworkSetRef
+SCNetworkSetCopy			(SCPreferencesRef		prefs,
+					 CFStringRef			setID);
+
+/*!
+	@function SCNetworkSetCopyAll
+	@discussion Returns every network set stored in `prefs`.
+	@result a CFArray of SCNetworkSetRef (caller releases).
+ */
+CFArrayRef
+SCNetworkSetCopyAll			(SCPreferencesRef		prefs);
+
+/*!
+	@function SCNetworkSetCopyCurrent
+	@discussion Returns the current (active) network set, or NULL.
+		Release the returned value.
+ */
+SCNetworkSetRef
+SCNetworkSetCopyCurrent			(SCPreferencesRef		prefs);
+
+/*!
+	@function SCNetworkSetSetCurrent
+	@discussion Makes `set` the current (active) network set.
+ */
+Boolean
+SCNetworkSetSetCurrent			(SCNetworkSetRef		set);
+
+/*!
+	@function SCNetworkSetGetSetID
+	@discussion Returns the set's identifier. Owned by the set.
+ */
+CFStringRef
+SCNetworkSetGetSetID			(SCNetworkSetRef		set);
+
+/*!
+	@function SCNetworkSetGetName
+	@discussion Returns the set's name, or NULL if it has none.
+ */
+CFStringRef
+SCNetworkSetGetName			(SCNetworkSetRef		set);
+
+/*!
+	@function SCNetworkSetSetName
+	@discussion Sets the set's name.
+ */
+Boolean
+SCNetworkSetSetName			(SCNetworkSetRef		set,
+					 CFStringRef			name);
+
+/*!
+	@function SCNetworkSetRemove
+	@discussion Removes the set from the preferences. The current
+		(active) set may not be removed.
+ */
+Boolean
+SCNetworkSetRemove			(SCNetworkSetRef		set);
+
+/*!
+	@function SCNetworkSetCopyServices
+	@discussion Returns the services that are members of the set.
+	@result a CFArray of SCNetworkServiceRef (caller releases).
+ */
+CFArrayRef
+SCNetworkSetCopyServices		(SCNetworkSetRef		set);
+
+/*!
+	@function SCNetworkSetAddService
+	@discussion Adds `service` to the set.
+ */
+Boolean
+SCNetworkSetAddService			(SCNetworkSetRef		set,
+					 SCNetworkServiceRef		service);
+
+/*!
+	@function SCNetworkSetRemoveService
+	@discussion Removes `service` from the set.
+ */
+Boolean
+SCNetworkSetRemoveService		(SCNetworkSetRef		set,
+					 SCNetworkServiceRef		service);
+
+/*!
+	@function SCNetworkSetGetServiceOrder
+	@discussion Returns the set's service order — a CFArray of
+		service identifiers — or NULL. Owned by the set.
+ */
+CFArrayRef
+SCNetworkSetGetServiceOrder		(SCNetworkSetRef		set);
+
+/*!
+	@function SCNetworkSetSetServiceOrder
+	@discussion Sets the set's service order.
+ */
+Boolean
+SCNetworkSetSetServiceOrder		(SCNetworkSetRef		set,
+					 CFArrayRef			newOrder);
+
 __END_DECLS
 
 #endif	/* _SCNETWORKCONFIGURATION_H */

--- a/src/libSystemConfiguration/scnetsettest.c
+++ b/src/libSystemConfiguration/scnetsettest.c
@@ -1,0 +1,310 @@
+/*
+ * scnetsettest.c — libSystemConfiguration SCNetworkConfiguration iter 4
+ * test client: SCNetworkSet.
+ *
+ * Creates a network set ("location"), names it, adds a network service
+ * to it (and removes / re-adds it), sets a service order, makes the set
+ * current, commits, reopens the preferences and confirms the set, its
+ * name, its members, its order and the current-set selection all
+ * persisted — and finally confirms the active set cannot be removed but
+ * an inactive one can.
+ *
+ * run.sh runs it and boot-test.sh gates on the SC-NETSET-OK / -FAIL
+ * marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+#define	SCT_ID	"scnetsettest.plist"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-NETSET-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+/* the first Ethernet interface from SCNetworkInterfaceCopyAll, or NULL */
+static SCNetworkInterfaceRef
+first_ethernet(CFArrayRef all)
+{
+	CFIndex	i, n;
+
+	n = (all != NULL) ? CFArrayGetCount(all) : 0;
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	iface;
+
+		iface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(all, i);
+		if (CFEqual(SCNetworkInterfaceGetInterfaceType(iface),
+			    kSCNetworkInterfaceTypeEthernet)) {
+			return iface;
+		}
+	}
+	return NULL;
+}
+
+/* TRUE iff `services` holds a service whose ID equals `serviceID` */
+static Boolean
+services_have(CFArrayRef services, CFStringRef serviceID)
+{
+	CFIndex	i, n;
+
+	n = (services != NULL) ? CFArrayGetCount(services) : 0;
+	for (i = 0; i < n; i++) {
+		SCNetworkServiceRef	svc;
+
+		svc = (SCNetworkServiceRef)CFArrayGetValueAtIndex(services, i);
+		if (CFEqual(SCNetworkServiceGetServiceID(svc), serviceID)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+int
+main(void)
+{
+	SCPreferencesRef	prefs	= NULL;
+	CFArrayRef		allif	= NULL;
+	SCNetworkInterfaceRef	iface;
+	SCNetworkServiceRef	svc	= NULL;
+	SCNetworkSetRef		set	= NULL;
+	SCNetworkSetRef		set2	= NULL;
+	SCNetworkSetRef		setB	= NULL;
+	SCNetworkSetRef		cur	= NULL;
+	CFArrayRef		services = NULL;
+	CFArrayRef		allsets	= NULL;
+	CFMutableArrayRef	order	= NULL;
+	CFStringRef		svcID	= NULL;
+	CFStringRef		setID	= NULL;
+	CFStringRef		name, prefsID, wantName;
+	int			rc	= 1;
+
+	printf("scnetsettest: SCNetworkSet\n");
+	fflush(stdout);
+
+	name	 = mkstr("scnetsettest");
+	prefsID	 = mkstr(SCT_ID);
+	wantName = mkstr("Test Location");
+
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate failed");
+		goto out;
+	}
+
+	/* a service to populate the set with */
+	allif = SCNetworkInterfaceCopyAll();
+	iface = first_ethernet(allif);
+	if (iface == NULL) {
+		fail("no Ethernet interface for a service");
+		goto out;
+	}
+	svc = SCNetworkServiceCreate(prefs, iface);
+	if (svc == NULL) {
+		fail("SCNetworkServiceCreate failed");
+		goto out;
+	}
+	svcID = CFStringCreateCopy(NULL, SCNetworkServiceGetServiceID(svc));
+
+	/* create + name the set */
+	set = SCNetworkSetCreate(prefs);
+	if (set == NULL) {
+		fail("SCNetworkSetCreate failed");
+		goto out;
+	}
+	setID = CFStringCreateCopy(NULL, SCNetworkSetGetSetID(set));
+	if (SCNetworkSetGetName(set) != NULL) {
+		fail("a new set already has a name");
+		goto out;
+	}
+	if (!SCNetworkSetSetName(set, wantName) ||
+	    !CFEqual(SCNetworkSetGetName(set), wantName)) {
+		fail("SCNetworkSetSetName did not round-trip");
+		goto out;
+	}
+	printf("  SetCreate/SetName: set named\n");
+
+	/* a new set has no services */
+	services = SCNetworkSetCopyServices(set);
+	if ((services == NULL) || (CFArrayGetCount(services) != 0)) {
+		fail("a new set is not empty");
+		goto out;
+	}
+	CFRelease(services);
+	services = NULL;
+
+	/* add, confirm, remove, re-add the service */
+	if (!SCNetworkSetAddService(set, svc)) {
+		fail("SCNetworkSetAddService failed");
+		goto out;
+	}
+	services = SCNetworkSetCopyServices(set);
+	if ((CFArrayGetCount(services) != 1) ||
+	    !services_have(services, svcID)) {
+		fail("set does not contain the added service");
+		goto out;
+	}
+	CFRelease(services);
+	services = NULL;
+
+	if (!SCNetworkSetRemoveService(set, svc)) {
+		fail("SCNetworkSetRemoveService failed");
+		goto out;
+	}
+	services = SCNetworkSetCopyServices(set);
+	if (CFArrayGetCount(services) != 0) {
+		fail("service still present after removal");
+		goto out;
+	}
+	CFRelease(services);
+	services = NULL;
+
+	if (!SCNetworkSetAddService(set, svc)) {
+		fail("SCNetworkSetAddService (re-add) failed");
+		goto out;
+	}
+	printf("  Add/RemoveService: membership works\n");
+
+	/* a service order */
+	order = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	CFArrayAppendValue(order, svcID);
+	if (!SCNetworkSetSetServiceOrder(set, order)) {
+		fail("SCNetworkSetSetServiceOrder failed");
+		goto out;
+	}
+	{
+		CFArrayRef	got = SCNetworkSetGetServiceOrder(set);
+
+		if ((got == NULL) || (CFArrayGetCount(got) != 1) ||
+		    !CFEqual(CFArrayGetValueAtIndex(got, 0), svcID)) {
+			fail("service order did not round-trip");
+			goto out;
+		}
+	}
+
+	/* make the set current */
+	if (!SCNetworkSetSetCurrent(set)) {
+		fail("SCNetworkSetSetCurrent failed");
+		goto out;
+	}
+	cur = SCNetworkSetCopyCurrent(prefs);
+	if ((cur == NULL) ||
+	    !CFEqual(SCNetworkSetGetSetID(cur), setID)) {
+		fail("SCNetworkSetCopyCurrent mismatch");
+		goto out;
+	}
+	CFRelease(cur);
+	cur = NULL;
+	printf("  ServiceOrder/SetCurrent: order + current set work\n");
+
+	/* commit, reopen, confirm everything persisted */
+	if (!SCPreferencesCommitChanges(prefs)) {
+		fail("SCPreferencesCommitChanges failed");
+		goto out;
+	}
+	CFRelease(set);
+	set = NULL;
+	CFRelease(prefs);
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate (reopen) failed");
+		goto out;
+	}
+
+	set2 = SCNetworkSetCopy(prefs, setID);
+	if (set2 == NULL) {
+		fail("SCNetworkSetCopy after reopen failed");
+		goto out;
+	}
+	if (!CFEqual(SCNetworkSetGetName(set2), wantName)) {
+		fail("set name did not persist");
+		goto out;
+	}
+	services = SCNetworkSetCopyServices(set2);
+	if ((CFArrayGetCount(services) != 1) ||
+	    !services_have(services, svcID)) {
+		fail("set membership did not persist");
+		goto out;
+	}
+	CFRelease(services);
+	services = NULL;
+	{
+		CFArrayRef	got = SCNetworkSetGetServiceOrder(set2);
+
+		if ((got == NULL) || (CFArrayGetCount(got) != 1)) {
+			fail("service order did not persist");
+			goto out;
+		}
+	}
+	cur = SCNetworkSetCopyCurrent(prefs);
+	if ((cur == NULL) ||
+	    !CFEqual(SCNetworkSetGetSetID(cur), setID)) {
+		fail("current set did not persist");
+		goto out;
+	}
+	CFRelease(cur);
+	cur = NULL;
+	allsets = SCNetworkSetCopyAll(prefs);
+	if ((allsets == NULL) || (CFArrayGetCount(allsets) < 1)) {
+		fail("SCNetworkSetCopyAll did not list the set");
+		goto out;
+	}
+	printf("  CommitChanges/reopen: set persisted\n");
+
+	/* the active set cannot be removed */
+	if (SCNetworkSetRemove(set2)) {
+		fail("the active set was removed");
+		goto out;
+	}
+	if (SCError() != kSCStatusInvalidArgument) {
+		fail("removing the active set gave the wrong error");
+		goto out;
+	}
+	/* make another set current, then the first is removable */
+	setB = SCNetworkSetCreate(prefs);
+	if ((setB == NULL) || !SCNetworkSetSetCurrent(setB)) {
+		fail("could not create + activate a second set");
+		goto out;
+	}
+	if (!SCNetworkSetRemove(set2)) {
+		fail("SCNetworkSetRemove failed for an inactive set");
+		goto out;
+	}
+	if (SCNetworkSetCopy(prefs, setID) != NULL) {
+		fail("set still present after removal");
+		goto out;
+	}
+	printf("  SetRemove: active set protected, inactive removed\n");
+
+	printf("SC-NETSET-OK: SCNetworkSet works\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (services != NULL)	CFRelease(services);
+	if (allsets != NULL)	CFRelease(allsets);
+	if (order != NULL)	CFRelease(order);
+	if (cur != NULL)	CFRelease(cur);
+	if (set != NULL)	CFRelease(set);
+	if (set2 != NULL)	CFRelease(set2);
+	if (setB != NULL)	CFRelease(setB);
+	if (svc != NULL)	CFRelease(svc);
+	if (allif != NULL)	CFRelease(allif);
+	if (prefs != NULL)	CFRelease(prefs);
+	if (svcID != NULL)	CFRelease(svcID);
+	if (setID != NULL)	CFRelease(setID);
+	CFRelease(name);
+	CFRelease(prefsID);
+	CFRelease(wantName);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -586,6 +586,18 @@ expect {
     "SC-NETSVC-OK" { puts "\nOK: SCNetworkService + SCNetworkProtocol work" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-NETSET marker not seen"
+        exit 1
+    }
+    "SC-NETSET-FAIL" {
+        puts "\nFAIL: SCNetworkSet failed"
+        exit 1
+    }
+    "SC-NETSET-OK" { puts "\nOK: SCNetworkSet works" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## SCNetworkConfiguration iter 4 — SCNetworkSet

Fourth iteration of the **SCNetworkConfiguration** port: the `SCNetworkSet` object. A set ("location") is an ordered collection of network services, persisted in the preferences plist at `/Sets/<setID>`. A service is a member via a `__LINK__` entry at `/Sets/<setID>/Network/Service/<serviceID>` pointing back at `/NetworkServices/<serviceID>` — the indirection iter 1 added `SCPreferencesPathSet/GetLink` for. The active set is named by the top-level `CurrentSet` preferences key.

### Changes

- **`SCNetworkSet.c`** — the set object: `Create` (mints a unique `/Sets/<id>`), `Copy` / `CopyAll`, `Copy/SetCurrent`, `GetSetID`, `Get/SetName`, `Remove` (the active set is protected), the membership calls `AddService` / `RemoveService` / `CopyServices`, and `Get/SetServiceOrder`.
- **`SCNetworkConfigurationInternal.{c,h}`** — the `SCNetworkSet` private struct, `isA_SCNetworkSet`, and the `Sets` / `CurrentSet` / `Network` path-key macros.

`AddService` links the service into the set with `SCPreferencesPathSetLink`; `CopyServices` walks the membership keys and rebuilds each service. Apple's `SCNetworkSet.c` additionally manages the special "Automatic" default set and per-interface deep configuration; the port keeps the core model.

### Test

New **`scnetsettest`** (`SC-NETSET` marker) creates a set, names it, adds + removes a service, sets a service order, makes the set current, commits, reopens to confirm the set / name / membership / order / current-set selection all persisted, and verifies the active set cannot be removed while an inactive one can.

This completes the **SCNetworkConfiguration core object model** — interface / protocol / service / set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)