### PR TITLE
feat(IPConfiguration): iter 2 — DHCPv4 DISCOVER/OFFER over BPF

### DIFF
--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -730,9 +730,23 @@ if [ ! -x "$ipconfigtest" ]; then
 fi
 "$ipconfigtest" || true	# marker (IPCFG-BOOT-OK/FAIL) gates in boot-test.sh
 
-# Dump ipconfigd's stderr log to the console so the iter-1 interface
-# enumeration shows up alongside the marker (debug aid; not gated).
+# IPCFG-DISCOVER — iter-2 DHCPv4 DISCOVER/OFFER probe. ipconfigd
+# fires it once at startup against the first Ethernet interface
+# (em0 in CI via QEMU SLIRP user-net) and logs IPCFG-DISCOVER-OK/
+# FAIL to /var/log/ipconfigd.stderr. Wait up to ~30s for the
+# marker to land (DHCP timeout is 10s; boot scheduling adds slack),
+# then cat the stderr log so the marker reaches this console for
+# the boot-test.sh expect block.
 if [ -f /var/log/ipconfigd.stderr ]; then
+    i=0
+    while [ $i -lt 15 ]; do
+        if grep -q 'IPCFG-DISCOVER-OK\|IPCFG-DISCOVER-FAIL' \
+            /var/log/ipconfigd.stderr 2>/dev/null; then
+            break
+        fi
+        sleep 2
+        i=$((i+1))
+    done
     echo "--- /var/log/ipconfigd.stderr ---"
     cat /var/log/ipconfigd.stderr
     echo "--- end ipconfigd.stderr ---"

--- a/src/IPConfiguration/Makefile
+++ b/src/IPConfiguration/Makefile
@@ -14,7 +14,7 @@ PROG=		ipconfigd
 # NO_MAN=yes alone is insufficient, the make rule still references it.
 # Same suppression hwregd / configd use.
 MAN=
-SRCS=		ipconfigd.c
+SRCS=		ipconfigd.c dhcp_discover.c
 
 WARNS?=		6
 NO_MAN=		yes

