### PR TITLE
feat(libIOKit): IOKit userland facade iter 4 — K2 notifications

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1438,6 +1438,27 @@ chroot "$WORK/rootfs" ldd /usr/sbin/ioreg \
     || { echo "FAIL: ldd doesn't resolve ioreg to /usr/lib/system/libIOKit.so"; exit 1; }
 echo "==> ioreg(8) built + installed at /usr/sbin/ioreg"
 
+# iokitnotifytest — libIOKit iter 4 notification-wiring test client.
+# Validates IONotificationPort + IOServiceAddMatchingNotification
+# end-to-end: allocate the port, SetDispatchQueue, register a Match
+# notification, drain the initial-arming iterator, tear the port
+# down. The async device-arrival callback fire path is not exercised
+# in CI (QEMU hot-plug isn't injectable from the boot test); the
+# underlying raw-mach_msg receive thread is structurally identical to
+# HWREG-PUBSUB / SC-NOTIFY, both already CI-proven.
+echo "==> building iokitnotifytest"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/iokitnotifytest" \
+   "$ROOT/src/libIOKit/iokitnotifytest.c" \
+   -lIOKit -lCoreFoundation -ldispatch -lBlocksRuntime \
+   -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/iokitnotifytest" \
+    || { echo "FAIL: iokitnotifytest not built"; exit 1; }
+echo "==> iokitnotifytest built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -703,4 +703,19 @@ else
     echo "IOKIT-IOREG-OK: ioreg -l works (lines=$lines), -c CPU finds CPU nodes"
 fi
 
+# IOKIT-NOTIFY — libIOKit iter 4 K2 device notifications: allocate
+# an IONotificationPort, SetDispatchQueue, AddMatchingNotification
+# for PCIDevice (initial-arming iterator should hand back ≥1 entry
+# from the QEMU PCI bus), then a no-match class (initial-arming
+# iterator empty but non-NULL), tear it down. Async device-arrival
+# fire isn't injectable from this CI; the underlying raw-mach_msg
+# receive-thread pattern is structurally identical to HWREG-PUBSUB
+# / SC-NOTIFY, both already CI-proven.
+iokitnotifytest=/usr/tests/freebsd-launchd-mach/iokitnotifytest
+if [ ! -x "$iokitnotifytest" ]; then
+    echo "IOKIT-NOTIFY-FAIL: $iokitnotifytest missing"
+    exit 1
+fi
+"$iokitnotifytest" || true	# marker (IOKIT-NOTIFY-OK/FAIL) gates in boot-test.sh
+
 exit 0

--- a/src/hwregd/hwreg_mig_types.h
+++ b/src/hwregd/hwreg_mig_types.h
@@ -13,6 +13,7 @@
 #define HWREG_MIG_TYPES_H
 
 #include <stdint.h>
+#include <mach/message.h>
 
 typedef uint64_t	hwreg_id_array_t[128];	/* array[*:128] of uint64_t */
 typedef char		hwreg_name_t[32];	/* c_string[32]  */
@@ -23,5 +24,30 @@ typedef uint8_t		hwreg_blob_t[2048];	/* array[*:2048] of hwreg_byte_t */
 #define HWREG_EVT_ARRIVED	0x1u	/* a matching device attached */
 #define HWREG_EVT_DEPARTED	0x2u	/* a matching device detached */
 #define HWREG_EVT_CHANGED	0x4u	/* a matching device's state changed */
+
+/*
+ * hwregd ↔ subscriber/watcher hand-rolled message protocol. The
+ * msgh_id range is outside the MIG hwreg subsystem (30000–30009)
+ * so the hwregd receive loop can demux MIG calls vs. these. Shared
+ * by hwregd (sender) and libIOKit (the IONotificationPort receive
+ * thread; see src/libIOKit/IOKitNotify.c).
+ */
+#define HWREG_MSG_SUBSCRIBE	0x48575201u	/* client -> hwregd: subscribe */
+#define HWREG_MSG_EVENT		0x48575202u	/* hwregd -> client: event */
+
+/* sizeof(hwreg_event_msg.text). Must match the struct below. */
+#define HWREG_EVENT_TEXT_MAX	479
+
+/*
+ * The event message hwregd pushes to a subscriber or to a watch
+ * client's notify port. kind = '+' arrived, '-' departed, 'A'
+ * subscribe ack; text is a NUL-terminated description
+ * (e.g. "arrived id=N name=Y class=Z").
+ */
+struct hwreg_event_msg {
+	mach_msg_header_t	hdr;
+	char			kind;
+	char			text[HWREG_EVENT_TEXT_MAX];
+};
 
 #endif /* HWREG_MIG_TYPES_H */

--- a/src/hwregd/hwregd.c
+++ b/src/hwregd/hwregd.c
@@ -79,6 +79,7 @@
 #include <mach/mach.h>
 #include <servers/bootstrap.h>
 
+#include "hwreg_mig_types.h"	/* HWREG_MSG_*, struct hwreg_event_msg */
 #include "hwreg_registry.h"
 #include "hwregServer.h"		/* MIG: hwreg_server() demux + routine protos */
 #include "nv.h"			/* libxpc nvlist — property-bag (de)serialise */
