### PR TITLE
feat(libSystemConfiguration): SCNetworkConfiguration iter 5 — SCVLANInterface

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1295,6 +1295,23 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scnetsettest" \
     || { echo "FAIL: scnetsettest not built"; exit 1; }
 echo "==> scnetsettest built"
 
+# scvlantest — libSystemConfiguration SCNetworkConfiguration iter 5
+# test client. Creates an SCVLANInterface on the e1000 interface,
+# checks its physical interface / tag / name / options, commits,
+# reopens and confirms it persisted, then removes it. run.sh runs it
+# and checks for the SC-VLAN-OK marker.
+echo "==> building scvlantest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scvlantest" \
+   "$ROOT/src/libSystemConfiguration/scvlantest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scvlantest" \
+    || { echo "FAIL: scvlantest not built"; exit 1; }
+echo "==> scvlantest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -627,4 +627,14 @@ if [ ! -x "$scnetsettest" ]; then
 fi
 "$scnetsettest" || true	# marker (SC-NETSET-OK/FAIL) gates in boot-test.sh
 
+# SC-VLAN — SCNetworkConfiguration VLAN virtual interface: create a
+# VLAN on the e1000 interface, check its physical interface / tag /
+# name / options, commit, reopen and confirm it persisted.
+scvlantest=/usr/tests/freebsd-launchd-mach/scvlantest
+if [ ! -x "$scvlantest" ]; then
+    echo "SC-VLAN-FAIL: $scvlantest missing"
+    exit 1
+fi
+"$scvlantest" || true	# marker (SC-VLAN-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/Makefile
+++ b/src/libSystemConfiguration/Makefile
@@ -23,6 +23,7 @@ SHLIB_MAJOR=	1
 SRCS=		SCD.c SCDynamicStore.c SCNotify.c SCDMultiple.c SCPreferences.c
 SRCS+=		SCNetworkConfigurationInternal.c SCNetworkInterface.c
 SRCS+=		SCNetworkProtocol.c SCNetworkService.c SCNetworkSet.c
+SRCS+=		SCVLANInterface.c
 
 # configUser.c — MIG-generated config.defs client stubs (same file
 # configd's test clients link). config_wire.c — configd's shared

--- a/src/libSystemConfiguration/SCNetworkConfigurationInternal.h
+++ b/src/libSystemConfiguration/SCNetworkConfigurationInternal.h
@@ -37,6 +37,17 @@
 #define kSCPropNetInterfaceDeviceName	CFSTR("DeviceName")
 #define kSCPropNetInterfaceHardware	CFSTR("Hardware")
 
+/*
+ * Virtual-interface (Bond / Bridge / VLAN) storage. The virtual
+ * interfaces live under /VirtualNetworkInterfaces/<type>/<bsdName> in
+ * the preferences plist.
+ */
+#define kSCPrefVirtualNetworkInterfaces	CFSTR("VirtualNetworkInterfaces")
+#define kSCPropVLANInterface		CFSTR("Interface")
+#define kSCPropVLANTag			CFSTR("Tag")
+#define kSCPropVirtualInterfaces	CFSTR("Interfaces")
+#define kSCPropVirtualOptions		CFSTR("Options")
+
 
 #pragma mark -
 #pragma mark SCNetworkInterface
@@ -69,6 +80,13 @@ typedef struct __SCNetworkInterface {
 
 	CFArrayRef		supported_interface_types;
 	CFArrayRef		supported_protocol_types;
+
+	/* virtual-interface detail (Bond / Bridge / VLAN interface types) */
+	CFArrayRef		member_interfaces;	/* Bond / Bridge members */
+	SCNetworkInterfaceRef	vlan_physical;		/* VLAN physical interface */
+	CFNumberRef		vlan_tag;		/* VLAN tag (1..4094) */
+	CFStringRef		bond_mode;		/* Bond aggregation mode */
+	CFDictionaryRef		virtual_options;	/* Bond / Bridge / VLAN options */
 } SCNetworkInterfacePrivate, *SCNetworkInterfacePrivateRef;
 
 
@@ -162,6 +180,22 @@ isA_SCNetworkSet(SCNetworkSetRef set)
 /* SCNetworkInterface.c — allocate a bare interface (all fields NULL). */
 SCNetworkInterfacePrivateRef
 __SCNetworkInterfaceCreatePrivate	(CFAllocatorRef		allocator);
