### PR TITLE
feat(libIOKit): IOKit userland facade iter 2 — properties + matching

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1400,6 +1400,24 @@ chroot "$WORK/rootfs" ldd /usr/tests/freebsd-launchd-mach/iokittest \
     || { echo "FAIL: ldd doesn't resolve iokittest to /usr/lib/system/libIOKit.so"; exit 1; }
 echo "==> iokittest built + ldd verified"
 
+# iokitmatchtest — libIOKit iter 2 properties + matching test client.
+# Pulls a node's property bag as a CFDictionary, fetches a single
+# property as a CFString, exercises IOServiceMatching +
+# IOServiceGetMatchingService(s) against PCIDevice (deterministic in
+# the QEMU guest), prints IOKIT-MATCH-OK. run.sh runs it and checks
+# for the marker.
+echo "==> building iokitmatchtest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/iokitmatchtest" \
+   "$ROOT/src/libIOKit/iokitmatchtest.c" \
+   -lIOKit -lCoreFoundation -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/iokitmatchtest" \
+    || { echo "FAIL: iokitmatchtest not built"; exit 1; }
+echo "==> iokitmatchtest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -669,4 +669,15 @@ if [ ! -x "$iokittest" ]; then
 fi
 "$iokittest" || true	# marker (IOKIT-WALK-OK/FAIL) gates in boot-test.sh
 
+# IOKIT-MATCH — libIOKit iter 2 properties + matching: pull a node's
+# property bag as a CFDictionary, fetch single CFString/CFNumber
+# properties, exercise IOServiceMatching + IOServiceGetMatching
+# Service(s) against PCIDevice (deterministic via PCI enrichment).
+iokitmatchtest=/usr/tests/freebsd-launchd-mach/iokitmatchtest
+if [ ! -x "$iokitmatchtest" ]; then
+    echo "IOKIT-MATCH-FAIL: $iokitmatchtest missing"
+    exit 1
+fi
+"$iokitmatchtest" || true	# marker (IOKIT-MATCH-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/libIOKit/IOKit/IOKitLib.h
+++ b/src/libIOKit/IOKit/IOKitLib.h
@@ -19,8 +19,13 @@
  *   IOIteratorNext, IORegistryEntryGetName, IORegistryEntryGetPath,
  *   IOObjectRetain, IOObjectRelease.
  *
- * Later iterations add properties + matching (iter 2), the `ioreg`
- * tool (iter 3) and notifications (iter 4, K2 of the plan).
+ * iter 2 — properties + matching (CF-typed):
+ *   IORegistryEntryCreateCFProperties, IORegistryEntryCreateCFProperty,
+ *   IOObjectGetClass, IOServiceMatching, IOServiceGetMatchingService,
+ *   IOServiceGetMatchingServices.
+ *
+ * Later iterations add the `ioreg` tool (iter 3) and notifications
+ * (iter 4, K2 of the plan).
  *
  * NOTE: there is also a separate Apple-API stub at
  * src/launchd/freebsd-shims/IOKit/IOKitLib.h covering the four IOKit
@@ -58,6 +63,13 @@ typedef io_object_t io_iterator_t;
  */
 typedef char io_name_t[128];
 typedef char io_string_t[512];
+
+/*
+ * IOOptionBits — Apple's IOKit options-mask typedef. Accepted by
+ * several routines (CreateCFProperties etc.) for source
+ * compatibility; iter 2 ignores it.
+ */
+typedef uint32_t IOOptionBits;
 
 /*
  * IOReturn — Apple's IOKit error code space. kern_return_t fits the
@@ -127,6 +139,72 @@ kern_return_t	IORegistryEntryGetPath(io_registry_entry_t entry,
  */
 kern_return_t	IOObjectRetain(io_object_t object);
 kern_return_t	IOObjectRelease(io_object_t object);
