### PR TITLE
feat(IPConfiguration): iter 5b — IPCONFIGD_FAST_LEASE + IPCFG-RENEW-OK CI gate

### DIFF
--- a/overlays/System/Library/LaunchDaemons/com.apple.IPConfiguration.plist
+++ b/overlays/System/Library/LaunchDaemons/com.apple.IPConfiguration.plist
@@ -42,5 +42,20 @@
     <string>/var/log/ipconfigd.stderr</string>
     <key>StandardErrorPath</key>
     <string>/var/log/ipconfigd.stderr</string>
+    <!--
+      iter 5b: cap the effective lease time for renewal timer math
+      so CI can exercise the RENEWING/REBINDING code path within the
+      boot-test budget. SLIRP hands out an 86400s lease — without
+      this cap, T1 would be 12 hours. The cap does NOT touch the
+      published lease (configd still sees the server's authoritative
+      lease_time); only the daemon's renewal-trigger timing is
+      shortened. Value: 10s → T1=5s, T2=8.75s → IPCFG-RENEW-OK
+      within ~10s of BOUND on a fast network like SLIRP.
+    -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>IPCONFIGD_FAST_LEASE</key>
+        <string>10</string>
+    </dict>
 </dict>
 </plist>

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -730,20 +730,23 @@ if [ ! -x "$ipconfigtest" ]; then
 fi
 "$ipconfigtest" || true	# marker (IPCFG-BOOT-OK/FAIL) gates in boot-test.sh
 
-# IPCFG-BOUND + IPCFG-STORE — iter-3 full DHCPv4 INIT → BOUND on em0
-# (DISCOVER → OFFER → REQUEST → ACK with the standard 4/8/16s RFC 2131
-# retransmit ladder, then apply_lease() runs SIOCAIFADDR + RTM_ADD
-# default route + /etc/resolv.conf write) followed by iter-4
-# SCDynamicStore publish of State:/Network/Service/<UUID>/IPv4 (+/DNS)
-# to configd. The bound IP comes from QEMU SLIRP (10.0.2.15 /
-# 10.0.2.2). Wait up to ~60s for both markers (worst-case retransmit
-# window 4+8+16 = 28s + SC publish round-trip; boot scheduling adds
-# slack), then cat the stderr log so the markers reach this console
-# for boot-test.sh's expect blocks.
+# IPCFG-BOUND + IPCFG-STORE + IPCFG-RENEW — iter-3 full DHCPv4 INIT →
+# BOUND on em0 (DISCOVER → OFFER → REQUEST → ACK with the standard
+# 4/8/16s RFC 2131 retransmit ladder, then apply_lease() runs
+# SIOCAIFADDR + RTM_ADD default route + /etc/resolv.conf write)
+# followed by iter-4 SCDynamicStore publish of
+# State:/Network/Service/<UUID>/IPv4 (+/DNS) to configd, then iter-5b
+# lease renewal (RENEWING DHCPREQUEST sent at T1 = 5s with
+# IPCONFIGD_FAST_LEASE=10 set in the plist; SLIRP ACKs with the same
+# address; IPCFG-RENEW-OK fires once). Wait up to ~60s for the
+# RENEW marker (worst case: BOUND ~5s + T1=5s + renew retransmit
+# ladder 4s = ~14s, boot scheduling adds slack). Cat the stderr
+# log so the markers reach this console for boot-test.sh's expect
+# blocks.
 if [ -f /var/log/ipconfigd.stderr ]; then
     i=0
     while [ $i -lt 30 ]; do
-        if grep -q 'IPCFG-STORE-OK\|IPCFG-STORE-FAIL\|IPCFG-BOUND-FAIL' \
+        if grep -q 'IPCFG-RENEW-OK\|IPCFG-STORE-FAIL\|IPCFG-BOUND-FAIL' \
             /var/log/ipconfigd.stderr 2>/dev/null; then
             break
         fi

--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -131,15 +131,46 @@ enumerate_interfaces(void)
 	return (total);
 }
 