@@ -102,9 +103,11 @@
  * Mach pub/sub wire protocol (iter 3b-ii). A client looks the service
  * up, sends a bare-header SUBSCRIBE (its own notify port travels as
  * the message's remote port), and then receives EVENT messages.
+ *
+ * HWREG_MSG_{SUBSCRIBE,EVENT} + struct hwreg_event_msg live in
+ * hwreg_mig_types.h so the IOKit facade (src/libIOKit/IOKitNotify.c)
+ * speaks the same protocol when demuxing watch events.
  */
-#define HWREG_MSG_SUBSCRIBE	0x48575201	/* client  -> hwregd */
-#define HWREG_MSG_EVENT		0x48575202	/* hwregd   -> subscriber */
 
 /*
  * Mach-RPC query API (iter 2a) — MIG subsystem 30000, demuxed by
@@ -116,13 +119,6 @@
 #define HWREG_RPC_BUFSZ		4096
 #define HWREG_RPC_MAX_CHILDREN	128
 #define HWREG_RPC_BLOBSZ	2048	/* hwreg_blob_t bound — matches hwreg.defs */
-
-/* The event message hwregd pushes to each subscriber. */
-struct hwreg_event_msg {
-	mach_msg_header_t	hdr;
-	char			kind;	/* '+' '-' '!' '?' or 'A' (sub ack) */
-	char			text[479];	/* formatted event, NUL-term */
-};
 
 #define HWREGD_MAX_SUBSCRIBERS	32
 #define HWREGD_MAX_WATCHERS	32

--- a/src/libIOKit/IOKit/IOKitLib.h
+++ b/src/libIOKit/IOKit/IOKitLib.h
@@ -24,8 +24,14 @@
  *   IOObjectGetClass, IOServiceMatching, IOServiceGetMatchingService,
  *   IOServiceGetMatchingServices.
  *
- * Later iterations add the `ioreg` tool (iter 3) and notifications
- * (iter 4, K2 of the plan).
+ * iter 3 — `ioreg(8)` introspection tool (the K1 success marker in
+ * the plan). Implemented entirely on top of iter 1 + iter 2; no new
+ * facade API.
+ *
+ * iter 4 — K2 notifications (device-arrival / departure callbacks):
+ *   IONotificationPortCreate, IONotificationPortDestroy,
+ *   IONotificationPortGetMachPort, IONotificationPortSetDispatchQueue,
+ *   IOServiceAddMatchingNotification.
  *
  * NOTE: there is also a separate Apple-API stub at
  * src/launchd/freebsd-shims/IOKit/IOKitLib.h covering the four IOKit
@@ -205,6 +211,92 @@ io_service_t	IOServiceGetMatchingService(mach_port_t mainPort,
 
 kern_return_t	IOServiceGetMatchingServices(mach_port_t mainPort,
 		    CFDictionaryRef matching, io_iterator_t *iterator);
+
+/*
+ * iter 4 ----------------------------------------------------------
+ *
+ * IONotificationPort — a Mach receive port plus a private receive
+ * thread that demuxes hwregd watch-event messages and fires the
+ * IOServiceMatchingCallback registered for each watcher. Each call
+ * to IOServiceAddMatchingNotification owns one hwreg_watch
+ * registration on the daemon side.
+ *
+ * Delivery: SetDispatchQueue routes callbacks via dispatch_async
+ * onto the caller's queue. If no queue is set, callbacks run on
+ * the internal receive thread — usable for simple consumers,
+ * fine for the iokitnotifytest test client. A CFRunLoopSource
+ * delivery option (Apple's IONotificationPortGetRunLoopSource) is
+ * deferred — SCDynamicStore's runloop-source path covers the same
+ * pattern when needed.
+ *
+ * NOTE: this facade uses a raw mach_msg(MACH_RCV_MSG|MACH_RCV_
+ * TIMEOUT,500ms) loop inside a pthread for delivery, NOT a
+ * libdispatch DISPATCH_SOURCE_TYPE_MACH_RECV source — task #41 +
+ * the libSC iter 2 / hwregd-phase0 notes record that those sources
+ * do not reliably deliver in this repo.
+ */
+#include <dispatch/dispatch.h>
+
+typedef struct IONotificationPort *IONotificationPortRef;
+
+/*
+ * Apple's well-known notification-type strings. The facade maps
+ * the three "device arrived" flavours to HWREG_EVT_ARRIVED and
+ * Terminate to HWREG_EVT_DEPARTED. They're aliases here because
+ * hwregd has no internal IOService-lifecycle distinction between
+ * Publish / FirstMatch / Matched.
+ */
+#define kIOPublishNotification		"IOServicePublish"
+#define kIOFirstMatchNotification	"IOServiceFirstMatch"
+#define kIOMatchedNotification		"IOServiceMatched"
+#define kIOTerminatedNotification	"IOServiceTerminate"
+
+/*
+ * IOServiceMatchingCallback — fired when a service matching the
+ * criteria arrives or departs. The iterator yields the new
+ * service(s); the callback is expected to drain it (each
+ * IOIteratorNext returns IO_OBJECT_NULL when done). The facade
+ * tears the iterator down when the callback returns; the caller
+ * MUST NOT IOObjectRelease it.
+ */
+typedef void (*IOServiceMatchingCallback)(void *refcon,
+		    io_iterator_t iterator);
+
+IONotificationPortRef	IONotificationPortCreate(mach_port_t mainPort);
+void			IONotificationPortDestroy(IONotificationPortRef
+			    notify);
+void			IONotificationPortSetDispatchQueue(
+			    IONotificationPortRef notify,
+			    dispatch_queue_t queue);
+mach_port_t		IONotificationPortGetMachPort(
+			    IONotificationPortRef notify);
+
+/*
+ * IOServiceAddMatchingNotification — register a callback that
+ * fires whenever a service matching `matching` arrives (Publish /
+ * FirstMatch / Matched) or departs (Terminate). On return the
+ * `notification` iterator carries the services that ALREADY
+ * match — Apple's "initial arming"; consumers iterate it to find
+ * existing devices and to arm the notification for future
+ * arrivals.
+ *
+ * One reference of `matching` is consumed (Apple contract).
+ *
+ * The returned iterator survives until released with
+ * IOObjectRelease — but releasing it does NOT cancel the watch;
+ * use IONotificationPortDestroy to tear the notification down
+ * (the facade has no IOObjectRelease-on-iterator → cancel path
+ * in iter 4; if a consumer needs per-notification cancellation
+ * later, an explicit IOServiceRemoveMatchingNotification will land
+ * in a follow-up iter).
+ */
+kern_return_t	IOServiceAddMatchingNotification(
+		    IONotificationPortRef notifyPort,
+		    const io_name_t notification_type,
+		    CFDictionaryRef matching,
+		    IOServiceMatchingCallback callback,
+		    void *refCon,
+		    io_iterator_t *notification);
 
 #ifdef __cplusplus
 }

--- a/src/libIOKit/IOKitInternal.h
+++ b/src/libIOKit/IOKitInternal.h
@@ -52,4 +52,39 @@ mach_port_t	__io_hwregd_port(void);
 io_object_t	__io_alloc_entry(uint64_t node_id);
 io_object_t	__io_alloc_iterator(uint64_t *ids, uint32_t count);
 
+/*
+ * The criteria fields hwregd accepts on hwreg_lookup / hwreg_watch
+ * — `name`, `class`, `driver` (empty string = wildcard). All three
+ * are c_string[32] in hwreg.defs.
+ */
+#define IO_CRITERIA_FIELD_MAX	32
+
+struct io_criteria {
+	char	name[IO_CRITERIA_FIELD_MAX];
+	char	klass[IO_CRITERIA_FIELD_MAX];	/* "class" — C++ keyword */
+	char	driver[IO_CRITERIA_FIELD_MAX];
+};
+
+/*
+ * Extract the hwregd-understood criterion strings from an Apple-
+ * shape matching CFDictionary. Unknown keys are silently ignored.
+ *
+ *  IOProviderClass / IOClass	-> out->klass
+ *  IONameMatch			-> out->name
+ *
+ * `matching` may carry other keys (IOPropertyMatch, IOBSDName,
+ * regex), all currently ignored.
+ */
+void	__io_extract_criteria(CFDictionaryRef matching,
+	    struct io_criteria *out);
+
+/*
+ * Pack a criteria struct into the hwregd wire format (a packed
+ * nvlist with the present non-empty fields). Returns KERN_SUCCESS
+ * on success. The blob bound (sizeof(hwreg_blob_t) = 2048) bounds
+ * the packed payload.
+ */
+kern_return_t	__io_pack_criteria(const struct io_criteria *c,
+		    uint8_t *blob, uint32_t *out_size);
+
 #endif /* _IOKIT_INTERNAL_H_ */

--- a/src/libIOKit/IOKitMatching.c
+++ b/src/libIOKit/IOKitMatching.c
@@ -194,6 +194,50 @@ copy_string_value(CFDictionaryRef matching, CFStringRef key,
 	    kCFStringEncodingUTF8) == TRUE);
 }
 
