### PR TITLE
feat(IPConfiguration): iter 5a — Mach-RPC surface (ipconfig.defs MIG)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1648,9 +1648,27 @@ echo "==> SYSLOG-CLI-BUILD-OK"
 #     track keeps Apple's Mach IPC + MIG, same as configd/hwregd).
 #
 echo "==> building ipconfigd (src/IPConfiguration)"
+# Phase K iter-5a: generate the ipconfig.defs MIG stubs
+# (_ipconfig_server() demux for ipconfigd, ipconfigUser.c for the
+# ipconfigrpctest client). Same mig.sh + migcom path as the
+# launchd / hwreg.defs MIG steps above.
+IPCFG_MIG="$WORK/ipcfg-mig"
+mkdir -p "$IPCFG_MIG"
+( cd "$IPCFG_MIG" && \
+  MIGCC=/usr/bin/cc MIGCOM="$WORK/rootfs/usr/libexec/migcom" \
+  /bin/sh "$ROOT/src/bootstrap_cmds/migcom.tproj/mig.sh" \
+    -I"$ROOT/src/libmach/include" \
+    -I"$ROOT/src/IPConfiguration" \
+    -header ipconfig.h -user ipconfigUser.c \
+    -server ipconfigServer.c -sheader ipconfigServer.h \
+    "$ROOT/src/IPConfiguration/ipconfig.defs" ) \
+  || { echo "FAIL: mig could not process ipconfig.defs"; exit 1; }
+test -s "$IPCFG_MIG/ipconfigServer.c" \
+    || { echo "FAIL: mig produced no ipconfigServer.c"; exit 1; }
 make -C "$ROOT/src/IPConfiguration" \
     DESTDIR="$WORK/rootfs" \
     SYSROOT="$WORK/rootfs" \
+    MIGOUT="$IPCFG_MIG" \
     all install
 ls -lh "$WORK/rootfs/usr/sbin/ipconfigd"
 test -x "$WORK/rootfs/usr/sbin/ipconfigd" \
@@ -1670,7 +1688,26 @@ cc -I"$ROOT/src/launchd/liblaunch" \
    -llaunch -lsystem_kernel
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/ipconfigtest" \
     || { echo "FAIL: ipconfigtest not built"; exit 1; }
-echo "==> ipconfigd + ipconfigtest built"
+
+# ipconfigrpctest — iter 5a RPC liveness probe. Links the
+# MIG-generated ipconfigUser.c (client stubs for ipconfig_if_count
+# / ipconfig_if_addr). run.sh runs it after IPCFG-STORE-OK; the
+# IPCFG-RPC-OK marker gates in tests/boot-test.sh.
+echo "==> building ipconfigrpctest"
+cc -I"$IPCFG_MIG" -I"$ROOT/src/IPConfiguration" \
+   -I"$ROOT/src/launchd/liblaunch" \
+   -I"$ROOT/src/launchd/freebsd-shims" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wno-macro-redefined \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/ipconfigrpctest" \
+   "$ROOT/src/IPConfiguration/ipconfigrpctest.c" \
+   "$IPCFG_MIG/ipconfigUser.c" \
+   -llaunch -lsystem_kernel
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/ipconfigrpctest" \
+    || { echo "FAIL: ipconfigrpctest not built"; exit 1; }
+echo "==> ipconfigd + ipconfigtest + ipconfigrpctest built"
 
 #
 # 3z. purge build packages + clean pkg cache + tear down chroot.

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -764,4 +764,17 @@ if [ -f /var/log/ipconfigd.stderr ]; then
     echo "--- end bound-state dump ---"
 fi
 
+# IPCFG-RPC — iter-5a Mach-RPC round-trip: ipconfigrpctest does
+# bootstrap_look_up for com.apple.IPConfiguration, calls
+# ipconfig_if_count (expects >= 1 after BOUND) + ipconfig_if_addr
+# ("em0") (expects 10.0.2.15 from SLIRP), prints IPCFG-RPC-OK on
+# success. Runs AFTER the BOUND/STORE markers so the worker has
+# already populated bound_state.
+ipconfigrpctest=/usr/tests/freebsd-launchd-mach/ipconfigrpctest
+if [ ! -x "$ipconfigrpctest" ]; then
+    echo "IPCFG-RPC-FAIL: $ipconfigrpctest missing"
+else
+    "$ipconfigrpctest" || true	# marker gates in boot-test.sh
+fi
+
 exit 0

--- a/src/IPConfiguration/Makefile
+++ b/src/IPConfiguration/Makefile
@@ -16,6 +16,25 @@ PROG=		ipconfigd
 MAN=
 SRCS=		ipconfigd.c dhcp_discover.c apply_lease.c
 SRCS+=		sc_publish.c lease_loop.c