+
+/*
+ * SCNetworkInterface.c — a fresh CFArray of the protocol types that can
+ * be configured on a network interface (IPv4/IPv6/DNS/Proxies/SMB).
+ */
+CFArrayRef
+__SCNetworkInterfaceCopyProtocolTypes	(void);
+
+/*
+ * SCNetworkInterface.c — synthesize an Ethernet interface for a BSD
+ * name (no hardware address). Used to rebuild the physical interface a
+ * stored virtual interface references.
+ */
+SCNetworkInterfaceRef
+__SCNetworkInterfaceCreateWithBSDName	(CFAllocatorRef		allocator,
+					 CFStringRef		bsdName);
 
 /*
  * SCNetworkInterface.c — the interface <-> preferences-entity bridge.

--- a/src/libSystemConfiguration/SCNetworkInterface.c
+++ b/src/libSystemConfiguration/SCNetworkInterface.c
@@ -66,6 +66,11 @@ __SCNetworkInterfaceDeallocate(CFTypeRef cf)
 		CFRelease(ip->supported_interface_types);
 	if (ip->supported_protocol_types != NULL)
 		CFRelease(ip->supported_protocol_types);
+	if (ip->member_interfaces != NULL)	CFRelease(ip->member_interfaces);
+	if (ip->vlan_physical != NULL)		CFRelease(ip->vlan_physical);
+	if (ip->vlan_tag != NULL)		CFRelease(ip->vlan_tag);
+	if (ip->bond_mode != NULL)		CFRelease(ip->bond_mode);
+	if (ip->virtual_options != NULL)	CFRelease(ip->virtual_options);
 }
 
 /*
@@ -172,6 +177,11 @@ __SCNetworkInterfaceCreatePrivate(CFAllocatorRef allocator)
 	ip->entity_subtype		= NULL;
 	ip->supported_interface_types	= NULL;
 	ip->supported_protocol_types	= NULL;
+	ip->member_interfaces		= NULL;
+	ip->vlan_physical		= NULL;
+	ip->vlan_tag			= NULL;
+	ip->bond_mode			= NULL;
+	ip->virtual_options		= NULL;
 	return ip;
 }
 
@@ -268,8 +278,8 @@ __SCNetworkInterfaceLocalizedName(CFStringRef type)
 	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
 }
 
-/* the protocol types configurable on a hardware network interface */
-static CFArrayRef
+/* the protocol types configurable on a network interface */
+CFArrayRef
 __SCNetworkInterfaceCopyProtocolTypes(void)
 {
 	const void	*protos[5];
@@ -536,5 +546,37 @@ _SCNetworkInterfaceCreateWithEntity(CFAllocatorRef allocator,
 			ip->serviceID = (CFStringRef)CFRetain(sp->serviceID);
 		}
 	}
