### PR TITLE
feat(IPConfiguration): IPConfiguration daemon iter 1 — skeleton

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1635,6 +1635,44 @@ test -x "$WORK/rootfs/usr/bin/syslog" \
 echo "==> SYSLOG-CLI-BUILD-OK"
 
 #
+# 3y. Phase K — build ipconfigd (src/IPConfiguration/) iter 1.
+#     Apple IPConfiguration daemon port (Mach-IPC track) — the real
+#     DHCPv4/DHCPv6/IPv4LL/RA client. iter 1 is the daemon skeleton:
+#     getifaddrs interface enumeration + bootstrap_check_in for
+#     com.apple.IPConfiguration. Later iters wire DHCPv4 + the
+#     SCDynamicStore publish path that the libSystemConfiguration
+#     port just built. Installs /usr/sbin/ipconfigd + the launchd
+#     plist (in overlays/, copied by step 4).
+#     Plan: pkgdemon.github.io/freebsd-ipconfiguration-plan.html
+#     (note: that doc targets the sibling AF_UNIX repo; this Mach
+#     track keeps Apple's Mach IPC + MIG, same as configd/hwregd).
+#
+echo "==> building ipconfigd (src/IPConfiguration)"
+make -C "$ROOT/src/IPConfiguration" \
+    DESTDIR="$WORK/rootfs" \
+    SYSROOT="$WORK/rootfs" \
+    all install
+ls -lh "$WORK/rootfs/usr/sbin/ipconfigd"
+test -x "$WORK/rootfs/usr/sbin/ipconfigd" \
+    || { echo "FAIL: /usr/sbin/ipconfigd not installed or not executable"; exit 1; }
+
+# ipconfigtest — iter 1 liveness probe. bootstrap_look_up for
+# com.apple.IPConfiguration; prints IPCFG-BOOT-OK on success.
+# run.sh runs it and the marker gates in tests/boot-test.sh.
+echo "==> building ipconfigtest"
+cc -I"$ROOT/src/launchd/liblaunch" \
+   -I"$ROOT/src/launchd/freebsd-shims" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/ipconfigtest" \
+   "$ROOT/src/IPConfiguration/ipconfigtest.c" \
+   -llaunch -lsystem_kernel
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/ipconfigtest" \
+    || { echo "FAIL: ipconfigtest not built"; exit 1; }
+echo "==> ipconfigd + ipconfigtest built"
+
+#
 # 3z. purge build packages + clean pkg cache + tear down chroot.
 #     Runs LAST in the build phase, after every chroot-side build
 #     (libdispatch) has used cmake/ninja/clang. Build pkgs (cmake/ninja

--- a/overlays/System/Library/LaunchDaemons/com.apple.IPConfiguration.plist
+++ b/overlays/System/Library/LaunchDaemons/com.apple.IPConfiguration.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.apple.IPConfiguration.plist
+
+  Boot-time launchd plist for ipconfigd (freebsd-launchd-mach
+  IPConfiguration daemon). Apple runs IPConfiguration as a configd
+  plugin; we run it standalone because this repo's configd has no
+  plugin loader (see the IPConfiguration port plan / the
+  configd-port-state memory).
+
+  iter 1 is the daemon skeleton: ipconfigd enumerates interfaces
+  via getifaddrs(3), checks the com.apple.IPConfiguration Mach
+  service in, and sleeps until SIGTERM. Later iters fold in the
+  DHCPv4 client (iter 2/3), the SCDynamicStore publish
+  (iter 4 — uses the libSystemConfiguration the SCNetworkConfig
+  port just built), and the config.defs MIG RPC surface (iter 5).
+  RunAtLoad + KeepAlive so it starts at PID-1 launchd boot and
+  respawns on crash. StandardErrorPath / StandardOutPath route the
+  daemon's log to /var/log/ipconfigd.stderr — same convention
+  hwregd / configd use; the CI boot test dumps the file
+  post-boot for verification.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.apple.IPConfiguration</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/sbin/ipconfigd</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>MachServices</key>
+    <dict>
+        <key>com.apple.IPConfiguration</key>
+        <true/>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/var/log/ipconfigd.stderr</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/ipconfigd.stderr</string>
+</dict>
+</plist>

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -718,4 +718,24 @@ if [ ! -x "$iokitnotifytest" ]; then
 fi
 "$iokitnotifytest" || true	# marker (IOKIT-NOTIFY-OK/FAIL) gates in boot-test.sh
 