+
+/*
+ * iter 2 ----------------------------------------------------------
+ *
+ * Well-known IOService matching dictionary keys (the small subset
+ * the facade understands). The full Apple set is much larger; the
+ * facade translates IOProviderClass / IOClass to hwregd's `class`
+ * criterion and IONameMatch to `name`.
+ */
+#define kIOProviderClassKey	"IOProviderClass"
+#define kIOClassKey		"IOClass"
+#define kIONameMatchKey		"IONameMatch"
+
+/*
+ * IORegistryEntryCreateCFProperties — `entry`'s full property bag
+ * as a freshly-allocated CFMutableDictionary (keys = CFString,
+ * values = CFString or CFNumber — the only types hwregd's bag
+ * carries). The caller releases the dictionary with CFRelease.
+ * `options` is ignored.
+ */
+kern_return_t	IORegistryEntryCreateCFProperties(io_registry_entry_t entry,
+		    CFMutableDictionaryRef *properties,
+		    CFAllocatorRef allocator, IOOptionBits options);
+
+/*
+ * IORegistryEntryCreateCFProperty — a single property's value, +1
+ * retain. NULL if `entry` has no such property. `options` is
+ * ignored.
+ */
+CFTypeRef	IORegistryEntryCreateCFProperty(io_registry_entry_t entry,
+		    CFStringRef key, CFAllocatorRef allocator,
+		    IOOptionBits options);
+
+/*
+ * IOObjectGetClass — the entry's class name (hwregd's `class`
+ * field — "CPU" / "PCIDevice" / "USBDevice" / etc.) into the
+ * caller's io_name_t buffer.
+ */
+kern_return_t	IOObjectGetClass(io_object_t object, io_name_t className);
+
+/*
+ * IOServiceMatching — build a fresh matching dictionary against a
+ * provider class. Equivalent to:
+ *   { kIOProviderClassKey: CFSTR(name) }
+ * Caller owns the returned dictionary; IOServiceGetMatchingService*
+ * consume one reference.
+ */
+CFMutableDictionaryRef	IOServiceMatching(const char *name);
+
+/*
+ * IOServiceGetMatchingService(s) — look up service(s) whose hwregd
+ * node matches `matching`. The single-result form returns the first
+ * match (or IO_OBJECT_NULL); the iterator form returns an iterator
+ * over all matches (always non-NULL on success — an empty iterator
+ * is valid and yields IO_OBJECT_NULL on first IOIteratorNext).
+ *
+ * BOTH forms consume one reference of `matching` (Apple contract:
+ * "one reference is always consumed by this function") so the
+ * idiom `IOServiceGetMatchingService(mp, IOServiceMatching("X"))`
+ * does not leak.
+ */
+io_service_t	IOServiceGetMatchingService(mach_port_t mainPort,
+		    CFDictionaryRef matching);
+
+kern_return_t	IOServiceGetMatchingServices(mach_port_t mainPort,
+		    CFDictionaryRef matching, io_iterator_t *iterator);
 
 #ifdef __cplusplus
 }

