### PR TITLE
feat(libIOKit): IOKit userland facade iter 1 — read-only registry walk

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1382,8 +1382,12 @@ echo "==> libIOKit built + installed"
 # iokittest — libIOKit iter 1 walk test client. Walks the hwregd
 # registry through the IOKit facade and prints IOKIT-WALK-OK. run.sh
 # runs it and checks for the marker.
+# -fblocks: IOKitLib.h pulls CoreFoundation; CF headers carry block
+# typedefs that need -fblocks even when iokittest itself doesn't use
+# any. Same flag the libSystemConfiguration test clients carry.
 echo "==> building iokittest"
-cc -I"$WORK/rootfs/usr/include" \
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
    -L"$WORK/rootfs/usr/lib/system" \
    -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
    -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/iokittest" \

--- a/build.sh
+++ b/build.sh
@@ -1348,6 +1348,55 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/scbridgetest" \
 echo "==> scbridgetest built"
 
 #
+# 3r4. build libIOKit (src/libIOKit/) — the IOKit userland facade,
+#      iter 1. Thin CF wrapper over hwregd's MIG hwreg.defs Mach RPC
+#      (K1 of the IOKit-userland port plan). iter 1 ships the read-
+#      only registry walk (IORegistryGetRootEntry, GetChildIterator,
+#      IOIteratorNext, GetName, GetPath, IOObject{Retain,Release}).
+#      Re-uses hwregd's MIG client stubs in $HWREG_MIG.
+#      Installs /usr/lib/system/libIOKit.so + /usr/include/IOKit/.
+#      Plan: pkgdemon.github.io/freebsd-hardware-registry-iokit-plan.html
+#
+echo "==> building libIOKit (src/libIOKit)"
+# bsd.incs.mk installs INCS into INCSDIR but does not create it —
+# match the same pre-mkdir libSystemConfiguration / libxpc use.
+mkdir -p "$WORK/rootfs/usr/include/IOKit"
+make -C "$ROOT/src/libIOKit" \
+    DESTDIR="$WORK/rootfs" \
+    SYSROOT="$WORK/rootfs" \
+    MIGOUT="$HWREG_MIG" \
+    all install
+# Re-prime ldconfig hints now that libIOKit is installed.
+chroot "$WORK/rootfs" ldconfig -m /usr/lib /usr/lib/system
+ls -lh "$WORK/rootfs/usr/lib/system/libIOKit.so"
+test -f "$WORK/rootfs/usr/lib/system/libIOKit.so.1" \
+    || { echo "FAIL: libIOKit.so.1 not installed"; exit 1; }
+test -L "$WORK/rootfs/usr/lib/system/libIOKit.so" \
+    || { echo "FAIL: libIOKit.so dev symlink missing"; exit 1; }
+test -f "$WORK/rootfs/usr/include/IOKit/IOKitLib.h" \
+    || { echo "FAIL: IOKit/IOKitLib.h header not installed"; exit 1; }
+chroot "$WORK/rootfs" ldconfig -r | grep -q libIOKit \
+    || { echo "FAIL: ldconfig hints missing libIOKit"; exit 1; }
+echo "==> libIOKit built + installed"
+
+# iokittest — libIOKit iter 1 walk test client. Walks the hwregd
+# registry through the IOKit facade and prints IOKIT-WALK-OK. run.sh
+# runs it and checks for the marker.
+echo "==> building iokittest"
+cc -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/iokittest" \
+   "$ROOT/src/libIOKit/iokittest.c" \
+   -lIOKit -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/iokittest" \
+    || { echo "FAIL: iokittest not built"; exit 1; }
+chroot "$WORK/rootfs" ldd /usr/tests/freebsd-launchd-mach/iokittest \
+    | grep -q "libIOKit.so.* => /usr/lib/system/" \
+    || { echo "FAIL: ldd doesn't resolve iokittest to /usr/lib/system/libIOKit.so"; exit 1; }
+echo "==> iokittest built + ldd verified"
+
+#
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at
 #     Phase J0 (commit 455a727). This step:

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -658,4 +658,15 @@ if [ ! -x "$scbridgetest" ]; then
 fi
 "$scbridgetest" || true	# marker (SC-BRIDGE-OK/FAIL) gates in boot-test.sh
 