+SRCS+=		bound_state.c mach_service.c ipconfigd_mig.c
+
+# ipconfigServer.c — MIG-generated server stub for ipconfig.defs
+# (iter 5a's two read-only routines). build.sh runs mig and passes
+# MIGOUT=; a bare standalone build without it fails at the generated
+# #include "ipconfigServer.h", the same way liblaunch / hwregd do.
+# -w on the generated TU: MIG output is not WARNS-clean and must
+# not gate the build. -Wno-macro-redefined: the MIG stubs pull
+# <mach/notify.h>, which redefines the MACH_NOTIFY_* macros
+# <mach/message.h> also defines (identical values, whitespace
+# differs) — same benign clash hwregd / configd document.
+MIGOUT?=
+.if !empty(MIGOUT)
+.PATH:				${MIGOUT}
+SRCS+=				ipconfigServer.c
+CFLAGS+=			-I${MIGOUT}
+CFLAGS.ipconfigServer.c+=	-w
+CFLAGS+=			-Wno-macro-redefined
+.endif
 
 # WARNS=0: sc_publish.c pulls the CoreFoundation public header tree
 # (CFRuntime.h, CFBundle.h, CFLocking.h ...). At WARNS>0 the FreeBSD

--- a/src/IPConfiguration/Makefile
+++ b/src/IPConfiguration/Makefile
@@ -32,6 +32,7 @@ MIGOUT?=
 .PATH:				${MIGOUT}
 SRCS+=				ipconfigServer.c
 CFLAGS+=			-I${MIGOUT}
+CFLAGS+=			-I${.CURDIR}	# generated stubs #include "ipconfig_mig_types.h"
 CFLAGS.ipconfigServer.c+=	-w
 CFLAGS+=			-Wno-macro-redefined
 .endif

--- a/src/IPConfiguration/bound_state.c
+++ b/src/IPConfiguration/bound_state.c
@@ -1,0 +1,81 @@
+/*
+ * bound_state.c — single global, mutex-guarded.
+ *
+ * iter 5a tracks one binding (em0 in CI). iter 5b widens to a small
+ * array of per-interface entries when the threading rework lands.
+ */
+#include "bound_state.h"
+
+#include <pthread.h>
+#include <string.h>
+
+struct {
+	pthread_mutex_t		lock;
+	bool			bound;
+	char			ifname[IF_NAMESIZE];
+	struct dhcp_lease	lease;
+} g_bound = { PTHREAD_MUTEX_INITIALIZER, false, "", { {0}, {0}, {0}, {0}, 0, {{0}}, 0 } };
+
+void
+bound_state_init(void)
+{
+	/* Static initializer above suffices; the function exists so
+	 * main() has a clear init-time hook for iter 5b's table init. */
+}
+
+void
+bound_state_set(const char *ifname, const struct dhcp_lease *lease)
+{
+	(void)pthread_mutex_lock(&g_bound.lock);
+	if (ifname == NULL || lease == NULL) {
+		g_bound.bound = false;
+		g_bound.ifname[0] = '\0';
+		(void)memset(&g_bound.lease, 0, sizeof(g_bound.lease));
+	} else {
+		g_bound.bound = true;
+		(void)strlcpy(g_bound.ifname, ifname,
+		    sizeof(g_bound.ifname));
+		g_bound.lease = *lease;
+	}
+	(void)pthread_mutex_unlock(&g_bound.lock);
+}
+
+bool
+bound_state_any(char *name_out, size_t name_out_sz)
+{
+	bool any;
+
+	(void)pthread_mutex_lock(&g_bound.lock);
+	any = g_bound.bound;
+	if (any && name_out != NULL && name_out_sz > 0)
+		(void)strlcpy(name_out, g_bound.ifname, name_out_sz);
+	(void)pthread_mutex_unlock(&g_bound.lock);
+	return (any);
+}
+
+int
+bound_state_count(void)
+{
+	int n;
+
+	(void)pthread_mutex_lock(&g_bound.lock);
+	n = g_bound.bound ? 1 : 0;
+	(void)pthread_mutex_unlock(&g_bound.lock);
+	return (n);
+}
+
+bool
+bound_state_get_addr(const char *ifname, uint32_t *addr_out)
+{
+	bool hit = false;
+
+	if (ifname == NULL || addr_out == NULL)
+		return (false);
+	(void)pthread_mutex_lock(&g_bound.lock);
+	if (g_bound.bound && strcmp(ifname, g_bound.ifname) == 0) {
+		*addr_out = g_bound.lease.addr.s_addr;
+		hit = true;
+	}
+	(void)pthread_mutex_unlock(&g_bound.lock);
+	return (hit);
+}