--- a/src/libIOKit/IOKitMatching.c
+++ b/src/libIOKit/IOKitMatching.c
@@ -1,0 +1,298 @@
+/*
+ * IOKitMatching.c — libIOKit iter 2: properties + matching.
+ *
+ * Translates hwregd's nvlist-shaped property bag into CFDictionary
+ * (hwregd emits only NV_TYPE_STRING and NV_TYPE_NUMBER — see
+ * src/hwregd/hwregd.c hwreg_get_properties) and Apple-style
+ * IOService matching dictionaries into hwreg_lookup criteria. The
+ * understood matching keys are IOProviderClass / IOClass (→
+ * hwregd's `class`) and IONameMatch (→ `name`); other Apple keys
+ * (IOPropertyMatch, IOBSDName, IOService plane parents/children,
+ * regex) are silently ignored and the lookup falls back to whatever
+ * criteria survived.
+ */
+#include <IOKit/IOKitLib.h>
+#include "IOKitInternal.h"
+
+#include "hwreg.h"
+#include "hwreg_mig_types.h"
+#include "nv.h"			/* libxpc nvlist API */
+
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Build a CFMutableDictionary from a hwregd property nvlist.
+ * Unknown nvlist entry types are silently skipped; hwregd's bag
+ * never carries them today but keeping the switch permissive lets
+ * later enrichment add types without breaking old clients.
+ */
+static CFMutableDictionaryRef
+nvlist_to_cfdict(const nvlist_t *nv, CFAllocatorRef allocator)
+{
+	CFMutableDictionaryRef d;
+	void *cookie = NULL;
+	const char *key;
+	int type;
+
+	d = CFDictionaryCreateMutable(allocator, 0,
+	    &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	if (d == NULL)
+		return (NULL);
+
+	while ((key = nvlist_next(nv, &type, &cookie)) != NULL) {
+		CFStringRef ck = CFStringCreateWithCString(allocator, key,
+		    kCFStringEncodingUTF8);
+
+		if (ck == NULL)
+			continue;
+		switch (type) {
+		case NV_TYPE_STRING: {
+			const char *s = nvlist_get_string(nv, key);
+			CFStringRef cv = CFStringCreateWithCString(allocator,
+			    s != NULL ? s : "", kCFStringEncodingUTF8);
+
+			if (cv != NULL) {
+				CFDictionarySetValue(d, ck, cv);
+				CFRelease(cv);
+			}
+			break;
+		}
+		case NV_TYPE_NUMBER: {
+			/* hwregd packs the unsigned PCI/id/state fields
+			 * as nvlist NUMBERs (uint64_t). CFNumber speaks
+			 * signed; cast through int64_t — every hwregd
+			 * value fits the positive half. */
+			uint64_t n = nvlist_get_number(nv, key);
+			int64_t s = (int64_t)n;
+			CFNumberRef cv = CFNumberCreate(allocator,
+			    kCFNumberSInt64Type, &s);
+
+			if (cv != NULL) {
+				CFDictionarySetValue(d, ck, cv);
+				CFRelease(cv);
+			}
+			break;
+		}
+		default:
+			/* unknown type — skip */
+			break;
+		}
+		CFRelease(ck);
+	}
+	return (d);
+}
+
+kern_return_t
+IORegistryEntryCreateCFProperties(io_registry_entry_t entry,
+    CFMutableDictionaryRef *properties, CFAllocatorRef allocator,
+    IOOptionBits options __unused)
+{
+	mach_port_t svc = __io_hwregd_port();
+	hwreg_blob_t blob;
+	mach_msg_type_number_t cnt = 0;
+	nvlist_t *nv;
+	kern_return_t kr;
+
+	if (entry == NULL || entry->kind != IOOBJ_KIND_ENTRY ||
+	    properties == NULL)
+		return (KERN_INVALID_ARGUMENT);
+	if (svc == MACH_PORT_NULL)
+		return (kIOReturnNoDevice);
+
+	kr = hwreg_get_properties(svc, entry->node_id, blob, &cnt);
+	if (kr != KERN_SUCCESS)
+		return (kr);
+
+	nv = nvlist_unpack(blob, cnt);
+	if (nv == NULL)
+		return (kIOReturnError);
+	*properties = nvlist_to_cfdict(nv, allocator);
+	nvlist_destroy(nv);
+	return (*properties != NULL ? KERN_SUCCESS : kIOReturnError);
+}
+
+CFTypeRef
+IORegistryEntryCreateCFProperty(io_registry_entry_t entry,
+    CFStringRef key, CFAllocatorRef allocator, IOOptionBits options)
+{
+	CFMutableDictionaryRef dict = NULL;
+	CFTypeRef val;
+
+	if (IORegistryEntryCreateCFProperties(entry, &dict, allocator,
+	    options) != KERN_SUCCESS || dict == NULL)
+		return (NULL);
+	val = CFDictionaryGetValue(dict, key);
+	if (val != NULL)
+		CFRetain(val);	/* Get returns +0; the contract here is +1 */
+	CFRelease(dict);
+	return (val);
+}
+
+kern_return_t
+IOObjectGetClass(io_object_t object, io_name_t className)
+{
+	mach_port_t svc = __io_hwregd_port();
+	uint64_t parent_id;
+	int state;
+	char name[32], classname[32], driver[32], path[256];
+	kern_return_t kr;
+
+	if (object == NULL || object->kind != IOOBJ_KIND_ENTRY ||
+	    className == NULL)
+		return (KERN_INVALID_ARGUMENT);
+	if (svc == MACH_PORT_NULL)
+		return (kIOReturnNoDevice);
+	kr = hwreg_get_node(svc, object->node_id, &parent_id, &state,
+	    name, classname, driver, path);
+	if (kr != KERN_SUCCESS)
+		return (kr);
+	(void)strlcpy(className, classname, sizeof(io_name_t));
+	return (KERN_SUCCESS);
+}
+
+CFMutableDictionaryRef
+IOServiceMatching(const char *name)
+{
+	CFMutableDictionaryRef d;
+	CFStringRef v;
+
+	if (name == NULL)
+		return (NULL);
+	d = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+	    &kCFTypeDictionaryKeyCallBacks,
+	    &kCFTypeDictionaryValueCallBacks);
+	if (d == NULL)
+		return (NULL);
+	v = CFStringCreateWithCString(kCFAllocatorDefault, name,
+	    kCFStringEncodingUTF8);
+	if (v == NULL) {
+		CFRelease(d);
+		return (NULL);
+	}
+	CFDictionarySetValue(d, CFSTR(kIOProviderClassKey), v);
+	CFRelease(v);
+	return (d);
+}
+
+/*
+ * Extract `key` from `matching` as a UTF-8 C-string, copied into
+ * `buf`. Returns true if a string value was found and fit.
+ */
+static bool
+copy_string_value(CFDictionaryRef matching, CFStringRef key,
+    char *buf, size_t bufsz)
+{
+	CFTypeRef v = CFDictionaryGetValue(matching, key);
+
+	if (v == NULL || CFGetTypeID(v) != CFStringGetTypeID())
+		return (false);
+	return (CFStringGetCString((CFStringRef)v, buf, (CFIndex)bufsz,
+	    kCFStringEncodingUTF8) == TRUE);
+}
+
+/*
+ * Translate `matching` to a hwreg_lookup criteria nvlist, pack it,
+ * fire the RPC, return the malloc'd id array + count. Caller frees
+ * `ids_out`. KERN_SUCCESS even when 0 matches — the result is
+ * "no matches", not an error.
+ */
+static kern_return_t
+lookup_matches(CFDictionaryRef matching, uint64_t **ids_out,
+    uint32_t *count_out)
+{
+	mach_port_t svc = __io_hwregd_port();
+	nvlist_t *crit;
+	void *packed = NULL;
+	size_t psz = 0;
+	hwreg_blob_t critblob;
+	uint64_t *ids;
+	mach_msg_type_number_t nids = 128;
+	char buf[64];
+	kern_return_t kr;
+
+	if (svc == MACH_PORT_NULL)
+		return (kIOReturnNoDevice);
+	crit = nvlist_create_dictionary(0);
+	if (crit == NULL)
+		return (kIOReturnError);
+
+	if (copy_string_value(matching, CFSTR(kIOProviderClassKey),
+	    buf, sizeof(buf)))
+		nvlist_add_string(crit, "class", buf);
+	else if (copy_string_value(matching, CFSTR(kIOClassKey),
+	    buf, sizeof(buf)))
+		nvlist_add_string(crit, "class", buf);
+	if (copy_string_value(matching, CFSTR(kIONameMatchKey),
+	    buf, sizeof(buf)))
+		nvlist_add_string(crit, "name", buf);
+
+	packed = nvlist_pack(crit, &psz);
+	nvlist_destroy(crit);
+	if (packed == NULL || psz > sizeof(critblob)) {
+		free(packed);
+		return (kIOReturnError);
+	}
+	(void)memcpy(critblob, packed, psz);
+	free(packed);
+
+	ids = calloc(nids, sizeof(*ids));
+	if (ids == NULL)
+		return (KERN_RESOURCE_SHORTAGE);
+	kr = hwreg_lookup(svc, critblob, (mach_msg_type_number_t)psz,
+	    ids, &nids);
+	if (kr != KERN_SUCCESS) {
+		free(ids);
+		return (kr);
+	}
+	*ids_out = ids;
+	*count_out = nids;
+	return (KERN_SUCCESS);
+}
+
+io_service_t
+IOServiceGetMatchingService(mach_port_t mainPort __unused,
+    CFDictionaryRef matching)
+{
+	uint64_t *ids = NULL;
+	uint32_t count = 0;
+	io_service_t result = IO_OBJECT_NULL;
+
+	if (matching == NULL)
+		return (IO_OBJECT_NULL);
+	if (lookup_matches(matching, &ids, &count) == KERN_SUCCESS &&
+	    count > 0)
+		result = __io_alloc_entry(ids[0]);
+	free(ids);
+	CFRelease(matching);	/* Apple contract: one reference consumed */
+	return (result);
+}
+
+kern_return_t
+IOServiceGetMatchingServices(mach_port_t mainPort __unused,
+    CFDictionaryRef matching, io_iterator_t *iterator)
+{
+	uint64_t *ids = NULL;
+	uint32_t count = 0;
+	kern_return_t kr;
+
+	if (iterator == NULL) {
+		if (matching != NULL)
+			CFRelease(matching);
+		return (KERN_INVALID_ARGUMENT);
+	}
+	if (matching == NULL)
+		return (KERN_INVALID_ARGUMENT);
+	kr = lookup_matches(matching, &ids, &count);
+	CFRelease(matching);	/* Apple contract: one reference consumed */
+	if (kr != KERN_SUCCESS) {
+		free(ids);
+		return (kr);
+	}
+	*iterator = __io_alloc_iterator(ids, count);
+	return (*iterator != IO_OBJECT_NULL ? KERN_SUCCESS
+	    : KERN_RESOURCE_SHORTAGE);
+}

