### PR TITLE
feat(libSystemConfiguration): SCNetworkConfiguration iter 7 — SCBridgeInterface

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1329,6 +1329,24 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scbondtest" \
     || { echo "FAIL: scbondtest not built"; exit 1; }
 echo "==> scbondtest built"
 
+# scbridgetest — libSystemConfiguration SCNetworkConfiguration iter 7
+# test client. Creates an SCBridgeInterface, adds the e1000 interface
+# as a member, checks the member list / name / options / the
+# AllowConfiguredMembers flag, commits, reopens and confirms it
+# persisted, then removes it. run.sh runs it and checks for the
+# SC-BRIDGE-OK marker.
+echo "==> building scbridgetest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scbridgetest" \
+   "$ROOT/src/libSystemConfiguration/scbridgetest.c" \
+   -lSystemConfiguration -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scbridgetest" \
+    || { echo "FAIL: scbridgetest not built"; exit 1; }
+echo "==> scbridgetest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -647,4 +647,15 @@ if [ ! -x "$scbondtest" ]; then
 fi
 "$scbondtest" || true	# marker (SC-BOND-OK/FAIL) gates in boot-test.sh
 
+# SC-BRIDGE — SCNetworkConfiguration bridge virtual interface: create a
+# bridge, add the e1000 interface as a member, check the member list /
+# name / options / AllowConfiguredMembers, commit, reopen and confirm
+# it persisted.
+scbridgetest=/usr/tests/freebsd-launchd-mach/scbridgetest
+if [ ! -x "$scbridgetest" ]; then
+    echo "SC-BRIDGE-FAIL: $scbridgetest missing"
+    exit 1
+fi
+"$scbridgetest" || true	# marker (SC-BRIDGE-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libSystemConfiguration/Makefile
+++ b/src/libSystemConfiguration/Makefile
@@ -23,7 +23,7 @@ SHLIB_MAJOR=	1
 SRCS=		SCD.c SCDynamicStore.c SCNotify.c SCDMultiple.c SCPreferences.c
 SRCS+=		SCNetworkConfigurationInternal.c SCNetworkInterface.c
 SRCS+=		SCNetworkProtocol.c SCNetworkService.c SCNetworkSet.c
-SRCS+=		SCVLANInterface.c SCBondInterface.c
+SRCS+=		SCVLANInterface.c SCBondInterface.c SCBridgeInterface.c
 
 # configUser.c — MIG-generated config.defs client stubs (same file
 # configd's test clients link). config_wire.c — configd's shared