--- a/src/IPConfiguration/bound_state.h
+++ b/src/IPConfiguration/bound_state.h
@@ -1,0 +1,45 @@
+/*
+ * bound_state.h — thread-safe holder for ipconfigd's current
+ * DHCPv4 BOUND lease.
+ *
+ * The main thread runs the DHCP exchange and writes the lease here
+ * on a successful BOUND. The Mach service thread reads from here
+ * when servicing RPCs (ipconfig_if_count / ipconfig_if_addr). A
+ * single pthread_mutex guards the storage — the access pattern is
+ * one writer + a low rate of readers, so mutex overhead is fine
+ * for iter 5a. iter 5b (per-interface workers) generalizes to one
+ * bound_state per interface; for now a single global suffices
+ * because ipconfigd only ever DHCPs em0.
+ */
+#ifndef _IPCFG_BOUND_STATE_H_
+#define _IPCFG_BOUND_STATE_H_
+
+#include <net/if.h>		/* IF_NAMESIZE */
+#include <stdbool.h>
+
+#include "dhcp_packet.h"
+
+/* Initialize the global storage. Safe to call before any writer. */
+void	bound_state_init(void);
+
+/* Mark `ifname` BOUND with `lease`. NULL ifname clears the binding. */
+void	bound_state_set(const char *ifname, const struct dhcp_lease *lease);
+
+/*
+ * Snapshot whether *any* interface is bound, and (if so) the ifname.
+ * `name_out` is filled iff the return is true; `name_out_sz` must
+ * be at least IF_NAMESIZE.
+ */
+bool	bound_state_any(char *name_out, size_t name_out_sz);
+
+/* Number of currently-bound interfaces (0 or 1 in iter 5a). */
+int	bound_state_count(void);
+
+/*
+ * Look up `ifname`'s bound IPv4 address. On hit returns true and
+ * writes the address into *addr_out (network byte order, packed as
+ * uint32_t — what ip_address_t carries on the MIG wire).
+ */
+bool	bound_state_get_addr(const char *ifname, uint32_t *addr_out);
+
+#endif /* _IPCFG_BOUND_STATE_H_ */

--- a/src/IPConfiguration/ipconfig.defs
+++ b/src/IPConfiguration/ipconfig.defs
@@ -1,0 +1,66 @@
+/*
+ * ipconfig.defs — Mach-RPC interface to ipconfigd.
+ *
+ * freebsd-launchd-mach port. Slimmed from Apple's
+ * bootp/bootplib/ipconfig.defs (~21 routines): iter 5a vendors the
+ * two read-only routines that prove the wire — ipconfig_if_count
+ * (scalar out) and ipconfig_if_addr (string in + ip_address out).
+ * Routine ORDER and msgh_id values (subsystem base 20000) match
+ * Apple so a later iter can grow the surface back to full ABI by
+ * appending — never reordering.
+ *
+ * Changes from Apple's defs:
+ *   - the `ServerAuditToken audit_token : audit_token_t` decorator
+ *     is dropped — no BSM identity in this port (configd / hwregd
+ *     drop it the same way).
+ *   - 18 routines that have no real consumer yet are omitted
+ *     entirely (iter 5b/6+ adds them when a client materializes —
+ *     iter 5a is the demux + worker-thread plumbing, not full ABI).
+ *   - xmlData / xmlDataOut / dataOut would be `^ array []` (OOL) on
+ *     Apple — broken in this port's kernel (the configd / hwreg.defs
+ *     ports document the same issue) — but the two iter-5a routines
+ *     don't use OOL data, so the question doesn't arise here.
+ *
+ * The server demux _ipconfig_server() runs inside ipconfigd's
+ * mach_service_thread receive loop. Per-routine implementations are
+ * in ipconfigd_mig.c.
+ *
+ * Apple's ipconfig.defs uses `subsystem ipconfig 20000;` — the same
+ * subsystem base as configd's `subsystem config 20000;`. The two
+ * never share a port set, so the id collision is harmless; keeping
+ * Apple's id makes msgh_id values match a real macOS dtrace.
+ */
+
+#include <mach/std_types.defs>
+#include <mach/mach_types.defs>
+
+subsystem ipconfig 20000;
+serverprefix _;
+
+import "ipconfig_mig_types.h";
+
+/* The Apple-original named types we need for the iter-5a routines. */
+type ip_address		= MACH_MSG_TYPE_INTEGER_32 ctype: ip_address_t;
+type ipconfig_status	= MACH_MSG_TYPE_INTEGER_32 ctype: ipconfig_status_t;
+type if_name		= array[16] of char ctype: InterfaceName;
+
+/*
+ * ipconfig_if_count — how many interfaces ipconfigd is currently
+ * tracking. iter 5a: returns 1 once BOUND on em0; 0 before.
+ */
+routine ipconfig_if_count(
+	server		: mach_port_t;
+	out count	: int
+);
+
+/*
+ * ipconfig_if_addr — the bound IPv4 address for `name` (network
+ * byte order, packed as a uint32_t). status = success_e if `name`
+ * is BOUND, no_server_e otherwise.
+ */
+routine ipconfig_if_addr(
+	server		: mach_port_t;
+	name		: if_name;
+	out addr	: ip_address;
+	out status	: ipconfig_status
+);