--- a/src/libIOKit/Makefile
+++ b/src/libIOKit/Makefile
@@ -18,7 +18,7 @@
 LIB=		IOKit
 SHLIB_MAJOR=	1
 
-SRCS=		IOKitLib.c
+SRCS=		IOKitLib.c IOKitMatching.c
 
 # hwregUser.c — MIG-generated hwreg.defs client stubs. build.sh runs
 # mig (step 3r) and passes MIGOUT=$HWREG_MIG. Same wiring
@@ -67,9 +67,12 @@ CFLAGS+=	-I${.CURDIR}
 
 # <servers/bootstrap.h> (bootstrap_look_up + the bootstrap_port
 # global) comes from liblaunch; its bootstrap.h pulls Apple shim
-# headers from launchd/freebsd-shims.
+# headers from launchd/freebsd-shims. -I libxpc gives IOKitMatching.c
+# the `nv.h` nvlist API (hwregd's property bag + hwreg_lookup
+# criteria cross MIG as packed nvlist blobs).
 CFLAGS+=	-I${.CURDIR}/../launchd/liblaunch
 CFLAGS+=	-I${.CURDIR}/../launchd/freebsd-shims
+CFLAGS+=	-I${.CURDIR}/../libxpc
 
 SYSROOT?=
 .if !empty(SYSROOT)