--- a/src/libSystemConfiguration/SCBridgeInterface.c
+++ b/src/libSystemConfiguration/SCBridgeInterface.c
@@ -1,0 +1,531 @@
+/*
+ * SCBridgeInterface.c — the SCBridgeInterface API (freebsd-launchd-mach
+ * port of Apple's SystemConfiguration.fproj BridgeConfiguration.c).
+ *
+ * A bridge interface joins several interfaces at layer 2 (FreeBSD
+ * if_bridge(4)). It is an SCNetworkInterface of type Bridge
+ * (SCBridgeInterfaceRef aliases SCNetworkInterfaceRef). Bridges are
+ * persisted in the preferences plist at
+ * /VirtualNetworkInterfaces/Bridge/<bridgeName>, each entry recording
+ * the member interfaces' BSD names, a display name and options. The
+ * "AllowConfiguredMembers" flag — whether a bridge member may itself
+ * carry a configured network service — is kept in the options.
+ *
+ * Apple's BridgeConfiguration.c also reflects the live kernel bridge
+ * state; the port keeps the stored configuration model.
+ */
+
+#include "SCNetworkConfigurationInternal.h"
+#include "SCInternal.h"
+
+#include <stdlib.h>
+
+#define	kAllowConfiguredMembers		CFSTR("AllowConfiguredMembers")
+
+
+#pragma mark -
+#pragma mark Helpers
+
+/* TRUE iff `bridge` is a live SCNetworkInterface of type Bridge */
+static Boolean
+isA_SCBridgeInterface(SCBridgeInterfaceRef bridge)
+{
+	return (isA_SCNetworkInterface(bridge) &&
+		CFEqual(((SCNetworkInterfacePrivateRef)bridge)->interface_type,
+			kSCNetworkInterfaceTypeBridge));
+}
+
+/* "/VirtualNetworkInterfaces/Bridge" */
+static CFStringRef
+__bridgeContainerPath(void)
+{
+	return CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@/%@"),
+					kSCPrefVirtualNetworkInterfaces,
+					kSCNetworkInterfaceTypeBridge);
+}
+
+/* "/VirtualNetworkInterfaces/Bridge/<bridgeName>" */
+static CFStringRef
+__bridgePath(CFStringRef bridgeName)
+{
+	return CFStringCreateWithFormat(NULL, NULL, CFSTR("/%@/%@/%@"),
+					kSCPrefVirtualNetworkInterfaces,
+					kSCNetworkInterfaceTypeBridge,
+					bridgeName);
+}
+
+/* allocate a Bridge interface object named `bridge_if` (e.g. "bridge0") */
+static SCBridgeInterfaceRef
+_SCBridgeInterfaceCreatePrivate(CFAllocatorRef allocator,
+				CFStringRef bridge_if)
+{
+	SCNetworkInterfacePrivateRef	ip;
+
+	ip = __SCNetworkInterfaceCreatePrivate(allocator);
+	if (ip == NULL) {
+		return NULL;
+	}
+	ip->interface_type =
+		(CFStringRef)CFRetain(kSCNetworkInterfaceTypeBridge);
+	ip->entity_device  = CFStringCreateCopy(allocator, bridge_if);
+	ip->builtin        = TRUE;
+	ip->localized_name = CFStringCreateWithCString(NULL, "Bridge",
+						       kCFStringEncodingUTF8);
+	ip->name           = (CFStringRef)CFRetain(ip->localized_name);
+	/* a bridge carries the usual protocols, so a service can use it */
+	ip->supported_protocol_types = __SCNetworkInterfaceCopyProtocolTypes();
+	/* a fresh bridge has an (empty) member list, never NULL */
+	ip->member_interfaces =
+		CFArrayCreate(NULL, NULL, 0, &kCFTypeArrayCallBacks);
+	return (SCBridgeInterfaceRef)ip;
+}
+
+/*
+ * Rewrite the stored entry for `bridge` with the value at `key` set to
+ * `value` (NULL removes). A bridge with no prefs is in-memory only,
+ * which the callers treat as success.
+ */
+static Boolean
+__bridgeStoreSet(SCNetworkInterfacePrivateRef ip, CFStringRef key,
+		 CFTypeRef value)
+{
+	CFDictionaryRef		dict;
+	CFMutableDictionaryRef	newDict;
+	CFStringRef		path;
+	Boolean			ok;
+
+	if (ip->prefs == NULL) {
+		return TRUE;
+	}
+	path = __bridgePath(ip->entity_device);
+	dict = SCPreferencesPathGetValue(ip->prefs, path);
+	if ((dict == NULL) ||
+	    (CFGetTypeID(dict) != CFDictionaryGetTypeID())) {
+		CFRelease(path);
+		_SCErrorSet(kSCStatusFailed);
+		return FALSE;
+	}
+	newDict = CFDictionaryCreateMutableCopy(NULL, 0, dict);
+	if (value != NULL) {
+		CFDictionarySetValue(newDict, key, value);
+	} else {
+		CFDictionaryRemoveValue(newDict, key);
+	}
+	ok = SCPreferencesPathSetValue(ip->prefs, path, newDict);
+	CFRelease(newDict);
+	CFRelease(path);
+	return ok;
+}
+
+
+#pragma mark -
+#pragma mark SCBridgeInterface APIs
+
+CFArrayRef
+SCBridgeInterfaceCopyAll(SCPreferencesRef prefs)
+{
+	CFMutableArrayRef	array;
+	CFDictionaryRef		container;
+	const void		**keys;
+	const void		**vals;
+	CFIndex			i, n;
+	CFStringRef		path;
+
+	array = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+
+	path      = __bridgeContainerPath();
+	container = SCPreferencesPathGetValue(prefs, path);
+	CFRelease(path);
+	if ((container == NULL) ||
+	    (CFGetTypeID(container) != CFDictionaryGetTypeID())) {
+		return array;
+	}
+
+	n = CFDictionaryGetCount(container);
+	if (n <= 0) {
+		return array;
+	}
+	keys = (const void **)malloc((size_t)n * sizeof(void *));
+	vals = (const void **)malloc((size_t)n * sizeof(void *));
+	CFDictionaryGetKeysAndValues(container, keys, vals);
+
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfacePrivateRef	ip;
+		SCBridgeInterfaceRef		bridge;
+		CFDictionaryRef			info	= (CFDictionaryRef)vals[i];
+		CFArrayRef			members;
+		CFDictionaryRef			options;
+		CFStringRef			name;
+		CFMutableArrayRef		ifaces;
+		CFIndex				j, m;
+
+		if (CFGetTypeID(info) != CFDictionaryGetTypeID()) {
+			continue;
+		}
+		bridge = _SCBridgeInterfaceCreatePrivate(NULL,
+							 (CFStringRef)keys[i]);
+		if (bridge == NULL) {
+			continue;
+		}
+		ip        = (SCNetworkInterfacePrivateRef)bridge;
+		ip->prefs = (SCPreferencesRef)CFRetain(prefs);
+
+		/* rebuild each member from its stored BSD name */
+		members = CFDictionaryGetValue(info, kSCPropVirtualInterfaces);
+		m       = ((members != NULL) &&
+			   (CFGetTypeID(members) == CFArrayGetTypeID()))
+			  ? CFArrayGetCount(members) : 0;
+		ifaces  = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+		for (j = 0; j < m; j++) {
+			CFStringRef		bsd;
+			SCNetworkInterfaceRef	iface;
+
+			bsd = CFArrayGetValueAtIndex(members, j);
+			if (CFGetTypeID(bsd) != CFStringGetTypeID()) {
+				continue;
+			}
+			iface = __SCNetworkInterfaceCreateWithBSDName(NULL, bsd);
+			if (iface != NULL) {
+				CFArrayAppendValue(ifaces, iface);
+				CFRelease(iface);
+			}
+		}
+		CFRelease(ip->member_interfaces);
+		ip->member_interfaces = ifaces;
+
+		options = CFDictionaryGetValue(info, kSCPropVirtualOptions);
+		if ((options != NULL) &&
+		    (CFGetTypeID(options) == CFDictionaryGetTypeID())) {
+			ip->virtual_options =
+				CFDictionaryCreateCopy(NULL, options);
+		}
+		name = CFDictionaryGetValue(info, kSCPropUserDefinedName);
+		if ((name != NULL) &&
+		    (CFGetTypeID(name) == CFStringGetTypeID())) {
+			if (ip->localized_name != NULL) {
+				CFRelease(ip->localized_name);
+			}
+			ip->localized_name = CFStringCreateCopy(NULL, name);
+		}
+
+		CFArrayAppendValue(array, bridge);
+		CFRelease(bridge);
+	}
+
+	free(keys);
+	free(vals);
+	return array;
+}
+
+CFArrayRef
+SCBridgeInterfaceCopyAvailableMemberInterfaces(SCPreferencesRef prefs)
+{
+	CFMutableArrayRef	available;
+	CFArrayRef		all;
+	CFArrayRef		bridges;
+	CFMutableSetRef		excluded;
+	CFIndex			i, n;
+
+	available = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	excluded  = CFSetCreateMutable(NULL, 0, &kCFTypeSetCallBacks);
+
+	/* an interface already in a bridge is not available */
+	bridges = SCBridgeInterfaceCopyAll(prefs);
+	n       = (bridges != NULL) ? CFArrayGetCount(bridges) : 0;
+	for (i = 0; i < n; i++) {
+		CFArrayRef	members;
+		CFIndex		j, m;
+
+		members = SCBridgeInterfaceGetMemberInterfaces(
+				(SCBridgeInterfaceRef)
+				CFArrayGetValueAtIndex(bridges, i));
+		m = (members != NULL) ? CFArrayGetCount(members) : 0;
+		for (j = 0; j < m; j++) {
+			CFStringRef	bsd;
+
+			bsd = SCNetworkInterfaceGetBSDName(
+				(SCNetworkInterfaceRef)
+				CFArrayGetValueAtIndex(members, j));
+			if (bsd != NULL) {
+				CFSetAddValue(excluded, bsd);
+			}
+		}
+	}
+	if (bridges != NULL) {
+		CFRelease(bridges);
+	}
+
+	all = SCNetworkInterfaceCopyAll();
+	n   = (all != NULL) ? CFArrayGetCount(all) : 0;
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	iface;
+		CFStringRef		bsd;
+
+		iface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(all, i);
+		bsd   = SCNetworkInterfaceGetBSDName(iface);
+		if ((bsd != NULL) && !CFSetContainsValue(excluded, bsd)) {
+			CFArrayAppendValue(available, iface);
+		}
+	}
+	if (all != NULL) {
+		CFRelease(all);
+	}
+	CFRelease(excluded);
+	return available;
+}
+
+SCBridgeInterfaceRef
+SCBridgeInterfaceCreate(SCPreferencesRef prefs)
+{
+	SCBridgeInterfaceRef	bridge	= NULL;
+	int			i;
+
+	if (prefs == NULL) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+
+	/* claim the first free bridgeN name */
+	for (i = 0; i < 1024; i++) {
+		CFMutableDictionaryRef	entry;
+		CFArrayRef		empty;
+		CFStringRef		bridge_if;
+		CFStringRef		path;
+		Boolean			ok;
+
+		bridge_if = CFStringCreateWithFormat(NULL, NULL,
+						     CFSTR("bridge%d"), i);
+		path      = __bridgePath(bridge_if);
+		if (SCPreferencesPathGetValue(prefs, path) != NULL) {
+			CFRelease(path);
+			CFRelease(bridge_if);
+			continue;
+		}
+
+		/* a new bridge starts with an empty member list */
+		entry = CFDictionaryCreateMutable(NULL, 0,
+					&kCFTypeDictionaryKeyCallBacks,
+					&kCFTypeDictionaryValueCallBacks);
+		empty = CFArrayCreate(NULL, NULL, 0, &kCFTypeArrayCallBacks);
+		CFDictionarySetValue(entry, kSCPropVirtualInterfaces, empty);
+		CFRelease(empty);
+		ok = SCPreferencesPathSetValue(prefs, path, entry);
+		CFRelease(entry);
+		CFRelease(path);
+		if (!ok) {
+			CFRelease(bridge_if);
+			_SCErrorSet(kSCStatusFailed);
+			return NULL;
+		}
+
+		bridge = _SCBridgeInterfaceCreatePrivate(NULL, bridge_if);
+		CFRelease(bridge_if);
+		if (bridge != NULL) {
+			((SCNetworkInterfacePrivateRef)bridge)->prefs =
+				(SCPreferencesRef)CFRetain(prefs);
+		}
+		break;
+	}
+	if (bridge == NULL) {
+		_SCErrorSet(kSCStatusFailed);
+	}
+	return bridge;
+}
+
+Boolean
+SCBridgeInterfaceRemove(SCBridgeInterfaceRef bridge)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)bridge;
+	CFStringRef			path;
+	Boolean				ok;
+
+	if (!isA_SCBridgeInterface(bridge) || (ip->prefs == NULL)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	path = __bridgePath(ip->entity_device);
+	ok   = SCPreferencesPathRemoveValue(ip->prefs, path);
+	CFRelease(path);
+	return ok;
+}
+
+CFArrayRef
+SCBridgeInterfaceGetMemberInterfaces(SCBridgeInterfaceRef bridge)
+{
+	if (!isA_SCBridgeInterface(bridge)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)bridge)->member_interfaces;
+}
+
+CFDictionaryRef
+SCBridgeInterfaceGetOptions(SCBridgeInterfaceRef bridge)
+{
+	if (!isA_SCBridgeInterface(bridge)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return NULL;
+	}
+	return ((SCNetworkInterfacePrivateRef)bridge)->virtual_options;
+}
+
+Boolean
+SCBridgeInterfaceSetMemberInterfaces(SCBridgeInterfaceRef bridge,
+				     CFArrayRef members)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)bridge;
+	CFMutableArrayRef		names;
+	CFMutableArrayRef		ifaces;
+	CFIndex				i, n;
+
+	if (!isA_SCBridgeInterface(bridge)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((members != NULL) &&
+	    (CFGetTypeID(members) != CFArrayGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+
+	/* the stored form is an array of member BSD names; the in-memory
+	 * form keeps the interface objects */
+	n      = (members != NULL) ? CFArrayGetCount(members) : 0;
+	names  = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	ifaces = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	member;
+		CFStringRef		bsd;
+
+		member = (SCNetworkInterfaceRef)
+			 CFArrayGetValueAtIndex(members, i);
+		bsd = isA_SCNetworkInterface(member)
+		      ? SCNetworkInterfaceGetBSDName(member) : NULL;
+		if (bsd == NULL) {
+			CFRelease(names);
+			CFRelease(ifaces);
+			_SCErrorSet(kSCStatusInvalidArgument);
+			return FALSE;
+		}
+		CFArrayAppendValue(names, bsd);
+		CFArrayAppendValue(ifaces, member);
+	}
+
+	if (!__bridgeStoreSet(ip, kSCPropVirtualInterfaces, names)) {
+		CFRelease(names);
+		CFRelease(ifaces);
+		return FALSE;
+	}
+	CFRelease(names);
+
+	/* update the in-memory member list */
+	if (ip->member_interfaces != NULL) {
+		CFRelease(ip->member_interfaces);
+	}
+	ip->member_interfaces = ifaces;
+	return TRUE;
+}
+
+Boolean
+SCBridgeInterfaceSetLocalizedDisplayName(SCBridgeInterfaceRef bridge,
+					 CFStringRef newName)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)bridge;
+
+	if (!isA_SCBridgeInterface(bridge)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((newName == NULL) ||
+	    (CFGetTypeID(newName) != CFStringGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!__bridgeStoreSet(ip, kSCPropUserDefinedName, newName)) {
+		return FALSE;
+	}
+	if (ip->localized_name != NULL) {
+		CFRelease(ip->localized_name);
+	}
+	ip->localized_name = CFStringCreateCopy(NULL, newName);
+	return TRUE;
+}
+
+Boolean
+SCBridgeInterfaceSetOptions(SCBridgeInterfaceRef bridge,
+			    CFDictionaryRef newOptions)
+{
+	SCNetworkInterfacePrivateRef	ip	= (SCNetworkInterfacePrivateRef)bridge;
+
+	if (!isA_SCBridgeInterface(bridge)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if ((newOptions != NULL) &&
+	    (CFGetTypeID(newOptions) != CFDictionaryGetTypeID())) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	if (!__bridgeStoreSet(ip, kSCPropVirtualOptions, newOptions)) {
+		return FALSE;
+	}
+	if (ip->virtual_options != NULL) {
+		CFRelease(ip->virtual_options);
+		ip->virtual_options = NULL;
+	}
+	if (newOptions != NULL) {
+		ip->virtual_options = CFDictionaryCreateCopy(NULL, newOptions);
+	}
+	return TRUE;
+}
+
+Boolean
+SCBridgeInterfaceSetAllowConfiguredMembers(SCBridgeInterfaceRef bridge,
+					   Boolean allow)
+{
+	CFDictionaryRef		options;
+	CFMutableDictionaryRef	newOptions;
+	Boolean			ok;
+
+	if (!isA_SCBridgeInterface(bridge)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	options = ((SCNetworkInterfacePrivateRef)bridge)->virtual_options;
+	if (options != NULL) {
+		newOptions = CFDictionaryCreateMutableCopy(NULL, 0, options);
+	} else {
+		newOptions = CFDictionaryCreateMutable(NULL, 0,
+					&kCFTypeDictionaryKeyCallBacks,
+					&kCFTypeDictionaryValueCallBacks);
+	}
+	if (allow) {
+		CFDictionarySetValue(newOptions, kAllowConfiguredMembers,
+				     kCFBooleanTrue);
+	} else {
+		CFDictionaryRemoveValue(newOptions, kAllowConfiguredMembers);
+	}
+	ok = SCBridgeInterfaceSetOptions(bridge, newOptions);
+	CFRelease(newOptions);
+	return ok;
+}
+
+Boolean
+SCBridgeInterfaceGetAllowConfiguredMembers(SCBridgeInterfaceRef bridge)
+{
+	CFDictionaryRef	options;
+	CFTypeRef	val;
+
+	if (!isA_SCBridgeInterface(bridge)) {
+		_SCErrorSet(kSCStatusInvalidArgument);
+		return FALSE;
+	}
+	options = ((SCNetworkInterfacePrivateRef)bridge)->virtual_options;
+	if (options == NULL) {
+		return FALSE;
+	}
+	val = CFDictionaryGetValue(options, kAllowConfiguredMembers);
+	return ((val != NULL) &&
+		(CFGetTypeID(val) == CFBooleanGetTypeID()) &&
+		CFBooleanGetValue(val));
+}

--- a/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
+++ b/src/libSystemConfiguration/SystemConfiguration/SCNetworkConfiguration.h
@@ -640,6 +640,102 @@ Boolean
 SCBondInterfaceSetOptions		(SCBondInterfaceRef		bond,
 					 CFDictionaryRef		newOptions);
 
+/* --------------------------------------------------------------------
+ * SCBridgeInterface — layer-2 bridging virtual interfaces
+ * ------------------------------------------------------------------ */
+
+/*!
+	@function SCBridgeInterfaceCopyAll
+	@discussion Returns every bridge interface stored in `prefs`.
+	@result a CFArray of SCBridgeInterfaceRef (caller releases).
+ */
+CFArrayRef
+SCBridgeInterfaceCopyAll		(SCPreferencesRef		prefs);
+
+/*!
+	@function SCBridgeInterfaceCopyAvailableMemberInterfaces
+	@discussion Returns the interfaces available to be bridge members
+		— hardware interfaces not already in a bridge.
+	@result a CFArray of SCNetworkInterfaceRef (caller releases).
+ */
+CFArrayRef
+SCBridgeInterfaceCopyAvailableMemberInterfaces
+					(SCPreferencesRef		prefs);
+
+/*!
+	@function SCBridgeInterfaceCreate
+	@discussion Creates a new, empty bridge interface in `prefs`.
+		Release the returned value.
+ */
+SCBridgeInterfaceRef
+SCBridgeInterfaceCreate			(SCPreferencesRef		prefs);
+
+/*!
+	@function SCBridgeInterfaceRemove
+	@discussion Removes the bridge interface from the preferences.
+ */
+Boolean
+SCBridgeInterfaceRemove			(SCBridgeInterfaceRef		bridge);
+
+/*!
+	@function SCBridgeInterfaceGetMemberInterfaces
+	@discussion Returns the bridge's member interfaces. Owned by the
+		bridge.
+ */
+CFArrayRef
+SCBridgeInterfaceGetMemberInterfaces	(SCBridgeInterfaceRef		bridge);
+
+/*!
+	@function SCBridgeInterfaceGetOptions
+	@discussion Returns the bridge's options dictionary, or NULL.
+ */
+CFDictionaryRef
+SCBridgeInterfaceGetOptions		(SCBridgeInterfaceRef		bridge);
+
+/*!
+	@function SCBridgeInterfaceSetMemberInterfaces
+	@discussion Sets the bridge's member interfaces.
+ */
+Boolean
+SCBridgeInterfaceSetMemberInterfaces	(SCBridgeInterfaceRef		bridge,
+					 CFArrayRef			members);
+
+/*!
+	@function SCBridgeInterfaceSetLocalizedDisplayName
+	@discussion Sets the bridge's display name.
+ */
+Boolean
+SCBridgeInterfaceSetLocalizedDisplayName
+					(SCBridgeInterfaceRef		bridge,
+					 CFStringRef			newName);
+
+/*!
+	@function SCBridgeInterfaceSetOptions
+	@discussion Sets the bridge's options dictionary.
+ */
+Boolean
+SCBridgeInterfaceSetOptions		(SCBridgeInterfaceRef		bridge,
+					 CFDictionaryRef		newOptions);
+
+/*!
+	@function SCBridgeInterfaceSetAllowConfiguredMembers
+	@discussion Sets whether a bridge member may itself carry a
+		configured network service.
+ */
+Boolean
+SCBridgeInterfaceSetAllowConfiguredMembers
+					(SCBridgeInterfaceRef		bridge,
+					 Boolean			allow);
+
+/*!
+	@function SCBridgeInterfaceGetAllowConfiguredMembers
+	@discussion Returns whether a bridge member may itself carry a
+		configured network service.
+ */
+Boolean
+SCBridgeInterfaceGetAllowConfiguredMembers
+					(SCBridgeInterfaceRef		bridge);
+
 __END_DECLS
 
 #endif	/* _SCNETWORKCONFIGURATION_H */

--- a/src/libSystemConfiguration/scbridgetest.c
+++ b/src/libSystemConfiguration/scbridgetest.c
@@ -1,0 +1,312 @@
+/*
+ * scbridgetest.c — libSystemConfiguration SCNetworkConfiguration iter 7
+ * test client: SCBridgeInterface.
+ *
+ * Creates a bridge interface, adds the guest's e1000 interface as a
+ * member, checks the member list / display name / options / the
+ * AllowConfiguredMembers flag and the available-member query, commits,
+ * reopens the preferences to confirm the bridge persisted, then removes
+ * it.
+ *
+ * run.sh runs it and boot-test.sh gates on the SC-BRIDGE-OK / -FAIL
+ * marker.
+ */
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+
+#define	SCT_ID	"scbridgetest.plist"
+
+static void
+fail(const char *msg)
+{
+	printf("SC-BRIDGE-FAIL: %s\n", msg);
+	fflush(stdout);
+}
+
+static CFStringRef
+mkstr(const char *s)
+{
+	return CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+}
+
+static SCNetworkInterfaceRef
+first_ethernet(CFArrayRef all)
+{
+	CFIndex	i, n;
+
+	n = (all != NULL) ? CFArrayGetCount(all) : 0;
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	iface;
+
+		iface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(all, i);
+		if (CFEqual(SCNetworkInterfaceGetInterfaceType(iface),
+			    kSCNetworkInterfaceTypeEthernet)) {
+			return iface;
+		}
+	}
+	return NULL;
+}
+
+/* TRUE iff `array` (of SCNetworkInterfaceRef) holds an iface named `bsd` */
+static Boolean
+array_has_bsd(CFArrayRef array, CFStringRef bsd)
+{
+	CFIndex	i, n;
+
+	n = (array != NULL) ? CFArrayGetCount(array) : 0;
+	for (i = 0; i < n; i++) {
+		SCNetworkInterfaceRef	iface;
+		CFStringRef		name;
+
+		iface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(array, i);
+		name  = SCNetworkInterfaceGetBSDName(iface);
+		if ((name != NULL) && CFEqual(name, bsd)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+int
+main(void)
+{
+	SCPreferencesRef	prefs	= NULL;
+	CFArrayRef		allif	= NULL;
+	CFArrayRef		bridges	= NULL;
+	CFArrayRef		avail	= NULL;
+	CFMutableArrayRef	members	= NULL;
+	CFMutableDictionaryRef	opts	= NULL;
+	SCNetworkInterfaceRef	member;
+	SCBridgeInterfaceRef	bridge	= NULL;
+	SCBridgeInterfaceRef	bridge2	= NULL;
+	CFStringRef		memberBSD = NULL;
+	CFStringRef		name, prefsID, wantName, fooKey, barVal;
+	int			rc	= 1;
+
+	printf("scbridgetest: SCBridgeInterface\n");
+	fflush(stdout);
+
+	name	 = mkstr("scbridgetest");
+	prefsID	 = mkstr(SCT_ID);
+	wantName = mkstr("My Bridge");
+	fooKey	 = mkstr("foo");
+	barVal	 = mkstr("bar");
+
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate failed");
+		goto out;
+	}
+
+	allif  = SCNetworkInterfaceCopyAll();
+	member = first_ethernet(allif);
+	if (member == NULL) {
+		fail("no Ethernet interface for a bridge member");
+		goto out;
+	}
+	memberBSD = CFStringCreateCopy(NULL, SCNetworkInterfaceGetBSDName(member));
+
+	/* no bridges to start */
+	bridges = SCBridgeInterfaceCopyAll(prefs);
+	if ((bridges == NULL) || (CFArrayGetCount(bridges) != 0)) {
+		fail("a fresh preferences has bridges");
+		goto out;
+	}
+	CFRelease(bridges);
+	bridges = NULL;
+
+	/* create an (empty) bridge */
+	bridge = SCBridgeInterfaceCreate(prefs);
+	if (bridge == NULL) {
+		fail("SCBridgeInterfaceCreate failed");
+		goto out;
+	}
+	if (!CFEqual(SCNetworkInterfaceGetInterfaceType(bridge),
+		     kSCNetworkInterfaceTypeBridge)) {
+		fail("created interface is not of type Bridge");
+		goto out;
+	}
+	if (!CFStringHasPrefix(SCNetworkInterfaceGetBSDName(bridge),
+			       CFSTR("bridge"))) {
+		fail("Bridge interface has no bridgeN BSD name");
+		goto out;
+	}
+	{
+		CFArrayRef	m0 = SCBridgeInterfaceGetMemberInterfaces(bridge);
+
+		if ((m0 == NULL) || (CFArrayGetCount(m0) != 0)) {
+			fail("a new bridge is not empty");
+			goto out;
+		}
+	}
+
+	/* the e1000 interface is available before it is bridged */
+	avail = SCBridgeInterfaceCopyAvailableMemberInterfaces(prefs);
+	if (!array_has_bsd(avail, memberBSD)) {
+		fail("interface not listed as an available bridge member");
+		goto out;
+	}
+	CFRelease(avail);
+	avail = NULL;
+	printf("  BridgeInterfaceCreate: empty bridge created\n");
+
+	/* add the interface as a member */
+	members = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	CFArrayAppendValue(members, member);
+	if (!SCBridgeInterfaceSetMemberInterfaces(bridge, members)) {
+		fail("SCBridgeInterfaceSetMemberInterfaces failed");
+		goto out;
+	}
+	{
+		CFArrayRef	got = SCBridgeInterfaceGetMemberInterfaces(bridge);
+
+		if ((got == NULL) || (CFArrayGetCount(got) != 1) ||
+		    !array_has_bsd(got, memberBSD)) {
+			fail("bridge member list did not round-trip");
+			goto out;
+		}
+	}
+
+	/* once bridged, the interface is no longer available */
+	avail = SCBridgeInterfaceCopyAvailableMemberInterfaces(prefs);
+	if (array_has_bsd(avail, memberBSD)) {
+		fail("a bridged interface is still listed as available");
+		goto out;
+	}
+	CFRelease(avail);
+	avail = NULL;
+	printf("  SetMemberInterfaces: member added, availability updated\n");
+
+	/* display name, options, and the AllowConfiguredMembers flag */
+	if (!SCBridgeInterfaceSetLocalizedDisplayName(bridge, wantName) ||
+	    !CFEqual(SCNetworkInterfaceGetLocalizedDisplayName(bridge),
+		     wantName)) {
+		fail("bridge display name did not round-trip");
+		goto out;
+	}
+	opts = CFDictionaryCreateMutable(NULL, 0,
+					 &kCFTypeDictionaryKeyCallBacks,
+					 &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(opts, fooKey, barVal);
+	if (!SCBridgeInterfaceSetOptions(bridge, opts)) {
+		fail("SCBridgeInterfaceSetOptions failed");
+		goto out;
+	}
+	if (SCBridgeInterfaceGetAllowConfiguredMembers(bridge)) {
+		fail("AllowConfiguredMembers is set on a new bridge");
+		goto out;
+	}
+	if (!SCBridgeInterfaceSetAllowConfiguredMembers(bridge, TRUE) ||
+	    !SCBridgeInterfaceGetAllowConfiguredMembers(bridge)) {
+		fail("SCBridgeInterfaceSetAllowConfiguredMembers did not take");
+		goto out;
+	}
+	{
+		/* setting the flag must not lose the existing options */
+		CFDictionaryRef	got = SCBridgeInterfaceGetOptions(bridge);
+		CFTypeRef	v   = (got != NULL)
+				      ? CFDictionaryGetValue(got, fooKey) : NULL;
+
+		if ((v == NULL) || !CFEqual(v, barVal)) {
+			fail("bridge options did not round-trip");
+			goto out;
+		}
+	}
+	printf("  SetOptions/AllowConfiguredMembers: bridge configured\n");
+
+	bridges = SCBridgeInterfaceCopyAll(prefs);
+	if ((bridges == NULL) || (CFArrayGetCount(bridges) != 1)) {
+		fail("SCBridgeInterfaceCopyAll count wrong");
+		goto out;
+	}
+	CFRelease(bridges);
+	bridges = NULL;
+
+	/* commit, reopen, confirm the bridge persisted */
+	if (!SCPreferencesCommitChanges(prefs)) {
+		fail("SCPreferencesCommitChanges failed");
+		goto out;
+	}
+	CFRelease(bridge);
+	bridge = NULL;
+	CFRelease(prefs);
+	prefs = SCPreferencesCreate(NULL, name, prefsID);
+	if (prefs == NULL) {
+		fail("SCPreferencesCreate (reopen) failed");
+		goto out;
+	}
+
+	bridges = SCBridgeInterfaceCopyAll(prefs);
+	if ((bridges == NULL) || (CFArrayGetCount(bridges) != 1)) {
+		fail("bridge did not persist");
+		goto out;
+	}
+	bridge2 = (SCBridgeInterfaceRef)CFArrayGetValueAtIndex(bridges, 0);
+	CFRetain(bridge2);
+	{
+		CFArrayRef	got = SCBridgeInterfaceGetMemberInterfaces(bridge2);
+
+		if ((got == NULL) || (CFArrayGetCount(got) != 1) ||
+		    !array_has_bsd(got, memberBSD)) {
+			fail("bridge members did not persist");
+			goto out;
+		}
+	}
+	if (!CFEqual(SCNetworkInterfaceGetLocalizedDisplayName(bridge2),
+		     wantName)) {
+		fail("bridge display name did not persist");
+		goto out;
+	}
+	if (!SCBridgeInterfaceGetAllowConfiguredMembers(bridge2)) {
+		fail("AllowConfiguredMembers did not persist");
+		goto out;
+	}
+	{
+		CFDictionaryRef	got = SCBridgeInterfaceGetOptions(bridge2);
+		CFTypeRef	v   = (got != NULL)
+				      ? CFDictionaryGetValue(got, fooKey) : NULL;
+
+		if ((v == NULL) || !CFEqual(v, barVal)) {
+			fail("bridge options did not persist");
+			goto out;
+		}
+	}
+	printf("  CommitChanges/reopen: bridge persisted\n");
+
+	/* remove it */
+	if (!SCBridgeInterfaceRemove(bridge2)) {
+		fail("SCBridgeInterfaceRemove failed");
+		goto out;
+	}
+	CFRelease(bridges);
+	bridges = SCBridgeInterfaceCopyAll(prefs);
+	if ((bridges == NULL) || (CFArrayGetCount(bridges) != 0)) {
+		fail("bridge still present after removal");
+		goto out;
+	}
+	printf("  BridgeInterfaceRemove: bridge removed\n");
+
+	printf("SC-BRIDGE-OK: SCBridgeInterface works\n");
+	rc = 0;
+
+    out :
+	fflush(stdout);
+	if (bridges != NULL)	CFRelease(bridges);
+	if (avail != NULL)	CFRelease(avail);
+	if (members != NULL)	CFRelease(members);
+	if (opts != NULL)	CFRelease(opts);
+	if (bridge != NULL)	CFRelease(bridge);
+	if (bridge2 != NULL)	CFRelease(bridge2);
+	if (allif != NULL)	CFRelease(allif);
+	if (prefs != NULL)	CFRelease(prefs);
+	if (memberBSD != NULL)	CFRelease(memberBSD);
+	CFRelease(name);
+	CFRelease(prefsID);
+	CFRelease(wantName);
+	CFRelease(fooKey);
+	CFRelease(barVal);
+	return rc;
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -622,6 +622,18 @@ expect {
     "SC-BOND-OK" { puts "\nOK: SCBondInterface works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: SC-BRIDGE marker not seen"
+        exit 1
+    }
+    "SC-BRIDGE-FAIL" {
+        puts "\nFAIL: SCBridgeInterface failed"
+        exit 1
+    }
+    "SC-BRIDGE-OK" { puts "\nOK: SCBridgeInterface works" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## SCNetworkConfiguration iter 7 — SCBridgeInterface

Seventh and **final** iteration of the SCNetworkConfiguration port: `SCBridgeInterface`, the last virtual network interface family. A bridge joins several interfaces at layer 2 (FreeBSD `if_bridge(4)`). It is an `SCNetworkInterface` of type Bridge (`SCBridgeInterfaceRef` aliases `SCNetworkInterfaceRef`). Bridges are persisted in the preferences plist at `/VirtualNetworkInterfaces/Bridge/<bridgeName>`, each entry recording the member interfaces' BSD names, a display name and options.

### Changes

- **`SCBridgeInterface.c`** — `SCBridgeInterfaceCopyAll`, `Create` (claims a free `bridgeN` name), `Remove`, `CopyAvailableMemberInterfaces` (hardware interfaces not already in a bridge), the `Get` accessors (`MemberInterfaces` / `Options`) and the `Set` calls (`MemberInterfaces` / `LocalizedDisplayName` / `Options`). Bridge adds the **`AllowConfiguredMembers`** flag — whether a bridge member may itself carry a configured network service — kept in the bridge's options.

Bridge follows the `SCBondInterface` model (members stored as a BSD-name array, rebuilt as interface objects on read).

### Test

New **`scbridgetest`** (`SC-BRIDGE` marker) creates a bridge, adds the e1000 interface as a member, checks the member list / display name / options / `AllowConfiguredMembers` flag and that a bridged interface drops out of the available-members query, commits, reopens to confirm persistence, then removes it.

---

This **completes the SCNetworkConfiguration port** — the interface / protocol / service / set core object model (iters 1–4) plus the VLAN / Bond / Bridge virtual interfaces (iters 5–7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)