+# IOKIT-WALK — libIOKit iter 1 read-only registry walk: walk the
+# hwregd registry tree through the IOKit facade (IORegistryGetRoot
+# Entry / GetChildIterator / IOIteratorNext / GetName / GetPath),
+# exercise IOObject Retain+Release.
+iokittest=/usr/tests/freebsd-launchd-mach/iokittest
+if [ ! -x "$iokittest" ]; then
+    echo "IOKIT-WALK-FAIL: $iokittest missing"
+    exit 1
+fi
+"$iokittest" || true	# marker (IOKIT-WALK-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libIOKit/IOKit/IOKitLib.h
+++ b/src/libIOKit/IOKit/IOKitLib.h
@@ -1,0 +1,135 @@
+/*
+ * IOKit/IOKitLib.h — public header for the freebsd-launchd-mach
+ * IOKit userland facade.
+ *
+ * This is the Apple IOKit C API as a thin client layered over
+ * hwregd's MIG hwreg.defs Mach RPC. Per the plan
+ * (pkgdemon.github.io/freebsd-hardware-registry-iokit-plan.html §5),
+ * the facade is NOT a port of Apple's IOKitUser source (which
+ * decomposes to a kernel device.defs surface this repo has no kernel
+ * for) — it is a fresh, thin CF wrapper over hwregd. Apple's
+ * io_object_t is a mach_port_t naming a kernel-resident IOService;
+ * the facade has no such kernel, so io_object_t here is an opaque
+ * pointer to a client-side struct holding a hwregd node id (or a
+ * captured id array for iterators). Each routine that returns one
+ * allocates it; the caller releases with IOObjectRelease.
+ *
+ * iter 1 — read-only registry walk:
+ *   IORegistryGetRootEntry, IORegistryEntryGetChildIterator,
+ *   IOIteratorNext, IORegistryEntryGetName, IORegistryEntryGetPath,
+ *   IOObjectRetain, IOObjectRelease.
+ *
+ * Later iterations add properties + matching (iter 2), the `ioreg`
+ * tool (iter 3) and notifications (iter 4, K2 of the plan).
+ *
+ * NOTE: there is also a separate Apple-API stub at
+ * src/launchd/freebsd-shims/IOKit/IOKitLib.h covering the four IOKit
+ * calls launchctl makes (IOKitWaitQuiet etc.). That shim aliases
+ * io_object_t to mach_port_t and is unrelated to this facade; they
+ * sit on different include paths and are not used in the same TU.
+ */
+#ifndef _IOKIT_IOKITLIB_H_
+#define _IOKIT_IOKITLIB_H_
+
+#include <sys/cdefs.h>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <mach/mach_port.h>
+#include <mach/kern_return.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Opaque client-side handle. See the header comment.
+ */
+typedef struct __IOObject *io_object_t;
+typedef io_object_t io_registry_entry_t;
+typedef io_object_t io_service_t;
+typedef io_object_t io_iterator_t;
+
+#define IO_OBJECT_NULL ((io_object_t)0)
+
+/*
+ * Apple's IOKit name + path buffer typedefs. io_name_t is a 128-byte
+ * fixed array used for class / registry-entry names; io_string_t is
+ * 512 bytes and carries plane-qualified paths.
+ */
+typedef char io_name_t[128];
+typedef char io_string_t[512];
+
+/*
+ * IOReturn — Apple's IOKit error code space. kern_return_t fits the
+ * same range. iter 1 only needs a small subset (the rest exist on
+ * macOS); add more as later iters grow the API.
+ */
+typedef int IOReturn;
+#define kIOReturnSuccess     0
+#define kIOReturnError       0x2bc
+#define kIOReturnNoDevice    0x2c0
+#define kIOReturnBadArgument 0x2c9
+#define kIOReturnNotFound    0x2f0
+
+/*
+ * "main port" sentinels. On macOS these select the IOKit master
+ * server. The facade resolves org.freebsd.hwregd lazily via
+ * bootstrap_look_up on first use; this argument is ignored, but
+ * declared so the Apple signatures match.
+ */
+#define kIOMainPortDefault   ((mach_port_t)0)
+#define kIOMasterPortDefault ((mach_port_t)0)	/* deprecated alias */
+
+/*
+ * IORegistryGetRootEntry — handle to the registry root (the newbus
+ * root device hwregd snapshots at startup). Returns IO_OBJECT_NULL
+ * if hwregd is unreachable or the registry is empty. The returned
+ * handle must be released with IOObjectRelease.
+ */
+io_registry_entry_t	IORegistryGetRootEntry(mach_port_t mainPort);
+
+/*
+ * IORegistryEntryGetChildIterator — iterator over `entry`'s direct
+ * children. `plane` is accepted for source compatibility and
+ * ignored (this facade has one plane, IOService). The iterator
+ * must be released with IOObjectRelease.
+ */
+kern_return_t	IORegistryEntryGetChildIterator(io_registry_entry_t entry,
+		    const io_name_t plane, io_iterator_t *iterator);
+
+/*
+ * IOIteratorNext — next entry from `iterator`, or IO_OBJECT_NULL
+ * when exhausted. Each returned entry must be released with
+ * IOObjectRelease.
+ */
+io_object_t	IOIteratorNext(io_iterator_t iterator);
+
+/*
+ * IORegistryEntryGetName — `entry`'s short name (e.g. "em0") into
+ * the caller's io_name_t buffer.
+ */
+kern_return_t	IORegistryEntryGetName(io_registry_entry_t entry,
+		    io_name_t name);
+
+/*
+ * IORegistryEntryGetPath — `entry`'s plane-qualified path into the
+ * caller's io_string_t buffer. The result is "IOService:" followed
+ * by the entry's newbus-tree path (e.g. "IOService:/pci0/em0").
+ * `plane` is ignored.
+ */
+kern_return_t	IORegistryEntryGetPath(io_registry_entry_t entry,
+		    const io_name_t plane, io_string_t path);
+
+/*
+ * IOObjectRetain — gain an additional reference to a handle.
+ * IOObjectRelease — drop a reference and free the handle at zero.
+ * Releasing IO_OBJECT_NULL is a no-op (matches macOS).
+ */
+kern_return_t	IOObjectRetain(io_object_t object);
+kern_return_t	IOObjectRelease(io_object_t object);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _IOKIT_IOKITLIB_H_ */

