### PR TITLE
feat(libSystemConfiguration): SCNetworkConfiguration iter 6 — SCBondInterface

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1312,6 +1312,23 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scvlantest" \
     || { echo "FAIL: scvlantest not built"; exit 1; }
 echo "==> scvlantest built"
 
+# scbondtest — libSystemConfiguration SCNetworkConfiguration iter 6
+# test client. Creates an SCBondInterface, adds the e1000 interface as
+# a member, checks the member list / name / options / availability,
+# commits, reopens and confirms it persisted, then removes it. run.sh
+# runs it and checks for the SC-BOND-OK marker.
+echo "==> building scbondtest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scbondtest" \
+   "$ROOT/src/libSystemConfiguration/scbondtest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scbondtest" \
+    || { echo "FAIL: scbondtest not built"; exit 1; }
+echo "==> scbondtest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -637,4 +637,14 @@ if [ ! -x "$scvlantest" ]; then
 fi
 "$scvlantest" || true	# marker (SC-VLAN-OK/FAIL) gates in boot-test.sh
 
+# SC-BOND — SCNetworkConfiguration bond virtual interface: create a
+# bond, add the e1000 interface as a member, check the member list /
+# name / options, commit, reopen and confirm it persisted.
+scbondtest=/usr/tests/freebsd-launchd-mach/scbondtest
+if [ ! -x "$scbondtest" ]; then
+    echo "SC-BOND-FAIL: $scbondtest missing"
+    exit 1
+fi
+"$scbondtest" || true	# marker (SC-BOND-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/Makefile
+++ b/src/libSystemConfiguration/Makefile
@@ -23,7 +23,7 @@ SHLIB_MAJOR=	1
 SRCS=		SCD.c SCDynamicStore.c SCNotify.c SCDMultiple.c SCPreferences.c
 SRCS+=		SCNetworkConfigurationInternal.c SCNetworkInterface.c
 SRCS+=		SCNetworkProtocol.c SCNetworkService.c SCNetworkSet.c
-SRCS+=		SCVLANInterface.c
+SRCS+=		SCVLANInterface.c SCBondInterface.c
 
 # configUser.c — MIG-generated config.defs client stubs (same file
 # configd's test clients link). config_wire.c — configd's shared