+/*
+ * Read IPCONFIGD_FAST_LEASE from the environment. The env var caps
+ * the effective lease time used for T1 / T2 timer math (the value
+ * published to configd is unaffected). Accepts integers in [4, 86400]
+ * seconds; outside that range, or unset, the cap is disabled (return
+ * 0). Floor of 4 because the iter-3 retransmit ladder is 4s.
+ */
+static uint32_t
+read_lease_cap_env(void)
+{
+	const char *s = getenv("IPCONFIGD_FAST_LEASE");
+	char *end;
+	long v;
+
+	if (s == NULL || *s == '\0')
+		return (0);
+	v = strtol(s, &end, 10);
+	if (end == s || *end != '\0' || v < 4 || v > 86400) {
+		xlog("IPCONFIGD_FAST_LEASE='%s' ignored (need integer "
+		    "in [4, 86400])", s);
+		return (0);
+	}
+	xlog("IPCONFIGD_FAST_LEASE=%ld — capping lease for renewal "
+	    "timer math (server lease still authoritative)", v);
+	return ((uint32_t)v);
+}
+
 int
 main(int argc, char **argv)
 {
 	struct sigaction sa;
+	uint32_t lease_cap_secs;
 
 	(void)argc;
 	(void)argv;
 
-	xlog("ipconfigd starting (iter 5a — MIG service + DHCPv4)");
+	xlog("ipconfigd starting (iter 5b — MIG service + DHCPv4 + "
+	    "renewal CI gate)");
+
+	lease_cap_secs = read_lease_cap_env();
 
 	/*
 	 * sa_flags = 0 — system calls are NOT auto-restarted on
@@ -257,7 +288,8 @@ main(int argc, char **argv)
 					} else {
 						xlog("IPCFG-STORE-OK");
 						(void)lease_loop_run(ifname,
-						    &lease, pub);
+						    &lease, pub,
+						    lease_cap_secs);
 					}
 					if (pub != NULL)
 						sc_publish_close(pub);

--- a/src/IPConfiguration/lease_loop.c
+++ b/src/IPConfiguration/lease_loop.c
@@ -5,6 +5,16 @@
  *
  * Sleep is 1s-tick polling on `got_term` so SIGTERM shortens any
  * wait; the longest contiguous block call is sleep(1).
+ *
+ * iter 5b: lease_cap_secs (from IPCONFIGD_FAST_LEASE in env) caps
+ * the effective lease time used to derive T1 / T2. Useful in CI
+ * where SLIRP hands out 86400s leases that would otherwise mean
+ * T1 = 12 hours; capping to e.g. 10s makes the renewal code run
+ * within the boot-test budget. The cap is NOT applied to
+ * lease->lease_time (the value sc_publish.c forwards to configd) —
+ * downstream consumers see the server's authoritative value. iter
+ * 5b also emits IPCFG-RENEW-OK once on the first successful
+ * RENEWING/REBINDING ACK so the gate fires deterministically.
  */
 #include "lease_loop.h"
 #include "dhcp_discover.h"
@@ -13,6 +23,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -49,11 +60,25 @@ sleep_interruptible(uint32_t seconds)
 	return (got_term ? -1 : 0);
 }
 