--- a/src/libIOKit/IOKitInternal.h
+++ b/src/libIOKit/IOKitInternal.h
@@ -1,0 +1,55 @@
+/*
+ * IOKitInternal.h — private to libIOKit.
+ *
+ * Defines the client-side handle struct that backs every io_object_t
+ * the facade hands out, plus the shared lazy-init helper for the
+ * hwregd Mach service port. iter 1 — read-only walk; later iters
+ * extend the struct as new handle flavors appear (matching
+ * iterators, notification iterators).
+ */
+#ifndef _IOKIT_INTERNAL_H_
+#define _IOKIT_INTERNAL_H_
+
+#include <IOKit/IOKitLib.h>
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <mach/mach.h>
+
+/*
+ * Handle flavors. iter 1 only has two — a registry entry (a single
+ * hwregd node id) and an iterator (a captured uint64_t id array).
+ * Each iter that adds a new flavor adds a constant here and a
+ * branch in IOObjectRelease.
+ */
+#define IOOBJ_KIND_ENTRY	1
+#define IOOBJ_KIND_ITERATOR	2
+
+struct __IOObject {
+	uint32_t	kind;		/* IOOBJ_KIND_* */
+	atomic_int	refcnt;		/* IOObjectRetain/Release */
+	/* entry: */
+	uint64_t	node_id;
+	/* iterator: */
+	uint64_t	*ids;		/* malloced; freed in release */
+	uint32_t	count;
+	uint32_t	cursor;
+};
+
+/*
+ * __io_hwregd_port — cached send right to org.freebsd.hwregd, looked
+ * up via bootstrap_look_up on first call (pthread_once-guarded).
+ * Returns MACH_PORT_NULL if the lookup fails; callers report the
+ * facade routine as kIOReturnNoDevice / IO_OBJECT_NULL.
+ */
+mach_port_t	__io_hwregd_port(void);
+
+/*
+ * Internal allocators. __io_alloc_iterator takes ownership of the
+ * id array (it is freed by IOObjectRelease) — on calloc failure the
+ * array is freed and IO_OBJECT_NULL returned.
+ */
+io_object_t	__io_alloc_entry(uint64_t node_id);
+io_object_t	__io_alloc_iterator(uint64_t *ids, uint32_t count);
+
+#endif /* _IOKIT_INTERNAL_H_ */