--- a/src/libSystemConfiguration/SCBondInterface.c
+++ b/src/libSystemConfiguration/SCBondInterface.c
@@ -1,0 +1,472 @@
+/*
+ * SCBondInterface.c — the SCBondInterface API (freebsd-launchd-mach port
+ * of Apple's SystemConfiguration.fproj BondConfiguration.c).
+ *
+ * A bond interface aggregates several physical interfaces into one
+ * (FreeBSD lagg(4)). It is an SCNetworkInterface of type Bond
+ * (SCBondInterfaceRef aliases SCNetworkInterfaceRef). Bonds are
+ * persisted in the preferences plist at
+ * /VirtualNetworkInterfaces/Bond/<bondName>, each entry recording the
+ * member interfaces' BSD names, a display name and options.
+ *
+ * Apple's BondConfiguration.c also reports live aggregation status
+ * (SCBondInterfaceCopyStatus, via lagg ioctls); the port keeps the
+ * stored configuration model.
+ */
+
+#include "SCNetworkConfigurationInternal.h"
+#include "SCInternal.h"
+
+#include <stdlib.h>
+
+
+#pragma mark -
+#pragma mark Helpers
+
+/* TRUE iff `bond` is a live SCNetworkInterface of type Bond */
+static Boolean
+isA_SCBondInterface(SCBondInterfaceRef bond)
+{
+	return (isA_SCNetworkInterface(bond) &&
+		CFEqual(((SCNetworkInterfacePrivateRef)bond)->interface_type,
+			kSCNetworkInterfaceTypeBond));
+}
+
+/* "/VirtualNetworkInterfaces/Bond" */
+static CFStringRef
+__bondContainerPath(void)
+{
+	return CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@/%@"),
+					kSCPrefVirtualNetworkInterfaces,
+					kSCNetworkInterfaceTypeBond);
+}
+
+/* "/VirtualNetworkInterfaces/Bond/<bondName>" */
+static CFStringRef
+__bondPath(CFStringRef bondName)
+{
+	return CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@/%@/%@"),
+					kSCPrefVirtualNetworkInterfaces,
+					kSCNetworkInterfaceTypeBond, bondName);
+}
+
+/* allocate a Bond interface object named `bond_if` (e.g. "bond0") */
+static SCBondInterfaceRef
+_SCBondInterfaceCreatePrivate(CFAllocatorRef allocator, CFStringRef bond_if)
+{
+	SCNetworkInterfacePrivateRef	ip;
+
+	ip = __SCNetworkInterfaceCreatePrivate(allocator);
+	if (ip == NULL) {
+		return NULL;
+	}
+	ip->interface_type =
+		(CFStringRef)CFRetain(kSCNetworkInterfaceTypeBond);
+	ip->entity_device  = CFStringCreateCopy(allocator, bond_if);
+	ip->builtin        = TRUE;
+	ip->localized_name = CFStringCreateWithCString(NULL, "Bond",
+						       kCFStringEncodingUTF8);
+	ip->name           = (CFStringRef)CFRetain(ip->localized_name);
+	/* a bond carries the usual protocols, so a service can use it */
+	ip->supported_protocol_types = __SCNetworkInterfaceCopyProtocolTypes();
+	/* a fresh bond has an (empty) member list, never NULL */
+	ip->member_interfaces =
+		CFArrayCreate(NULL, NULL, 0, &kCFTypeArrayCallBacks);
+	return (SCBondInterfaceRef)ip;
+}
+
+/*
+ * Rewrite the stored entry for `bond` with the value at `key` set to
+ * `value` (NULL removes). A bond with no prefs is in-memory only, which
+ * the callers treat as success.
+ */
+static Boolean
+__bondStoreSet(SCNetworkInterfacePrivateRef ip, CFStringRef key,
+	       CFTypeRef value)
+{
+	CFDictionaryRef		dict;
+	CFMutableDictionaryRef	newDict;
+	CFStringRef		path;
+	Boolean			ok;
+
+	if (ip->prefs == NULL) {
+		return TRUE;
+	}
+	path = __bondPath(ip->entity_device);
+	dict = SCPreferencesPathGetValue(ip->prefs, path);
+	if ((dict == NULL) ||
+	    (CFGetTypeID(dict) != CFDictionaryGetTypeID())) {
+		CFRelease(path);
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+	newDict = CFDictionaryCreateMutableCopy(NULL, 0, dict);
+	if (value != NULL) {
+		CFDictionarySetValue(newDict, key, value);
+	} else {
+		CFDictionaryRemoveValue(newDict, key);
+	}
+	ok = SCPreferencesPathSetValue(ip->prefs, path, newDict);
+	CFRelease(newDict);
+	CFRelease(path);
+	return ok;
+}
+
+
+#pragma mark -
+#pragma mark SCBondInterface APIs
+
+CFArrayRef
+SCBondInterfaceCopyAll(SCPreferencesRef prefs)
+{
+	CFMutableArrayRef	array;
+	CFDictionaryRef		container;
+	const void		**keys;
+	const void		**vals;
+	CFIndex			i, n;
+	CFStringRef		path;
+
+	array = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+
+	path      = __bondContainerPath();
+	container = SCPreferencesPathGetValue(prefs, path);
+	CFRelease(path);
+	if ((container == NULL) ||
+	    (CFGetTypeID(container) != CFDictionaryGetTypeID())) {
+		return array;
+	}
+
+	n = CFDictionaryGetCount(container);
+	if (n <= 0) {
+		return array;
+	}
+	keys = (const void **)malloc((size_t)n * sizeof(void *));
+	vals = (const void **)malloc((size_t)n * sizeof(void *));
+	CFDictionaryGetKeysAndValues(container, keys, vals);
+
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfacePrivateRef	ip;
+		SCBondInterfaceRef		bond;
+		CFDictionaryRef			info	= (CFDictionaryRef)vals[i];
+		CFArrayRef			members;
+		CFDictionaryRef			options;
+		CFStringRef			name;
+		CFMutableArrayRef		ifaces;
+		CFIndex				j, m;
+
+		if (CFGetTypeID(info) != CFDictionaryGetTypeID()) {
+			continue;
+		}
+		bond = _SCBondInterfaceCreatePrivate(NULL, (CFStringRef)keys[i]);
+		if (bond == NULL) {
+			continue;
+		}
+		ip        = (SCNetworkInterfacePrivateRef)bond;
+		ip->prefs = (SCPreferencesRef)CFRetain(prefs);
+
+		/* rebuild each member from its stored BSD name */
+		members = CFDictionaryGetValue(info, kSCPropVirtualInterfaces);
+		m       = ((members != NULL) &&
+			   (CFGetTypeID(members) == CFArrayGetTypeID()))
+			  ? CFArrayGetCount(members) : 0;
+		ifaces  = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+		for (j = 0; j < m; j++) {
+			CFStringRef		bsd;
+			SCNetworkInterfaceRef	iface;
+
+			bsd = CFArrayGetValueAtIndex(members, j);
+			if (CFGetTypeID(bsd) != CFStringGetTypeID()) {
+				continue;
+			}
+			iface = __SCNetworkInterfaceCreateWithBSDName(NULL, bsd);
+			if (iface != NULL) {
+				CFArrayAppendValue(ifaces, iface);
+				CFRelease(iface);
+			}
+		}
+		CFRelease(ip->member_interfaces);
+		ip->member_interfaces = ifaces;
+
+		options = CFDictionaryGetValue(info, kSCPropVirtualOptions);
+		if ((options != NULL) &&
+		    (CFGetTypeID(options) == CFDictionaryGetTypeID())) {
+			ip->virtual_options =
+				CFDictionaryCreateCopy(NULL, options);
+		}
+		name = CFDictionaryGetValue(info, kSCPropUserDefinedName);
+		if ((name != NULL) &&
+		    (CFGetTypeID(name) == CFStringGetTypeID())) {
+			if (ip->localized_name != NULL) {
+				CFRelease(ip->localized_name);
+			}
+			ip->localized_name = CFStringCreateCopy(NULL, name);
+		}
+
+		CFArrayAppendValue(array, bond);
+		CFRelease(bond);
+	}
+
+	free(keys);
+	free(vals);
+	return array;
+}
+
+CFArrayRef
+SCBondInterfaceCopyAvailableMemberInterfaces(SCPreferencesRef prefs)
+{
+	CFMutableArrayRef	available;
+	CFArrayRef		all;
+	CFArrayRef		bonds;
+	CFMutableSetRef		excluded;
+	CFIndex			i, n;
+
+	available = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	excluded  = CFSetCreateMutable(NULL, 0, &kCFTypeSetCallBacks);
+
+	/* an interface already in a bond is not available */
+	bonds = SCBondInterfaceCopyAll(prefs);
+	n     = (bonds != NULL) ? CFArrayGetCount(bonds) : 0;
+	for (i = 0; i < n; i++) {
+		CFArrayRef	members;
+		CFIndex		j, m;
+
+		members = SCBondInterfaceGetMemberInterfaces(
+				(SCBondInterfaceRef)
+				CFArrayGetValueAtIndex(bonds, i));
+		m = (members != NULL) ? CFArrayGetCount(members) : 0;
+		for (j = 0; j < m; j++) {
+			CFStringRef	bsd;
+
+			bsd = SCNetworkInterfaceGetBSDName(
+				(SCNetworkInterfaceRef)
+				CFArrayGetValueAtIndex(members, j));
+			if (bsd != NULL) {
+				CFSetAddValue(excluded, bsd);
+			}
+		}
+	}
+	if (bonds != NULL) {
+		CFRelease(bonds);
+	}
+
+	all = SCNetworkInterfaceCopyAll();
+	n   = (all != NULL) ? CFArrayGetCount(all) : 0;
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	iface;
+		CFStringRef		bsd;
+
+		iface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(all, i);
+		bsd   = SCNetworkInterfaceGetBSDName(iface);
+		if ((bsd != NULL) && !CFSetContainsValue(excluded, bsd)) {
+			CFArrayAppendValue(available, iface);
+		}
+	}
+	if (all != NULL) {
+		CFRelease(all);
+	}
+	CFRelease(excluded);
+	return available;
+}
+
+SCBondInterfaceRef
+SCBondInterfaceCreate(SCPreferencesRef prefs)
+{
+	SCBondInterfaceRef	bond	= NULL;
+	int			i;
+
+	if (prefs == NULL) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	/* claim the first free bondN name */
+	for (i = 0; i < 1024; i++) {
+		CFMutableDictionaryRef	entry;
+		CFArrayRef		empty;
+		CFStringRef		bond_if;
+		CFStringRef		path;
+		Boolean			ok;
+
+		bond_if = CFStringCreateWithFormat(NULL, NULL,
+						   CFSTR("bond%d"), i);
+		path    = __bondPath(bond_if);
+		if (SCPreferencesPathGetValue(prefs, path) != NULL) {
+			CFRelease(path);
+			CFRelease(bond_if);
+			continue;
+		}
+
+		/* a new bond starts with an empty member list */
+		entry = CFDictionaryCreateMutable(NULL, 0,
+					&kCFTypeDictionaryKeyCallBacks,
+					&kCFTypeDictionaryValueCallBacks);
+		empty = CFArrayCreate(NULL, NULL, 0, &kCFTypeArrayCallBacks);
+		CFDictionarySetValue(entry, kSCPropVirtualInterfaces, empty);
+		CFRelease(empty);
+		ok = SCPreferencesPathSetValue(prefs, path, entry);
+		CFRelease(entry);
+		CFRelease(path);
+		if (!ok) {
+			CFRelease(bond_if);
+			_SCErrorSet(kSCStatusFailed);
+			return NULL;
+		}
+
+		bond = _SCBondInterfaceCreatePrivate(NULL, bond_if);
+		CFRelease(bond_if);
+		if (bond != NULL) {
+			((SCNetworkInterfacePrivateRef)bond)->prefs =
+				(SCPreferencesRef)CFRetain(prefs);
+		}
+		break;
+	}
+	if (bond == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+	}
+	return bond;
+}
+
+Boolean
+SCBondInterfaceRemove(SCBondInterfaceRef bond)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)bond;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCBondInterface(bond) || (ip->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	path = __bondPath(ip->entity_device);
+	ok   = SCPreferencesPathRemoveValue(ip->prefs, path);
+	CFRelease(path);
+	return ok;
+}
+
+CFArrayRef
+SCBondInterfaceGetMemberInterfaces(SCBondInterfaceRef bond)
+{
+	if (!isA_SCBondInterface(bond)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)bond)->member_interfaces;
+}
+
+CFDictionaryRef
+SCBondInterfaceGetOptions(SCBondInterfaceRef bond)
+{
+	if (!isA_SCBondInterface(bond)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)bond)->virtual_options;
+}
+
+Boolean
+SCBondInterfaceSetMemberInterfaces(SCBondInterfaceRef bond, CFArrayRef members)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)bond;
+	CFMutableArrayRef		names;
+	CFMutableArrayRef		ifaces;
+	CFIndex				i, n;
+
+	if (!isA_SCBondInterface(bond)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((members != NULL) &&
+	    (CFGetTypeID(members) != CFArrayGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	/* the stored form is an array of member BSD names; the in-memory
+	 * form keeps the interface objects */
+	n      = (members != NULL) ? CFArrayGetCount(members) : 0;
+	names  = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	ifaces = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	member;
+		CFStringRef		bsd;
+
+		member = (SCNetworkInterfaceRef)
+			 CFArrayGetValueAtIndex(members, i);
+		bsd = isA_SCNetworkInterface(member)
+		      ? SCNetworkInterfaceGetBSDName(member) : NULL;
+		if (bsd == NULL) {
+			CFRelease(names);
+			CFRelease(ifaces);
+			_SCErrorSet(kSCStatusInvalidArgument);
+			return FALSE;
+		}
+		CFArrayAppendValue(names, bsd);
+		CFArrayAppendValue(ifaces, member);
+	}
+
+	if (!__bondStoreSet(ip, kSCPropVirtualInterfaces, names)) {
+		CFRelease(names);
+		CFRelease(ifaces);
+		return FALSE;
+	}
+	CFRelease(names);
+
+	/* update the in-memory member list */
+	if (ip->member_interfaces != NULL) {
+		CFRelease(ip->member_interfaces);
+	}
+	ip->member_interfaces = ifaces;
+	return TRUE;
+}
+
+Boolean
+SCBondInterfaceSetLocalizedDisplayName(SCBondInterfaceRef bond,
+				       CFStringRef newName)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)bond;
+
+	if (!isA_SCBondInterface(bond)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((newName == NULL) ||
+	    (CFGetTypeID(newName) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!__bondStoreSet(ip, kSCPropUserDefinedName, newName)) {
+		return FALSE;
+	}
+	if (ip->localized_name != NULL) {
+		CFRelease(ip->localized_name);
+	}
+	ip->localized_name = CFStringCreateCopy(NULL, newName);
+	return TRUE;
+}
+
+Boolean
+SCBondInterfaceSetOptions(SCBondInterfaceRef bond, CFDictionaryRef newOptions)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)bond;
+
+	if (!isA_SCBondInterface(bond)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((newOptions != NULL) &&
+	    (CFGetTypeID(newOptions) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!__bondStoreSet(ip, kSCPropVirtualOptions, newOptions)) {
+		return FALSE;
+	}
+	if (ip->virtual_options != NULL) {
+		CFRelease(ip->virtual_options);
+		ip->virtual_options = NULL;
+	}
+	if (newOptions != NULL) {
+		ip->virtual_options = CFDictionaryCreateCopy(NULL, newOptions);
+	}
+	return TRUE;
+}

--- a/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
@@ -564,6 +564,82 @@ Boolean
 SCVLANInterfaceSetOptions		(SCVLANInterfaceRef		vlan,
 					 CFDictionaryRef		newOptions);
 
+/* --------------------------------------------------------------------
+ * SCBondInterface — link-aggregation virtual interfaces
+ * ------------------------------------------------------------------ */
+
+/*!
+	@function SCBondInterfaceCopyAll
+	@discussion Returns every bond interface stored in `prefs`.
+	@result a CFArray of SCBondInterfaceRef (caller releases).
+ */
+CFArrayRef
+SCBondInterfaceCopyAll			(SCPreferencesRef		prefs);
+
+/*!
+	@function SCBondInterfaceCopyAvailableMemberInterfaces
+	@discussion Returns the interfaces available to be bond members
+		— hardware interfaces not already in a bond.
+	@result a CFArray of SCNetworkInterfaceRef (caller releases).
+ */
+CFArrayRef
+SCBondInterfaceCopyAvailableMemberInterfaces
+					(SCPreferencesRef		prefs);
+
+/*!
+	@function SCBondInterfaceCreate
+	@discussion Creates a new, empty bond interface in `prefs`.
+		Release the returned value.
+ */
+SCBondInterfaceRef
+SCBondInterfaceCreate			(SCPreferencesRef		prefs);
+
+/*!
+	@function SCBondInterfaceRemove
+	@discussion Removes the bond interface from the preferences.
+ */
+Boolean
+SCBondInterfaceRemove			(SCBondInterfaceRef		bond);
+
+/*!
+	@function SCBondInterfaceGetMemberInterfaces
+	@discussion Returns the bond's member interfaces. Owned by the
+		bond.
+ */
+CFArrayRef
+SCBondInterfaceGetMemberInterfaces	(SCBondInterfaceRef		bond);
+
+/*!
+	@function SCBondInterfaceGetOptions
+	@discussion Returns the bond's options dictionary, or NULL.
+ */
+CFDictionaryRef
+SCBondInterfaceGetOptions		(SCBondInterfaceRef		bond);
+
+/*!
+	@function SCBondInterfaceSetMemberInterfaces
+	@discussion Sets the bond's member interfaces.
+ */
+Boolean
+SCBondInterfaceSetMemberInterfaces	(SCBondInterfaceRef		bond,
+					 CFArrayRef			members);
+
+/*!
+	@function SCBondInterfaceSetLocalizedDisplayName
+	@discussion Sets the bond's display name.
+ */
+Boolean
+SCBondInterfaceSetLocalizedDisplayName	(SCBondInterfaceRef		bond,
+					 CFStringRef			newName);
+
+/*!
+	@function SCBondInterfaceSetOptions
+	@discussion Sets the bond's options dictionary.
+ */
+Boolean
+SCBondInterfaceSetOptions		(SCBondInterfaceRef		bond,
+					 CFDictionaryRef		newOptions);
+
 __END_DECLS
 
 #endif	/* _SCNETWORKCONFIGURATION_H */

--- a/src/libSystemConfiguration/scbondtest.c
+++ b/src/libSystemConfiguration/scbondtest.c
@@ -1,0 +1,297 @@
+/*
+ * scbondtest.c — libSystemConfiguration SCNetworkConfiguration iter 6
+ * test client: SCBondInterface.
+ *
+ * Creates a bond (link-aggregation) interface, adds the guest's e1000
+ * interface as a member, checks the member list / display name /
+ * options and the available-member query, commits, reopens the
+ * preferences to confirm the bond persisted, then removes it.
+ *
+ * run.sh runs it and boot-test.sh gates on the SC-BOND-OK / -FAIL
+ * marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+#define	SCT_ID	"scbondtest.plist"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-BOND-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+static SCNetworkInterfaceRef
+first_ethernet(CFArrayRef all)
+{
+	CFIndex	i, n;
+
+	n = (all != NULL) ? CFArrayGetCount(all) : 0;
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	iface;
+
+		iface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(all, i);
+		if (CFEqual(SCNetworkInterfaceGetInterfaceType(iface),
+			    kSCNetworkInterfaceTypeEthernet)) {
+			return iface;
+		}
+	}
+	return NULL;
+}
+
+/* TRUE iff `array` (of SCNetworkInterfaceRef) holds an iface named `bsd` */
+static Boolean
+array_has_bsd(CFArrayRef array, CFStringRef bsd)
+{
+	CFIndex	i, n;
+
+	n = (array != NULL) ? CFArrayGetCount(array) : 0;
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	iface;
+		CFStringRef		name;
+
+		iface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(array, i);
+		name  = SCNetworkInterfaceGetBSDName(iface);
+		if ((name != NULL) && CFEqual(name, bsd)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+int
+main(void)
+{
+	SCPreferencesRef	prefs	= NULL;
+	CFArrayRef		allif	= NULL;
+	CFArrayRef		bonds	= NULL;
+	CFArrayRef		avail	= NULL;
+	CFMutableArrayRef	members	= NULL;
+	CFMutableDictionaryRef	opts	= NULL;
+	SCNetworkInterfaceRef	member;
+	SCBondInterfaceRef	bond	= NULL;
+	SCBondInterfaceRef	bond2	= NULL;
+	CFStringRef		memberBSD = NULL;
+	CFStringRef		name, prefsID, wantName, modeKey, modeVal;
+	int			rc	= 1;
+
+	printf("scbondtest: SCBondInterface\n");
+	fflush(stdout);
+
+	name	 = mkstr("scbondtest");
+	prefsID	 = mkstr(SCT_ID);
+	wantName = mkstr("My Bond");
+	modeKey	 = mkstr("mode");
+	modeVal	 = mkstr("lacp");
+
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate failed");
+		goto out;
+	}
+
+	allif  = SCNetworkInterfaceCopyAll();
+	member = first_ethernet(allif);
+	if (member == NULL) {
+		fail("no Ethernet interface for a bond member");
+		goto out;
+	}
+	memberBSD = CFStringCreateCopy(NULL, SCNetworkInterfaceGetBSDName(member));
+
+	/* no bonds to start */
+	bonds = SCBondInterfaceCopyAll(prefs);
+	if ((bonds == NULL) || (CFArrayGetCount(bonds) != 0)) {
+		fail("a fresh preferences has bonds");
+		goto out;
+	}
+	CFRelease(bonds);
+	bonds = NULL;
+
+	/* create an (empty) bond */
+	bond = SCBondInterfaceCreate(prefs);
+	if (bond == NULL) {
+		fail("SCBondInterfaceCreate failed");
+		goto out;
+	}
+	if (!CFEqual(SCNetworkInterfaceGetInterfaceType(bond),
+		     kSCNetworkInterfaceTypeBond)) {
+		fail("created interface is not of type Bond");
+		goto out;
+	}
+	if (!CFStringHasPrefix(SCNetworkInterfaceGetBSDName(bond),
+			       CFSTR("bond"))) {
+		fail("Bond interface has no bondN BSD name");
+		goto out;
+	}
+	{
+		CFArrayRef	m0 = SCBondInterfaceGetMemberInterfaces(bond);
+
+		if ((m0 == NULL) || (CFArrayGetCount(m0) != 0)) {
+			fail("a new bond is not empty");
+			goto out;
+		}
+	}
+
+	/* the e1000 interface is available before it is bonded */
+	avail = SCBondInterfaceCopyAvailableMemberInterfaces(prefs);
+	if (!array_has_bsd(avail, memberBSD)) {
+		fail("interface not listed as an available bond member");
+		goto out;
+	}
+	CFRelease(avail);
+	avail = NULL;
+	printf("  BondInterfaceCreate: empty bond created\n");
+
+	/* add the interface as a member */
+	members = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	CFArrayAppendValue(members, member);
+	if (!SCBondInterfaceSetMemberInterfaces(bond, members)) {
+		fail("SCBondInterfaceSetMemberInterfaces failed");
+		goto out;
+	}
+	{
+		CFArrayRef	got = SCBondInterfaceGetMemberInterfaces(bond);
+
+		if ((got == NULL) || (CFArrayGetCount(got) != 1) ||
+		    !array_has_bsd(got, memberBSD)) {
+			fail("bond member list did not round-trip");
+			goto out;
+		}
+	}
+
+	/* once bonded, the interface is no longer available */
+	avail = SCBondInterfaceCopyAvailableMemberInterfaces(prefs);
+	if (array_has_bsd(avail, memberBSD)) {
+		fail("a bonded interface is still listed as available");
+		goto out;
+	}
+	CFRelease(avail);
+	avail = NULL;
+	printf("  SetMemberInterfaces: member added, availability updated\n");
+
+	/* display name + options */
+	if (!SCBondInterfaceSetLocalizedDisplayName(bond, wantName) ||
+	    !CFEqual(SCNetworkInterfaceGetLocalizedDisplayName(bond),
+		     wantName)) {
+		fail("bond display name did not round-trip");
+		goto out;
+	}
+	opts = CFDictionaryCreateMutable(NULL, 0,
+					 &kCFTypeDictionaryKeyCallBacks,
+					 &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(opts, modeKey, modeVal);
+	if (!SCBondInterfaceSetOptions(bond, opts)) {
+		fail("SCBondInterfaceSetOptions failed");
+		goto out;
+	}
+	{
+		CFDictionaryRef	got = SCBondInterfaceGetOptions(bond);
+		CFTypeRef	v   = (got != NULL)
+				      ? CFDictionaryGetValue(got, modeKey) : NULL;
+
+		if ((v == NULL) || !CFEqual(v, modeVal)) {
+			fail("bond options did not round-trip");
+			goto out;
+		}
+	}
+	printf("  SetDisplayName/SetOptions: bond configured\n");
+
+	bonds = SCBondInterfaceCopyAll(prefs);
+	if ((bonds == NULL) || (CFArrayGetCount(bonds) != 1)) {
+		fail("SCBondInterfaceCopyAll count wrong");
+		goto out;
+	}
+	CFRelease(bonds);
+	bonds = NULL;
+
+	/* commit, reopen, confirm the bond persisted */
+	if (!SCPreferencesCommitChanges(prefs)) {
+		fail("SCPreferencesCommitChanges failed");
+		goto out;
+	}
+	CFRelease(bond);
+	bond = NULL;
+	CFRelease(prefs);
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate (reopen) failed");
+		goto out;
+	}
+
+	bonds = SCBondInterfaceCopyAll(prefs);
+	if ((bonds == NULL) || (CFArrayGetCount(bonds) != 1)) {
+		fail("bond did not persist");
+		goto out;
+	}
+	bond2 = (SCBondInterfaceRef)CFArrayGetValueAtIndex(bonds, 0);
+	CFRetain(bond2);
+	{
+		CFArrayRef	got = SCBondInterfaceGetMemberInterfaces(bond2);
+
+		if ((got == NULL) || (CFArrayGetCount(got) != 1) ||
+		    !array_has_bsd(got, memberBSD)) {
+			fail("bond members did not persist");
+			goto out;
+		}
+	}
+	if (!CFEqual(SCNetworkInterfaceGetLocalizedDisplayName(bond2),
+		     wantName)) {
+		fail("bond display name did not persist");
+		goto out;
+	}
+	{
+		CFDictionaryRef	got = SCBondInterfaceGetOptions(bond2);
+		CFTypeRef	v   = (got != NULL)
+				      ? CFDictionaryGetValue(got, modeKey) : NULL;
+
+		if ((v == NULL) || !CFEqual(v, modeVal)) {
+			fail("bond options did not persist");
+			goto out;
+		}
+	}
+	printf("  CommitChanges/reopen: bond persisted\n");
+
+	/* remove it */
+	if (!SCBondInterfaceRemove(bond2)) {
+		fail("SCBondInterfaceRemove failed");
+		goto out;
+	}
+	CFRelease(bonds);
+	bonds = SCBondInterfaceCopyAll(prefs);
+	if ((bonds == NULL) || (CFArrayGetCount(bonds) != 0)) {
+		fail("bond still present after removal");
+		goto out;
+	}
+	printf("  BondInterfaceRemove: bond removed\n");
+
+	printf("SC-BOND-OK: SCBondInterface works\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (bonds != NULL)	CFRelease(bonds);
+	if (avail != NULL)	CFRelease(avail);
+	if (members != NULL)	CFRelease(members);
+	if (opts != NULL)	CFRelease(opts);
+	if (bond != NULL)	CFRelease(bond);
+	if (bond2 != NULL)	CFRelease(bond2);
+	if (allif != NULL)	CFRelease(allif);
+	if (prefs != NULL)	CFRelease(prefs);
+	if (memberBSD != NULL)	CFRelease(memberBSD);
+	CFRelease(name);
+	CFRelease(prefsID);
+	CFRelease(wantName);
+	CFRelease(modeKey);
+	CFRelease(modeVal);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -610,6 +610,18 @@ expect {
     "SC-VLAN-OK" { puts "\nOK: SCVLANInterface works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-BOND marker not seen"
+        exit 1
+    }
+    "SC-BOND-FAIL" {
+        puts "\nFAIL: SCBondInterface failed"
+        exit 1
+    }
+    "SC-BOND-OK" { puts "\nOK: SCBondInterface works" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## SCNetworkConfiguration iter 6 — SCBondInterface

Sixth iteration of the **SCNetworkConfiguration** port: `SCBondInterface`, the second of the three virtual network interface families. A bond aggregates several physical interfaces into one (FreeBSD `lagg(4)`). It is an `SCNetworkInterface` of type Bond (`SCBondInterfaceRef` aliases `SCNetworkInterfaceRef`). Bonds are persisted in the preferences plist at `/VirtualNetworkInterfaces/Bond/<bondName>`, each entry recording the member interfaces' BSD names, a display name and options.

### Changes

- **`SCBondInterface.c`** — `SCBondInterfaceCopyAll`, `Create` (claims a free `bondN` name), `Remove`, `CopyAvailableMemberInterfaces` (hardware interfaces not already in a bond), the `Get` accessors (`MemberInterfaces` / `Options`) and the `Set` calls (`MemberInterfaces` / `LocalizedDisplayName` / `Options`).

Bond reuses the virtual-interface struct fields and the `__SCNetworkInterfaceCreateWithBSDName` helper iter 5 added; members are stored as an array of BSD names and rebuilt as interface objects on read. Apple's `BondConfiguration.c` also reports live `lagg` aggregation status (`SCBondInterfaceCopyStatus`); the port keeps the stored configuration model. **Bridge** — the last virtual interface family — follows in iter 7.

### Test

New **`scbondtest`** (`SC-BOND` marker) creates a bond, adds the e1000 interface as a member, checks the member list / display name / options and that a bonded interface drops out of the available-members query, commits, reopens to confirm persistence, then removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)