--- a/src/IPConfiguration/ipconfig_mig_types.h
+++ b/src/IPConfiguration/ipconfig_mig_types.h
@@ -1,0 +1,62 @@
+/*
+ * ipconfig_mig_types.h — C typedefs for the named MIG types in
+ * ipconfig.defs.
+ *
+ * MIG records the wire layout of a `type` declaration but does not
+ * emit a C typedef for it: the generated stubs use the type name
+ * as-is and expect an imported header to define it. ipconfig.defs
+ * imports this header so both the generated server (ipconfigServer
+ * .{c,h}) and user (ipconfigUser.c / ipconfig.h) sides agree.
+ *
+ * Slimmed from Apple's bootp/bootplib/ipconfig_types.h: only the
+ * names ipconfig.defs references. Apple's header pulls cfutil.h +
+ * util.h + a wall of SystemConfiguration #defines we don't need
+ * yet — vendor those when a routine that actually uses them lands.
+ */
+#ifndef _IPCONFIG_MIG_TYPES_H
+#define _IPCONFIG_MIG_TYPES_H
+
+#include <stdint.h>
+#include <net/if.h>		/* IF_NAMESIZE */
+
+/* Matches Apple's ipconfig_types.h:
+ *   typedef char InterfaceName[IF_NAMESIZE];
+ * MIG renders if_name = array[16] of char as `char if_name[16]` —
+ * with `ctype: InterfaceName`, the generated stubs use the typedef. */
+typedef char	InterfaceName[IF_NAMESIZE];
+
+typedef uint32_t	ip_address_t;
+
+/*
+ * Apple's enum is a 21-value status code (success / permission-denied /
+ * interface-does-not-exist / ...). iter 5a uses three of them;
+ * preserve the numeric values + names so a later iter can append
+ * without breaking wire compat. The enum is copied from
+ * bootp/bootplib/ipconfig_types.h.
+ */
+typedef enum {
+	ipconfig_status_success_e			= 0,
+	ipconfig_status_permission_denied_e		= 1,
+	ipconfig_status_interface_does_not_exist_e	= 2,
+	ipconfig_status_invalid_parameter_e		= 3,
+	ipconfig_status_invalid_operation_e		= 4,
+	ipconfig_status_allocation_failed_e		= 5,
+	ipconfig_status_internal_error_e		= 6,
+	ipconfig_status_operation_not_supported_e	= 7,
+	ipconfig_status_address_in_use_e		= 8,
+	ipconfig_status_no_server_e			= 9,
+	ipconfig_status_server_not_responding_e		= 10,
+	ipconfig_status_lease_terminated_e		= 11,
+	ipconfig_status_media_inactive_e		= 12,
+	ipconfig_status_server_error_e			= 13,
+	ipconfig_status_no_such_service_e		= 14,
+	ipconfig_status_duplicate_service_e		= 15,
+	ipconfig_status_address_timed_out_e		= 16,
+	ipconfig_status_not_found_e			= 17,
+	ipconfig_status_resource_unavailable_e		= 18,
+	ipconfig_status_network_changed_e		= 19,
+	ipconfig_status_lease_expired_e			= 20,
+	ipconfig_status_dhcp_waiting_e			= 21
+} ipconfig_status_t;
+
+#endif /* _IPCONFIG_MIG_TYPES_H */

--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -19,18 +19,22 @@
  *
  * iter 2 — one-shot DHCPv4 DISCOVER/OFFER probe (dhcp_discover.c).
  *
- * iter 3 — full RFC 2131 INIT → BOUND. dhcp_discover.c now runs
- * the SELECTING → REQUESTING → BOUND state machine with the
- * standard 4/8/16s retransmit ladder + ±1s jitter, returning a
- * struct dhcp_lease. apply_lease.c then installs it: SIOCAIFADDR
- * for the address+netmask+broadcast, PF_ROUTE RTM_ADD for the
- * default route via the offered router, and a best-effort
- * /etc/resolv.conf write. Long BPF reads are signal-aware via the
- * shared `got_term` flag — a SIGTERM/SIGHUP during the wait
- * short-circuits the loop instead of holding the daemon for the
- * full ladder. Marker IPCFG-BOUND-OK on success, IPCFG-BOUND-FAIL
- * on any failure path. Lease renewal / SCDynamicStore publish is
- * iter 4+.
+ * iter 3 — full RFC 2131 INIT → BOUND. dhcp_discover.c runs the
+ * SELECTING → REQUESTING → BOUND state machine; apply_lease.c then
+ * installs the result (SIOCAIFADDR, default route, /etc/resolv.conf).
+ *
+ * iter 4 — SCDynamicStore publish on BOUND + RFC 2131 §4.4.5
+ * RENEWING/REBINDING lease loop. sc_publish.c builds the
+ * State:/Network/Service/<UUID>/IPv4 dictionary; lease_loop.c
+ * sleeps until T1, sends a broadcast RENEWING REQUEST, etc.
+ *
+ * iter 5a — raw mach_msg MIG demux + worker thread.
+ * mach_service.c spawns a pthread that bootstrap_check_in's the
+ * service port and runs _ipconfig_server() (MIG demux for
+ * ipconfig.defs) on each request. The worker reads live state via
+ * bound_state.{c,h}; the main thread (DHCP + lease loop) writes it
+ * on BOUND. iter 5a vendors 2 read-only routines (if_count,
+ * if_addr); the full ipconfig.defs surface grows in iter 6+.
  */
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -39,9 +43,6 @@
 #include <net/if_dl.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>		/* inet_ntop for the BOUND log line */