@@ -81,12 +84,15 @@ INCS=		IOKit/IOKitLib.h
 INCSDIR=	${PREFIX}/include/IOKit
 LIBDIR=		${PREFIX}/lib/system
 
-# -lCoreFoundation: pulled by the public header; later iters use it
-# for CFDictionary properties. -lsystem_kernel: mach_msg + the Mach
-# port syscalls behind the MIG client stubs. -llaunch:
-# bootstrap_look_up + bootstrap_port. -lpthread: pthread_once for the
-# lazy hwregd service-port lookup.
-LDADD+=		-lCoreFoundation
+# -lCoreFoundation: the CFDictionary / CFString / CFNumber object
+# model behind the iter-2 property and matching surface (the public
+# header pulls CoreFoundation too). -lxpc: the nvlist API
+# (nvlist_unpack / pack / next / get_*) IOKitMatching.c uses to
+# bridge hwregd's property bag and lookup criteria. -lsystem_kernel:
+# mach_msg + the Mach port syscalls behind the MIG client stubs.
+# -llaunch: bootstrap_look_up + bootstrap_port. -lpthread:
+# pthread_once for the lazy hwregd service-port lookup.
+LDADD+=		-lCoreFoundation -lxpc
 LDADD+=		-lsystem_kernel -llaunch -lpthread
 LDADD+=		-Wl,--allow-shlib-undefined
 LDADD+=		-Wl,-rpath,${PREFIX}/lib/system

