### PR TITLE
feat(IPConfiguration): iter 4 — SCDynamicStore publish + RENEWING/REBINDING

### DIFF
--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -730,18 +730,20 @@ if [ ! -x "$ipconfigtest" ]; then
 fi
 "$ipconfigtest" || true	# marker (IPCFG-BOOT-OK/FAIL) gates in boot-test.sh
 
-# IPCFG-BOUND — iter-3 full DHCPv4 INIT → BOUND on em0: ipconfigd
-# runs DISCOVER → OFFER → REQUEST → ACK with the standard 4/8/16s
-# RFC 2131 retransmit ladder, then apply_lease() runs SIOCAIFADDR
-# + RTM_ADD default route + /etc/resolv.conf write. The bound IP
-# comes from QEMU SLIRP (10.0.2.15 / 10.0.2.2). Wait up to ~60s
-# for the marker (worst-case retransmit window 4+8+16 = 28s; boot
-# scheduling adds slack), then cat the stderr log so the marker
-# reaches this console for boot-test.sh's expect block.
+# IPCFG-BOUND + IPCFG-STORE — iter-3 full DHCPv4 INIT → BOUND on em0
+# (DISCOVER → OFFER → REQUEST → ACK with the standard 4/8/16s RFC 2131
+# retransmit ladder, then apply_lease() runs SIOCAIFADDR + RTM_ADD
+# default route + /etc/resolv.conf write) followed by iter-4
+# SCDynamicStore publish of State:/Network/Service/<UUID>/IPv4 (+/DNS)
+# to configd. The bound IP comes from QEMU SLIRP (10.0.2.15 /
+# 10.0.2.2). Wait up to ~60s for both markers (worst-case retransmit
+# window 4+8+16 = 28s + SC publish round-trip; boot scheduling adds
+# slack), then cat the stderr log so the markers reach this console
+# for boot-test.sh's expect blocks.
 if [ -f /var/log/ipconfigd.stderr ]; then
     i=0
     while [ $i -lt 30 ]; do
-        if grep -q 'IPCFG-BOUND-OK\|IPCFG-BOUND-FAIL' \
+        if grep -q 'IPCFG-STORE-OK\|IPCFG-STORE-FAIL\|IPCFG-BOUND-FAIL' \
             /var/log/ipconfigd.stderr 2>/dev/null; then
             break
         fi

--- a/src/IPConfiguration/Makefile
+++ b/src/IPConfiguration/Makefile
@@ -15,11 +15,17 @@ PROG=		ipconfigd
 # Same suppression hwregd / configd use.
 MAN=
 SRCS=		ipconfigd.c dhcp_discover.c apply_lease.c
+SRCS+=		sc_publish.c lease_loop.c
 
-WARNS?=		6
+# WARNS=0: sc_publish.c pulls the CoreFoundation public header tree
+# (CFRuntime.h, CFBundle.h, CFLocking.h ...). At WARNS>0 the FreeBSD
+# warning machinery adds -Wsystem-headers -Werror which promotes
+# warnings inside the vendored CF headers into hard errors. Same
+# carry libSystemConfiguration / libxpc / libCoreFoundation use.
+WARNS=		0
 NO_MAN=		yes
 
-CFLAGS+=	-O2 -pipe
+CFLAGS+=	-O2 -pipe -fblocks
 CFLAGS+=	-Wall -Wextra -Wshadow -Wstrict-prototypes
 CFLAGS+=	-Wmissing-prototypes -Wpointer-arith
 
@@ -40,7 +46,14 @@ LDFLAGS+=	-Wl,--allow-shlib-undefined
 
 # -llaunch: bootstrap_check_in + the bootstrap_port global.
 # -lsystem_kernel: mach_msg + the Mach port syscalls behind it.
+# -lSystemConfiguration: SCDynamicStoreSetValue — the configd publish
+# that sc_publish.c wraps. -lCoreFoundation: CFDictionary / CFString
+# / CFArray, the dictionary shape sc_publish.c builds for State:/...
+# -ldispatch -lBlocksRuntime: pulled transitively by the SC umbrella
+# header (SCDynamicStoreSetDispatchQueue ABI surface).
 LDADD+=		-llaunch -lsystem_kernel
+LDADD+=		-lSystemConfiguration -lCoreFoundation
+LDADD+=		-ldispatch -lBlocksRuntime -lpthread
 
 BINDIR=		/usr/sbin
 