-
-#include <mach/mach.h>
-#include <servers/bootstrap.h>
 
 #include <errno.h>
 #include <ifaddrs.h>
@@ -54,11 +55,11 @@
 #include <unistd.h>
 
 #include "apply_lease.h"
+#include "bound_state.h"
 #include "dhcp_discover.h"
 #include "lease_loop.h"
+#include "mach_service.h"
 #include "sc_publish.h"
-
-#define IPCFG_SERVICE_NAME	"com.apple.IPConfiguration"
 
 /*
  * Global (non-static): dhcp_discover.c's recv loop polls this
@@ -134,13 +135,11 @@ int
 main(int argc, char **argv)
 {
 	struct sigaction sa;
-	mach_port_t service = MACH_PORT_NULL;
-	kern_return_t kr;
 
 	(void)argc;
 	(void)argv;
 
-	xlog("ipconfigd starting (iter 1 skeleton — no DHCP yet)");
+	xlog("ipconfigd starting (iter 5a — MIG service + DHCPv4)");
 
 	/*
 	 * sa_flags = 0 — system calls are NOT auto-restarted on
@@ -161,23 +160,19 @@ main(int argc, char **argv)
 	}
 
 	/*
-	 * launchd handed us the receive right for the
-	 * com.apple.IPConfiguration MachServices entry via the
-	 * bootstrap port. bootstrap_check_in claims it. Without
-	 * RunAtLoad-then-check-in the service would not be reachable
-	 * from clients.
+	 * iter 5a: the Mach service thread now owns the receive right
+	 * for com.apple.IPConfiguration (bootstrap_check_in lives in
+	 * mach_service.c). It is spawned up-front so the service is
+	 * reachable while DHCP is still in flight — RPC routines
+	 * return ipconfig_status_no_server_e until the BOUND lease
+	 * lands in bound_state. iter-1 IPCFG-BOOT (ipconfigtest's
+	 * bootstrap_look_up) is now answered by launchd's broker, not
+	 * a direct send to our checked-in port; the Mach plumbing is
+	 * identical from the client side.
 	 */