--- a/src/libIOKit/iokitmatchtest.c
+++ b/src/libIOKit/iokitmatchtest.c
@@ -1,0 +1,194 @@
+/*
+ * iokitmatchtest — libIOKit iter 2 test client. Exercises the
+ * property + matching surface on the live hwregd registry: pull a
+ * node's property bag as a CFDictionary, fetch a single property
+ * as a CFString, look up the class name, look up nodes by class via
+ * IOServiceMatching + IOServiceGetMatchingService(s), iterate the
+ * matches.  Prints IOKIT-MATCH-OK on success; the boot marker
+ * gates in tests/boot-test.sh.
+ */
+#include <IOKit/IOKitLib.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Copy a CFString-typed dict value into `out`, "(missing)" on absence. */
+static void
+cfstr_value(CFDictionaryRef d, const char *key, char *out, size_t outsz)
+{
+	CFStringRef ck = CFStringCreateWithCString(NULL, key,
+	    kCFStringEncodingUTF8);
+	CFTypeRef v = ck != NULL ? CFDictionaryGetValue(d, ck) : NULL;
+
+	if (ck != NULL)
+		CFRelease(ck);
+	if (v != NULL && CFGetTypeID(v) == CFStringGetTypeID() &&
+	    CFStringGetCString((CFStringRef)v, out, (CFIndex)outsz,
+	        kCFStringEncodingUTF8))
+		return;
+	(void)strlcpy(out, "(missing)", outsz);
+}
+
+int
+main(void)
+{
+	io_registry_entry_t	root;
+	CFMutableDictionaryRef	props = NULL;
+	CFTypeRef		class_val;
+	io_name_t		class_buf;
+	io_iterator_t		it;
+	io_service_t		s;
+	CFMutableDictionaryRef	matching;
+	char			classname[64], name[64];
+	int			matched = 0;
+
+	/* --- properties ----------------------------------------- */
+	root = IORegistryGetRootEntry(kIOMainPortDefault);
+	if (root == IO_OBJECT_NULL) {
+		printf("IOKIT-MATCH-FAIL: IORegistryGetRootEntry\n");
+		return (1);
+	}
+	if (IORegistryEntryCreateCFProperties(root, &props,
+	    kCFAllocatorDefault, 0) != KERN_SUCCESS || props == NULL) {
+		printf("IOKIT-MATCH-FAIL: IORegistryEntryCreateCFProperties\n");
+		IOObjectRelease(root);
+		return (1);
+	}
+	{
+		/* hwregd's bag is always at least id/parent-id/state/name/
+		 * class/driver/description/pnpinfo/location/path (10 keys);
+		 * an empty bag means the unpack collapsed. */
+		CFIndex n = CFDictionaryGetCount(props);
+
+		printf("  root properties: %ld keys\n", (long)n);
+		if (n < 5) {
+			printf("IOKIT-MATCH-FAIL: too few root properties\n");
+			return (1);
+		}
+		cfstr_value(props, "name", name, sizeof(name));
+		cfstr_value(props, "class", classname, sizeof(classname));
+		printf("  root.name=%s root.class=%s\n", name, classname);
+	}
+	CFRelease(props);
+
+	/* --- IORegistryEntryCreateCFProperty (single key) -------- */
+	class_val = IORegistryEntryCreateCFProperty(root, CFSTR("class"),
+	    kCFAllocatorDefault, 0);
+	if (class_val == NULL ||
+	    CFGetTypeID(class_val) != CFStringGetTypeID()) {
+		printf("IOKIT-MATCH-FAIL: CreateCFProperty(class)\n");
+		return (1);
+	}
+	if (!CFStringGetCString((CFStringRef)class_val, classname,
+	    sizeof(classname), kCFStringEncodingUTF8)) {
+		printf("IOKIT-MATCH-FAIL: CFStringGetCString\n");
+		return (1);
+	}
+	printf("  CreateCFProperty(class) -> %s\n", classname);
+	CFRelease(class_val);
+
+	/* --- IOObjectGetClass ------------------------------------ */
+	if (IOObjectGetClass(root, class_buf) != KERN_SUCCESS) {
+		printf("IOKIT-MATCH-FAIL: IOObjectGetClass\n");
+		return (1);
+	}
+	printf("  IOObjectGetClass(root) -> %s\n", class_buf);
+
+	IOObjectRelease(root);
+
+	/* --- IOServiceMatching + IOServiceGetMatchingServices ---- */
+	/* hwregd's PCI enrichment (iter 4b) reports ≥1 PCIDevice in the
+	 * QEMU guest — i440FX hostb0 is always present, plus the e1000
+	 * NIC the run.sh boot adds. So PCIDevice is a deterministic
+	 * matching target. */
+	matching = IOServiceMatching("PCIDevice");
+	if (matching == NULL) {
+		printf("IOKIT-MATCH-FAIL: IOServiceMatching\n");
+		return (1);
+	}
+	if (IOServiceGetMatchingServices(kIOMainPortDefault, matching, &it)
+	    != KERN_SUCCESS || it == IO_OBJECT_NULL) {
+		printf("IOKIT-MATCH-FAIL: IOServiceGetMatchingServices\n");
+		return (1);
+	}
+	/* matching has been consumed by IOServiceGetMatchingServices */
+	while ((s = IOIteratorNext(it)) != IO_OBJECT_NULL) {
+		io_name_t nm;
+
+		if (IORegistryEntryGetName(s, nm) == KERN_SUCCESS && matched < 3)
+			printf("  PCIDevice[%d] = %s\n", matched, nm);
+		matched++;
+		IOObjectRelease(s);
+	}
+	IOObjectRelease(it);
+	if (matched == 0) {
+		printf("IOKIT-MATCH-FAIL: no PCIDevice matches\n");
+		return (1);
+	}
+	printf("  IOServiceGetMatchingServices(PCIDevice) -> %d match(es)\n",
+	    matched);
+
+	/* --- IOServiceGetMatchingService (single) ---------------- */
+	s = IOServiceGetMatchingService(kIOMainPortDefault,
+	    IOServiceMatching("PCIDevice"));
+	if (s == IO_OBJECT_NULL) {
+		printf("IOKIT-MATCH-FAIL: IOServiceGetMatchingService\n");
+		return (1);
+	}
+	if (IORegistryEntryGetName(s, name) != KERN_SUCCESS) {
+		printf("IOKIT-MATCH-FAIL: GetName on single match\n");
+		IOObjectRelease(s);
+		return (1);
+	}
+	printf("  IOServiceGetMatchingService(PCIDevice) -> %s\n", name);
+	IOObjectRelease(s);
+
+	/* --- pci-vendor as a CFNumber from PCI-enriched node ----- */
+	{
+		CFTypeRef vendor;
+
+		s = IOServiceGetMatchingService(kIOMainPortDefault,
+		    IOServiceMatching("PCIDevice"));
+		if (s == IO_OBJECT_NULL) {
+			printf("IOKIT-MATCH-FAIL: refetch PCI node\n");
+			return (1);
+		}
+		vendor = IORegistryEntryCreateCFProperty(s,
+		    CFSTR("pci-vendor"), kCFAllocatorDefault, 0);
+		if (vendor != NULL && CFGetTypeID(vendor) ==
+		    CFNumberGetTypeID()) {
+			int64_t n = 0;
+
+			CFNumberGetValue((CFNumberRef)vendor,
+			    kCFNumberSInt64Type, &n);
+			printf("  pci-vendor = 0x%04llx (CFNumber)\n",
+			    (unsigned long long)n);
+		} else {
+			printf("  pci-vendor not present "
+			    "(node missing PCI enrichment?)\n");
+		}
+		if (vendor != NULL)
+			CFRelease(vendor);
+		IOObjectRelease(s);
+	}
+
+	/* --- empty match path: a class that does not exist ------- */
+	matching = IOServiceMatching("ThisClassDoesNotExist");
+	if (IOServiceGetMatchingServices(kIOMainPortDefault, matching, &it)
+	    != KERN_SUCCESS) {
+		printf("IOKIT-MATCH-FAIL: empty-match call failed\n");
+		return (1);
+	}
+	if (IOIteratorNext(it) != IO_OBJECT_NULL) {
+		printf("IOKIT-MATCH-FAIL: empty match yielded an entry\n");
+		IOObjectRelease(it);
+		return (1);
+	}
+	IOObjectRelease(it);
+
+	printf("IOKIT-MATCH-OK: %d PCIDevice match(es); properties + "
+	    "matching work via the IOKit facade\n", matched);
+	return (0);
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -646,6 +646,18 @@ expect {
     "IOKIT-WALK-OK" { puts "\nOK: libIOKit registry walk works" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: IOKIT-MATCH marker not seen"
+        exit 1
+    }
+    "IOKIT-MATCH-FAIL" {
+        puts "\nFAIL: libIOKit properties + matching failed"
+        exit 1
+    }
+    "IOKIT-MATCH-OK" { puts "\nOK: libIOKit properties + matching work" }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
Extends K1 of the [IOKit-userland port plan](https://pkgdemon.github.io/freebsd-hardware-registry-iokit-plan.html) with the CF-typed property and matching surface. Follow-up to PR #38 (iter 1, registry walk).

## Public surface added

| API | Backing |
|---|---|
| `IORegistryEntryCreateCFProperties` | `hwreg_get_properties` → nvlist → `CFMutableDictionary` |
| `IORegistryEntryCreateCFProperty` | single-key wrapper, +1 retain |
| `IOObjectGetClass` | `hwreg_get_node` (classname field) |
| `IOServiceMatching` | client-side `{kIOProviderClassKey: name}` builder |
| `IOServiceGetMatchingService` | translate matching dict → `hwreg_lookup`, first id |
| `IOServiceGetMatchingServices` | same, returns iterator over all matches |

## nvlist → CFDictionary

hwregd's property bag is only `NV_TYPE_STRING` and `NV_TYPE_NUMBER` (see `src/hwregd/hwregd.c` `hwreg_get_properties`) so the bridge is a tight switch:
- string → `CFString`
- number → `CFNumber(kCFNumberSInt64Type)` (every hwregd value fits the positive half)

## Matching-dict translation

Small understood set:
- `IOProviderClass` / `IOClass` → hwregd criteria's `class`
- `IONameMatch` → hwregd criteria's `name`

Other Apple keys (`IOPropertyMatch`, `IOBSDName`, plane parents/children, regex) are silently ignored and the lookup falls back to whatever criteria survived. Apple's "one reference is always consumed" contract is honoured — both `IOServiceGetMatchingService*` `CFRelease` the matching dict so `IOServiceGetMatchingService(mp, IOServiceMatching(\"X\"))` does not leak.

## Build wiring

`src/libIOKit/Makefile` gains `IOKitMatching.c` in SRCS, `-I${.CURDIR}/../libxpc` (for `nv.h`), and `-lxpc` in LDADD. `build.sh` adds an `iokitmatchtest` cc step alongside `iokittest`. New marker **`IOKIT-MATCH`** gates in `tests/boot-test.sh` and the overlays `run.sh`.

## Test coverage

`iokitmatchtest` exercises:
1. `IORegistryEntryCreateCFProperties` (≥5 keys, root `.name`/`.class`)
2. `IORegistryEntryCreateCFProperty(\"class\")` as a CFString
3. `IOObjectGetClass`
4. `IOServiceMatching(\"PCIDevice\")` + `IOServiceGetMatchingServices` — deterministic ≥1 match via the QEMU guest's PCI enrichment (i440FX hostb0 + the e1000 NIC).
5. `pci-vendor` as a `CFNumber` from a PCI-enriched node
6. `IOServiceGetMatchingService` (single)
7. Empty-match path: a class that doesn't exist must return an empty iterator, not an error.

## Next iters

- **iter 3** — `ioreg(8)` tool (the plan's K1 success marker — "ioreg -l works").
- **iter 4** — K2 notifications: `IONotificationPortCreate` + `IOServiceAddMatchingNotification` over `hwreg_watch`, raw `mach_msg` receive thread (task #41).