--- a/src/IPConfiguration/dhcp_discover.c
+++ b/src/IPConfiguration/dhcp_discover.c
@@ -232,14 +232,18 @@ bpf_open(const char *ifname)
 
 /*
  * Build a DHCPDISCOVER or DHCPREQUEST frame into `buf` (≥ 1024
- * bytes). For DISCOVER, requested_ip / server_id are both NULL;
- * for REQUEST, both come from the OFFER we just received. Returns
- * the total Ethernet frame length.
+ * bytes). For DISCOVER, requested_ip / server_id / ciaddr are all
+ * NULL. For a SELECTING-state REQUEST, requested_ip + server_id
+ * come from the OFFER we just received and ciaddr is NULL. For a
+ * RENEWING/REBINDING REQUEST (iter 4), requested_ip + server_id are
+ * NULL but ciaddr is set to the bound address — RFC 2131 §4.3.2
+ * encoding for the post-BOUND renewal request. Returns the total
+ * Ethernet frame length.
  */
 static size_t
 build_dhcp_msg(uint8_t *buf, const uint8_t mac[6], uint32_t xid,
     uint8_t msgtype, const struct in_addr *requested_ip,
-    const struct in_addr *server_id)
+    const struct in_addr *server_id, const struct in_addr *ciaddr)
 {
 	struct ether_header *eh;
 	struct ip *ip;
@@ -277,6 +281,8 @@ build_dhcp_msg(uint8_t *buf, const uint8_t mac[6], uint32_t xid,
 	dh->dp_hlen = 6;
 	dh->dp_xid = htonl(xid);
 	dh->dp_flags = htons(DHCP_FLAG_BROADCAST);
+	if (ciaddr != NULL)
+		dh->dp_ciaddr = *ciaddr;
 	(void)memcpy(dh->dp_chaddr, mac, 6);
 
 	opt = (uint8_t *)dh + sizeof(*dh);
@@ -638,7 +644,7 @@ dhcp_lease_acquire(const char *ifname, struct dhcp_lease *lease_out)
 		if (got_term)
 			goto shutdown;
 		frame_len = build_dhcp_msg(frame, mac, xid,
-		    DHCP_MTYPE_DISCOVER, NULL, NULL);
+		    DHCP_MTYPE_DISCOVER, NULL, NULL, NULL);
 		if (send_dhcp(bpf_fd, frame, frame_len) != 0) {
 			xlog("IPCFG-BOUND-FAIL");
 			(void)close(bpf_fd);
@@ -677,7 +683,7 @@ dhcp_lease_acquire(const char *ifname, struct dhcp_lease *lease_out)
 		if (got_term)
 			goto shutdown;
 		frame_len = build_dhcp_msg(frame, mac, xid,
-		    DHCP_MTYPE_REQUEST, &offer.addr, &offer.server);
+		    DHCP_MTYPE_REQUEST, &offer.addr, &offer.server, NULL);
 		if (send_dhcp(bpf_fd, frame, frame_len) != 0) {
 			xlog("IPCFG-BOUND-FAIL");
 			(void)close(bpf_fd);
@@ -706,6 +712,69 @@ shutdown:
 	xlog("DHCP exchange interrupted by signal (got_term=%d)",
 	    (int)got_term);
 	xlog("IPCFG-BOUND-FAIL");
+	(void)close(bpf_fd);
+	return (-1);
+}
+
+int
+dhcp_renew(const char *ifname, const struct dhcp_lease *existing,
+    struct dhcp_lease *new_lease)
+{
+	uint8_t mac[6];
+	uint8_t frame[1024];
+	uint32_t xid;
+	int bpf_fd, try;
+	size_t frame_len;
+	struct timespec deadline;
+
+	if (get_interface_mac(ifname, mac) != 0)
+		return (-1);
+
+	/* Interface is already up (we have a lease on it) — no
+	 * bring_interface_up call needed. Open a fresh BPF descriptor
+	 * just for this exchange so we don't have to plumb the fd
+	 * across the lease loop. */
+	bpf_fd = bpf_open(ifname);
+	if (bpf_fd < 0) {
+		xlog("renew: bpf_open(%s) failed: %s", ifname,
+		    strerror(errno));
+		return (-1);
+	}
+
+	{
+		struct timespec ts;
+
+		(void)clock_gettime(CLOCK_REALTIME, &ts);
+		xid = (uint32_t)ts.tv_nsec ^ (uint32_t)ts.tv_sec ^
+		    (uint32_t)(mac[5] | (mac[4] << 8));
+	}
+
+	for (try = 0; try < DHCP_MAX_RETRIES; try++) {
+		int r;
+
+		if (got_term)
+			break;
+		frame_len = build_dhcp_msg(frame, mac, xid,
+		    DHCP_MTYPE_REQUEST, NULL, NULL, &existing->addr);
+		if (send_dhcp(bpf_fd, frame, frame_len) != 0) {
+			(void)close(bpf_fd);
+			return (-1);
+		}
+		xlog("renew: sent DHCPREQUEST (xid=0x%08x, try=%d/%d)",
+		    xid, try + 1, DHCP_MAX_RETRIES);
+
+		deadline_in(&deadline, retry_seconds[try]);
+		r = recv_dhcp_reply(bpf_fd, xid, DHCP_MTYPE_ACK,
+		    &deadline, new_lease);
+		if (r == 1) {
+			(void)close(bpf_fd);
+			return (0);
+		}
+		if (r < 0)
+			break;
+	}
+	xlog("renew: no DHCPACK after %d retries (iface=%s xid=0x%08x)",
+	    DHCP_MAX_RETRIES, ifname, xid);
 	(void)close(bpf_fd);
 	return (-1);
 }

--- a/src/IPConfiguration/dhcp_discover.h
+++ b/src/IPConfiguration/dhcp_discover.h
@@ -43,6 +43,23 @@ extern volatile sig_atomic_t got_term;
 int	dhcp_lease_acquire(const char *ifname, struct dhcp_lease *out);
 
 /*
+ * Renew a bound lease — send a DHCPREQUEST in BOUND/RENEWING form
+ * (ciaddr=current addr, no opt 50/54, broadcast flag set so SLIRP
+ * and other simple servers accept it without ARP-resolving the
+ * client first), wait for the DHCPACK, fill *new_lease.
+ *
+ * iter 4 keeps RENEWING and REBINDING on the same broadcast-BPF
+ * path; RFC 2131 §4.3.2 says RENEWING SHOULD unicast but servers
+ * MAY (and most do) accept the broadcast form. Splitting unicast
+ * out is iter 5+ work alongside the threading rework.
+ *
+ * Returns 0 on success, -1 on timeout / shutdown / fatal error.
+ */
+int	dhcp_renew(const char *ifname,
+	    const struct dhcp_lease *existing,
+	    struct dhcp_lease *new_lease);
+
+/*
  * Pick the first non-loopback Ethernet interface (the QEMU guest's
  * em0 in CI). Writes the name into ifname_out (buffer is at least
  * IFNAMSIZ).  Returns 0 on success.

--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -55,6 +55,8 @@
 
 #include "apply_lease.h"
 #include "dhcp_discover.h"
+#include "lease_loop.h"
+#include "sc_publish.h"
 
 #define IPCFG_SERVICE_NAME	"com.apple.IPConfiguration"
 
@@ -185,6 +187,12 @@ main(int argc, char **argv)
 	 * Marker IPCFG-BOUND-OK / IPCFG-BOUND-FAIL — emitted by the
 	 * helpers on their own log lines so the boot-test console
 	 * captures the diagnostic before the marker fires expect.
+	 *
+	 * iter 4: on BOUND, publish State:/Network/Service/<UUID>/IPv4
+	 * (+ optional /DNS) to configd via libSystemConfiguration —
+	 * marker IPCFG-STORE-OK. Then enter the post-BOUND lease loop:
+	 * sleep until T1, RENEWING, on fail sleep to T2, REBINDING.
+	 *
 	 * Failure does NOT exit ipconfigd — the Mach service stays
 	 * registered (iter-1 IPCFG-BOOT still passes), and a future
 	 * iter's retry logic will pick up.
@@ -208,6 +216,8 @@ main(int argc, char **argv)
 					    ifname);
 					xlog("IPCFG-BOUND-FAIL");
 				} else {
+					struct sc_publish *pub;
+
 					(void)inet_ntop(AF_INET,
 					    &lease.addr, a, sizeof(a));
 					(void)inet_ntop(AF_INET,
@@ -222,6 +232,31 @@ main(int argc, char **argv)
 					    ifname, a, m, r, s,
 					    (unsigned)lease.lease_time);
 					xlog("IPCFG-BOUND-OK");
+
+					/*
+					 * Publish to configd. Failure is
+					 * non-fatal: the daemon stays up,
+					 * the lease is already applied at
+					 * the kernel level, but observers
+					 * watching State:/Network/Service/.
+					 * won't see this binding. CI marker
+					 * IPCFG-STORE-FAIL flags it.
+					 */
+					pub = sc_publish_open("ipconfigd");
+					if (pub == NULL) {
+						xlog("IPCFG-STORE-FAIL: "
+						    "no configd session");
+					} else if (sc_publish_ipv4(pub,
+					    ifname, &lease) != 0) {
+						xlog("IPCFG-STORE-FAIL: "
+						    "set State:/.../IPv4");
+					} else {
+						xlog("IPCFG-STORE-OK");
+						(void)lease_loop_run(ifname,
+						    &lease, pub);
+					}
+					if (pub != NULL)
+						sc_publish_close(pub);
 				}
 			}
 			/* failure case: dhcp_lease_acquire already logged

--- a/src/IPConfiguration/lease_loop.c
+++ b/src/IPConfiguration/lease_loop.c
@@ -1,0 +1,122 @@
+/*
+ * lease_loop.c — post-BOUND lease management. RFC 2131 §4.4.5
+ * BOUND/RENEWING/REBINDING state-machine on the daemon's main
+ * thread.
+ *
+ * Sleep is 1s-tick polling on `got_term` so SIGTERM shortens any
+ * wait; the longest contiguous block call is sleep(1).
+ */
+#include "lease_loop.h"
+#include "dhcp_discover.h"
+#include "sc_publish.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+static void
+xlog(const char *fmt, ...)
+{
+	va_list ap;
+
+	(void)fprintf(stderr, "ipconfigd[lease] ");
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+/*
+ * Sleep for `seconds` in 1-second ticks, returning early if
+ * `got_term` is asserted. Returns 0 on full wait, -1 if interrupted.
+ */
+static int
+sleep_interruptible(uint32_t seconds)
+{
+	uint32_t i;
+
+	for (i = 0; i < seconds; i++) {
+		if (got_term)
+			return (-1);
+		(void)sleep(1);
+	}
+	return (got_term ? -1 : 0);
+}
+
+int
+lease_loop_run(const char *ifname, struct dhcp_lease *lease,
+    struct sc_publish *pub)
+{
+	uint32_t lease_secs = lease->lease_time;
+
+	if (lease_secs == 0) {
+		xlog("zero lease time — treating as infinite (no renewal)");
+		while (!got_term)
+			(void)sleep(60);
+		return (0);
+	}
+
+	for (;;) {
+		uint32_t t1, t2_after_t1, expiry_after_t2;
+		struct dhcp_lease renewed;
+
+		/*
+		 * RFC 2131 §4.4.5:
+		 *   T1 = lease/2
+		 *   T2 = 0.875 * lease
+		 * Use integer math: T2 - T1 ≈ lease*3/8. Expiry - T2 ≈ lease/8.
+		 */
+		t1 = lease_secs / 2;
+		t2_after_t1 = (lease_secs * 3) / 8;
+		expiry_after_t2 = lease_secs - (t1 + t2_after_t1);
+
+		xlog("BOUND: lease=%us T1=+%us T2=+%us expiry=+%us",
+		    lease_secs, t1, t1 + t2_after_t1, lease_secs);
+
+		if (sleep_interruptible(t1) < 0)
+			return (0);
+
+		/* RENEWING. */
+		xlog("RENEWING: T1 fired, sending DHCPREQUEST");
+		if (dhcp_renew(ifname, lease, &renewed) == 0) {
+			*lease = renewed;
+			lease_secs = lease->lease_time;
+			if (pub != NULL &&
+			    sc_publish_ipv4(pub, ifname, lease) != 0)
+				xlog("RENEWING: re-publish failed (continuing)");
+			xlog("RENEWING -> BOUND (new lease=%us)", lease_secs);
+			continue;
+		}
+		xlog("RENEWING: no ACK; waiting until T2");
+
+		if (sleep_interruptible(t2_after_t1) < 0)
+			return (0);
+
+		/* REBINDING. */
+		xlog("REBINDING: T2 fired, sending DHCPREQUEST");
+		if (dhcp_renew(ifname, lease, &renewed) == 0) {
+			*lease = renewed;
+			lease_secs = lease->lease_time;
+			if (pub != NULL &&
+			    sc_publish_ipv4(pub, ifname, lease) != 0)
+				xlog("REBINDING: re-publish failed (continuing)");
+			xlog("REBINDING -> BOUND (new lease=%us)", lease_secs);
+			continue;
+		}
+		xlog("REBINDING: no ACK; waiting until lease expiry");
+
+		if (sleep_interruptible(expiry_after_t2) < 0)
+			return (0);
+
+		xlog("lease expired without renewal — unpublishing");
+		if (pub != NULL)
+			(void)sc_publish_remove(pub, ifname);
+		return (-1);
+	}
+}

--- a/src/IPConfiguration/lease_loop.h
+++ b/src/IPConfiguration/lease_loop.h
@@ -1,0 +1,36 @@
+/*
+ * lease_loop.h — post-BOUND lease management for ipconfigd.
+ *
+ * iter 4 owns the BOUND lifecycle:
+ *   BOUND      -> sleep until T1 (lease/2)
+ *   T1 fires   -> RENEWING: dhcp_renew(); on success re-publish + reset
+ *                            timers; on fail, sleep to T2
+ *   T2 fires   -> REBINDING: dhcp_renew() (same broadcast path);
+ *                            on success re-publish + reset; on fail,
+ *                            sleep until lease expiry, then unpublish
+ *                            and exit (caller may restart from INIT)
+ *
+ * Runs on the daemon's main thread — sleeps in 1s ticks so SIGTERM
+ * shortens the wait. iter 5 moves this to a per-interface worker
+ * alongside the MIG receive loop.
+ */
+#ifndef _IPCFG_LEASE_LOOP_H_
+#define _IPCFG_LEASE_LOOP_H_
+
+#include "dhcp_packet.h"
+
+struct sc_publish;
+
+/*
+ * Run the BOUND lease loop for `ifname` until lease expiry or
+ * SIGTERM. `lease` is the freshly-bound lease (updated in-place
+ * on every successful renewal). `pub` is the (optional) configd
+ * publish session — re-publish after each renewal; NULL means no
+ * publishing.
+ *
+ * Returns 0 on clean shutdown (signal), -1 on lease loss.
+ */
+int	lease_loop_run(const char *ifname, struct dhcp_lease *lease,
+	    struct sc_publish *pub);
+
+#endif /* _IPCFG_LEASE_LOOP_H_ */

--- a/src/IPConfiguration/sc_publish.c
+++ b/src/IPConfiguration/sc_publish.c
@@ -1,0 +1,304 @@
+/*
+ * sc_publish.c — SCDynamicStore publish glue for ipconfigd.
+ *
+ * Builds Apple's State:/Network/Service/<UUID>/IPv4 (+ optional /DNS)
+ * CFDictionary and pushes it into configd via libSystemConfiguration.
+ * The <UUID> is a deterministic 8-4-4-4-12-hex string derived from
+ * the interface MAC — stable across daemon restarts even without
+ * SCPreferences persistence, so a watcher's regex match stays put.
+ *
+ * Single CF translation unit on purpose: everything else in the
+ * daemon stays plain-C / plain-Apple-headers.
+ */
+#include "sc_publish.h"
+
+#include <SystemConfiguration/SCDynamicStore.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <errno.h>
+#include <ifaddrs.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct sc_publish {
+	SCDynamicStoreRef	store;
+};
+
+static void
+xlog(const char *fmt, ...)
+{
+	va_list ap;
+
+	(void)fprintf(stderr, "ipconfigd[sc] ");
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+/* CFStringCreateWithCString wrapper — avoids -fconstant-cfstrings. */
+static CFStringRef
+mkstr(const char *s)
+{
+	return (CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8));
+}
+
+static int
+get_mac(const char *ifname, uint8_t mac[6])
+{
+	struct ifaddrs *ifa, *p;
+	int ok = -1;
+
+	if (getifaddrs(&ifa) != 0)
+		return (-1);
+	for (p = ifa; p != NULL; p = p->ifa_next) {
+		const struct sockaddr_dl *dl;
+
+		if (p->ifa_addr == NULL ||
+		    p->ifa_addr->sa_family != AF_LINK)
+			continue;
+		if (strcmp(p->ifa_name, ifname) != 0)
+			continue;
+		dl = (const struct sockaddr_dl *)(const void *)p->ifa_addr;
+		if (dl->sdl_alen != 6)
+			break;
+		(void)memcpy(mac, LLADDR(dl), 6);
+		ok = 0;
+		break;
+	}
+	freeifaddrs(ifa);
+	return (ok);
+}
+
+/*
+ * Format an Apple-shaped UUID string from the interface MAC. Apple's
+ * IPConfiguration draws UUIDs from SCPreferences (a user-configured
+ * SCNetworkService maps to a UUID); we have no prefs persistence yet,
+ * so synthesize one. Format is real 8-4-4-4-12 lowercase hex so
+ * downstream observers that regex-match on UUID keys work unchanged.
+ *
+ *   00000000-0000-0000-AABB-AABBCCDDEEFF
+ *                      ^^^^ ^^^^^^^^^^^^
+ *                      MAC[0..1] MAC[0..5]
+ *
+ * Result is heap-allocated; caller releases with CFRelease.
+ */
+static CFStringRef
+make_service_uuid(const char *ifname)
+{
+	uint8_t mac[6] = { 0, 0, 0, 0, 0, 0 };
+	char buf[40];
+
+	(void)get_mac(ifname, mac);
+	(void)snprintf(buf, sizeof(buf),
+	    "00000000-0000-0000-%02x%02x-%02x%02x%02x%02x%02x%02x",
+	    mac[0], mac[1],
+	    mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+	return (mkstr(buf));
+}
+
+static CFStringRef
+make_key(const char *ifname, const char *suffix)
+{
+	CFStringRef uuid = make_service_uuid(ifname);
+	CFStringRef key;
+
+	key = CFStringCreateWithFormat(NULL, NULL,
+	    CFSTR("State:/Network/Service/%@/%s"), uuid, suffix);
+	CFRelease(uuid);
+	return (key);
+}
+
+struct sc_publish *
+sc_publish_open(const char *session_name)
+{
+	struct sc_publish *p;
+	CFStringRef name;
+
+	p = calloc(1, sizeof(*p));
+	if (p == NULL)
+		return (NULL);
+
+	name = mkstr(session_name);
+	p->store = SCDynamicStoreCreate(NULL, name, NULL, NULL);
+	CFRelease(name);
+	if (p->store == NULL) {
+		xlog("SCDynamicStoreCreate failed: %s",
+		    SCErrorString(SCError()));
+		free(p);
+		return (NULL);
+	}
+	return (p);
+}
+
+static void
+add_addr_string(CFMutableDictionaryRef dict, CFStringRef key,
+    const struct in_addr *a)
+{
+	char buf[INET_ADDRSTRLEN];
+	CFStringRef s;
+
+	if (inet_ntop(AF_INET, a, buf, sizeof(buf)) == NULL)
+		return;
+	s = mkstr(buf);
+	CFDictionarySetValue(dict, key, s);
+	CFRelease(s);
+}
+
+static void
+add_single_addr_array(CFMutableDictionaryRef dict, CFStringRef key,
+    const struct in_addr *a)
+{
+	char buf[INET_ADDRSTRLEN];
+	CFStringRef s;
+	CFArrayRef arr;
+	const void *vals[1];
+
+	if (inet_ntop(AF_INET, a, buf, sizeof(buf)) == NULL)
+		return;
+	s = mkstr(buf);
+	vals[0] = s;
+	arr = CFArrayCreate(NULL, vals, 1, &kCFTypeArrayCallBacks);
+	CFDictionarySetValue(dict, key, arr);
+	CFRelease(arr);
+	CFRelease(s);
+}
+
+int
+sc_publish_ipv4(struct sc_publish *p, const char *ifname,
+    const struct dhcp_lease *lease)
+{
+	CFMutableDictionaryRef dict;
+	CFStringRef key, k_addresses, k_masks, k_router, k_iface, k_server;
+	CFStringRef iface_str;
+	Boolean ok;
+
+	if (p == NULL || p->store == NULL)
+		return (-1);
+
+	dict = CFDictionaryCreateMutable(NULL, 0,
+	    &kCFTypeDictionaryKeyCallBacks,
+	    &kCFTypeDictionaryValueCallBacks);
+	if (dict == NULL)
+		return (-1);
+
+	k_addresses = mkstr("Addresses");
+	k_masks = mkstr("SubnetMasks");
+	k_router = mkstr("Router");
+	k_iface = mkstr("InterfaceName");
+	k_server = mkstr("ServerIdentifier");
+
+	add_single_addr_array(dict, k_addresses, &lease->addr);
+	add_single_addr_array(dict, k_masks, &lease->netmask);
+	add_addr_string(dict, k_router, &lease->router);
+	add_addr_string(dict, k_server, &lease->server);
+
+	iface_str = mkstr(ifname);
+	CFDictionarySetValue(dict, k_iface, iface_str);
+	CFRelease(iface_str);
+
+	CFRelease(k_addresses);
+	CFRelease(k_masks);
+	CFRelease(k_router);
+	CFRelease(k_iface);
+	CFRelease(k_server);
+
+	key = make_key(ifname, "IPv4");
+	ok = SCDynamicStoreSetValue(p->store, key, dict);
+	CFRelease(key);
+	CFRelease(dict);
+
+	if (!ok) {
+		xlog("SCDynamicStoreSetValue(IPv4) failed: %s",
+		    SCErrorString(SCError()));
+		return (-1);
+	}
+
+	/* DNS — optional, only if the lease carried DNS option 6. */
+	if (lease->dns_count > 0) {
+		CFMutableDictionaryRef dns_dict;
+		CFMutableArrayRef dns_arr;
+		CFStringRef k_servers;
+		unsigned i;
+
+		dns_dict = CFDictionaryCreateMutable(NULL, 0,
+		    &kCFTypeDictionaryKeyCallBacks,
+		    &kCFTypeDictionaryValueCallBacks);
+		dns_arr = CFArrayCreateMutable(NULL, 0,
+		    &kCFTypeArrayCallBacks);
+		if (dns_dict == NULL || dns_arr == NULL) {
+			if (dns_dict != NULL)
+				CFRelease(dns_dict);
+			if (dns_arr != NULL)
+				CFRelease(dns_arr);
+			return (0);	/* IPv4 publish succeeded */
+		}
+		for (i = 0; i < lease->dns_count; i++) {
+			char buf[INET_ADDRSTRLEN];
+			CFStringRef s;
+
+			if (inet_ntop(AF_INET, &lease->dns[i], buf,
+			    sizeof(buf)) == NULL)
+				continue;
+			s = mkstr(buf);
+			CFArrayAppendValue(dns_arr, s);
+			CFRelease(s);
+		}
+		k_servers = mkstr("ServerAddresses");
+		CFDictionarySetValue(dns_dict, k_servers, dns_arr);
+		CFRelease(k_servers);
+		CFRelease(dns_arr);
+
+		key = make_key(ifname, "DNS");
+		ok = SCDynamicStoreSetValue(p->store, key, dns_dict);
+		CFRelease(key);
+		CFRelease(dns_dict);
+		if (!ok)
+			xlog("SCDynamicStoreSetValue(DNS) failed: %s",
+			    SCErrorString(SCError()));
+	}
+	return (0);
+}
+
+int
+sc_publish_remove(struct sc_publish *p, const char *ifname)
+{
+	CFStringRef key;
+	Boolean ok = TRUE;
+
+	if (p == NULL || p->store == NULL)
+		return (-1);
+
+	key = make_key(ifname, "IPv4");
+	if (!SCDynamicStoreRemoveValue(p->store, key))
+		ok = FALSE;
+	CFRelease(key);
+
+	key = make_key(ifname, "DNS");
+	(void)SCDynamicStoreRemoveValue(p->store, key);
+	CFRelease(key);
+
+	return (ok ? 0 : -1);
+}
+
+void
+sc_publish_close(struct sc_publish *p)
+{
+	if (p == NULL)
+		return;
+	if (p->store != NULL)
+		CFRelease(p->store);
+	free(p);
+}

--- a/src/IPConfiguration/sc_publish.h
+++ b/src/IPConfiguration/sc_publish.h
@@ -1,0 +1,52 @@
+/*
+ * sc_publish.h — SCDynamicStore publish glue for ipconfigd.
+ *
+ * Wraps an SCDynamicStoreRef so the DHCPv4 state machine can publish
+ * a bound lease under State:/Network/Service/<UUID>/IPv4 — Apple's
+ * canonical key for the IPConfiguration -> SystemConfiguration
+ * handoff. A SystemConfiguration client (SCNetworkService observer,
+ * ipconfig(8), an NSD plugin) sees the same dictionary shape it
+ * expects on macOS: Addresses, SubnetMasks, Router, InterfaceName,
+ * ServerIdentifier. DNS goes under .../DNS as ServerAddresses.
+ *
+ * The handle is opaque so the CoreFoundation / SCDynamicStore.h pull
+ * stays inside sc_publish.c; ipconfigd.c / lease_loop.c only see
+ * plain-C struct dhcp_lease and char *ifname.
+ */
+#ifndef _IPCFG_SC_PUBLISH_H_
+#define _IPCFG_SC_PUBLISH_H_
+
+#include "dhcp_packet.h"
+
+struct sc_publish;
+
+/*
+ * Open a session with configd. session_name is the human-readable
+ * label configd uses to identify this publisher (shows up in its
+ * session table). Returns NULL on failure — the daemon should keep
+ * running (CI marker IPCFG-STORE-OK won't fire, but DHCP still
+ * works at the kernel level via apply_lease).
+ */
+struct sc_publish	*sc_publish_open(const char *session_name);
+
+/*
+ * Publish lease state for `ifname`. Sets two keys:
+ *   State:/Network/Service/<UUID>/IPv4
+ *   State:/Network/Service/<UUID>/DNS   (only if lease has DNS)
+ * The <UUID> is derived deterministically from the interface MAC so
+ * the keys are stable across daemon restarts. Returns 0 on success.
+ */
+int	sc_publish_ipv4(struct sc_publish *p, const char *ifname,
+	    const struct dhcp_lease *lease);
+
+/*
+ * Remove the previously-published keys for `ifname`. Called on
+ * lease loss (REBINDING also fails) so observers see the service
+ * transition to "no v4".
+ */
+int	sc_publish_remove(struct sc_publish *p, const char *ifname);
+
+/* Close the session. Safe to pass NULL. */
+void	sc_publish_close(struct sc_publish *p);
+
+#endif /* _IPCFG_SC_PUBLISH_H_ */

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -712,6 +712,20 @@ expect {
     }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: IPCFG-STORE marker not seen"
+        exit 1
+    }
+    "IPCFG-STORE-FAIL" {
+        puts "\nFAIL: ipconfigd SCDynamicStore publish failed"
+        exit 1
+    }
+    "IPCFG-STORE-OK" {
+        puts "\nOK: ipconfigd published State:/Network/Service/.../IPv4 to configd"
+    }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