-	kr = bootstrap_check_in(bootstrap_port, IPCFG_SERVICE_NAME,
-	    &service);
-	if (kr != KERN_SUCCESS) {
-		xlog("bootstrap_check_in('%s') failed: 0x%x — "
-		    "ipconfigtest will not see the service",
-		    IPCFG_SERVICE_NAME, (unsigned)kr);
-		/* don't exit; let launchd respawn surface the issue */
-	} else {
-		xlog("bootstrap_check_in('%s') ok: service port=0x%x",
-		    IPCFG_SERVICE_NAME, (unsigned)service);
-	}
+	bound_state_init();
+	if (mach_service_start() != 0)
+		xlog("mach_service_start failed; RPC off");
 
 	/*
 	 * iter 3: full DHCPv4 INIT → BOUND on the first non-loopback
@@ -231,6 +226,15 @@ main(int argc, char **argv)
 					    "server=%s lease=%us",
 					    ifname, a, m, r, s,
 					    (unsigned)lease.lease_time);
+					/*
+					 * Make the lease visible to the
+					 * Mach service worker before the
+					 * BOUND marker fires — so any
+					 * client racing IPCFG-RPC-OK
+					 * against IPCFG-BOUND-OK sees the
+					 * address it expects.
+					 */
+					bound_state_set(ifname, &lease);
 					xlog("IPCFG-BOUND-OK");
 
 					/*
@@ -274,5 +278,6 @@ main(int argc, char **argv)
 	}
 
 	xlog("ipconfigd exiting on signal %d", (int)got_term);
+	mach_service_join();
 	return (0);
 }

--- a/src/IPConfiguration/ipconfigd_mig.c
+++ b/src/IPConfiguration/ipconfigd_mig.c
@@ -1,0 +1,62 @@
+/*
+ * ipconfigd_mig.c — server-side bodies for ipconfig.defs.
+ *
+ * The MIG-generated demux _ipconfig_server() (in ipconfigServer.c)
+ * calls these per routine. Both iter-5a routines are read-only and
+ * pull live data from bound_state.{c,h}.
+ *
+ * Apple's per-routine bodies live inline in IPConfiguration.bproj/
+ * ipconfigd.c (10k+ LOC of plugin shell); we keep ours in a small
+ * dedicated TU so the daemon main and the lease-loop stay clean.
+ */
+
+#include "bound_state.h"
+#include "ipconfig_mig_types.h"
+
+#include <mach/mach.h>
+#include "ipconfigServer.h"		/* MIG-emitted prototypes */
+
+#include <string.h>
+
+/*
+ * iter 5a: scalar out, no input. Returns 0 or 1 depending on
+ * whether ipconfigd has any interface BOUND.
+ */
+kern_return_t
+_ipconfig_if_count(mach_port_t server, int *count)
+{
+	(void)server;
+	*count = bound_state_count();
+	return (KERN_SUCCESS);
+}
+
+/*
+ * iter 5a: input if_name + scalar out + status. Returns the BOUND
+ * IPv4 address as a network-order packed uint32 (matches Apple's
+ * ip_address_t wire encoding). Unknown / unbound interfaces return
+ * ipconfig_status_no_server_e.
+ *
+ * MIG passes `name` as an array[16] of char — may not be NUL
+ * terminated if the client filled all 16 bytes. Force a NUL at the
+ * last slot before strcmp.
+ */
+kern_return_t
+_ipconfig_if_addr(mach_port_t server, InterfaceName name,
+    ip_address_t *addr, ipconfig_status_t *status)
+{
+	char ifname[IF_NAMESIZE];
+	uint32_t a = 0;
+
+	(void)server;
+	(void)memset(ifname, 0, sizeof(ifname));
+	(void)memcpy(ifname, name, sizeof(ifname) - 1);
+
+	if (bound_state_get_addr(ifname, &a)) {
+		*addr = a;
+		*status = ipconfig_status_success_e;
+	} else {
+		*addr = 0;
+		*status = ipconfig_status_no_server_e;
+	}
+	return (KERN_SUCCESS);
+}

--- a/src/IPConfiguration/ipconfigrpctest.c
+++ b/src/IPConfiguration/ipconfigrpctest.c
@@ -1,0 +1,76 @@
+/*
+ * ipconfigrpctest — iter 5a RPC liveness probe for ipconfigd.
+ *
+ * bootstrap_look_up the service, call ipconfig_if_count (expects
+ * 1 after BOUND), call ipconfig_if_addr("em0") (expects the
+ * SLIRP-assigned address, typically 10.0.2.15). Prints
+ * IPCFG-RPC-OK on success; the marker gates in tests/boot-test.sh.
+ *
+ * Build (build.sh): cc + the MIG-generated ipconfigUser.c.
+ */
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include "ipconfig_mig_types.h"
+#include "ipconfig.h"		/* MIG: ipconfig_* client stubs */
+
+#include <stdio.h>
+#include <string.h>
+
+int
+main(void)
+{
+	mach_port_t svc = MACH_PORT_NULL;
+	kern_return_t kr;
+	int count = -1;
+	InterfaceName name;
+	ip_address_t addr = 0;
+	ipconfig_status_t status = ipconfig_status_internal_error_e;
+	char abuf[INET_ADDRSTRLEN];
+	struct in_addr in_a;
+
+	kr = bootstrap_look_up(bootstrap_port,
+	    "com.apple.IPConfiguration", &svc);
+	if (kr != KERN_SUCCESS || svc == MACH_PORT_NULL) {
+		printf("IPCFG-RPC-FAIL: bootstrap_look_up: 0x%x\n",
+		    (unsigned)kr);
+		return (1);
+	}
+
+	kr = ipconfig_if_count(svc, &count);
+	if (kr != KERN_SUCCESS) {
+		printf("IPCFG-RPC-FAIL: ipconfig_if_count returned 0x%x\n",
+		    (unsigned)kr);
+		return (1);
+	}
+	printf("  ipconfig_if_count -> %d\n", count);
+	if (count < 1) {
+		printf("IPCFG-RPC-FAIL: ipconfig_if_count returned %d "
+		    "(expected >= 1)\n", count);
+		return (1);
+	}
+
+	(void)memset(name, 0, sizeof(name));
+	(void)strlcpy(name, "em0", sizeof(name));
+	kr = ipconfig_if_addr(svc, name, &addr, &status);
+	if (kr != KERN_SUCCESS) {
+		printf("IPCFG-RPC-FAIL: ipconfig_if_addr returned 0x%x\n",
+		    (unsigned)kr);
+		return (1);
+	}
+	if (status != ipconfig_status_success_e) {
+		printf("IPCFG-RPC-FAIL: ipconfig_if_addr status=%d\n",
+		    (int)status);
+		return (1);
+	}
+	in_a.s_addr = addr;
+	if (inet_ntop(AF_INET, &in_a, abuf, sizeof(abuf)) == NULL)
+		(void)strlcpy(abuf, "?", sizeof(abuf));
+	printf("  ipconfig_if_addr(em0) -> %s\n", abuf);
+
+	printf("IPCFG-RPC-OK: ipconfig_if_count=%d em0=%s\n", count, abuf);
+	return (0);
+}