+/*
+ * Apply the iter-5b lease cap. Returns min(in, cap) when cap > 0;
+ * `in` unchanged otherwise. The cap only shortens timer math —
+ * lease->lease_time (the value published to configd) is untouched.
+ */
+static uint32_t
+cap_lease(uint32_t in, uint32_t cap)
+{
+	if (cap > 0 && in > cap)
+		return (cap);
+	return (in);
+}
+
 int
 lease_loop_run(const char *ifname, struct dhcp_lease *lease,
-    struct sc_publish *pub)
+    struct sc_publish *pub, uint32_t lease_cap_secs)
 {
-	uint32_t lease_secs = lease->lease_time;
+	uint32_t lease_secs = cap_lease(lease->lease_time, lease_cap_secs);
+	bool renew_marker_fired = false;
 
 	if (lease_secs == 0) {
 		xlog("zero lease time — treating as infinite (no renewal)");
@@ -61,6 +86,9 @@ lease_loop_run(const char *ifname, struct dhcp_lease *lease,
 			(void)sleep(60);
 		return (0);
 	}
+	if (lease_cap_secs > 0)
+		xlog("lease cap active: server lease=%us → effective=%us",
+		    (unsigned)lease->lease_time, lease_secs);
 
 	for (;;) {
 		uint32_t t1, t2_after_t1, expiry_after_t2;
@@ -86,11 +114,18 @@ lease_loop_run(const char *ifname, struct dhcp_lease *lease,
 		xlog("RENEWING: T1 fired, sending DHCPREQUEST");
 		if (dhcp_renew(ifname, lease, &renewed) == 0) {
 			*lease = renewed;
-			lease_secs = lease->lease_time;
+			lease_secs = cap_lease(lease->lease_time,
+			    lease_cap_secs);
 			if (pub != NULL &&
 			    sc_publish_ipv4(pub, ifname, lease) != 0)
 				xlog("RENEWING: re-publish failed (continuing)");
-			xlog("RENEWING -> BOUND (new lease=%us)", lease_secs);
+			xlog("RENEWING -> BOUND (server lease=%us, "
+			    "effective=%us)",
+			    (unsigned)lease->lease_time, lease_secs);
+			if (!renew_marker_fired) {
+				xlog("IPCFG-RENEW-OK");
+				renew_marker_fired = true;
+			}
 			continue;
 		}
 		xlog("RENEWING: no ACK; waiting until T2");
@@ -102,11 +137,18 @@ lease_loop_run(const char *ifname, struct dhcp_lease *lease,
 		xlog("REBINDING: T2 fired, sending DHCPREQUEST");
 		if (dhcp_renew(ifname, lease, &renewed) == 0) {
 			*lease = renewed;
-			lease_secs = lease->lease_time;
+			lease_secs = cap_lease(lease->lease_time,
+			    lease_cap_secs);
 			if (pub != NULL &&
 			    sc_publish_ipv4(pub, ifname, lease) != 0)
 				xlog("REBINDING: re-publish failed (continuing)");
-			xlog("REBINDING -> BOUND (new lease=%us)", lease_secs);
+			xlog("REBINDING -> BOUND (server lease=%us, "
+			    "effective=%us)",
+			    (unsigned)lease->lease_time, lease_secs);
+			if (!renew_marker_fired) {
+				xlog("IPCFG-RENEW-OK");
+				renew_marker_fired = true;
+			}
 			continue;
 		}
 		xlog("REBINDING: no ACK; waiting until lease expiry");

--- a/src/IPConfiguration/lease_loop.h
+++ b/src/IPConfiguration/lease_loop.h
@@ -17,6 +17,8 @@
 #ifndef _IPCFG_LEASE_LOOP_H_
 #define _IPCFG_LEASE_LOOP_H_
 
+#include <stdint.h>
+
 #include "dhcp_packet.h"
 
 struct sc_publish;
@@ -28,9 +30,17 @@ struct sc_publish;
  * publish session — re-publish after each renewal; NULL means no
  * publishing.
  *
+ * `lease_cap_secs` (iter 5b) caps the effective lease time used to
+ * derive T1 / T2 — useful for CI where SLIRP hands out 86400s
+ * leases that would otherwise mean T1 = 12 hours. 0 = no cap.
+ * Both initial lease and post-renewal leases are capped. The cap
+ * does NOT touch `lease->lease_time` (the published lease
+ * authoritatively reports the server's value); it only shortens
+ * the daemon's renewal-trigger timing.
+ *
  * Returns 0 on clean shutdown (signal), -1 on lease loss.
  */
 int	lease_loop_run(const char *ifname, struct dhcp_lease *lease,
-	    struct sc_publish *pub);
+	    struct sc_publish *pub, uint32_t lease_cap_secs);
 
 #endif /* _IPCFG_LEASE_LOOP_H_ */

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -728,6 +728,18 @@ expect {
 
 expect {
     timeout {
+        puts "\nFAIL: IPCFG-RENEW-OK marker not seen (iter 5b lease renewal CI gate)"
+        exit 1
+    }
+    "IPCFG-RENEW-OK" {
+        puts "\nOK: ipconfigd lease renewal works (RENEWING DHCPREQUEST → ACK, lease re-published)"
+    }
+}
+
+# IPCFG-RPC fires AFTER the daemon log dump (ipconfigrpctest runs at
+# the end of run.sh), so expect for it last.
+expect {
+    timeout {
         puts "\nFAIL: IPCFG-RPC marker not seen"
         exit 1
     }


### PR DESCRIPTION
## Summary

Iter 4 shipped RENEWING/REBINDING code that never fired in CI — SLIRP's 86400s lease makes T1 = 12 hours. Iter 5b adds the smallest plumbing needed to exercise the code end-to-end:

- **IPCONFIGD_FAST_LEASE** env var caps the effective lease time used to derive T1 / T2 (range [4, 86400]). Cap does NOT touch \`lease->lease_time\` — configd still sees the server's authoritative value.
- **Plist** sets \`IPCONFIGD_FAST_LEASE=10\` via launchd's \`EnvironmentVariables\` (same pattern syslogd uses).
- **lease_loop_run** grows a \`lease_cap_secs\` parameter; applies the cap on entry + after each renewal; emits **IPCFG-RENEW-OK** once on the first successful RENEWING/REBINDING ACK.
- **boot-test.sh** expects \`IPCFG-RENEW-OK\` between \`IPCFG-STORE-OK\` and \`IPCFG-RPC-OK\` (matches the run.sh log-dump-then-rpctest ordering).

Per-interface DHCP worker threads + BPF→kqueue are deferred — no real consumer yet (ipconfigd only DHCPs em0; BIOCSRTIMEOUT already sleeps efficiently).

The CI bet: SLIRP accepts a RENEWING-form REQUEST (ciaddr set, broadcast flag set, no opt 50/54) and ACKs it. Most simple DHCP servers (SLIRP, dnsmasq) are stateless and respond to any chaddr-keyed REQUEST. If it doesn't, we'll see \`IPCFG-RENEW-FAIL\`-equivalent in the log dump and need a NAK→INIT fallback in dhcp_renew.

## Test plan

- [ ] CI build (FreeBSD 15.0 amd64) green
- [ ] All five markers in order: \`IPCFG-BOOT-OK\` → \`IPCFG-BOUND-OK\` → \`IPCFG-STORE-OK\` → \`IPCFG-RENEW-OK\` → \`IPCFG-RPC-OK\`
- [ ] Log line \`RENEWING -> BOUND (server lease=86400s, effective=10s)\` confirms the cap is applied while the published value is intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)