--- a/src/libIOKit/IOKitLib.c
+++ b/src/libIOKit/IOKitLib.c
@@ -1,0 +1,202 @@
+/*
+ * IOKitLib.c — libIOKit iter 1: read-only registry walk.
+ *
+ * Each entry point is a thin wrapper over hwregd's MIG RPC
+ * (src/hwregd/hwreg.defs). Handles are client-side structs with a
+ * hwregd node id (or a captured id array for iterators) and an
+ * atomic refcount. The hwregd service port is looked up lazily via
+ * bootstrap_look_up on first use and cached process-wide.
+ */
+#include <IOKit/IOKitLib.h>
+#include "IOKitInternal.h"
+
+#include "hwreg.h"		/* MIG hwreg.defs user-side stubs */
+#include "hwreg_mig_types.h"	/* hwreg_id_array_t / hwreg_name_t / ... */
+
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* hwregd send right — cached after the first bootstrap_look_up. */
+static pthread_once_t	hwregd_once = PTHREAD_ONCE_INIT;
+static mach_port_t	hwregd_port = MACH_PORT_NULL;
+
+static void
+hwregd_lookup(void)
+{
+	if (bootstrap_look_up(bootstrap_port,
+	    "org.freebsd.hwregd", &hwregd_port) != KERN_SUCCESS)
+		hwregd_port = MACH_PORT_NULL;
+}
+
+mach_port_t
+__io_hwregd_port(void)
+{
+	(void)pthread_once(&hwregd_once, hwregd_lookup);
+	return (hwregd_port);
+}
+
+io_object_t
+__io_alloc_entry(uint64_t node_id)
+{
+	struct __IOObject *o = calloc(1, sizeof(*o));
+
+	if (o == NULL)
+		return (IO_OBJECT_NULL);
+	o->kind = IOOBJ_KIND_ENTRY;
+	atomic_store(&o->refcnt, 1);
+	o->node_id = node_id;
+	return (o);
+}
+
+io_object_t
+__io_alloc_iterator(uint64_t *ids, uint32_t count)
+{
+	struct __IOObject *o = calloc(1, sizeof(*o));
+
+	if (o == NULL) {
+		free(ids);
+		return (IO_OBJECT_NULL);
+	}
+	o->kind = IOOBJ_KIND_ITERATOR;
+	atomic_store(&o->refcnt, 1);
+	o->ids = ids;
+	o->count = count;
+	o->cursor = 0;
+	return (o);
+}
+
+io_registry_entry_t
+IORegistryGetRootEntry(mach_port_t mainPort __unused)
+{
+	mach_port_t svc = __io_hwregd_port();
+	uint64_t root = 0;
+
+	if (svc == MACH_PORT_NULL)
+		return (IO_OBJECT_NULL);
+	if (hwreg_get_root(svc, &root) != KERN_SUCCESS || root == 0)
+		return (IO_OBJECT_NULL);
+	return (__io_alloc_entry(root));
+}
+
+/*
+ * hwreg.defs caps a single get_children reply at 128 ids — see the
+ * hwreg_id_array_t bound. Mirror it here.
+ */
+#define IOKIT_MAX_CHILDREN	128
+
+kern_return_t
+IORegistryEntryGetChildIterator(io_registry_entry_t entry,
+    const io_name_t plane __unused, io_iterator_t *iterator)
+{
+	mach_port_t svc = __io_hwregd_port();
+	uint64_t *ids;
+	mach_msg_type_number_t nids = IOKIT_MAX_CHILDREN;
+	kern_return_t kr;
+
+	if (entry == NULL || entry->kind != IOOBJ_KIND_ENTRY ||
+	    iterator == NULL)
+		return (KERN_INVALID_ARGUMENT);
+	if (svc == MACH_PORT_NULL)
+		return (kIOReturnNoDevice);
+
+	ids = calloc(nids, sizeof(*ids));
+	if (ids == NULL)
+		return (KERN_RESOURCE_SHORTAGE);
+
+	kr = hwreg_get_children(svc, entry->node_id, ids, &nids);
+	if (kr != KERN_SUCCESS) {
+		free(ids);
+		return (kr);
+	}
+	*iterator = __io_alloc_iterator(ids, nids);
+	return (*iterator != IO_OBJECT_NULL ? KERN_SUCCESS
+	    : KERN_RESOURCE_SHORTAGE);
+}
+
+io_object_t
+IOIteratorNext(io_iterator_t iterator)
+{
+	if (iterator == NULL || iterator->kind != IOOBJ_KIND_ITERATOR)
+		return (IO_OBJECT_NULL);
+	if (iterator->cursor >= iterator->count)
+		return (IO_OBJECT_NULL);
+	return (__io_alloc_entry(iterator->ids[iterator->cursor++]));
+}
+
+kern_return_t
+IORegistryEntryGetName(io_registry_entry_t entry, io_name_t name)
+{
+	mach_port_t svc = __io_hwregd_port();
+	uint64_t parent_id;
+	int state;
+	/* hwreg.defs bounds: hwreg_name_t = c_string[32], hwreg_path_t
+	 * = c_string[256]. Mirror exactly so MIG fills them safely. */
+	char hwname[32], classname[32], driver[32], path[256];
+	kern_return_t kr;
+
+	if (entry == NULL || entry->kind != IOOBJ_KIND_ENTRY ||
+	    name == NULL)
+		return (KERN_INVALID_ARGUMENT);
+	if (svc == MACH_PORT_NULL)
+		return (kIOReturnNoDevice);
+	kr = hwreg_get_node(svc, entry->node_id, &parent_id, &state,
+	    hwname, classname, driver, path);
+	if (kr != KERN_SUCCESS)
+		return (kr);
+	(void)strlcpy(name, hwname, sizeof(io_name_t));
+	return (KERN_SUCCESS);
+}
+
+kern_return_t
+IORegistryEntryGetPath(io_registry_entry_t entry,
+    const io_name_t plane __unused, io_string_t path)
+{
+	mach_port_t svc = __io_hwregd_port();
+	uint64_t parent_id;
+	int state;
+	char name[32], classname[32], driver[32], hwpath[256];
+	kern_return_t kr;
+
+	if (entry == NULL || entry->kind != IOOBJ_KIND_ENTRY ||
+	    path == NULL)
+		return (KERN_INVALID_ARGUMENT);
+	if (svc == MACH_PORT_NULL)
+		return (kIOReturnNoDevice);
+	kr = hwreg_get_node(svc, entry->node_id, &parent_id, &state,
+	    name, classname, driver, hwpath);
+	if (kr != KERN_SUCCESS)
+		return (kr);
+	/* Apple format: "<plane>:<components>". One plane → IOService. */
+	(void)snprintf(path, sizeof(io_string_t), "IOService:%s", hwpath);
+	return (KERN_SUCCESS);
+}
+
+kern_return_t
+IOObjectRetain(io_object_t object)
+{
+	if (object == NULL)
+		return (KERN_INVALID_ARGUMENT);
+	(void)atomic_fetch_add(&object->refcnt, 1);
+	return (KERN_SUCCESS);
+}
+
+kern_return_t
+IOObjectRelease(io_object_t object)
+{
+	int prev;
+
+	if (object == NULL)	/* releasing NULL is a no-op (macOS) */
+		return (KERN_SUCCESS);
+	prev = atomic_fetch_sub(&object->refcnt, 1);
+	if (prev != 1)
+		return (KERN_SUCCESS);
+	if (object->kind == IOOBJ_KIND_ITERATOR)
+		free(object->ids);
+	free(object);
+	return (KERN_SUCCESS);
+}