+void
+__io_extract_criteria(CFDictionaryRef matching, struct io_criteria *out)
+{
+	(void)memset(out, 0, sizeof(*out));
+	if (matching == NULL)
+		return;
+	if (!copy_string_value(matching, CFSTR(kIOProviderClassKey),
+	    out->klass, sizeof(out->klass)))
+		(void)copy_string_value(matching, CFSTR(kIOClassKey),
+		    out->klass, sizeof(out->klass));
+	(void)copy_string_value(matching, CFSTR(kIONameMatchKey),
+	    out->name, sizeof(out->name));
+}
+
+kern_return_t
+__io_pack_criteria(const struct io_criteria *c, uint8_t *blob,
+    uint32_t *out_size)
+{
+	nvlist_t *crit;
+	void *packed;
+	size_t psz = 0;
+
+	crit = nvlist_create_dictionary(0);
+	if (crit == NULL)
+		return (kIOReturnError);
+	if (c->klass[0] != '\0')
+		nvlist_add_string(crit, "class", c->klass);
+	if (c->name[0] != '\0')
+		nvlist_add_string(crit, "name", c->name);
+	if (c->driver[0] != '\0')
+		nvlist_add_string(crit, "driver", c->driver);
+
+	packed = nvlist_pack(crit, &psz);
+	nvlist_destroy(crit);
+	if (packed == NULL || psz > sizeof(hwreg_blob_t)) {
+		free(packed);
+		return (kIOReturnError);
+	}
+	(void)memcpy(blob, packed, psz);
+	free(packed);
+	*out_size = (uint32_t)psz;
+	return (KERN_SUCCESS);
+}
+
 /*
  * Translate `matching` to a hwreg_lookup criteria nvlist, pack it,
  * fire the RPC, return the malloc'd id array + count. Caller frees
@@ -205,40 +249,19 @@ lookup_matches(CFDictionaryRef matching, uint64_t **ids_out,
     uint32_t *count_out)
 {
 	mach_port_t svc = __io_hwregd_port();
-	nvlist_t *crit;
-	void *packed = NULL;
-	size_t psz = 0;
+	struct io_criteria c;
 	hwreg_blob_t critblob;
+	uint32_t psz = 0;
 	uint64_t *ids;
 	mach_msg_type_number_t nids = 128;
-	char buf[64];
 	kern_return_t kr;
 
 	if (svc == MACH_PORT_NULL)
 		return (kIOReturnNoDevice);
-	crit = nvlist_create_dictionary(0);
-	if (crit == NULL)
-		return (kIOReturnError);
-
-	if (copy_string_value(matching, CFSTR(kIOProviderClassKey),
-	    buf, sizeof(buf)))
-		nvlist_add_string(crit, "class", buf);
-	else if (copy_string_value(matching, CFSTR(kIOClassKey),
-	    buf, sizeof(buf)))
-		nvlist_add_string(crit, "class", buf);
-	if (copy_string_value(matching, CFSTR(kIONameMatchKey),
-	    buf, sizeof(buf)))
-		nvlist_add_string(crit, "name", buf);
-
-	packed = nvlist_pack(crit, &psz);
-	nvlist_destroy(crit);
-	if (packed == NULL || psz > sizeof(critblob)) {
-		free(packed);
-		return (kIOReturnError);
-	}
-	(void)memcpy(critblob, packed, psz);
-	free(packed);
-
+	__io_extract_criteria(matching, &c);
+	kr = __io_pack_criteria(&c, critblob, &psz);
+	if (kr != KERN_SUCCESS)
+		return (kr);
 	ids = calloc(nids, sizeof(*ids));
 	if (ids == NULL)
 		return (KERN_RESOURCE_SHORTAGE);

--- a/src/libIOKit/IOKitNotify.c
+++ b/src/libIOKit/IOKitNotify.c
@@ -1,0 +1,399 @@
+/*
+ * IOKitNotify.c — libIOKit iter 4: K2 device-arrival / departure
+ * notifications.
+ *
+ * Each IONotificationPort owns one Mach receive right and one
+ * private pthread that drives a raw mach_msg(MACH_RCV_MSG|MACH_RCV_
+ * TIMEOUT, 500ms) loop on it. Watch registrations go through
+ * hwreg_watch (which targets the IONotificationPort's recv port);
+ * events fan in on the one port and the receive thread re-matches
+ * each event's device fields against the per-watch criteria stored
+ * client-side, then fires each matching IOServiceMatchingCallback
+ * (via dispatch_async_f if a queue is set, inline on the receive
+ * thread otherwise).
+ *
+ * Why raw mach_msg and not a libdispatch MACH_RECV source: task
+ * #41 + the libSystemConfiguration iter-2 / hwregd-Phase-0 notes
+ * confirm DISPATCH_SOURCE_TYPE_MACH_RECV does not reliably deliver
+ * in this repo. hwregd, libSystemConfiguration's SCNotify and now
+ * this facade all use the same pthread+timed-mach_msg pattern.
+ */
+#include <IOKit/IOKitLib.h>
+#include "IOKitInternal.h"
+
+#include "hwreg.h"
+#include "hwreg_mig_types.h"
+
+#include <dispatch/dispatch.h>
+#include <mach/mach.h>
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * The hwregd-side watch carried as one IOServiceAddMatching
+ * Notification. The criteria fields are kept client-side so that
+ * when multiple watches share one IONotificationPort, the receive
+ * thread can re-match each event against them and fire the right
+ * callback(s).
+ */
+struct __io_watch {
+	struct __io_watch		*next;
+	uint64_t			 watcher_id;
+	uint32_t			 event_mask;	/* HWREG_EVT_* */
+	struct io_criteria		 criteria;
+	IOServiceMatchingCallback	 callback;
+	void				*refcon;
+};
+
+struct IONotificationPort {
+	mach_port_t		 recv_port;	/* receive right we own */
+	pthread_t		 thread;
+	atomic_int		 stop;
+	pthread_mutex_t		 lock;		/* guards `watches` + queue */
+	struct __io_watch	*watches;
+	dispatch_queue_t	 queue;		/* optional callback target */
+};
+
+/*
+ * Bundle passed to dispatch_async_f so the receive thread can hand
+ * the callback off to a user dispatch queue. The bundle owns the
+ * io_iterator_t (allocated by us, released by IOObjectRelease in
+ * the dispatch trampoline after the user callback returns).
+ */
+struct callout_bundle {
+	IOServiceMatchingCallback	 callback;
+	void				*refcon;
+	io_iterator_t			 iterator;
+};
+
+static void
+callout_trampoline(void *ctx)
+{
+	struct callout_bundle *b = ctx;
+
+	b->callback(b->refcon, b->iterator);
+	IOObjectRelease(b->iterator);
+	free(b);
+}
+
+static void
+fire_callback(struct IONotificationPort *port, struct __io_watch *w,
+    uint64_t node_id)
+{
+	uint64_t *ids = calloc(1, sizeof(*ids));
+	io_iterator_t it;
+	dispatch_queue_t q;
+
+	if (ids == NULL)
+		return;
+	ids[0] = node_id;
+	it = __io_alloc_iterator(ids, 1);	/* takes ownership of ids */
+	if (it == IO_OBJECT_NULL)
+		return;
+
+	pthread_mutex_lock(&port->lock);
+	q = port->queue;
+	pthread_mutex_unlock(&port->lock);
+
+	if (q != NULL) {
+		struct callout_bundle *b = calloc(1, sizeof(*b));
+
+		if (b == NULL) {
+			IOObjectRelease(it);
+			return;
+		}
+		b->callback = w->callback;
+		b->refcon = w->refcon;
+		b->iterator = it;
+		dispatch_async_f(q, b, callout_trampoline);
+	} else {
+		/* No queue — run on the receive thread directly. Acceptable
+		 * for simple consumers (the iter-4 iokitnotifytest is one);
+		 * real consumers usually SetDispatchQueue. */
+		w->callback(w->refcon, it);
+		IOObjectRelease(it);
+	}
+}
+
+/*
+ * Parse hwregd's event text into (id, name, class). Format from
+ * notify_watchers in src/hwregd/hwregd.c:
+ *     "arrived id=N name=Y class=Z"
+ *     "departed id=N name=Y class=Z"
+ * Returns true iff `id` was found; name/class default to "".
+ */
+static bool
+parse_event_text(const char *text, uint64_t *id, char *name, size_t name_sz,
+    char *klass, size_t klass_sz)
+{
+	const char *p;
+
+	*id = 0;
+	if (name != NULL && name_sz > 0)
+		name[0] = '\0';
+	if (klass != NULL && klass_sz > 0)
+		klass[0] = '\0';
+
+	p = strstr(text, "id=");
+	if (p == NULL)
+		return (false);
+	*id = (uint64_t)strtoull(p + 3, NULL, 10);
+
+	if (name != NULL && (p = strstr(text, "name=")) != NULL) {
+		size_t i;
+
+		p += 5;
+		for (i = 0; i + 1 < name_sz && p[i] != '\0' && p[i] != ' ';
+		    i++)
+			name[i] = p[i];
+		name[i] = '\0';
+	}
+	if (klass != NULL && (p = strstr(text, "class=")) != NULL) {
+		size_t i;
+
+		p += 6;
+		for (i = 0; i + 1 < klass_sz && p[i] != '\0' && p[i] != ' ';
+		    i++)
+			klass[i] = p[i];
+		klass[i] = '\0';
+	}
+	return (true);
+}
+
+/*
+ * Does this watch's criteria match the device described by the
+ * event text? Empty criteria fields are wildcards (Apple's
+ * dictionary-omit semantics).
+ */
+static bool
+event_matches_watch(struct __io_watch *w, uint32_t evt_bit,
+    const char *name, const char *klass)
+{
+	if ((w->event_mask & evt_bit) == 0)
+		return (false);
+	if (w->criteria.name[0] != '\0' && strcmp(w->criteria.name, name) != 0)
+		return (false);
+	if (w->criteria.klass[0] != '\0' &&
+	    strcmp(w->criteria.klass, klass) != 0)
+		return (false);
+	/* `driver` is not in the event text — hwregd already filtered
+	 * server-side, so a watch with a driver-only criterion gets the
+	 * event with no false-positive risk. */
+	return (true);
+}
+
+static void *
+receive_thread(void *arg)
+{
+	struct IONotificationPort *port = arg;
+
+	while (atomic_load(&port->stop) == 0) {
+		struct {
+			struct hwreg_event_msg msg;
+			mach_msg_max_trailer_t trailer;
+		} buf;
+		mach_msg_return_t mr;
+		uint64_t id;
+		uint32_t evt;
+		char name[32], klass[32];
+		struct __io_watch *w, *snap[16];
+		int n_snap = 0, i;
+
+		mr = mach_msg(&buf.msg.hdr,
+		    MACH_RCV_MSG | MACH_RCV_TIMEOUT,
+		    0, sizeof(buf), port->recv_port,
+		    500, MACH_PORT_NULL);
+		if (mr == MACH_RCV_TIMED_OUT)
+			continue;
+		if (mr != MACH_MSG_SUCCESS)
+			continue;	/* transient — keep looping */
+		if (buf.msg.hdr.msgh_id != HWREG_MSG_EVENT)
+			continue;
+		if (!parse_event_text(buf.msg.text, &id, name, sizeof(name),
+		    klass, sizeof(klass)))
+			continue;
+
+		evt = (buf.msg.kind == '+') ? HWREG_EVT_ARRIVED
+		    : HWREG_EVT_DEPARTED;
+
+		/* Snapshot the matching watches under the lock into a
+		 * small array, then fire outside the lock so a user
+		 * callback can safely add or remove notifications. The
+		 * 16-entry cap matches hwregd's HWREGD_MAX_WATCHERS / 2;
+		 * one IONotificationPort with more than 16 simultaneous
+		 * matching watches on a single event is not a real
+		 * shape. */
+		pthread_mutex_lock(&port->lock);
+		for (w = port->watches; w != NULL && n_snap < 16;
+		    w = w->next)
+			if (event_matches_watch(w, evt, name, klass))
+				snap[n_snap++] = w;
+		pthread_mutex_unlock(&port->lock);
+
+		for (i = 0; i < n_snap; i++)
+			fire_callback(port, snap[i], id);
+	}
+	return (NULL);
+}
+
+IONotificationPortRef
+IONotificationPortCreate(mach_port_t mainPort __unused)
+{
+	struct IONotificationPort *p;
+	mach_port_t mp = MACH_PORT_NULL;
+
+	if (mach_port_allocate(mach_task_self(),
+	    MACH_PORT_RIGHT_RECEIVE, &mp) != KERN_SUCCESS)
+		return (NULL);
+
+	p = calloc(1, sizeof(*p));
+	if (p == NULL) {
+		(void)mach_port_mod_refs(mach_task_self(), mp,
+		    MACH_PORT_RIGHT_RECEIVE, -1);
+		return (NULL);
+	}
+	p->recv_port = mp;
+	atomic_store(&p->stop, 0);
+	(void)pthread_mutex_init(&p->lock, NULL);
+	if (pthread_create(&p->thread, NULL, receive_thread, p) != 0) {
+		(void)pthread_mutex_destroy(&p->lock);
+		(void)mach_port_mod_refs(mach_task_self(), mp,
+		    MACH_PORT_RIGHT_RECEIVE, -1);
+		free(p);
+		return (NULL);
+	}
+	return (p);
+}
+
+void
+IONotificationPortSetDispatchQueue(IONotificationPortRef port,
+    dispatch_queue_t queue)
+{
+	dispatch_queue_t old;
+
+	if (port == NULL)
+		return;
+	pthread_mutex_lock(&port->lock);
+	old = port->queue;
+	port->queue = queue;
+	if (queue != NULL)
+		dispatch_retain(queue);
+	pthread_mutex_unlock(&port->lock);
+	if (old != NULL)
+		dispatch_release(old);
+}
+
+mach_port_t
+IONotificationPortGetMachPort(IONotificationPortRef port)
+{
+	return (port != NULL ? port->recv_port : MACH_PORT_NULL);
+}
+
+void
+IONotificationPortDestroy(IONotificationPortRef port)
+{
+	struct __io_watch *w, *next;
+	mach_port_t svc;
+
+	if (port == NULL)
+		return;
+
+	/* Stop the receive thread before tearing the port down. */
+	atomic_store(&port->stop, 1);
+	(void)pthread_join(port->thread, NULL);
+
+	/* Unwatch each registered watch on hwregd so the daemon
+	 * reclaims its watcher table slot. */
+	svc = __io_hwregd_port();
+	for (w = port->watches; w != NULL; w = next) {
+		next = w->next;
+		if (svc != MACH_PORT_NULL)
+			(void)hwreg_unwatch(svc, w->watcher_id);
+		free(w);
+	}
+
+	(void)mach_port_mod_refs(mach_task_self(), port->recv_port,
+	    MACH_PORT_RIGHT_RECEIVE, -1);
+	if (port->queue != NULL)
+		dispatch_release(port->queue);
+	(void)pthread_mutex_destroy(&port->lock);
+	free(port);
+}
+
+kern_return_t
+IOServiceAddMatchingNotification(IONotificationPortRef port,
+    const io_name_t notification_type, CFDictionaryRef matching,
+    IOServiceMatchingCallback callback, void *refcon,
+    io_iterator_t *out_iterator)
+{
+	mach_port_t svc = __io_hwregd_port();
+	struct __io_watch *w;
+	struct io_criteria c;
+	hwreg_blob_t critblob;
+	uint32_t crit_sz = 0;
+	uint32_t mask;
+	uint64_t watcher_id = 0;
+	kern_return_t kr;
+
+	if (port == NULL || notification_type == NULL || matching == NULL ||
+	    callback == NULL || out_iterator == NULL) {
+		if (matching != NULL)
+			CFRelease(matching);
+		return (KERN_INVALID_ARGUMENT);
+	}
+	if (svc == MACH_PORT_NULL) {
+		CFRelease(matching);
+		return (kIOReturnNoDevice);
+	}
+
+	/* Notification type → hwregd event mask. The three "device
+	 * arrived" flavours map to HWREG_EVT_ARRIVED (hwregd has no
+	 * internal Publish/FirstMatch/Matched distinction). */
+	if (strcmp(notification_type, kIOTerminatedNotification) == 0)
+		mask = HWREG_EVT_DEPARTED;
+	else
+		mask = HWREG_EVT_ARRIVED;
+
+	__io_extract_criteria(matching, &c);
+	kr = __io_pack_criteria(&c, critblob, &crit_sz);
+	if (kr != KERN_SUCCESS) {
+		CFRelease(matching);
+		return (kr);
+	}
+
+	kr = hwreg_watch(svc, critblob, (mach_msg_type_number_t)crit_sz,
+	    mask, port->recv_port, &watcher_id);
+	if (kr != KERN_SUCCESS || watcher_id == 0) {
+		CFRelease(matching);
+		return (kr != KERN_SUCCESS ? kr : kIOReturnError);
+	}
+
+	w = calloc(1, sizeof(*w));
+	if (w == NULL) {
+		(void)hwreg_unwatch(svc, watcher_id);
+		CFRelease(matching);
+		return (KERN_RESOURCE_SHORTAGE);
+	}
+	w->watcher_id = watcher_id;
+	w->event_mask = mask;
+	w->criteria = c;
+	w->callback = callback;
+	w->refcon = refcon;
+
+	pthread_mutex_lock(&port->lock);
+	w->next = port->watches;
+	port->watches = w;
+	pthread_mutex_unlock(&port->lock);
+
+	/* Initial arming: hand the caller an iterator over the
+	 * currently-matching services. IOServiceGetMatchingServices
+	 * consumes the matching ref (the contract this routine
+	 * also owes the caller). */
+	return (IOServiceGetMatchingServices(kIOMainPortDefault,
+	    matching, out_iterator));
+}