--- a/src/IPConfiguration/mach_service.c
+++ b/src/IPConfiguration/mach_service.c
@@ -1,0 +1,125 @@
+/*
+ * mach_service.c — ipconfigd's Mach service thread.
+ *
+ * Owns the receive right for com.apple.IPConfiguration. Runs a raw
+ * mach_msg(MACH_RCV_MSG | MACH_RCV_TIMEOUT, 500ms) loop and hands
+ * each message to _ipconfig_server() (the MIG demux for
+ * ipconfig.defs). Same shape as configd_serve() / hwregd's
+ * mach_service_thread().
+ *
+ * 500ms receive timeout: keeps the loop awake to notice got_term
+ * for a clean shutdown.
+ */
+#include "mach_service.h"
+#include "dhcp_discover.h"		/* got_term */
+#include "ipconfigServer.h"		/* MIG: _ipconfig_server() */
+
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+/* RPC receive buffer size — Apple's ipconfig.defs has no OOL data
+ * in iter 5a (just scalars + a 16-byte if_name), so a 4 KiB buffer
+ * is generous. iter 5b/6's xmlDataOut routines may need 8 KiB+. */
+#define IPCFG_RPC_BUFSZ		4096
+
+#define IPCFG_SERVICE_NAME	"com.apple.IPConfiguration"
+
+static pthread_t	worker;
+static int		worker_running;
+
+static void
+xlog(const char *fmt, ...)
+{
+	va_list ap;
+
+	(void)fprintf(stderr, "ipconfigd[mach] ");
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+static void *
+mach_service_thread(void *arg)
+{
+	mach_port_t sp = MACH_PORT_NULL;
+	kern_return_t kr;
+
+	(void)arg;
+
+	kr = bootstrap_check_in(bootstrap_port, IPCFG_SERVICE_NAME, &sp);
+	if (kr != KERN_SUCCESS) {
+		xlog("bootstrap_check_in('%s') failed: 0x%x — RPC off",
+		    IPCFG_SERVICE_NAME, (unsigned)kr);
+		return (NULL);
+	}
+	xlog("Mach service '%s' checked in (port=0x%x)",
+	    IPCFG_SERVICE_NAME, (unsigned)sp);
+
+	while (!got_term) {
+		union {
+			mach_msg_header_t	hdr;
+			char			buf[IPCFG_RPC_BUFSZ];
+		} req, rep;
+		mach_msg_return_t mr;
+
+		(void)memset(&req, 0, sizeof(req));
+		mr = mach_msg(&req.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT,
+		    0, sizeof(req), sp, 500, MACH_PORT_NULL);
+		if (mr == MACH_RCV_TIMED_OUT)
+			continue;
+		if (mr != MACH_MSG_SUCCESS) {
+			xlog("receive failed: 0x%x — service off",
+			    (unsigned)mr);
+			break;
+		}
+
+		(void)memset(&rep, 0, sizeof(rep));
+		if (!_ipconfig_server(&req.hdr, &rep.hdr)) {
+			xlog("ignoring message id=%d", req.hdr.msgh_id);
+			continue;
+		}
+		if (rep.hdr.msgh_remote_port != MACH_PORT_NULL) {
+			mr = mach_msg(&rep.hdr,
+			    MACH_SEND_MSG | MACH_SEND_TIMEOUT,
+			    rep.hdr.msgh_size, 0, MACH_PORT_NULL, 200,
+			    MACH_PORT_NULL);
+			if (mr != MACH_MSG_SUCCESS)
+				xlog("reply send failed: 0x%x",
+				    (unsigned)mr);
+		}
+	}
+	return (NULL);
+}
+
+int
+mach_service_start(void)
+{
+	int rc;
+
+	if (worker_running)
+		return (0);
+	rc = pthread_create(&worker, NULL, mach_service_thread, NULL);
+	if (rc != 0) {
+		xlog("pthread_create failed: %s", strerror(rc));
+		return (-1);
+	}
+	worker_running = 1;
+	return (0);
+}
+
+void
+mach_service_join(void)
+{
+	if (!worker_running)
+		return;
+	(void)pthread_join(worker, NULL);
+	worker_running = 0;
+}

--- a/src/IPConfiguration/mach_service.c
+++ b/src/IPConfiguration/mach_service.c
@@ -3,7 +3,7 @@
  *
  * Owns the receive right for com.apple.IPConfiguration. Runs a raw
  * mach_msg(MACH_RCV_MSG | MACH_RCV_TIMEOUT, 500ms) loop and hands
- * each message to _ipconfig_server() (the MIG demux for
+ * each message to ipconfig_server() (the MIG demux for
  * ipconfig.defs). Same shape as configd_serve() / hwregd's
  * mach_service_thread().
  *
@@ -12,7 +12,7 @@
  */
 #include "mach_service.h"
 #include "dhcp_discover.h"		/* got_term */
-#include "ipconfigServer.h"		/* MIG: _ipconfig_server() */
+#include "ipconfigServer.h"		/* MIG: ipconfig_server() */
 
 #include <mach/mach.h>
 #include <servers/bootstrap.h>
@@ -82,7 +82,7 @@ mach_service_thread(void *arg)
 		}
 
 		(void)memset(&rep, 0, sizeof(rep));
-		if (!_ipconfig_server(&req.hdr, &rep.hdr)) {
+		if (!ipconfig_server(&req.hdr, &rep.hdr)) {
 			xlog("ignoring message id=%d", req.hdr.msgh_id);
 			continue;
 		}

--- a/src/IPConfiguration/mach_service.h
+++ b/src/IPConfiguration/mach_service.h
@@ -1,0 +1,32 @@
+/*
+ * mach_service.h — ipconfigd's Mach service thread.
+ *
+ * Owns the receive side of com.apple.IPConfiguration: spawns a
+ * worker pthread that bootstrap_check_in's the service port, then
+ * runs a raw mach_msg(MACH_RCV_MSG ...) demux loop calling
+ * _ipconfig_server() (the MIG-generated demux for ipconfig.defs)
+ * on each request. Configd / hwregd use the same pattern.
+ *
+ * The worker is started up-front so the service is reachable
+ * before DHCP completes; routine bodies (in ipconfigd_mig.c)
+ * consult bound_state.{c,h} for live lease data and return
+ * ipconfig_status_no_server_e until a BOUND lease lands.
+ *
+ * iter 5b moves per-interface DHCP onto worker threads alongside
+ * this one.
+ */
+#ifndef _IPCFG_MACH_SERVICE_H_
+#define _IPCFG_MACH_SERVICE_H_
+
+/*
+ * Start the Mach service thread. The thread bootstrap_check_in's
+ * the service port itself (so the main thread doesn't have to
+ * juggle the receive right) and runs until got_term is set. Safe
+ * to call once at daemon startup. Returns 0 on success.
+ */
+int	mach_service_start(void);
+
+/* Best-effort: wait for the worker to exit (used at shutdown). */
+void	mach_service_join(void);
+
+#endif /* _IPCFG_MACH_SERVICE_H_ */

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -726,6 +726,20 @@ expect {
     }
 }
 
+expect {
+    timeout {
+        puts "\nFAIL: IPCFG-RPC marker not seen"
+        exit 1
+    }
+    "IPCFG-RPC-FAIL" {
+        puts "\nFAIL: ipconfigd MIG RPC (ipconfig_if_count / if_addr) failed"
+        exit 1
+    }
+    "IPCFG-RPC-OK" {
+        puts "\nOK: ipconfigd MIG RPC works (ipconfig_if_count + ipconfig_if_addr returned the BOUND lease)"
+    }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

Iter 5a — ipconfigd's first MIG-defined RPC surface.

- **Worker thread** owns the service receive right + the `mach_msg` demux loop calling `_ipconfig_server()`. Main thread keeps doing DHCP + the lease loop.
- **bound_state.{c,h}** — mutex-guarded current-lease holder. Writers (DHCP) and readers (RPC routines) coordinate through this.
- **Slim 2-routine wire**: `ipconfig_if_count` + `ipconfig_if_addr`. msgh_id/order matches Apple's `bootp/bootplib/ipconfig.defs` so iter 6+ grows the surface by appending. ServerAuditToken decorators dropped (no BSM in this port).
- **ipconfigrpctest** exercises both routines via the mig-generated `ipconfigUser.c`. Marker `IPCFG-RPC-OK` gates in boot-test.sh.
- **build.sh** runs mig into `\$WORK/ipcfg-mig/` (same hwreg.defs shape), passes MIGOUT= to the ipconfigd Makefile + cc line for the test client.

Threading rework (per-interface DHCP workers, BPF→kqueue, `IPCONFIGD_FAST_LEASE` knob + `IPCFG-RENEW-OK` marker) is iter 5b.

## Test plan

- [ ] CI build (FreeBSD 15.0 amd64) green
- [ ] CI boot test through `IPCFG-RPC-OK`
- [ ] Existing markers still fire: `IPCFG-BOOT-OK`, `IPCFG-BOUND-OK`, `IPCFG-STORE-OK`
- [ ] ipconfigrpctest log shows `ipconfig_if_count -> 1` and `ipconfig_if_addr(em0) -> 10.0.2.15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)