--- a/src/libIOKit/Makefile
+++ b/src/libIOKit/Makefile
@@ -50,7 +50,13 @@ CFLAGS+=		-Wno-macro-redefined
 WARNS=		0
 NO_MAN=		yes
 
-CFLAGS+=	-O2 -pipe
+# -fblocks: the public header pulls CoreFoundation, and CoreFoundation's
+# ForSwiftFoundationOnly.h / CFCalendarPriv.h / CFStreamPriv.h declare
+# block-typed function pointers (`void (^block)(...)`). Without -fblocks
+# clang errors out with "blocks support disabled" on every include
+# site. libSystemConfiguration / libxpc carry -fblocks for the same
+# reason.
+CFLAGS+=	-O2 -pipe -fblocks
 
 # -I${.CURDIR} MUST come first so <IOKit/IOKitLib.h> resolves to this
 # library's public header (src/libIOKit/IOKit/IOKitLib.h) rather than

--- a/src/libIOKit/Makefile
+++ b/src/libIOKit/Makefile
@@ -1,0 +1,90 @@
+# libIOKit — the IOKit userland facade (freebsd-launchd-mach K1+K2 of
+# the IOKit-userland port plan), iter 1.
+#
+# A thin CF-flavored client over hwregd's MIG Mach RPC (hwreg.defs).
+# Not a port of Apple's IOKitUser source — that library decomposes to
+# a kernel device.defs surface this repo has no kernel for; instead
+# the facade re-aims the Apple-shape API at hwregd. iter 1 ships the
+# read-only registry walk (IORegistryGetRootEntry,
+# IORegistryEntryGetChildIterator, IOIteratorNext, GetName, GetPath,
+# IOObject{Retain,Release}); later iters add properties + matching,
+# the ioreg tool, and notifications.
+#
+# Build:   cd src/libIOKit && make SYSROOT=... MIGOUT=...
+# Install: make DESTDIR=/path/to/rootfs install
+#   -> /usr/lib/system/libIOKit.so(.1)
+#   -> /usr/include/IOKit/IOKitLib.h
+
+LIB=		IOKit
+SHLIB_MAJOR=	1
+
+SRCS=		IOKitLib.c
+
+# hwregUser.c — MIG-generated hwreg.defs client stubs. build.sh runs
+# mig (step 3r) and passes MIGOUT=$HWREG_MIG. Same wiring
+# libSystemConfiguration's Makefile uses for configUser.c. Pulled in
+# only when MIGOUT is set; a bare standalone build (no MIGOUT) fails
+# at the generated #include "hwreg.h", which is expected.
+MIGOUT?=
+.if !empty(MIGOUT)
+.PATH:			${MIGOUT}
+.PATH:			${.CURDIR}/../hwregd
+SRCS+=			hwregUser.c
+CFLAGS+=		-I${MIGOUT}
+CFLAGS+=		-I${.CURDIR}/../hwregd	# hwreg_mig_types.h
+CFLAGS.hwregUser.c+=	-w
+# <mach/notify.h> (pulled by the MIG stubs) redefines the MACH_NOTIFY_*
+# macros <mach/message.h> also defines — identical values, whitespace
+# differs. A benign clash in the vendored mach headers; the hwregd and
+# libSystemConfiguration build steps suppress it the same way.
+CFLAGS+=		-Wno-macro-redefined
+.endif
+
+# WARNS=0: the public header pulls the whole CoreFoundation public
+# header tree (for later iters' CFDictionary / CFString surfaces).
+# At WARNS>0 the FreeBSD warning machinery adds -Wsystem-headers
+# -Werror, which promotes warnings *inside* the vendored CF headers
+# (-Wexpansion-to-defined; CFLocking.h's "CF is not thread-safe"
+# #warning) into hard errors. libxpc / libCoreFoundation /
+# libSystemConfiguration build at WARNS=0 for the same reason.
+WARNS=		0
+NO_MAN=		yes
+
+CFLAGS+=	-O2 -pipe
+
+# -I${.CURDIR} MUST come first so <IOKit/IOKitLib.h> resolves to this
+# library's public header (src/libIOKit/IOKit/IOKitLib.h) rather than
+# the small launchctl stub at src/launchd/freebsd-shims/IOKit/
+# IOKitLib.h that the freebsd-shims -I below also covers. Search
+# order matches first; that umbrella -I also picks up IOKitInternal.h.
+CFLAGS+=	-I${.CURDIR}
+
+# <servers/bootstrap.h> (bootstrap_look_up + the bootstrap_port
+# global) comes from liblaunch; its bootstrap.h pulls Apple shim
+# headers from launchd/freebsd-shims.
+CFLAGS+=	-I${.CURDIR}/../launchd/liblaunch
+CFLAGS+=	-I${.CURDIR}/../launchd/freebsd-shims
+
+SYSROOT?=
+.if !empty(SYSROOT)
+CFLAGS+=	-I${SYSROOT}/usr/include
+LDADD+=		-L${SYSROOT}/usr/lib/system
+.endif
+
+INCS=		IOKit/IOKitLib.h
+INCSDIR=	${PREFIX}/include/IOKit
+LIBDIR=		${PREFIX}/lib/system
+
+# -lCoreFoundation: pulled by the public header; later iters use it
+# for CFDictionary properties. -lsystem_kernel: mach_msg + the Mach
+# port syscalls behind the MIG client stubs. -llaunch:
+# bootstrap_look_up + bootstrap_port. -lpthread: pthread_once for the
+# lazy hwregd service-port lookup.
+LDADD+=		-lCoreFoundation
+LDADD+=		-lsystem_kernel -llaunch -lpthread
+LDADD+=		-Wl,--allow-shlib-undefined
+LDADD+=		-Wl,-rpath,${PREFIX}/lib/system
+
+PREFIX?=	/usr
+
+.include <bsd.lib.mk>