+# IPCFG-BOOT — IPConfiguration daemon iter 1 liveness probe:
+# bootstrap_look_up against com.apple.IPConfiguration. If ipconfigd
+# launched + claimed its service, the lookup returns a non-null
+# send right and the test client prints IPCFG-BOOT-OK. DHCP itself
+# isn't exercised in this iter (the next iter wires DHCPDISCOVER).
+ipconfigtest=/usr/tests/freebsd-launchd-mach/ipconfigtest
+if [ ! -x "$ipconfigtest" ]; then
+    echo "IPCFG-BOOT-FAIL: $ipconfigtest missing"
+    exit 1
+fi
+"$ipconfigtest" || true	# marker (IPCFG-BOOT-OK/FAIL) gates in boot-test.sh
+
+# Dump ipconfigd's stderr log to the console so the iter-1 interface
+# enumeration shows up alongside the marker (debug aid; not gated).
+if [ -f /var/log/ipconfigd.stderr ]; then
+    echo "--- /var/log/ipconfigd.stderr ---"
+    cat /var/log/ipconfigd.stderr
+    echo "--- end ipconfigd.stderr ---"
+fi
+
 exit 0

--- a/src/IPConfiguration/Makefile
+++ b/src/IPConfiguration/Makefile
@@ -1,0 +1,43 @@
+# ipconfigd — freebsd-launchd-mach IPConfiguration daemon.
+#
+# Mach-IPC track port of Apple's IPConfiguration. iter 1 ships the
+# daemon skeleton: getifaddrs interface enumeration +
+# bootstrap_check_in(com.apple.IPConfiguration) + a sleep loop.
+# Builds /usr/sbin/ipconfigd; runs as a launchd-managed daemon under
+# the com.apple.IPConfiguration.plist in overlays/.
+#
+# Build:   cd src/IPConfiguration && make SYSROOT=/path/to/rootfs
+# Install: make DESTDIR=/path/to/rootfs install
+
+PROG=		ipconfigd
+SRCS=		ipconfigd.c
+
+WARNS?=		6
+NO_MAN=		yes
+
+CFLAGS+=	-O2 -pipe
+CFLAGS+=	-Wall -Wextra -Wshadow -Wstrict-prototypes
+CFLAGS+=	-Wmissing-prototypes -Wpointer-arith
+
+# <servers/bootstrap.h> (bootstrap_check_in + bootstrap_port global)
+# comes from liblaunch; its bootstrap.h pulls in Apple shim headers
+# (AvailabilityMacros.h, ...) from launchd/freebsd-shims. Same -I
+# pair hwregd / configd use.
+CFLAGS+=	-I${.CURDIR}/../launchd/liblaunch
+CFLAGS+=	-I${.CURDIR}/../launchd/freebsd-shims
+
+SYSROOT?=
+.if !empty(SYSROOT)
+CFLAGS+=	-I${SYSROOT}/usr/include
+LDFLAGS+=	-L${SYSROOT}/usr/lib/system
+LDFLAGS+=	-Wl,-rpath,/usr/lib/system
+LDFLAGS+=	-Wl,--allow-shlib-undefined
+.endif
+
+# -llaunch: bootstrap_check_in + the bootstrap_port global.
+# -lsystem_kernel: mach_msg + the Mach port syscalls behind it.
+LDADD+=		-llaunch -lsystem_kernel
+
+BINDIR=		/usr/sbin
+
+.include <bsd.prog.mk>

--- a/src/IPConfiguration/Makefile
+++ b/src/IPConfiguration/Makefile
@@ -10,6 +10,10 @@
 # Install: make DESTDIR=/path/to/rootfs install
 
 PROG=		ipconfigd