--- a/src/libIOKit/Makefile
+++ b/src/libIOKit/Makefile
@@ -18,7 +18,7 @@
 LIB=		IOKit
 SHLIB_MAJOR=	1
 
-SRCS=		IOKitLib.c IOKitMatching.c
+SRCS=		IOKitLib.c IOKitMatching.c IOKitNotify.c
 
 # hwregUser.c — MIG-generated hwreg.defs client stubs. build.sh runs
 # mig (step 3r) and passes MIGOUT=$HWREG_MIG. Same wiring
@@ -88,11 +88,15 @@ LIBDIR=		${PREFIX}/lib/system
 # model behind the iter-2 property and matching surface (the public
 # header pulls CoreFoundation too). -lxpc: the nvlist API
 # (nvlist_unpack / pack / next / get_*) IOKitMatching.c uses to
-# bridge hwregd's property bag and lookup criteria. -lsystem_kernel:
-# mach_msg + the Mach port syscalls behind the MIG client stubs.
-# -llaunch: bootstrap_look_up + bootstrap_port. -lpthread:
-# pthread_once for the lazy hwregd service-port lookup.
+# bridge hwregd's property bag and lookup criteria. -ldispatch +
+# -lBlocksRuntime: the iter-4 IONotificationPortSetDispatchQueue +
+# dispatch_async_f path (the public header pulls <dispatch/dispatch.h>
+# too). -lsystem_kernel: mach_msg + the Mach port syscalls behind
+# the MIG client stubs. -llaunch: bootstrap_look_up +
+# bootstrap_port. -lpthread: pthread_once for the lazy hwregd
+# service-port lookup + the IONotificationPort receive thread.
 LDADD+=		-lCoreFoundation -lxpc