Iter 4 — IPConfiguration becomes a real consumer of configd.

- **SCDynamicStore publish** on BOUND: `State:/Network/Service/<UUID>/IPv4` (+ optional `/DNS`) pushed via libSystemConfiguration. UUID is deterministic from MAC so observer regex matches stay stable across daemon restarts. Dictionary shape matches Apple's IPConfiguration (`Addresses`, `SubnetMasks`, `Router`, `InterfaceName`, `ServerIdentifier`; DNS via `ServerAddresses`). New marker **`IPCFG-STORE-OK`**.
- **RFC 2131 §4.4.5 lease loop**: T1 = lease/2, T2 = 0.875·lease. RENEWING/REBINDING send broadcast DHCPREQUEST in the §4.3.2 form (ciaddr set, no opt 50/54). On ACK, re-publish + reset timers; on full expiry, unpublish + exit loop.
- **Code lands**: new `sc_publish.{c,h}` (single CF translation unit) + `lease_loop.{c,h}` (main-thread state machine). `dhcp_discover.c` grew `dhcp_renew()` reusing the BPF path; `build_dhcp_msg()` grew a `ciaddr` parameter.

CI gates only on `IPCFG-STORE-OK`. SLIRP's 86400s lease makes T1 = 12 hours, so renewal isn't exercised end-to-end in CI yet — that needs a lease-time override knob and naturally lands with iter 5's threading rework.

## Test plan

- [ ] CI build (FreeBSD 15.0 amd64) green
- [ ] CI boot test green through `IPCFG-STORE-OK`
- [ ] `IPCFG-BOUND-OK` still fires (no regression)
- [ ] /var/log/ipconfigd.stderr dump shows `lease loop entering wait until T1 (+...)` log line proving the lease loop is armed

🤖 Generated with [Claude Code](https://claude.com/claude-code)