+# MAN= (empty) suppresses bsd.prog.mk's default ipconfigd.1 build —
+# NO_MAN=yes alone is insufficient, the make rule still references it.
+# Same suppression hwregd / configd use.
+MAN=
 SRCS=		ipconfigd.c
 
 WARNS?=		6

--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -1,0 +1,160 @@
+/*
+ * ipconfigd — freebsd-launchd-mach IPConfiguration daemon.
+ *
+ * The Mach-IPC track port of Apple's IPConfiguration
+ * (apple-oss-distributions/bootp / IPConfiguration.bproj). Apple
+ * runs it as a configd plugin; we run standalone because this
+ * repo's configd has no plugin loader (see [[configd-port-state]]
+ * memory). Plan inventory + amputation list at
+ * pkgdemon.github.io/freebsd-ipconfiguration-plan.html (note: that
+ * doc targets the sibling AF_UNIX / GNUstep-DO repo; here we keep
+ * Apple's Mach IPC + MIG, same as configd / hwregd).
+ *
+ * iter 1 — daemon skeleton. main + signal handling + getifaddrs
+ * interface enumeration + bootstrap_check_in for
+ * com.apple.IPConfiguration + a sleep loop that holds the service
+ * port until SIGTERM. No DHCP yet — that lands in iter 2
+ * (DHCPDISCOVER/OFFER over BPF) and iter 3 (full INIT → BOUND with
+ * SIOCSIFADDR + default route). Marker IPCFG-BOOT-OK is emitted by
+ * the separate `ipconfigtest` client (bootstrap_look_up against
+ * this service) — same pattern hwregd / configd iter 1 use.
+ */
+#include <sys/types.h>
+#include <sys/socket.h>
+
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <netinet/in.h>
+
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <errno.h>
+#include <ifaddrs.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define IPCFG_SERVICE_NAME	"com.apple.IPConfiguration"
+
+static volatile sig_atomic_t got_term;
+
+static void
+on_signal(int sig)
+{
+	got_term = sig;
+}
+
+static void
+xlog(const char *fmt, ...)
+{
+	struct timespec ts;
+	struct tm tm;
+	char tbuf[32];
+	va_list ap;
+
+	(void)clock_gettime(CLOCK_REALTIME, &ts);
+	(void)gmtime_r(&ts.tv_sec, &tm);
+	(void)strftime(tbuf, sizeof(tbuf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+	(void)fprintf(stderr, "ipconfigd %s ", tbuf);
+
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+/*
+ * Walk getifaddrs(3) and log each interface's BSD name + family.
+ * iter 1's "real" content: the same enumeration later iters use to
+ * pick which interfaces to DHCP on. The AF_LINK pass also surfaces
+ * the MAC address — useful when DHCP needs it for the chaddr.
+ */
+static int
+enumerate_interfaces(void)
+{
+	struct ifaddrs *ifa, *p;
+	int total = 0, with_link = 0;
+
+	if (getifaddrs(&ifa) != 0) {
+		xlog("getifaddrs failed: %s", strerror(errno));
+		return (-1);
+	}
+	for (p = ifa; p != NULL; p = p->ifa_next) {
+		const char *fam = "?";
+
+		if (p->ifa_addr == NULL)
+			continue;
+		switch (p->ifa_addr->sa_family) {
+		case AF_INET:	fam = "AF_INET"; break;
+		case AF_INET6:	fam = "AF_INET6"; break;
+		case AF_LINK:	fam = "AF_LINK"; with_link++; break;
+		default:	continue;
+		}
+		xlog("iface: %s family=%s flags=0x%x", p->ifa_name, fam,
+		    p->ifa_flags);
+		total++;
+	}
+	freeifaddrs(ifa);
+	xlog("interface scan: %d records (%d AF_LINK)", total, with_link);
+	return (total);
+}
+
+int
+main(int argc, char **argv)
+{
+	struct sigaction sa;
+	mach_port_t service = MACH_PORT_NULL;
+	kern_return_t kr;
+
+	(void)argc;
+	(void)argv;
+
+	xlog("ipconfigd starting (iter 1 skeleton — no DHCP yet)");
+
+	(void)memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = on_signal;
+	(void)sigaction(SIGTERM, &sa, NULL);
+	(void)sigaction(SIGINT, &sa, NULL);
+
+	if (enumerate_interfaces() < 0) {
+		xlog("interface enumeration failed; continuing anyway");
+		/* not fatal — the daemon still exposes its Mach service */
+	}
+
+	/*
+	 * launchd handed us the receive right for the
+	 * com.apple.IPConfiguration MachServices entry via the
+	 * bootstrap port. bootstrap_check_in claims it. Without
+	 * RunAtLoad-then-check-in the service would not be reachable
+	 * from clients.
+	 */
+	kr = bootstrap_check_in(bootstrap_port, IPCFG_SERVICE_NAME,
+	    &service);
+	if (kr != KERN_SUCCESS) {
+		xlog("bootstrap_check_in('%s') failed: 0x%x — "
+		    "ipconfigtest will not see the service",
+		    IPCFG_SERVICE_NAME, (unsigned)kr);
+		/* don't exit; let launchd respawn surface the issue */
+	} else {
+		xlog("bootstrap_check_in('%s') ok: service port=0x%x",
+		    IPCFG_SERVICE_NAME, (unsigned)service);
+	}
+
+	/*
+	 * Hold the daemon alive. iter 1 has no MIG demux; later iters
+	 * replace this loop with a mach_msg(MACH_RCV_MSG ...) receive
+	 * over the service port (the configd / hwregd shape).
+	 */
+	while (!got_term) {
+		(void)sleep(60);
+	}
+
+	xlog("ipconfigd exiting on signal %d", (int)got_term);
+	return (0);
+}

--- a/src/IPConfiguration/ipconfigtest.c
+++ b/src/IPConfiguration/ipconfigtest.c
@@ -1,0 +1,38 @@
+/*
+ * ipconfigtest — iter 1 liveness probe for ipconfigd.
+ *
+ * iter 1 has no Mach RPC surface yet (the config.defs MIG demux
+ * lands later). The signal that the daemon launched + claimed its
+ * service is that bootstrap_look_up returns a non-null send right
+ * for com.apple.IPConfiguration. That is the iter-1 marker.
+ *
+ * Same shape as hwregtest / configtest's first-iter probes — they
+ * test exactly this property of their respective daemons. Marker
+ * IPCFG-BOOT-OK gates in tests/boot-test.sh.
+ */
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <stdio.h>
+
+int
+main(void)
+{
+	mach_port_t svc = MACH_PORT_NULL;
+	kern_return_t kr;
+
+	kr = bootstrap_look_up(bootstrap_port,
+	    "com.apple.IPConfiguration", &svc);
+	if (kr != KERN_SUCCESS) {
+		printf("IPCFG-BOOT-FAIL: bootstrap_look_up: 0x%x\n",
+		    (unsigned)kr);
+		return (1);
+	}
+	if (svc == MACH_PORT_NULL) {
+		printf("IPCFG-BOOT-FAIL: service port is MACH_PORT_NULL\n");
+		return (1);
+	}
+	printf("IPCFG-BOOT-OK: com.apple.IPConfiguration registered "
+	    "(send right=0x%x)\n", (unsigned)svc);
+	return (0);
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -684,6 +684,20 @@ expect {
     }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: IPCFG-BOOT marker not seen"
+        exit 1
+    }
+    "IPCFG-BOOT-FAIL" {
+        puts "\nFAIL: ipconfigd skeleton did not claim its Mach service"
+        exit 1
+    }
+    "IPCFG-BOOT-OK" {
+        puts "\nOK: ipconfigd skeleton up (com.apple.IPConfiguration registered)"
+    }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
Begin porting Apple's **IPConfiguration** daemon (apple-oss-distributions/bootp / IPConfiguration.bproj) to this Mach-IPC track. The long-anticipated *real consumer* of the libSystemConfiguration stack — replaces the interim dhclient with the Apple-shape DHCPv4 + DHCPv6 + IPv4LL + RA client.

## Plug-vs-daemon

Apple runs IPConfiguration as a configd plugin; this repo's configd has no plugin loader. So this port runs **standalone**: own daemon binary `/usr/sbin/ipconfigd`, own launchd plist `com.apple.IPConfiguration.plist`, own Mach service `com.apple.IPConfiguration`. Same shape as hwregd / configd.

## Architecture caveat

The plan HTML at [pkgdemon.github.io/freebsd-ipconfiguration-plan.html](https://pkgdemon.github.io/freebsd-ipconfiguration-plan.html) targets the *sibling* `freebsd-launchd` repo (AF_UNIX / GNUstep-DO track). Its scope inventory + amputation list carry over verbatim:

- delete: SymptomReporter, IPv6AWDReport, IPConfigurationHelper (XPC PvD fetch), NetBoot pieces, MobileGestalt, BSM audit-token entitlements, IO80211, IORegisterForSystemPower, CLAT46/L4S ioctls
- vendor portable: `bootp.h`, `bootplib/dhcp.h`, `bootplib/dhcp_options.{c,h}` (option parser), `bootplib/bpflib.{c,h}`, `bootplib/arp.{c,h}`, `bootplib/RouterAdvertisement.c`, etc.
- defer vendoring: `ipconfigd.c` (10.3k LOC of plugin shell), `dhcp.c` (4.6k state machine), `DHCPv6Client.c`, `arp_session.c`, `rtadv.c`

But the plan's architecture (NSConnection over AF_UNIX) does not apply here. This Mach track keeps Apple's Mach IPC + MIG (`bootplib/ipconfig.defs`, 21 routines) served via a raw `mach_msg` demux, same as configd / hwregd.

## What this iter ships

| File | Purpose |
|---|---|
| `src/IPConfiguration/ipconfigd.c` | main + signal + `getifaddrs(3)` interface enum + `bootstrap_check_in("com.apple.IPConfiguration")` + sleep loop |
| `src/IPConfiguration/Makefile` | `PROG=ipconfigd`, `WARNS=6`, `-llaunch -lsystem_kernel`, `BINDIR=/usr/sbin` |
| `src/IPConfiguration/ipconfigtest.c` | iter-1 liveness probe: `bootstrap_look_up` for `com.apple.IPConfiguration`, prints `IPCFG-BOOT-OK` |
| `overlays/.../com.apple.IPConfiguration.plist` | RunAtLoad + KeepAlive + `MachServices`, logs to `/var/log/ipconfigd.stderr` |
| `build.sh` step 3y | Builds `ipconfigd` + `ipconfigtest` |
| `run.sh` + `tests/boot-test.sh` | New marker `IPCFG-BOOT` |

`run.sh` also dumps `/var/log/ipconfigd.stderr` to the console post-boot so the iter-1 interface enumeration shows up (debug aid; not gated).

## Iter roadmap

- **iter 1** — this PR. Skeleton.
- **iter 2** — DHCPDISCOVER/OFFER over BPF; vendor `bootp.h` + `dhcp_options.{c,h}` + `bpflib.{c,h}`. Marker `IPCFG-DISCOVER`.
- **iter 3** — full INIT → BOUND, `SIOCSIFADDR`, default route. Box gets `10.0.2.15` from QEMU SLIRP. Marker `IPCFG-BOUND`.
- **iter 4** — lease renewal + `State:/Network/Service/<UUID>/IPv4` publish via libSystemConfiguration. Marker `IPCFG-STORE`.
- **iter 5** — `ipconfig.defs` MIG demux + a few high-value routines (`ipconfig_get_summary`, `ipconfig_get_dhcp_info`). Marker `IPCFG-RPC`.
- **iter 6+** — ARP conflict (RFC 5227), DHCPv6, RA/SLAAC, IPv4LL, `ipconfig(8)` CLI.

Scope tracking in `[[ipconfiguration-port-state]]` memory.