--- a/src/IPConfiguration/dhcp_discover.c
+++ b/src/IPConfiguration/dhcp_discover.c
@@ -168,26 +168,35 @@ bring_interface_up(const char *ifname)
 }
 
 /*
- * Open /dev/bpfN, BIOCSETIF to ifname, set immediate mode + the
- * hdrcmplt flag so our prebuilt Ethernet header is sent verbatim.
+ * Open a BPF descriptor, BIOCSETIF to ifname, set immediate mode +
+ * the hdrcmplt flag so our prebuilt Ethernet header is sent
+ * verbatim.
+ *
+ * FreeBSD ships /dev/bpf as a cloning device — open("/dev/bpf")
+ * autocreates a fresh /dev/bpfN and returns its descriptor. We
+ * also fall back to the /dev/bpfN loop (the Apple bootp/bootplib/
+ * bpflib.c shape) for older or non-cloning configurations.
  */
 static int
 bpf_open(const char *ifname)
 {
 	struct ifreq ifr;
-	int fd = -1, i;
+	int fd, i;
 	u_int one = 1;
 	struct timeval tv;
 
-	for (i = 0; i < 256; i++) {
-		char path[32];
+	fd = open("/dev/bpf", O_RDWR);
+	if (fd < 0 && (errno == ENOENT || errno == ENXIO)) {
+		for (i = 0; i < 256; i++) {
+			char path[32];
 
-		(void)snprintf(path, sizeof(path), "/dev/bpf%d", i);
-		fd = open(path, O_RDWR);
-		if (fd >= 0)
-			break;
-		if (errno != EBUSY)
-			break;
+			(void)snprintf(path, sizeof(path), "/dev/bpf%d", i);
+			fd = open(path, O_RDWR);
+			if (fd >= 0)
+				break;
+			if (errno != EBUSY)
+				break;
+		}
 	}
 	if (fd < 0)
 		return (-1);
@@ -470,24 +479,35 @@ dhcp_discover_run(const char *ifname)
 	time_t deadline;
 	int got = 0;
 
+	/*
+	 * On every failure path: log the diagnostic on its own line
+	 * FIRST, then emit the bare `IPCFG-DISCOVER-FAIL` marker on
+	 * its own line. tests/boot-test.sh's expect block matches on
+	 * the marker substring and exits immediately, so anything on
+	 * the same line as the marker is lost from the captured
+	 * console; keeping the marker bare guarantees the diagnostic
+	 * survives.
+	 */
 	if (get_interface_mac(ifname, mac) != 0) {
-		xlog("IPCFG-DISCOVER-FAIL: get_interface_mac(%s): %s",
+		xlog("get_interface_mac(%s) failed: %s",
 		    ifname, strerror(errno));
+		xlog("IPCFG-DISCOVER-FAIL");
 		return (-1);
 	}
 	xlog("iface %s mac %02x:%02x:%02x:%02x:%02x:%02x",
 	    ifname, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
 	if (bring_interface_up(ifname) != 0) {
-		xlog("IPCFG-DISCOVER-FAIL: bring_interface_up(%s): %s",
+		xlog("bring_interface_up(%s) failed: %s",
 		    ifname, strerror(errno));
+		xlog("IPCFG-DISCOVER-FAIL");
 		return (-1);
 	}
 
 	bpf_fd = bpf_open(ifname);
 	if (bpf_fd < 0) {
-		xlog("IPCFG-DISCOVER-FAIL: bpf_open(%s): %s",
-		    ifname, strerror(errno));
+		xlog("bpf_open(%s) failed: %s", ifname, strerror(errno));
+		xlog("IPCFG-DISCOVER-FAIL");
 		return (-1);
 	}
 
@@ -497,8 +517,9 @@ dhcp_discover_run(const char *ifname)
 
 	frame_len = build_discover(frame, mac, xid);
 	if (write(bpf_fd, frame, frame_len) != (ssize_t)frame_len) {
-		xlog("IPCFG-DISCOVER-FAIL: write(bpf, %zu): %s",
+		xlog("write(bpf, %zu) failed: %s",
 		    frame_len, strerror(errno));
+		xlog("IPCFG-DISCOVER-FAIL");
 		(void)close(bpf_fd);
 		return (-1);
 	}
@@ -550,7 +571,8 @@ dhcp_discover_run(const char *ifname)
 		    "server=%s", ifname, xid, y, s);
 		return (0);
 	}
-	xlog("IPCFG-DISCOVER-FAIL: no DHCPOFFER received within 10s "
-	    "(iface=%s xid=0x%08x)", ifname, xid);
+	xlog("no DHCPOFFER received within 10s (iface=%s xid=0x%08x)",
+	    ifname, xid);
+	xlog("IPCFG-DISCOVER-FAIL");
 	return (-1);
 }

--- a/src/IPConfiguration/dhcp_discover.c
+++ b/src/IPConfiguration/dhcp_discover.c
@@ -1,0 +1,556 @@
+/*
+ * dhcp_discover.c — iter 2 one-shot DHCPv4 DISCOVER/OFFER probe.
+ *
+ * The minimum DHCPv4 logic to prove the daemon can fly packets:
+ * pick an interface, bring it up, open a BPF descriptor, send a
+ * raw Ethernet/IP/UDP DHCPDISCOVER (the interface has no IP yet
+ * so plain UDP sockets can't address the DHCP server), read raw
+ * frames until a DHCPOFFER matching our xid arrives.
+ *
+ * NOT vendored from Apple's IPConfiguration.bproj. The Apple
+ * bootp/bootplib/{bpflib,dhcp_options}.c source is the long-term
+ * destination; this iter writes ~250 LOC of clean BSD-licensed
+ * code to land the marker fast. iter 3 starts pulling in Apple's
+ * option parser when REQUEST/ACK needs it.
+ *
+ * QEMU SLIRP user-network (the CI guest's only NIC) runs an
+ * internal DHCP server at 10.0.2.2 offering 10.0.2.15 — the
+ * deterministic test target.
+ */
+#include "dhcp_discover.h"
+#include "dhcp_packet.h"
+
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+
+#include <net/bpf.h>
+#include <net/ethernet.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/udp.h>
+
+#include <arpa/inet.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <ifaddrs.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define DHCP_CLIENT_PORT	68
+#define DHCP_SERVER_PORT	67
+
+static void
+xlog(const char *fmt, ...)
+{
+	va_list ap;
+
+	(void)fprintf(stderr, "ipconfigd[dhcp] ");
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+/* RFC 1071 one's-complement Internet checksum. */
+static uint16_t
+in_cksum(const void *buf, size_t len)
+{
+	const uint8_t *p = buf;
+	uint32_t sum = 0;
+
+	while (len > 1) {
+		sum += (uint32_t)((p[0] << 8) | p[1]);
+		p += 2;
+		len -= 2;
+	}
+	if (len == 1)
+		sum += (uint32_t)(p[0] << 8);
+	while (sum >> 16)
+		sum = (sum & 0xffff) + (sum >> 16);
+	return ((uint16_t)~sum);
+}
+
+int
+dhcp_pick_interface(char *ifname_out, size_t ifname_sz)
+{
+	struct ifaddrs *ifa, *p;
+	int found = 0;
+
+	if (getifaddrs(&ifa) != 0)
+		return (-1);
+	for (p = ifa; p != NULL; p = p->ifa_next) {
+		const struct sockaddr_dl *dl;
+
+		if (p->ifa_addr == NULL ||
+		    p->ifa_addr->sa_family != AF_LINK)
+			continue;
+		if ((p->ifa_flags & IFF_LOOPBACK) != 0)
+			continue;
+		dl = (const struct sockaddr_dl *)(void *)p->ifa_addr;
+		/* IFT_ETHER = 6, the type for ordinary Ethernet. */
+		if (dl->sdl_type != 6)
+			continue;
+		(void)strlcpy(ifname_out, p->ifa_name, ifname_sz);
+		found = 1;
+		break;
+	}
+	freeifaddrs(ifa);
+	return (found ? 0 : -1);
+}
+
+/*
+ * Copy the AF_LINK MAC for `ifname` into mac[6]. Returns 0 on
+ * success.
+ */
+static int
+get_interface_mac(const char *ifname, uint8_t mac[6])
+{
+	struct ifaddrs *ifa, *p;
+	int ok = -1;
+
+	if (getifaddrs(&ifa) != 0)
+		return (-1);
+	for (p = ifa; p != NULL; p = p->ifa_next) {
+		const struct sockaddr_dl *dl;
+
+		if (p->ifa_addr == NULL ||
+		    p->ifa_addr->sa_family != AF_LINK)
+			continue;
+		if (strcmp(p->ifa_name, ifname) != 0)
+			continue;
+		dl = (const struct sockaddr_dl *)(void *)p->ifa_addr;
+		if (dl->sdl_alen != 6)
+			break;
+		(void)memcpy(mac, LLADDR(dl), 6);
+		ok = 0;
+		break;
+	}
+	freeifaddrs(ifa);
+	return (ok);
+}
+
+/* OR IFF_UP into ifname's flags via a configuration socket. */
+static int
+bring_interface_up(const char *ifname)
+{
+	struct ifreq ifr;
+	int sock, rc;
+
+	sock = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sock < 0)
+		return (-1);
+	(void)memset(&ifr, 0, sizeof(ifr));
+	(void)strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+	if (ioctl(sock, SIOCGIFFLAGS, &ifr) != 0) {
+		(void)close(sock);
+		return (-1);
+	}
+	if ((ifr.ifr_flags & IFF_UP) == 0) {
+		ifr.ifr_flags |= IFF_UP;
+		rc = ioctl(sock, SIOCSIFFLAGS, &ifr);
+	} else {
+		rc = 0;
+	}
+	(void)close(sock);
+	return (rc);
+}
+
+/*
+ * Open /dev/bpfN, BIOCSETIF to ifname, set immediate mode + the
+ * hdrcmplt flag so our prebuilt Ethernet header is sent verbatim.
+ */
+static int
+bpf_open(const char *ifname)
+{
+	struct ifreq ifr;
+	int fd = -1, i;
+	u_int one = 1;
+	struct timeval tv;
+
+	for (i = 0; i < 256; i++) {
+		char path[32];
+
+		(void)snprintf(path, sizeof(path), "/dev/bpf%d", i);
+		fd = open(path, O_RDWR);
+		if (fd >= 0)
+			break;
+		if (errno != EBUSY)
+			break;
+	}
+	if (fd < 0)
+		return (-1);
+
+	(void)memset(&ifr, 0, sizeof(ifr));
+	(void)strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+	if (ioctl(fd, BIOCSETIF, &ifr) != 0) {
+		(void)close(fd);
+		return (-1);
+	}
+	/* immediate = wake on each packet. */
+	(void)ioctl(fd, BIOCIMMEDIATE, &one);
+	/* hdrcmplt = 1 — we provide the full Ethernet header (incl.
+	 * the src MAC); the kernel must NOT rewrite it. */
+	(void)ioctl(fd, BIOCSHDRCMPLT, &one);
+	/* Read timeout: 5s. Receive blocks at most this long. */
+	tv.tv_sec = 5;
+	tv.tv_usec = 0;
+	(void)ioctl(fd, BIOCSRTIMEOUT, &tv);
+	return (fd);
+}
+
+/*
+ * Build the iter-2 DISCOVER frame into `buf` (must be at least
+ * 1024 bytes). Returns the total frame length.
+ *
+ * Layout:
+ *   [0..13]                   Ethernet (dst=broadcast, src=mac, type=0x0800)
+ *   [14..33]                  IPv4 (src=0.0.0.0, dst=255.255.255.255, proto=17)
+ *   [34..41]                  UDP (sport=68, dport=67)
+ *   [42..277]                 BOOTP/DHCP fixed-form (236 bytes)
+ *   [278..281]                magic cookie
+ *   [282..]                   options (msg-type DISCOVER, client-id, param-req, end, pad)
+ *
+ * Pad to >= DHCP_PACKET_MIN-overhead so router/firewall hardware
+ * with minimum-payload assumptions doesn't drop the frame.
+ */
+static size_t
+build_discover(uint8_t *buf, const uint8_t mac[6], uint32_t xid)
+{
+	struct ether_header *eh;
+	struct ip *ip;
+	struct udphdr *udp;
+	struct dhcp *dh;
+	const uint8_t cookie[4] = DHCP_MAGIC_COOKIE;
+	uint8_t *opt;
+	size_t udp_len, ip_len, frame_len;
+	uint8_t pseudo[12];
+
+	(void)memset(buf, 0, 1024);
+
+	eh = (struct ether_header *)(void *)buf;
+	(void)memset(eh->ether_dhost, 0xff, 6);
+	(void)memcpy(eh->ether_shost, mac, 6);
+	eh->ether_type = htons(ETHERTYPE_IP);
+
+	ip = (struct ip *)(void *)(buf + sizeof(*eh));
+	ip->ip_v = 4;
+	ip->ip_hl = 5;
+	ip->ip_tos = 0;
+	ip->ip_id = htons(0);
+	ip->ip_off = 0;
+	ip->ip_ttl = 64;
+	ip->ip_p = IPPROTO_UDP;
+	ip->ip_sum = 0;
+	ip->ip_src.s_addr = htonl(INADDR_ANY);
+	ip->ip_dst.s_addr = htonl(INADDR_BROADCAST);
+
+	udp = (struct udphdr *)(void *)(buf + sizeof(*eh) + sizeof(*ip));
+	udp->uh_sport = htons(DHCP_CLIENT_PORT);
+	udp->uh_dport = htons(DHCP_SERVER_PORT);
+	udp->uh_sum = 0;
+
+	dh = (struct dhcp *)(void *)(buf + sizeof(*eh) + sizeof(*ip) +
+	    sizeof(*udp));
+	dh->dp_op = BOOTREQUEST;
+	dh->dp_htype = HTYPE_ETHERNET;
+	dh->dp_hlen = 6;
+	dh->dp_xid = htonl(xid);
+	dh->dp_flags = htons(DHCP_FLAG_BROADCAST);
+	(void)memcpy(dh->dp_chaddr, mac, 6);
+
+	opt = (uint8_t *)dh + sizeof(*dh);
+	(void)memcpy(opt, cookie, 4);
+	opt += 4;
+	/* option 53: DHCP message type = DISCOVER */
+	*opt++ = DHCP_OPT_MESSAGE_TYPE;
+	*opt++ = 1;
+	*opt++ = DHCP_MTYPE_DISCOVER;
+	/* option 61: client id = htype 01 + mac */
+	*opt++ = DHCP_OPT_CLIENT_ID;
+	*opt++ = 7;
+	*opt++ = HTYPE_ETHERNET;
+	(void)memcpy(opt, mac, 6);
+	opt += 6;
+	/* option 55: parameter request list (subnet, router, DNS,
+	 * lease, server-id). iter 2 doesn't consume these but
+	 * sending the list shapes the OFFER. */
+	*opt++ = DHCP_OPT_PARAM_REQUEST;
+	*opt++ = 5;
+	*opt++ = DHCP_OPT_SUBNET_MASK;
+	*opt++ = DHCP_OPT_ROUTER;
+	*opt++ = DHCP_OPT_DNS_SERVER;
+	*opt++ = DHCP_OPT_LEASE_TIME;
+	*opt++ = DHCP_OPT_SERVER_ID;
+	*opt++ = DHCP_OPT_END;
+
+	/* Pad up to the RFC 2131 minimum frame (576 IP bytes). */
+	frame_len = (size_t)(opt - buf);
+	while (frame_len < sizeof(*eh) + DHCP_PACKET_MIN) {
+		buf[frame_len++] = DHCP_OPT_PAD;
+	}
+
+	udp_len = frame_len - sizeof(*eh) - sizeof(*ip);
+	ip_len = frame_len - sizeof(*eh);
+	ip->ip_len = htons((u_short)ip_len);
+	udp->uh_ulen = htons((u_short)udp_len);
+
+	/* IP header checksum (header only). Recompute after setting
+	 * ip_len. */
+	ip->ip_sum = 0;
+	ip->ip_sum = htons(in_cksum(ip, sizeof(*ip)));
+
+	/* UDP checksum: pseudo-header(12) + UDP header + payload.
+	 * SLIRP requires a valid UDP checksum on broadcast DHCP. */
+	(void)memset(pseudo, 0, sizeof(pseudo));
+	(void)memcpy(pseudo, &ip->ip_src.s_addr, 4);
+	(void)memcpy(pseudo + 4, &ip->ip_dst.s_addr, 4);
+	pseudo[8] = 0;
+	pseudo[9] = IPPROTO_UDP;
+	pseudo[10] = (uint8_t)(udp_len >> 8);
+	pseudo[11] = (uint8_t)(udp_len & 0xff);
+	{
+		/* Run the checksum over a temp buffer concatenating
+		 * the pseudo-header with the UDP header+payload. */
+		uint8_t tmp[2048];
+		size_t n;
+
+		if (udp_len > sizeof(tmp) - sizeof(pseudo)) {
+			/* should not happen for iter-2 sizes */
+			return (frame_len);
+		}
+		(void)memcpy(tmp, pseudo, sizeof(pseudo));
+		(void)memcpy(tmp + sizeof(pseudo), udp, udp_len);
+		n = sizeof(pseudo) + udp_len;
+		udp->uh_sum = htons(in_cksum(tmp, n));
+		if (udp->uh_sum == 0)
+			udp->uh_sum = 0xffff;	/* RFC 768: 0 means "no cksum" */
+	}
+
+	return (frame_len);
+}
+
+/*
+ * Scan DHCP options for the message type (53). Returns the value,
+ * or 0 if not found. opts_len is the trailing space available
+ * past the magic cookie.
+ */
+static uint8_t
+dhcp_msgtype(const uint8_t *opts, size_t opts_len)
+{
+	size_t i = 4;	/* skip the magic cookie */
+
+	while (i + 1 < opts_len) {
+		uint8_t code = opts[i];
+		uint8_t len;
+
+		if (code == DHCP_OPT_PAD) {
+			i++;
+			continue;
+		}
+		if (code == DHCP_OPT_END)
+			break;
+		len = opts[i + 1];
+		if (i + 2 + len > opts_len)
+			break;
+		if (code == DHCP_OPT_MESSAGE_TYPE && len == 1)
+			return (opts[i + 2]);
+		i += 2 + len;
+	}
+	return (0);
+}
+
+/*
+ * Fetch the value of option `code` from the options blob (after
+ * the cookie). Returns a pointer + length, or NULL on absence.
+ */
+static const uint8_t *
+dhcp_option(const uint8_t *opts, size_t opts_len, uint8_t code,
+    uint8_t *len_out)
+{
+	size_t i = 4;
+
+	while (i + 1 < opts_len) {
+		uint8_t c = opts[i];
+		uint8_t l;
+
+		if (c == DHCP_OPT_PAD) {
+			i++;
+			continue;
+		}
+		if (c == DHCP_OPT_END)
+			break;
+		l = opts[i + 1];
+		if (i + 2 + l > opts_len)
+			break;
+		if (c == code) {
+			*len_out = l;
+			return (&opts[i + 2]);
+		}
+		i += 2 + l;
+	}
+	return (NULL);
+}
+
+/*
+ * Parse one BPF-delivered frame. Returns 1 + sets yiaddr_out /
+ * server_out if it is a DHCPOFFER with our xid; 0 otherwise.
+ */
+static int
+parse_offer(const uint8_t *frame, size_t frame_len, uint32_t want_xid,
+    struct in_addr *yiaddr_out, struct in_addr *server_out)
+{
+	const struct ether_header *eh;
+	const struct ip *ip;
+	const struct udphdr *udp;
+	const struct dhcp *dh;
+	const uint8_t *opts;
+	const uint8_t cookie[4] = DHCP_MAGIC_COOKIE;
+	const uint8_t *v;
+	size_t opts_len;
+	uint8_t l = 0;
+
+	if (frame_len < sizeof(*eh) + sizeof(*ip) + sizeof(*udp) +
+	    sizeof(*dh) + 4)
+		return (0);
+	eh = (const struct ether_header *)(const void *)frame;
+	if (ntohs(eh->ether_type) != ETHERTYPE_IP)
+		return (0);
+	ip = (const struct ip *)(const void *)(frame + sizeof(*eh));
+	if (ip->ip_v != 4 || ip->ip_p != IPPROTO_UDP)
+		return (0);
+	udp = (const struct udphdr *)(const void *)
+	    (frame + sizeof(*eh) + (ip->ip_hl * 4));
+	if (ntohs(udp->uh_dport) != DHCP_CLIENT_PORT)
+		return (0);
+	dh = (const struct dhcp *)(const void *)
+	    ((const uint8_t *)udp + sizeof(*udp));
+	if (dh->dp_op != BOOTREPLY)
+		return (0);
+	if (ntohl(dh->dp_xid) != want_xid)
+		return (0);
+
+	opts = (const uint8_t *)dh + sizeof(*dh);
+	opts_len = frame + frame_len - opts;
+	if (opts_len < 4 || memcmp(opts, cookie, 4) != 0)
+		return (0);
+	if (dhcp_msgtype(opts, opts_len) != DHCP_MTYPE_OFFER)
+		return (0);
+
+	yiaddr_out->s_addr = dh->dp_yiaddr.s_addr;
+	server_out->s_addr = 0;
+	v = dhcp_option(opts, opts_len, DHCP_OPT_SERVER_ID, &l);
+	if (v != NULL && l == 4)
+		(void)memcpy(&server_out->s_addr, v, 4);
+	return (1);
+}
+
+int
+dhcp_discover_run(const char *ifname)
+{
+	uint8_t mac[6];
+	uint8_t frame[1024];
+	uint8_t rxbuf[4096];
+	uint32_t xid;
+	int bpf_fd;
+	size_t frame_len;
+	struct timespec ts;
+	struct in_addr yiaddr, server;
+	time_t deadline;
+	int got = 0;
+
+	if (get_interface_mac(ifname, mac) != 0) {
+		xlog("IPCFG-DISCOVER-FAIL: get_interface_mac(%s): %s",
+		    ifname, strerror(errno));
+		return (-1);
+	}
+	xlog("iface %s mac %02x:%02x:%02x:%02x:%02x:%02x",
+	    ifname, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
+	if (bring_interface_up(ifname) != 0) {
+		xlog("IPCFG-DISCOVER-FAIL: bring_interface_up(%s): %s",
+		    ifname, strerror(errno));
+		return (-1);
+	}
+
+	bpf_fd = bpf_open(ifname);
+	if (bpf_fd < 0) {
+		xlog("IPCFG-DISCOVER-FAIL: bpf_open(%s): %s",
+		    ifname, strerror(errno));
+		return (-1);
+	}
+
+	(void)clock_gettime(CLOCK_REALTIME, &ts);
+	xid = (uint32_t)ts.tv_nsec ^ (uint32_t)ts.tv_sec ^
+	    (uint32_t)(mac[5] | (mac[4] << 8));
+
+	frame_len = build_discover(frame, mac, xid);
+	if (write(bpf_fd, frame, frame_len) != (ssize_t)frame_len) {
+		xlog("IPCFG-DISCOVER-FAIL: write(bpf, %zu): %s",
+		    frame_len, strerror(errno));
+		(void)close(bpf_fd);
+		return (-1);
+	}
+	xlog("sent DHCPDISCOVER (xid=0x%08x, len=%zu)", xid, frame_len);
+
+	/* Read BPF responses until we get a matching DHCPOFFER or
+	 * 10 seconds elapse — the BPF descriptor has a 5s read
+	 * timeout so this is two read attempts. */
+	deadline = time(NULL) + 10;
+	while (!got && time(NULL) < deadline) {
+		ssize_t n = read(bpf_fd, rxbuf, sizeof(rxbuf));
+		uint8_t *p, *end;
+
+		if (n <= 0) {
+			if (errno == EINTR || errno == EAGAIN)
+				continue;
+			break;	/* timeout or error */
+		}
+		p = rxbuf;
+		end = rxbuf + n;
+		/* BPF return buffer can carry multiple packets, each
+		 * preceded by a struct bpf_hdr and aligned. */
+		while (p + sizeof(struct bpf_hdr) <= end) {
+			struct bpf_hdr bh;
+			uint8_t *pkt;
+			size_t caplen;
+
+			(void)memcpy(&bh, p, sizeof(bh));
+			pkt = p + bh.bh_hdrlen;
+			caplen = bh.bh_caplen;
+			if (pkt + caplen > end)
+				break;
+			if (parse_offer(pkt, caplen, xid, &yiaddr,
+			    &server)) {
+				got = 1;
+				break;
+			}
+			p += BPF_WORDALIGN(bh.bh_hdrlen + caplen);
+		}
+	}
+	(void)close(bpf_fd);
+
+	if (got) {
+		char y[INET_ADDRSTRLEN], s[INET_ADDRSTRLEN];
+
+		(void)inet_ntop(AF_INET, &yiaddr, y, sizeof(y));
+		(void)inet_ntop(AF_INET, &server, s, sizeof(s));
+		xlog("IPCFG-DISCOVER-OK: iface=%s xid=0x%08x yiaddr=%s "
+		    "server=%s", ifname, xid, y, s);
+		return (0);
+	}
+	xlog("IPCFG-DISCOVER-FAIL: no DHCPOFFER received within 10s "
+	    "(iface=%s xid=0x%08x)", ifname, xid);
+	return (-1);
+}

--- a/src/IPConfiguration/dhcp_discover.c
+++ b/src/IPConfiguration/dhcp_discover.c
@@ -141,12 +141,21 @@ get_interface_mac(const char *ifname, uint8_t mac[6])
 	return (ok);
 }
 
-/* OR IFF_UP into ifname's flags via a configuration socket. */
+/*
+ * OR IFF_UP into ifname's flags via a configuration socket, then
+ * spin-wait briefly for IFF_UP to actually be reflected (driver
+ * init via iflib may complete deferred admin work after
+ * SIOCSIFFLAGS returns). Returns 0 on success.
+ *
+ * Diagnostic flag values are logged before / after so a future
+ * round of CI red surfaces what actually changed.
+ */
 static int
 bring_interface_up(const char *ifname)
 {
 	struct ifreq ifr;
-	int sock, rc;
+	int sock, rc = -1, i;
+	unsigned before, after = 0;
 
 	sock = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sock < 0)
@@ -157,12 +166,34 @@ bring_interface_up(const char *ifname)
 		(void)close(sock);
 		return (-1);
 	}
+	before = (unsigned)(uint16_t)ifr.ifr_flags;
 	if ((ifr.ifr_flags & IFF_UP) == 0) {
 		ifr.ifr_flags |= IFF_UP;
 		rc = ioctl(sock, SIOCSIFFLAGS, &ifr);
+		if (rc != 0) {
+			xlog("SIOCSIFFLAGS(%s, +IFF_UP) failed: %s",
+			    ifname, strerror(errno));
+			(void)close(sock);
+			return (rc);
+		}
 	} else {
 		rc = 0;
 	}
+	/* Poll up to ~3s for IFF_UP to land. Each iteration sleeps
+	 * 100ms; em(4)/iflib drivers init synchronously today but
+	 * leaving slack is cheap. */
+	for (i = 0; i < 30; i++) {
+		(void)memset(&ifr, 0, sizeof(ifr));
+		(void)strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+		if (ioctl(sock, SIOCGIFFLAGS, &ifr) == 0) {
+			after = (unsigned)(uint16_t)ifr.ifr_flags;
+			if ((after & IFF_UP) != 0)
+				break;
+		}
+		(void)usleep(100000);
+	}
+	xlog("bring_interface_up(%s) flags=0x%x -> 0x%x (waited %d/30)",
+	    ifname, before, after, i);
 	(void)close(sock);
 	return (rc);
 }
@@ -516,12 +547,36 @@ dhcp_discover_run(const char *ifname)
 	    (uint32_t)(mac[5] | (mac[4] << 8));
 
 	frame_len = build_discover(frame, mac, xid);
-	if (write(bpf_fd, frame, frame_len) != (ssize_t)frame_len) {
-		xlog("write(bpf, %zu) failed: %s",
-		    frame_len, strerror(errno));
-		xlog("IPCFG-DISCOVER-FAIL");
-		(void)close(bpf_fd);
-		return (-1);
+	/*
+	 * Retry bpf_write a few times — em(4)/iflib's if_transmit
+	 * checks IFF_DRV_RUNNING in addition to IFF_UP and returns
+	 * ENETDOWN until the driver finishes init after SIOCSIFFLAGS.
+	 * 10×100ms is generous; the path normally settles instantly.
+	 */
+	{
+		int try;
+		ssize_t n = -1;
+
+		for (try = 0; try < 10; try++) {
+			n = write(bpf_fd, frame, frame_len);
+			if (n == (ssize_t)frame_len)
+				break;
+			if (errno != ENETDOWN) {
+				/* a different failure — stop retrying */
+				break;
+			}
+			(void)usleep(100000);
+		}
+		if (n != (ssize_t)frame_len) {
+			xlog("write(bpf, %zu) failed after %d tries: %s",
+			    frame_len, try + 1, strerror(errno));
+			xlog("IPCFG-DISCOVER-FAIL");
+			(void)close(bpf_fd);
+			return (-1);
+		}
+		if (try > 0)
+			xlog("write(bpf) succeeded after %d retries "
+			    "(driver init race)", try);
 	}
 	xlog("sent DHCPDISCOVER (xid=0x%08x, len=%zu)", xid, frame_len);
 

--- a/src/IPConfiguration/dhcp_discover.h
+++ b/src/IPConfiguration/dhcp_discover.h
@@ -1,0 +1,32 @@
+/*
+ * dhcp_discover.h — iter 2 one-shot DHCPv4 DISCOVER/OFFER probe.
+ *
+ * Brings the interface up, opens a BPF descriptor on it, sends a
+ * DHCPDISCOVER as a raw Ethernet frame (because the iface has no
+ * IP yet), and waits for the first DHCPOFFER matching our xid.
+ * Logs IPCFG-DISCOVER-OK on success / -FAIL on error / timeout —
+ * that's the iter-2 boot marker.
+ *
+ * Full INIT → BOUND with SIOCSIFADDR + default route + the BOOTP/
+ * DHCP option parser is iter 3+.
+ */
+#ifndef _IPCFG_DHCP_DISCOVER_H_
+#define _IPCFG_DHCP_DISCOVER_H_
+
+#include <stddef.h>	/* size_t */
+
+/*
+ * Run one DISCOVER/OFFER exchange on `ifname`. Returns 0 if an
+ * OFFER was received and logged (marker emitted), non-zero
+ * otherwise.
+ */
+int	dhcp_discover_run(const char *ifname);
+
+/*
+ * Pick the first non-loopback Ethernet interface (the QEMU guest's
+ * em0 in CI). Writes the name into ifname_out (buffer is at least
+ * IFNAMSIZ).  Returns 0 on success.
+ */
+int	dhcp_pick_interface(char *ifname_out, size_t ifname_sz);
+
+#endif /* _IPCFG_DHCP_DISCOVER_H_ */

--- a/src/IPConfiguration/dhcp_packet.h
+++ b/src/IPConfiguration/dhcp_packet.h
@@ -1,0 +1,75 @@
+/*
+ * dhcp_packet.h — DHCPv4 wire format (RFC 2131 / 2132).
+ *
+ * Self-contained, sized to what iter 2 needs (DISCOVER/OFFER). The
+ * struct layout mirrors Apple's bootp/bootplib/dhcp.h — same field
+ * names — so when later iters pull in dhcp_options.c verbatim the
+ * struct names line up. Constants are RFC, not Apple-private.
+ */
+#ifndef _IPCFG_DHCP_PACKET_H_
+#define _IPCFG_DHCP_PACKET_H_
+
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <stdint.h>
+
+#define DHCP_MAGIC_COOKIE	{ 99, 130, 83, 99 }	/* RFC 1497 */
+
+/* DHCP message-type option values (option 53). */
+#define DHCP_MTYPE_DISCOVER	1
+#define DHCP_MTYPE_OFFER	2
+#define DHCP_MTYPE_REQUEST	3
+#define DHCP_MTYPE_DECLINE	4
+#define DHCP_MTYPE_ACK		5
+#define DHCP_MTYPE_NAK		6
+#define DHCP_MTYPE_RELEASE	7
+#define DHCP_MTYPE_INFORM	8
+
+/* BOOTP opcodes. */
+#define BOOTREQUEST		1
+#define BOOTREPLY		2
+
+#define HTYPE_ETHERNET		1
+
+/* DHCP option codes (subset for iter 2). */
+#define DHCP_OPT_PAD		  0
+#define DHCP_OPT_SUBNET_MASK	  1
+#define DHCP_OPT_ROUTER		  3
+#define DHCP_OPT_DNS_SERVER	  6
+#define DHCP_OPT_HOST_NAME	 12
+#define DHCP_OPT_REQUESTED_IP	 50
+#define DHCP_OPT_LEASE_TIME	 51
+#define DHCP_OPT_MESSAGE_TYPE	 53
+#define DHCP_OPT_SERVER_ID	 54
+#define DHCP_OPT_PARAM_REQUEST	 55
+#define DHCP_OPT_CLIENT_ID	 61
+#define DHCP_OPT_END		255
+
+#define DHCP_FLAG_BROADCAST	0x8000
+
+/*
+ * The DHCP/BOOTP header. Apple names the fields dp_*. Sized 236
+ * bytes; options follow.
+ */
+struct dhcp {
+	uint8_t		dp_op;
+	uint8_t		dp_htype;
+	uint8_t		dp_hlen;
+	uint8_t		dp_hops;
+	uint32_t	dp_xid;
+	uint16_t	dp_secs;
+	uint16_t	dp_flags;
+	struct in_addr	dp_ciaddr;
+	struct in_addr	dp_yiaddr;
+	struct in_addr	dp_siaddr;
+	struct in_addr	dp_giaddr;
+	uint8_t		dp_chaddr[16];
+	uint8_t		dp_sname[64];
+	uint8_t		dp_file[128];
+	/* 4-byte magic cookie + variable options follow as packed
+	 * bytes; we treat them as an opaque tail. */
+};
+
+#define DHCP_PACKET_MIN		576	/* RFC 2131 minimum 576 octets */
+
+#endif /* _IPCFG_DHCP_PACKET_H_ */

--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -13,11 +13,17 @@
  * iter 1 — daemon skeleton. main + signal handling + getifaddrs
  * interface enumeration + bootstrap_check_in for
  * com.apple.IPConfiguration + a sleep loop that holds the service
- * port until SIGTERM. No DHCP yet — that lands in iter 2
- * (DHCPDISCOVER/OFFER over BPF) and iter 3 (full INIT → BOUND with
- * SIOCSIFADDR + default route). Marker IPCFG-BOOT-OK is emitted by
- * the separate `ipconfigtest` client (bootstrap_look_up against
- * this service) — same pattern hwregd / configd iter 1 use.
+ * port until SIGTERM. Marker IPCFG-BOOT-OK is emitted by the
+ * separate `ipconfigtest` client (bootstrap_look_up against this
+ * service) — same pattern hwregd / configd iter 1 use.
+ *
+ * iter 2 — one-shot DHCPv4 DISCOVER/OFFER probe (dhcp_discover.c).
+ * After bootstrap_check_in, ipconfigd picks the first non-loopback
+ * Ethernet interface, brings it up, opens BPF, sends DHCPDISCOVER
+ * and waits for a DHCPOFFER. Logs IPCFG-DISCOVER-OK/FAIL to stderr
+ * (run.sh cats the stderr file post-boot so the marker reaches the
+ * boot-test console). Full INIT → BOUND with SIOCSIFADDR + the
+ * default route is iter 3+.
  */
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -38,6 +44,8 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+
+#include "dhcp_discover.h"
 
 #define IPCFG_SERVICE_NAME	"com.apple.IPConfiguration"
 
@@ -147,9 +155,31 @@ main(int argc, char **argv)
 	}
 
 	/*
-	 * Hold the daemon alive. iter 1 has no MIG demux; later iters
-	 * replace this loop with a mach_msg(MACH_RCV_MSG ...) receive
-	 * over the service port (the configd / hwregd shape).
+	 * iter 2: one-shot DHCPv4 DISCOVER/OFFER probe on the first
+	 * non-loopback Ethernet interface (em0 in CI). Logs
+	 * IPCFG-DISCOVER-OK/FAIL via dhcp_discover_run's xlog. We do
+	 * not exit on failure — the daemon keeps the Mach service
+	 * registered either way; the marker is the test signal.
+	 * iter 3+ replaces this one-shot with the full INIT → BOUND
+	 * state machine.
+	 */
+	{
+		char ifname[IFNAMSIZ] = "";
+
+		if (dhcp_pick_interface(ifname, sizeof(ifname)) == 0) {
+			xlog("selected interface for DHCPv4 probe: %s",
+			    ifname);
+			(void)dhcp_discover_run(ifname);
+		} else {
+			xlog("IPCFG-DISCOVER-FAIL: no Ethernet interface "
+			    "found");
+		}
+	}
+
+	/*
+	 * Hold the daemon alive. iter 1/2 have no MIG demux; later
+	 * iters replace this loop with a mach_msg(MACH_RCV_MSG ...)
+	 * receive over the service port (the configd / hwregd shape).
 	 */
 	while (!got_term) {
 		(void)sleep(60);

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -698,6 +698,20 @@ expect {
     }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: IPCFG-DISCOVER marker not seen"
+        exit 1
+    }
+    "IPCFG-DISCOVER-FAIL" {
+        puts "\nFAIL: ipconfigd DHCPv4 DISCOVER/OFFER probe failed"
+        exit 1
+    }
+    "IPCFG-DISCOVER-OK" {
+        puts "\nOK: ipconfigd DHCPv4 DISCOVER/OFFER round-trip works"
+    }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
ipconfigd now flies real DHCP packets. Follow-up to PR #42 (iter 1 skeleton).

## What this iter does

At startup, after `bootstrap_check_in`, ipconfigd:

1. Picks the first non-loopback Ethernet interface (`em0` in CI via QEMU SLIRP user-net).
2. Brings it up (`SIOCSIFFLAGS | IFF_UP`).
3. Opens `/dev/bpfN`, `BIOCSETIF`, `BIOCIMMEDIATE`, `BIOCSHDRCMPLT` (so our Ethernet header is sent verbatim), `BIOCSRTIMEOUT(5s)`.
4. Builds a raw Ethernet+IP+UDP+DHCP DHCPDISCOVER frame (the iface has no IP yet so plain UDP can't address the server), pads to RFC-2131 minimum 576 bytes, signs the IP header and the UDP pseudo-header + payload with the standard RFC-1071 one's-complement checksum.
5. Reads BPF, walks the `bpf_hdr`-prefixed packet records, parses Ethernet/IP/UDP/DHCP, matches an OFFER by xid + msg-type 2, extracts `yiaddr` + server-id (option 54).
6. Logs `IPCFG-DISCOVER-OK: iface=em0 xid=0x... yiaddr=10.0.2.15 server=10.0.2.2` (the QEMU SLIRP DHCP server is at 10.0.2.2 offering 10.0.2.15 — deterministic test target).

## New files

| File | LOC | Purpose |
|---|---|---|
| `src/IPConfiguration/dhcp_packet.h` | ~80 | DHCPv4 wire format (RFC 2131/2132). Field names mirror Apple's `bootp/bootplib/dhcp.h` `dp_*` so when later iters pull in Apple's option parser verbatim the structs line up. |
| `src/IPConfiguration/dhcp_discover.{c,h}` | ~370 | Self-contained DISCOVER/OFFER probe: getifaddrs, IFF_UP, BPF open/setif/imm/hdrcmplt, frame build + checksums, BPF read + parse + match. |

**Not vendored from Apple** — clean BSD-licensed code; `bootp/bootplib/bpflib.c` + `dhcp_options.c` are the long-term destination but iter 2 is faster to land fresh than to vendor (no `symbol_scope.h` / Apple-private macro wrangling). iter 3+ pulls in Apple's option parser when REQUEST/ACK needs the full 113-option set.

## Wiring

- `ipconfigd.c` — after `bootstrap_check_in`, calls `dhcp_pick_interface` + `dhcp_discover_run`. Outcome doesn't gate the daemon (the Mach service stays registered either way, so the iter-1 `IPCFG-BOOT` marker survives a DISCOVER failure).
- `Makefile` — `SRCS` gains `dhcp_discover.c`.
- `run.sh` — after `ipconfigtest`, waits up to ~30s for the `IPCFG-DISCOVER-OK/FAIL` marker in `/var/log/ipconfigd.stderr` (DHCP timeout is 10s; the wait absorbs boot scheduling slack), then `cat`s the file so the marker reaches the boot-test console.
- `tests/boot-test.sh` — new `IPCFG-DISCOVER` expect block right after `IPCFG-BOOT`.

## What's next

- **iter 3** — full INIT → BOUND: REQUEST/ACK, `SIOCSIFADDR`, install default route. Box gets `10.0.2.15` for real. Marker `IPCFG-BOUND`.
- **iter 4** — lease renewal + publish `State:/Network/Service/<UUID>/IPv4` via libSystemConfiguration.