+	return (SCNetworkInterfaceRef)ip;
+}
+
+/*
+ * Synthesize an Ethernet interface for a BSD name. A stored virtual
+ * interface records only the BSD name of its physical / member
+ * interfaces; this rebuilds an interface object for one. There is no
+ * hardware address — the synthetic interface is a configuration handle,
+ * matched against the live hardware by BSD name when needed.
+ */
+SCNetworkInterfaceRef
+__SCNetworkInterfaceCreateWithBSDName(CFAllocatorRef allocator,
+				      CFStringRef bsdName)
+{
+	SCNetworkInterfacePrivateRef	ip;
+
+	if ((bsdName == NULL) ||
+	    (CFGetTypeID(bsdName) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	ip = __SCNetworkInterfaceCreatePrivate(allocator);
+	if (ip == NULL) {
+		return NULL;
+	}
+	ip->interface_type =
+		(CFStringRef)CFRetain(kSCNetworkInterfaceTypeEthernet);
+	ip->entity_device  = CFStringCreateCopy(NULL, bsdName);
+	ip->builtin        = TRUE;
+	ip->localized_name = __SCNetworkInterfaceLocalizedName(ip->interface_type);
+	ip->name           = (CFStringRef)CFRetain(ip->localized_name);
+	ip->supported_protocol_types = __SCNetworkInterfaceCopyProtocolTypes();
 	return (SCNetworkInterfaceRef)ip;
 }

--- a/src/libSystemConfiguration/SCVLANInterface.c
+++ b/src/libSystemConfiguration/SCVLANInterface.c
@@ -1,0 +1,488 @@
+/*
+ * SCVLANInterface.c — the SCVLANInterface API (freebsd-launchd-mach port
+ * of Apple's SystemConfiguration.fproj VLANConfiguration.c).
+ *
+ * A VLAN interface is a virtual network interface: an 802.1Q tag on top
+ * of a physical interface. It is an SCNetworkInterface of type VLAN
+ * (SCVLANInterfaceRef is an alias of SCNetworkInterfaceRef). VLANs are
+ * persisted in the preferences plist at
+ * /VirtualNetworkInterfaces/VLAN/<vlanName>, each entry recording the
+ * physical interface's BSD name, the tag, a display name and options.
+ *
+ * Apple's VLANConfiguration.c also reflects the live kernel state
+ * (SIOCGIFVLAN) and cross-references Bond / Bridge membership for the
+ * "available physical interfaces" query; the port keeps the stored
+ * configuration model.
+ */
+
+#include "SCNetworkConfigurationInternal.h"
+#include "SCInternal.h"
+
+#include <stdlib.h>
+
+
+#pragma mark -
+#pragma mark Helpers
+
+/* TRUE iff `vlan` is a live SCNetworkInterface of type VLAN */
+static Boolean
+isA_SCVLANInterface(SCVLANInterfaceRef vlan)
+{
+	return (isA_SCNetworkInterface(vlan) &&
+		CFEqual(((SCNetworkInterfacePrivateRef)vlan)->interface_type,
+			kSCNetworkInterfaceTypeVLAN));
+}
+
+/* "/VirtualNetworkInterfaces/VLAN" */
+static CFStringRef
+__vlanContainerPath(void)
+{
+	return CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@/%@"),
+					kSCPrefVirtualNetworkInterfaces,
+					kSCNetworkInterfaceTypeVLAN);
+}
+
+/* "/VirtualNetworkInterfaces/VLAN/<vlanName>" */
+static CFStringRef
+__vlanPath(CFStringRef vlanName)
+{
+	return CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@/%@/%@"),
+					kSCPrefVirtualNetworkInterfaces,
+					kSCNetworkInterfaceTypeVLAN, vlanName);
+}
+
+/* allocate a VLAN interface object named `vlan_if` (e.g. "vlan0") */
+static SCVLANInterfaceRef
+_SCVLANInterfaceCreatePrivate(CFAllocatorRef allocator, CFStringRef vlan_if)
+{
+	SCNetworkInterfacePrivateRef	ip;
+
+	ip = __SCNetworkInterfaceCreatePrivate(allocator);
+	if (ip == NULL) {
+		return NULL;
+	}
+	ip->interface_type =
+		(CFStringRef)CFRetain(kSCNetworkInterfaceTypeVLAN);
+	ip->entity_device  = CFStringCreateCopy(allocator, vlan_if);
+	ip->builtin        = TRUE;
+	ip->localized_name = CFStringCreateWithCString(NULL, "VLAN",
+						       kCFStringEncodingUTF8);
+	ip->name           = (CFStringRef)CFRetain(ip->localized_name);
+	/* a VLAN can carry the usual protocols, so a service can use it */
+	ip->supported_protocol_types = __SCNetworkInterfaceCopyProtocolTypes();
+	return (SCVLANInterfaceRef)ip;
+}
+
+/* TRUE iff `tag` is a CFNumber in the valid 802.1Q range (1..4094) */
+static Boolean
+__vlanTagIsValid(CFNumberRef tag)
+{
+	int	value;
+
+	if ((tag == NULL) || (CFGetTypeID(tag) != CFNumberGetTypeID())) {
+		return FALSE;
+	}
+	if (!CFNumberGetValue(tag, kCFNumberIntType, &value)) {
+		return FALSE;
+	}
+	return ((value >= 1) && (value <= 4094));
+}
+
+/* the stored VLAN with this physical interface + tag, or NULL */
+static SCVLANInterfaceRef
+__findVLANInterfaceAndTag(SCPreferencesRef prefs,
+			  SCNetworkInterfaceRef physical, CFNumberRef tag)
+{
+	CFArrayRef		vlans;
+	CFIndex			i, n;
+	SCVLANInterfaceRef	found	= NULL;
+
+	vlans = SCVLANInterfaceCopyAll(prefs);
+	n     = (vlans != NULL) ? CFArrayGetCount(vlans) : 0;
+	for (i = 0; i < n; i++) {
+		SCVLANInterfaceRef	vlan;
+		SCNetworkInterfaceRef	vp;
+		CFNumberRef		vt;
+
+		vlan = (SCVLANInterfaceRef)CFArrayGetValueAtIndex(vlans, i);
+		vp   = SCVLANInterfaceGetPhysicalInterface(vlan);
+		vt   = SCVLANInterfaceGetTag(vlan);
+		if ((vp != NULL) && (vt != NULL) &&
+		    CFEqual(physical, vp) && CFEqual(tag, vt)) {
+			found = (SCVLANInterfaceRef)CFRetain(vlan);
+			break;
+		}
+	}
+	if (vlans != NULL) {
+		CFRelease(vlans);
+	}
+	return found;
+}
+
+
+#pragma mark -
+#pragma mark SCVLANInterface APIs
+
+CFArrayRef
+SCVLANInterfaceCopyAll(SCPreferencesRef prefs)
+{
+	CFMutableArrayRef	array;
+	CFDictionaryRef		container;
+	const void		**keys;
+	const void		**vals;
+	CFIndex			i, n;
+	CFStringRef		path;
+
+	array = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+
+	path      = __vlanContainerPath();
+	container = SCPreferencesPathGetValue(prefs, path);
+	CFRelease(path);
+	if ((container == NULL) ||
+	    (CFGetTypeID(container) != CFDictionaryGetTypeID())) {
+		return array;
+	}
+
+	n    = CFDictionaryGetCount(container);
+	if (n <= 0) {
+		return array;
+	}
+	keys = (const void **)malloc((size_t)n * sizeof(void *));
+	vals = (const void **)malloc((size_t)n * sizeof(void *));
+	CFDictionaryGetKeysAndValues(container, keys, vals);
+
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfacePrivateRef	ip;
+		SCVLANInterfaceRef		vlan;
+		CFDictionaryRef			info	= (CFDictionaryRef)vals[i];
+		CFStringRef			physIf;
+		CFNumberRef			tag;
+		CFStringRef			name;
+		CFDictionaryRef			options;
+
+		if (CFGetTypeID(info) != CFDictionaryGetTypeID()) {
+			continue;
+		}
+		physIf = CFDictionaryGetValue(info, kSCPropVLANInterface);
+		tag    = CFDictionaryGetValue(info, kSCPropVLANTag);
+		if ((physIf == NULL) ||
+		    (CFGetTypeID(physIf) != CFStringGetTypeID()) ||
+		    (tag == NULL) ||
+		    (CFGetTypeID(tag) != CFNumberGetTypeID())) {
+			/* an incomplete entry — skip it */
+			continue;
+		}
+
+		vlan = _SCVLANInterfaceCreatePrivate(NULL, (CFStringRef)keys[i]);
+		if (vlan == NULL) {
+			continue;
+		}
+		ip = (SCNetworkInterfacePrivateRef)vlan;
+		ip->prefs         = (SCPreferencesRef)CFRetain(prefs);
+		ip->vlan_physical = __SCNetworkInterfaceCreateWithBSDName(NULL,
+									 physIf);
+		ip->vlan_tag      = (CFNumberRef)CFRetain(tag);
+
+		options = CFDictionaryGetValue(info, kSCPropVirtualOptions);
+		if ((options != NULL) &&
+		    (CFGetTypeID(options) == CFDictionaryGetTypeID())) {
+			ip->virtual_options =
+				CFDictionaryCreateCopy(NULL, options);
+		}
+		name = CFDictionaryGetValue(info, kSCPropUserDefinedName);
+		if ((name != NULL) &&
+		    (CFGetTypeID(name) == CFStringGetTypeID())) {
+			if (ip->localized_name != NULL) {
+				CFRelease(ip->localized_name);
+			}
+			ip->localized_name = CFStringCreateCopy(NULL, name);
+		}
+
+		CFArrayAppendValue(array, vlan);
+		CFRelease(vlan);
+	}
+
+	free(keys);
+	free(vals);
+	return array;
+}
+
+CFArrayRef
+SCVLANInterfaceCopyAvailablePhysicalInterfaces(void)
+{
+	/*
+	 * Every hardware interface can host a VLAN. Apple additionally
+	 * folds in Bond / Bridge interfaces and excludes interfaces that
+	 * are already members of one — handled once those land.
+	 */
+	return SCNetworkInterfaceCopyAll();
+}
+
+SCVLANInterfaceRef
+SCVLANInterfaceCreate(SCPreferencesRef prefs, SCNetworkInterfaceRef physical,
+		      CFNumberRef tag)
+{
+	SCVLANInterfaceRef	existing;
+	SCVLANInterfaceRef	vlan	= NULL;
+	int			i;
+
+	if (prefs == NULL) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	if (!isA_SCNetworkInterface(physical) || !__vlanTagIsValid(tag)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	/* the physical interface + tag pair must be unused */
+	existing = __findVLANInterfaceAndTag(prefs, physical, tag);
+	if (existing != NULL) {
+		CFRelease(existing);
+		_SCErrorSet(kSCStatusKeyExists);
+		return NULL;
+	}
+
+	/* claim the first free vlanN name */
+	for (i = 0; i < 1024; i++) {
+		CFDictionaryRef	empty;
+		CFStringRef	path;
+		CFStringRef	vlan_if;
+		Boolean		taken;
+
+		vlan_if = CFStringCreateWithFormat(NULL, NULL,
+						   CFSTR("vlan%d"), i);
+		path    = __vlanPath(vlan_if);
+		taken   = (SCPreferencesPathGetValue(prefs, path) != NULL);
+		if (taken) {
+			CFRelease(path);
+			CFRelease(vlan_if);
+			continue;
+		}
+
+		empty = CFDictionaryCreate(NULL, NULL, NULL, 0,
+					   &kCFTypeDictionaryKeyCallBacks,
+					   &kCFTypeDictionaryValueCallBacks);
+		if (!SCPreferencesPathSetValue(prefs, path, empty)) {
+			CFRelease(empty);
+			CFRelease(path);
+			CFRelease(vlan_if);
+			_SCErrorSet(kSCStatusFailed);
+			return NULL;
+		}
+		CFRelease(empty);
+		CFRelease(path);
+
+		vlan = _SCVLANInterfaceCreatePrivate(NULL, vlan_if);
+		CFRelease(vlan_if);
+		if (vlan != NULL) {
+			((SCNetworkInterfacePrivateRef)vlan)->prefs =
+				(SCPreferencesRef)CFRetain(prefs);
+		}
+		break;
+	}
+	if (vlan == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+		return NULL;
+	}
+
+	/* record the physical interface + tag */
+	if (!SCVLANInterfaceSetPhysicalInterfaceAndTag(vlan, physical, tag)) {
+		CFRelease(vlan);
+		return NULL;
+	}
+	return vlan;
+}
+
+Boolean
+SCVLANInterfaceRemove(SCVLANInterfaceRef vlan)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)vlan;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCVLANInterface(vlan) || (ip->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	path = __vlanPath(ip->entity_device);
+	ok   = SCPreferencesPathRemoveValue(ip->prefs, path);
+	CFRelease(path);
+	return ok;
+}
+
+SCNetworkInterfaceRef
+SCVLANInterfaceGetPhysicalInterface(SCVLANInterfaceRef vlan)
+{
+	if (!isA_SCVLANInterface(vlan)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)vlan)->vlan_physical;
+}
+
+CFNumberRef
+SCVLANInterfaceGetTag(SCVLANInterfaceRef vlan)
+{
+	if (!isA_SCVLANInterface(vlan)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)vlan)->vlan_tag;
+}
+
+CFDictionaryRef
+SCVLANInterfaceGetOptions(SCVLANInterfaceRef vlan)
+{
+	if (!isA_SCVLANInterface(vlan)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)vlan)->virtual_options;
+}
+
+/*
+ * Rewrite the stored entry for `vlan` with the value at `key` set to
+ * `value` (NULL removes). Returns FALSE (and sets SCError) if the entry
+ * is missing or the write fails. A vlan with no prefs is in-memory only,
+ * which the callers treat as success.
+ */
+static Boolean
+__vlanStoreSet(SCNetworkInterfacePrivateRef ip, CFStringRef key,
+	       CFTypeRef value)
+{
+	CFDictionaryRef		dict;
+	CFMutableDictionaryRef	newDict;
+	CFStringRef		path;
+	Boolean			ok;
+
+	if (ip->prefs == NULL) {
+		return TRUE;
+	}
+	path = __vlanPath(ip->entity_device);
+	dict = SCPreferencesPathGetValue(ip->prefs, path);
+	if ((dict == NULL) ||
+	    (CFGetTypeID(dict) != CFDictionaryGetTypeID())) {
+		CFRelease(path);
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+	newDict = CFDictionaryCreateMutableCopy(NULL, 0, dict);
+	if (value != NULL) {
+		CFDictionarySetValue(newDict, key, value);
+	} else {
+		CFDictionaryRemoveValue(newDict, key);
+	}
+	ok = SCPreferencesPathSetValue(ip->prefs, path, newDict);
+	CFRelease(newDict);
+	CFRelease(path);
+	return ok;
+}
+
+Boolean
+SCVLANInterfaceSetPhysicalInterfaceAndTag(SCVLANInterfaceRef vlan,
+					  SCNetworkInterfaceRef physical,
+					  CFNumberRef tag)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)vlan;
+	CFStringRef			bsdName;
+
+	if (!isA_SCVLANInterface(vlan)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!isA_SCNetworkInterface(physical) || !__vlanTagIsValid(tag)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	bsdName = SCNetworkInterfaceGetBSDName(physical);
+	if (bsdName == NULL) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	if (ip->prefs != NULL) {
+		SCVLANInterfaceRef	other;
+
+		/* the physical + tag pair must not be used by another VLAN */
+		other = __findVLANInterfaceAndTag(ip->prefs, physical, tag);
+		if (other != NULL) {
+			Boolean	isSelf = CFEqual(vlan, other);
+
+			CFRelease(other);
+			if (!isSelf) {
+				_SCErrorSet(kSCStatusKeyExists);
+				return FALSE;
+			}
+		}
+		if (!__vlanStoreSet(ip, kSCPropVLANInterface, bsdName)) {
+			return FALSE;
+		}
+		if (!__vlanStoreSet(ip, kSCPropVLANTag, tag)) {
+			return FALSE;
+		}
+	}
+
+	/* update the in-memory object */
+	if (ip->vlan_physical != NULL) {
+		CFRelease(ip->vlan_physical);
+	}
+	ip->vlan_physical = (SCNetworkInterfaceRef)CFRetain(physical);
+	if (ip->vlan_tag != NULL) {
+		CFRelease(ip->vlan_tag);
+	}
+	ip->vlan_tag = (CFNumberRef)CFRetain(tag);
+	return TRUE;
+}
+
+Boolean
+SCVLANInterfaceSetLocalizedDisplayName(SCVLANInterfaceRef vlan,
+				       CFStringRef newName)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)vlan;
+
+	if (!isA_SCVLANInterface(vlan)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((newName == NULL) ||
+	    (CFGetTypeID(newName) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!__vlanStoreSet(ip, kSCPropUserDefinedName, newName)) {
+		return FALSE;
+	}
+	if (ip->localized_name != NULL) {
+		CFRelease(ip->localized_name);
+	}
+	ip->localized_name = CFStringCreateCopy(NULL, newName);
+	return TRUE;
+}
+
+Boolean
+SCVLANInterfaceSetOptions(SCVLANInterfaceRef vlan, CFDictionaryRef newOptions)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)vlan;
+
+	if (!isA_SCVLANInterface(vlan)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((newOptions != NULL) &&
+	    (CFGetTypeID(newOptions) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!__vlanStoreSet(ip, kSCPropVirtualOptions, newOptions)) {
+		return FALSE;
+	}
+	if (ip->virtual_options != NULL) {
+		CFRelease(ip->virtual_options);
+		ip->virtual_options = NULL;
+	}
+	if (newOptions != NULL) {
+		ip->virtual_options = CFDictionaryCreateCopy(NULL, newOptions);
+	}
+	return TRUE;
+}

--- a/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
@@ -49,6 +49,17 @@
 typedef const struct __SCNetworkInterface *	SCNetworkInterfaceRef;
 
 /*!
+	@typedef SCBondInterfaceRef
+	@typedef SCBridgeInterfaceRef
+	@typedef SCVLANInterfaceRef
+	@discussion The virtual network interfaces — link aggregation,
+		bridging and 802.1Q VLANs — are each an SCNetworkInterface.
+ */
+typedef SCNetworkInterfaceRef			SCBondInterfaceRef;
+typedef SCNetworkInterfaceRef			SCBridgeInterfaceRef;
+typedef SCNetworkInterfaceRef			SCVLANInterfaceRef;
+
+/*!
 	@typedef SCNetworkProtocolRef
 	@discussion Handle to the configuration of one protocol (IPv4,
 		IPv6, DNS, Proxies, SMB) on a network service.
@@ -466,6 +477,92 @@ SCNetworkSetGetServiceOrder		(SCNetworkSetRef		set);
 Boolean
 SCNetworkSetSetServiceOrder		(SCNetworkSetRef		set,
 					 CFArrayRef			newOrder);
+
+/* --------------------------------------------------------------------
+ * SCVLANInterface — 802.1Q VLAN virtual interfaces
+ * ------------------------------------------------------------------ */
+
+/*!
+	@function SCVLANInterfaceCopyAll
+	@discussion Returns every VLAN interface stored in `prefs`.
+	@result a CFArray of SCVLANInterfaceRef (caller releases).
+ */
+CFArrayRef
+SCVLANInterfaceCopyAll			(SCPreferencesRef		prefs);
+
+/*!
+	@function SCVLANInterfaceCopyAvailablePhysicalInterfaces
+	@discussion Returns the interfaces a VLAN can be created on.
+	@result a CFArray of SCNetworkInterfaceRef (caller releases).
+ */
+CFArrayRef
+SCVLANInterfaceCopyAvailablePhysicalInterfaces
+					(void);
+
+/*!
+	@function SCVLANInterfaceCreate
+	@discussion Creates a new VLAN interface on `physical` with 802.1Q
+		tag `tag` (1..4094), stored in `prefs`. Release the result.
+ */
+SCVLANInterfaceRef
+SCVLANInterfaceCreate			(SCPreferencesRef		prefs,
+					 SCNetworkInterfaceRef		physical,
+					 CFNumberRef			tag);
+
+/*!
+	@function SCVLANInterfaceRemove
+	@discussion Removes the VLAN interface from the preferences.
+ */
+Boolean
+SCVLANInterfaceRemove			(SCVLANInterfaceRef		vlan);
+
+/*!
+	@function SCVLANInterfaceGetPhysicalInterface
+	@discussion Returns the VLAN's physical interface. Owned by the
+		VLAN.
+ */
+SCNetworkInterfaceRef
+SCVLANInterfaceGetPhysicalInterface	(SCVLANInterfaceRef		vlan);
+
+/*!
+	@function SCVLANInterfaceGetTag
+	@discussion Returns the VLAN's 802.1Q tag. Owned by the VLAN.
+ */
+CFNumberRef
+SCVLANInterfaceGetTag			(SCVLANInterfaceRef		vlan);
+
+/*!
+	@function SCVLANInterfaceGetOptions
+	@discussion Returns the VLAN's options dictionary, or NULL.
+ */
+CFDictionaryRef
+SCVLANInterfaceGetOptions		(SCVLANInterfaceRef		vlan);
+
+/*!
+	@function SCVLANInterfaceSetPhysicalInterfaceAndTag
+	@discussion Changes the VLAN's physical interface and tag.
+ */
+Boolean
+SCVLANInterfaceSetPhysicalInterfaceAndTag
+					(SCVLANInterfaceRef		vlan,
+					 SCNetworkInterfaceRef		physical,
+					 CFNumberRef			tag);
+
+/*!
+	@function SCVLANInterfaceSetLocalizedDisplayName
+	@discussion Sets the VLAN's display name.
+ */
+Boolean
+SCVLANInterfaceSetLocalizedDisplayName	(SCVLANInterfaceRef		vlan,
+					 CFStringRef			newName);
+
+/*!
+	@function SCVLANInterfaceSetOptions
+	@discussion Sets the VLAN's options dictionary.
+ */
+Boolean
+SCVLANInterfaceSetOptions		(SCVLANInterfaceRef		vlan,
+					 CFDictionaryRef		newOptions);
 
 __END_DECLS
 

--- a/src/libSystemConfiguration/scvlantest.c
+++ b/src/libSystemConfiguration/scvlantest.c
@@ -1,0 +1,256 @@
+/*
+ * scvlantest.c — libSystemConfiguration SCNetworkConfiguration iter 5
+ * test client: SCVLANInterface.
+ *
+ * Creates an 802.1Q VLAN interface on the guest's e1000 interface,
+ * checks its physical interface / tag / display name / options, commits,
+ * reopens the preferences and confirms the VLAN persisted, then removes
+ * it. Also confirms a duplicate physical+tag pair is rejected.
+ *
+ * run.sh runs it and boot-test.sh gates on the SC-VLAN-OK / -FAIL
+ * marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+#define	SCT_ID	"scvlantest.plist"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-VLAN-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+static SCNetworkInterfaceRef
+first_ethernet(CFArrayRef all)
+{
+	CFIndex	i, n;
+
+	n = (all != NULL) ? CFArrayGetCount(all) : 0;
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	iface;
+
+		iface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(all, i);
+		if (CFEqual(SCNetworkInterfaceGetInterfaceType(iface),
+			    kSCNetworkInterfaceTypeEthernet)) {
+			return iface;
+		}
+	}
+	return NULL;
+}
+
+/* TRUE iff `vlan` looks right: a VLAN on `physBSD` with tag `tag` */
+static Boolean
+vlan_matches(SCVLANInterfaceRef vlan, CFStringRef physBSD, CFNumberRef tag)
+{
+	SCNetworkInterfaceRef	phys = SCVLANInterfaceGetPhysicalInterface(vlan);
+	CFNumberRef		t    = SCVLANInterfaceGetTag(vlan);
+
+	return ((phys != NULL) && (t != NULL) &&
+		CFEqual(SCNetworkInterfaceGetBSDName(phys), physBSD) &&
+		CFEqual(t, tag));
+}
+
+int
+main(void)
+{
+	SCPreferencesRef	prefs	= NULL;
+	CFArrayRef		allif	= NULL;
+	CFArrayRef		vlans	= NULL;
+	SCNetworkInterfaceRef	physical;
+	SCVLANInterfaceRef	vlan	= NULL;
+	SCVLANInterfaceRef	vlan2	= NULL;
+	CFNumberRef		tag	= NULL;
+	CFMutableDictionaryRef	opts	= NULL;
+	CFStringRef		origBSD	= NULL;
+	CFStringRef		name, prefsID, wantName, mtuKey, mtuVal;
+	int			tagVal	= 100;
+	int			rc	= 1;
+
+	printf("scvlantest: SCVLANInterface\n");
+	fflush(stdout);
+
+	name	 = mkstr("scvlantest");
+	prefsID	 = mkstr(SCT_ID);
+	wantName = mkstr("My VLAN");
+	mtuKey	 = mkstr("mtu");
+	mtuVal	 = mkstr("1500");
+	tag	 = CFNumberCreate(NULL, kCFNumberIntType, &tagVal);
+
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate failed");
+		goto out;
+	}
+
+	allif    = SCNetworkInterfaceCopyAll();
+	physical = first_ethernet(allif);
+	if (physical == NULL) {
+		fail("no Ethernet interface for a VLAN");
+		goto out;
+	}
+	origBSD = CFStringCreateCopy(NULL, SCNetworkInterfaceGetBSDName(physical));
+
+	/* no VLANs to start */
+	vlans = SCVLANInterfaceCopyAll(prefs);
+	if ((vlans == NULL) || (CFArrayGetCount(vlans) != 0)) {
+		fail("a fresh preferences has VLANs");
+		goto out;
+	}
+	CFRelease(vlans);
+	vlans = NULL;
+
+	/* create a VLAN */
+	vlan = SCVLANInterfaceCreate(prefs, physical, tag);
+	if (vlan == NULL) {
+		fail("SCVLANInterfaceCreate failed");
+		goto out;
+	}
+	if (!CFEqual(SCNetworkInterfaceGetInterfaceType(vlan),
+		     kSCNetworkInterfaceTypeVLAN)) {
+		fail("created interface is not of type VLAN");
+		goto out;
+	}
+	if (!CFStringHasPrefix(SCNetworkInterfaceGetBSDName(vlan),
+			       CFSTR("vlan"))) {
+		fail("VLAN interface has no vlanN BSD name");
+		goto out;
+	}
+	if (!vlan_matches(vlan, origBSD, tag)) {
+		fail("VLAN physical interface / tag wrong");
+		goto out;
+	}
+	printf("  VLANInterfaceCreate: VLAN created on the interface\n");
+
+	/* a duplicate physical + tag pair is rejected */
+	{
+		SCVLANInterfaceRef	dup;
+
+		dup = SCVLANInterfaceCreate(prefs, physical, tag);
+		if ((dup != NULL) || (SCError() != kSCStatusKeyExists)) {
+			if (dup != NULL) CFRelease(dup);
+			fail("a duplicate VLAN was allowed");
+			goto out;
+		}
+	}
+
+	/* display name + options */
+	if (!SCVLANInterfaceSetLocalizedDisplayName(vlan, wantName) ||
+	    !CFEqual(SCNetworkInterfaceGetLocalizedDisplayName(vlan),
+		     wantName)) {
+		fail("VLAN display name did not round-trip");
+		goto out;
+	}
+	opts = CFDictionaryCreateMutable(NULL, 0,
+					 &kCFTypeDictionaryKeyCallBacks,
+					 &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(opts, mtuKey, mtuVal);
+	if (!SCVLANInterfaceSetOptions(vlan, opts)) {
+		fail("SCVLANInterfaceSetOptions failed");
+		goto out;
+	}
+	{
+		CFDictionaryRef	got = SCVLANInterfaceGetOptions(vlan);
+		CFTypeRef	v   = (got != NULL)
+				      ? CFDictionaryGetValue(got, mtuKey) : NULL;
+
+		if ((v == NULL) || !CFEqual(v, mtuVal)) {
+			fail("VLAN options did not round-trip");
+			goto out;
+		}
+	}
+	printf("  SetDisplayName/SetOptions: VLAN configured\n");
+
+	vlans = SCVLANInterfaceCopyAll(prefs);
+	if ((vlans == NULL) || (CFArrayGetCount(vlans) != 1)) {
+		fail("SCVLANInterfaceCopyAll count wrong");
+		goto out;
+	}
+	CFRelease(vlans);
+	vlans = NULL;
+
+	/* commit, reopen, confirm the VLAN persisted */
+	if (!SCPreferencesCommitChanges(prefs)) {
+		fail("SCPreferencesCommitChanges failed");
+		goto out;
+	}
+	CFRelease(vlan);
+	vlan = NULL;
+	CFRelease(prefs);
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate (reopen) failed");
+		goto out;
+	}
+
+	vlans = SCVLANInterfaceCopyAll(prefs);
+	if ((vlans == NULL) || (CFArrayGetCount(vlans) != 1)) {
+		fail("VLAN did not persist");
+		goto out;
+	}
+	vlan2 = (SCVLANInterfaceRef)CFArrayGetValueAtIndex(vlans, 0);
+	CFRetain(vlan2);
+	if (!vlan_matches(vlan2, origBSD, tag)) {
+		fail("persisted VLAN physical / tag wrong");
+		goto out;
+	}
+	if (!CFEqual(SCNetworkInterfaceGetLocalizedDisplayName(vlan2),
+		     wantName)) {
+		fail("VLAN display name did not persist");
+		goto out;
+	}
+	{
+		CFDictionaryRef	got = SCVLANInterfaceGetOptions(vlan2);
+		CFTypeRef	v   = (got != NULL)
+				      ? CFDictionaryGetValue(got, mtuKey) : NULL;
+
+		if ((v == NULL) || !CFEqual(v, mtuVal)) {
+			fail("VLAN options did not persist");
+			goto out;
+		}
+	}
+	printf("  CommitChanges/reopen: VLAN persisted\n");
+
+	/* remove it */
+	if (!SCVLANInterfaceRemove(vlan2)) {
+		fail("SCVLANInterfaceRemove failed");
+		goto out;
+	}
+	CFRelease(vlans);
+	vlans = SCVLANInterfaceCopyAll(prefs);
+	if ((vlans == NULL) || (CFArrayGetCount(vlans) != 0)) {
+		fail("VLAN still present after removal");
+		goto out;
+	}
+	printf("  VLANInterfaceRemove: VLAN removed\n");
+
+	printf("SC-VLAN-OK: SCVLANInterface works\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (vlans != NULL)	CFRelease(vlans);
+	if (vlan != NULL)	CFRelease(vlan);
+	if (vlan2 != NULL)	CFRelease(vlan2);
+	if (opts != NULL)	CFRelease(opts);
+	if (allif != NULL)	CFRelease(allif);
+	if (prefs != NULL)	CFRelease(prefs);
+	if (tag != NULL)	CFRelease(tag);
+	if (origBSD != NULL)	CFRelease(origBSD);
+	CFRelease(name);
+	CFRelease(prefsID);
+	CFRelease(wantName);
+	CFRelease(mtuKey);
+	CFRelease(mtuVal);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -598,6 +598,18 @@ expect {
     "SC-NETSET-OK" { puts "\nOK: SCNetworkSet works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-VLAN marker not seen"
+        exit 1
+    }
+    "SC-VLAN-FAIL" {
+        puts "\nFAIL: SCVLANInterface failed"
+        exit 1
+    }
+    "SC-VLAN-OK" { puts "\nOK: SCVLANInterface works" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## SCNetworkConfiguration iter 5 — SCVLANInterface

Fifth iteration of the **SCNetworkConfiguration** port: `SCVLANInterface`, the first of the three virtual network interface families. A VLAN is an 802.1Q tag on top of a physical interface — an `SCNetworkInterface` of type VLAN (`SCVLANInterfaceRef` aliases `SCNetworkInterfaceRef`). VLANs are persisted in the preferences plist at `/VirtualNetworkInterfaces/VLAN/<vlanName>`, each entry recording the physical interface's BSD name, the tag, a display name and options.

### Changes

- **`SCVLANInterface.c`** — `SCVLANInterfaceCopyAll`, `CopyAvailablePhysicalInterfaces`, `Create` (claims a free `vlanN` name, rejects a duplicate physical+tag pair), `Remove`, the `Get` accessors (`PhysicalInterface` / `Tag` / `Options`) and the `Set` calls (`PhysicalInterfaceAndTag` / `LocalizedDisplayName` / `Options`).
- **`SCNetworkInterface.c`** — the `SCNetworkInterfacePrivate` struct gains the virtual-interface fields (`member_interfaces` / `vlan_physical` / `vlan_tag` / `bond_mode` / `virtual_options`); `__SCNetworkInterfaceCopyProtocolTypes` is now shared, and `__SCNetworkInterfaceCreateWithBSDName` synthesizes the physical interface a stored VLAN references.

Apple's `VLANConfiguration.c` also reflects the live kernel VLAN state (`SIOCGIFVLAN`); the port keeps the stored configuration model. **Bond** and **Bridge** — the other two virtual interface families — follow in iters 6 and 7.

### Test

New **`scvlantest`** (`SC-VLAN` marker) creates a VLAN on the e1000 interface, checks its physical interface / tag / display name / options, commits, reopens to confirm persistence, removes it, and verifies a duplicate physical+tag pair is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)