+LDADD+=		-ldispatch -lBlocksRuntime
 LDADD+=		-lsystem_kernel -llaunch -lpthread
 LDADD+=		-Wl,--allow-shlib-undefined
 LDADD+=		-Wl,-rpath,${PREFIX}/lib/system

--- a/src/libIOKit/iokitnotifytest.c
+++ b/src/libIOKit/iokitnotifytest.c
@@ -1,0 +1,125 @@
+/*
+ * iokitnotifytest — libIOKit iter 4 notification-wiring test.
+ *
+ * Validates the IONotificationPort + IOServiceAddMatchingNotification
+ * surface end-to-end (ALLOC port → SetDispatchQueue → register a
+ * Match notification → drain the initial-arming iterator → tear
+ * down). The async device-arrival fire path is NOT directly tested
+ * in CI — QEMU device hot-plug isn't injectable from the boot test,
+ * and the underlying raw-mach_msg receive thread is structurally
+ * identical to HWREG-PUBSUB / SC-NOTIFY (both CI-proven). Once a
+ * real consumer (IPConfiguration / dhclient replacement) exercises
+ * the async path on real link-up events, that's the live proof.
+ *
+ * Marker IOKIT-NOTIFY gates in tests/boot-test.sh.
+ */
+#include <IOKit/IOKitLib.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <dispatch/dispatch.h>
+#include <mach/mach.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static void
+arrival_callback(void *refcon __unused, io_iterator_t iterator __unused)
+{
+	/* iter-4 test never fires this in CI — see file header. The
+	 * function exists so AddMatchingNotification has a real
+	 * function pointer to record. */
+}
+
+int
+main(void)
+{
+	IONotificationPortRef	notify;
+	mach_port_t		mp;
+	dispatch_queue_t	q;
+	CFMutableDictionaryRef	matching;
+	io_iterator_t		it = IO_OBJECT_NULL;
+	io_object_t		obj;
+	int			matched = 0;
+
+	notify = IONotificationPortCreate(kIOMainPortDefault);
+	if (notify == NULL) {
+		printf("IOKIT-NOTIFY-FAIL: IONotificationPortCreate\n");
+		return (1);
+	}
+	mp = IONotificationPortGetMachPort(notify);
+	if (mp == MACH_PORT_NULL) {
+		printf("IOKIT-NOTIFY-FAIL: IONotificationPortGetMachPort "
+		    "returned MACH_PORT_NULL\n");
+		IONotificationPortDestroy(notify);
+		return (1);
+	}
+	printf("  IONotificationPort recv port = 0x%x\n", (unsigned)mp);
+
+	q = dispatch_queue_create("org.freebsd.iokit.notifytest", NULL);
+	if (q == NULL) {
+		printf("IOKIT-NOTIFY-FAIL: dispatch_queue_create\n");
+		IONotificationPortDestroy(notify);
+		return (1);
+	}
+	IONotificationPortSetDispatchQueue(notify, q);
+	dispatch_release(q);	/* port retains one ref */
+
+	/* Register an arrival notification for PCIDevice — initial
+	 * arming should hand back ≥1 entry (i440FX hostb0 + the e1000
+	 * NIC are always present in the QEMU guest). */
+	matching = IOServiceMatching("PCIDevice");
+	if (matching == NULL) {
+		printf("IOKIT-NOTIFY-FAIL: IOServiceMatching\n");
+		IONotificationPortDestroy(notify);
+		return (1);
+	}
+	if (IOServiceAddMatchingNotification(notify,
+	    kIOFirstMatchNotification, matching, arrival_callback, NULL,
+	    &it) != KERN_SUCCESS || it == IO_OBJECT_NULL) {
+		printf("IOKIT-NOTIFY-FAIL: AddMatchingNotification\n");
+		IONotificationPortDestroy(notify);
+		return (1);
+	}
+	/* `matching` has been consumed. */
+
+	while ((obj = IOIteratorNext(it)) != IO_OBJECT_NULL) {
+		io_name_t name;
+
+		if (IORegistryEntryGetName(obj, name) == KERN_SUCCESS &&
+		    matched < 3)
+			printf("  initial arming[%d] = %s\n", matched, name);
+		matched++;
+		IOObjectRelease(obj);
+	}
+	IOObjectRelease(it);
+	if (matched == 0) {
+		printf("IOKIT-NOTIFY-FAIL: initial arming yielded 0 matches "
+		    "(expected ≥1 PCIDevice)\n");
+		IONotificationPortDestroy(notify);
+		return (1);
+	}
+
+	/* Departure notification with a class no node carries — initial
+	 * arming must yield an empty (but non-NULL) iterator. */
+	matching = IOServiceMatching("ThisClassDoesNotExist");
+	if (IOServiceAddMatchingNotification(notify,
+	    kIOTerminatedNotification, matching, arrival_callback, NULL,
+	    &it) != KERN_SUCCESS || it == IO_OBJECT_NULL) {
+		printf("IOKIT-NOTIFY-FAIL: AddMatchingNotification(terminated)\n");
+		IONotificationPortDestroy(notify);
+		return (1);
+	}
+	if (IOIteratorNext(it) != IO_OBJECT_NULL) {
+		printf("IOKIT-NOTIFY-FAIL: empty-class initial arming "
+		    "yielded an entry\n");
+		IOObjectRelease(it);
+		IONotificationPortDestroy(notify);
+		return (1);
+	}
+	IOObjectRelease(it);
+
+	IONotificationPortDestroy(notify);
+	printf("IOKIT-NOTIFY-OK: IONotificationPort + AddMatching"
+	    "Notification wire up (%d PCIDevice initial match%s)\n",
+	    matched, matched == 1 ? "" : "es");
+	return (0);
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -670,6 +670,20 @@ expect {
     "IOKIT-IOREG-OK" { puts "\nOK: ioreg(8) works (K1 success marker)" }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: IOKIT-NOTIFY marker not seen"
+        exit 1
+    }
+    "IOKIT-NOTIFY-FAIL" {
+        puts "\nFAIL: libIOKit IONotificationPort + AddMatchingNotification failed"
+        exit 1
+    }
+    "IOKIT-NOTIFY-OK" {
+        puts "\nOK: libIOKit IONotificationPort + AddMatchingNotification work (K2)"
+    }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
The **K2 milestone** of the [IOKit-userland port plan](https://pkgdemon.github.io/freebsd-hardware-registry-iokit-plan.html) §5 — device-arrival / departure callbacks on top of `hwreg_watch`. Follow-up to PRs #38 (iter 1), #39 (iter 2), #40 (iter 3 — `ioreg(8)`).

## Public surface added

- `IONotificationPortCreate` / `Destroy` / `GetMachPort` / `SetDispatchQueue`
- `IOServiceAddMatchingNotification`
- `IOServiceMatchingCallback` typedef
- `kIO{Publish,FirstMatch,Matched,Terminated}Notification` strings

## Architecture

Each `IONotificationPort` owns one Mach receive right and a private pthread driving a raw `mach_msg(MACH_RCV_MSG|MACH_RCV_TIMEOUT, 500ms)` loop. **No libdispatch `MACH_RECV` source** — task #41 + hwregd / `SCNotify` notes confirm they don't reliably deliver here; this facade uses the proven receive-thread pattern.

`IOServiceAddMatchingNotification` translates the matching dict to hwregd criteria via new `__io_extract_criteria` + `__io_pack_criteria` helpers (factored out of `IOKitMatching.c` so matching + notify share one translator), then fires `hwreg_watch` with the IONotificationPort's recv port as the watch target.

The hand-rolled `HWREG_MSG_EVENT` / `HWREG_MSG_SUBSCRIBE` constants and the `struct hwreg_event_msg` wire format were moved from `hwregd.c` into `src/hwregd/hwreg_mig_types.h` so the facade's receive thread speaks the same protocol. `hwregd.c` gains an explicit `#include "hwreg_mig_types.h"`; the values are unchanged (`0x48575201u` / `0x48575202u`).

One `IONotificationPort` can carry many watches. Events fan in on the one port; the receive thread parses hwregd's event text (`arrived id=N name=Y class=Z`) and re-matches client-side against each watch's stored criteria to fire the right callback(s). hwregd already filters server-side, so the client re-match only disambiguates between watches on the same port.

Delivery:
- `SetDispatchQueue` → callbacks via `dispatch_async_f` on the caller's queue.
- Without one → callbacks run on the receive thread (acceptable for simple consumers; the test uses a queue).

`IONotificationPortDestroy` stops the thread (atomic stop + `pthread_join`), `hwreg_unwatch`s each registered `watcher_id` so hwregd reclaims the table slot, releases the queue, deallocates the recv port.

## Test coverage

`iokitnotifytest`:
1. `IONotificationPortCreate`, `GetMachPort` returns non-NULL.
2. `SetDispatchQueue` with a fresh dispatch queue.
3. `AddMatchingNotification(kIOFirstMatchNotification, PCIDevice)` — initial arming yields ≥1 entry (i440FX hostb0 + e1000 NIC always in the QEMU guest).
4. `AddMatchingNotification(kIOTerminatedNotification, no-such-class)` — empty (non-NULL) iterator.
5. Clean `Destroy`.

**Async fire is NOT exercised in CI** — QEMU device hot-plug isn't injectable from the boot test, and the underlying raw-mach_msg-receive-thread pattern is structurally identical to `HWREG-PUBSUB` + `SC-NOTIFY` (both CI-proven). Once IPConfiguration consumes the facade on real link-up events, the live integration is the proof.

## Marker

`IOKIT-NOTIFY` gates in `tests/boot-test.sh` and the overlays `run.sh`.

## What this closes out

This completes **K1+K2** as scoped in the plan. After this PR the IOKit userland surface is feature-complete for everything the plan calls out:
- `ioreg(8)` works (K1, iter 3).
- Apple device-arrival APIs work (K2, this iter).

K3 (power management — `IOPMAssertion*`, `IOPSCopyPowerSourcesInfo`) and K4 (HID/USB/audio) remain deferred per the plan ("port only when a consumer actually needs it"). `IOServiceOpen` / `IOConnectCallMethod` are still in the plan's **SKIP** column.

Next major: **IPConfiguration** (the real DHCP/network-config daemon — the long-anticipated consumer of the libSystemConfiguration stack the SCNetworkConfiguration port just built).