--- a/src/libIOKit/iokittest.c
+++ b/src/libIOKit/iokittest.c
@@ -1,0 +1,83 @@
+/*
+ * iokittest — libIOKit iter 1 test client. Walks the hwregd registry
+ * via the IOKit facade — IORegistryGetRootEntry / GetChildIterator /
+ * IOIteratorNext / GetName / GetPath — and prints IOKIT-WALK-OK on
+ * success. Same shape as hwregquery (the direct-MIG client) but
+ * goes through the facade. Boot marker IOKIT-WALK gates in
+ * tests/boot-test.sh.
+ */
+#include <IOKit/IOKitLib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int	walked;
+static int	failed;
+
+static void
+walk(io_registry_entry_t entry, int depth)
+{
+	io_name_t	name;
+	io_string_t	path;
+	io_iterator_t	it = IO_OBJECT_NULL;
+	io_object_t	child;
+
+	if (IORegistryEntryGetName(entry, name) != KERN_SUCCESS) {
+		printf("IOKIT-WALK-FAIL: IORegistryEntryGetName at depth %d\n",
+		    depth);
+		failed = 1;
+		return;
+	}
+	walked++;
+	if (depth < 3) {
+		if (IORegistryEntryGetPath(entry, "IOService", path) !=
+		    KERN_SUCCESS)
+			(void)strlcpy(path, "?", sizeof(path));
+		printf("  %*s%s [%s]\n", depth * 2, "", name, path);
+	}
+
+	if (IORegistryEntryGetChildIterator(entry, "IOService", &it) !=
+	    KERN_SUCCESS) {
+		printf("IOKIT-WALK-FAIL: GetChildIterator at %s\n", name);
+		failed = 1;
+		return;
+	}
+	while ((child = IOIteratorNext(it)) != IO_OBJECT_NULL) {
+		walk(child, depth + 1);
+		IOObjectRelease(child);
+	}
+	IOObjectRelease(it);
+}
+
+int
+main(void)
+{
+	io_registry_entry_t root;
+
+	root = IORegistryGetRootEntry(kIOMainPortDefault);
+	if (root == IO_OBJECT_NULL) {
+		printf("IOKIT-WALK-FAIL: IORegistryGetRootEntry returned "
+		    "IO_OBJECT_NULL (hwregd unreachable?)\n");
+		return (1);
+	}
+
+	walk(root, 0);
+
+	/* IOObjectRetain/Release round-trip on a live handle. */
+	if (IOObjectRetain(root) != KERN_SUCCESS) {
+		printf("IOKIT-WALK-FAIL: IOObjectRetain failed\n");
+		IOObjectRelease(root);
+		return (1);
+	}
+	IOObjectRelease(root);	/* drop the retain */
+	IOObjectRelease(root);	/* drop the original */
+
+	if (failed) {
+		printf("IOKIT-WALK-FAIL: tree walk hit an error\n");
+		return (1);
+	}
+	printf("IOKIT-WALK-OK: walked %d entries via the IOKit facade\n",
+	    walked);
+	return (0);
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -634,6 +634,18 @@ expect {
     "SC-BRIDGE-OK" { puts "\nOK: SCBridgeInterface works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: IOKIT-WALK marker not seen"
+        exit 1
+    }
+    "IOKIT-WALK-FAIL" {
+        puts "\nFAIL: libIOKit registry walk failed"
+        exit 1
+    }
+    "IOKIT-WALK-OK" { puts "\nOK: libIOKit registry walk works" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
K1 (read-only registry walk) of the IOKit-userland port plan
([freebsd-hardware-registry-iokit-plan.html §5](https://pkgdemon.github.io/freebsd-hardware-registry-iokit-plan.html)).
The facade is a thin CF-flavored client over hwregd's MIG `hwreg.defs`
Mach RPC — **not** a port of Apple's `IOKitUser` source, which
decomposes to a kernel `device.defs` surface this repo has no kernel
for; the Apple-shape API is re-aimed at hwregd instead.

## What's in iter 1

New tree `src/libIOKit/` builds `libIOKit.so` → `/usr/lib/system/`,
public header → `/usr/include/IOKit/IOKitLib.h`. Reuses hwregd's
existing MIG client stubs (`$HWREG_MIG/hwregUser.c`) for the RPC.

| Public API | Backing |
|---|---|
| `IORegistryGetRootEntry` | `hwreg_get_root` |
| `IORegistryEntryGetChildIterator` | `hwreg_get_children` |
| `IOIteratorNext` | client-side cursor over the captured id array |
| `IORegistryEntryGetName` | `hwreg_get_node` (name) |
| `IORegistryEntryGetPath` | `hwreg_get_node` (path, prefixed `IOService:`) |
| `IOObjectRetain` / `IOObjectRelease` | atomic client-side refcount |

## Handle representation

`io_object_t` is an opaque pointer to a client-side struct (kind +
refcount + node id, or kind + captured id array + cursor for an
iterator). Apple's macOS typedef aliases it to `mach_port_t` naming
a kernel-resident `IOService`, which we have no kernel for.

The hwregd send right is looked up via `bootstrap_look_up`
(`org.freebsd.hwregd`) on first use and cached process-wide
(`pthread_once`); failure surfaces as `IO_OBJECT_NULL` /
`kIOReturnNoDevice`. `plane` arguments are accepted for source
compatibility and ignored (this facade has one plane).

## Build wiring

Mirrors `libSystemConfiguration`: `WARNS=0` for the CoreFoundation
header tree, `-Wno-macro-redefined` for the `<mach/notify.h>` ↔
`<mach/message.h>` `MACH_NOTIFY_*` clash the MIG stubs pull in,
`-I${.CURDIR}` first so this library's `IOKit/IOKitLib.h` wins over
the small launchctl stub at `src/launchd/freebsd-shims/IOKit/IOKitLib.h`.

New `build.sh` step **3r4** builds `libIOKit` + a new `iokittest`
test client that walks the registry through the facade. CI marker
**`IOKIT-WALK`** gates in `tests/boot-test.sh` and the overlays
`run.sh`, alongside `HWREG-RPC` / `SC-*` / `CONFIGD-*`.

## Plan for next iters

- **iter 2** — properties + matching: `IORegistryEntryCreateCFProperty`/`CreateCFProperties`
  (unpack hwregd's nvlist bag → `CFDictionary`), `IOServiceMatching` +
  `IOServiceGetMatchingService(s)` over `hwreg_lookup`.
- **iter 3** — `ioreg(8)` (the K1 success marker in the plan).
- **iter 4** — K2 notifications: `IOServiceAddMatchingNotification` +
  `IONotificationPortCreate` backed by `hwreg_watch` and a raw-`mach_msg`
  receive thread (not a dispatch MACH_RECV source — task #41).