### PR TITLE
feat(IPConfiguration): iter 7a — IPv6 RA/SLAAC listener

### DIFF
--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -762,6 +762,8 @@ if [ -f /var/log/ipconfigd.stderr ]; then
     ifconfig em0 2>&1 || true
     echo "--- netstat -rn (default route) ---"
     netstat -rn -f inet 2>&1 | head -20 || true
+    echo "--- netstat -rn -f inet6 (iter 7a SLAAC default) ---"
+    netstat -rn -f inet6 2>&1 | head -20 || true
     echo "--- /etc/resolv.conf ---"
     cat /etc/resolv.conf 2>/dev/null || echo "(missing)"
     echo "--- end bound-state dump ---"

--- a/src/IPConfiguration/Makefile
+++ b/src/IPConfiguration/Makefile
@@ -18,6 +18,7 @@ SRCS=		ipconfigd.c dhcp_discover.c apply_lease.c
 SRCS+=		sc_publish.c lease_loop.c
 SRCS+=		bound_state.c mach_service.c ipconfigd_mig.c
 SRCS+=		arp_probe.c
+SRCS+=		ra_listen.c apply_lease_v6.c
 
 # ipconfigServer.c — MIG-generated server stub for ipconfig.defs
 # (iter 5a's two read-only routines). build.sh runs mig and passes

--- a/src/IPConfiguration/apply_lease_v6.c
+++ b/src/IPConfiguration/apply_lease_v6.c
@@ -113,6 +113,107 @@ make_prefix_mask(uint8_t prefix_len, struct in6_addr *mask)
 		mask->s6_addr[i / 8] |= (uint8_t)(0x80 >> (i % 8));
 }
 
+/*
+ * Compute the EUI-64 modified-IID for `mac` into `iid` (RFC 4862
+ * §A "Creating Modified EUI-64 Format Interface Identifiers").
+ */
+static void
+mac_to_eui64(const uint8_t mac[6], uint8_t iid[8])
+{
+	iid[0] = mac[0] ^ 0x02;
+	iid[1] = mac[1];
+	iid[2] = mac[2];
+	iid[3] = 0xff;
+	iid[4] = 0xfe;
+	iid[5] = mac[3];
+	iid[6] = mac[4];
+	iid[7] = mac[5];
+}
+
+int
+bring_v6_up(const char *ifname)
+{
+	struct in6_ndireq ndi;
+	struct in6_aliasreq req;
+	uint8_t mac[6], iid[8];
+	int sock, rc, had_disabled;
+
+	if (get_iface_mac(ifname, mac) != 0) {
+		xlog("get_iface_mac(%s) failed", ifname);
+		return (-1);
+	}
+
+	sock = socket(AF_INET6, SOCK_DGRAM, 0);
+	if (sock < 0) {
+		xlog("socket(AF_INET6) failed: %s", strerror(errno));
+		return (-1);
+	}
+
+	/*
+	 * Read current nd6 flags. ND6_IFF_IFDISABLED is the bit FreeBSD
+	 * sets when net.inet6.ip6.auto_linklocal is 0 at attach. Clear
+	 * it (also enable ACCEPT_RTADV so kernel-side ND processing
+	 * isn't surprised when our RA arrives) and write back.
+	 */
+	(void)memset(&ndi, 0, sizeof(ndi));
+	(void)strlcpy(ndi.ifname, ifname, sizeof(ndi.ifname));
+	had_disabled = 0;
+	if (ioctl(sock, SIOCGIFINFO_IN6, &ndi) == 0) {
+		had_disabled = (ndi.ndi.flags & ND6_IFF_IFDISABLED) != 0;
+		ndi.ndi.flags &= ~ND6_IFF_IFDISABLED;
+		ndi.ndi.flags |= ND6_IFF_ACCEPT_RTADV;
+		if (ioctl(sock, SIOCSIFINFO_IN6, &ndi) != 0)
+			xlog("SIOCSIFINFO_IN6(%s) failed: %s (continuing)",
+			    ifname, strerror(errno));
+		else if (had_disabled)
+			xlog("cleared ND6_IFF_IFDISABLED on %s", ifname);
+	} else {
+		xlog("SIOCGIFINFO_IN6(%s) failed: %s (continuing)",
+		    ifname, strerror(errno));
+	}
+
+	/*
+	 * Install fe80::<EUI-64>/64. If the kernel cleared IFDISABLED
+	 * and auto-added one in the moment between our two ioctls, this
+	 * returns EEXIST — benign.
+	 */
+	(void)memset(&req, 0, sizeof(req));
+	(void)strlcpy(req.ifra_name, ifname, sizeof(req.ifra_name));
+	req.ifra_addr.sin6_family = AF_INET6;
+	req.ifra_addr.sin6_len = sizeof(struct sockaddr_in6);
+	req.ifra_addr.sin6_addr.s6_addr[0] = 0xfe;
+	req.ifra_addr.sin6_addr.s6_addr[1] = 0x80;
+	mac_to_eui64(mac, iid);
+	(void)memcpy(&req.ifra_addr.sin6_addr.s6_addr[8], iid, 8);
+
+	req.ifra_prefixmask.sin6_family = AF_INET6;
+	req.ifra_prefixmask.sin6_len = sizeof(struct sockaddr_in6);
+	make_prefix_mask(64, &req.ifra_prefixmask.sin6_addr);
+
+	req.ifra_flags = IN6_IFF_AUTOCONF;
+	req.ifra_lifetime.ia6t_vltime = ND6_INFINITE_LIFETIME;
+	req.ifra_lifetime.ia6t_pltime = ND6_INFINITE_LIFETIME;
+
+	rc = ioctl(sock, SIOCAIFADDR_IN6, &req);
+	if (rc != 0 && errno != EEXIST) {
+		xlog("SIOCAIFADDR_IN6(%s, fe80::…) failed: %s",
+		    ifname, strerror(errno));
+		(void)close(sock);
+		return (-1);
+	}
+	(void)close(sock);
+
+	{
+		char buf[INET6_ADDRSTRLEN];
+
+		(void)inet_ntop(AF_INET6, &req.ifra_addr.sin6_addr, buf,
+		    sizeof(buf));
+		xlog("link-local %s installed on %s%s", buf, ifname,
+		    rc != 0 ? " (already present)" : "");
+	}
+	return (0);
+}
+
 static int
 install_v6_address(const char *ifname, const struct in6_addr *addr,
     uint8_t prefix_len, uint32_t valid_lt, uint32_t preferred_lt)

--- a/src/IPConfiguration/apply_lease_v6.c
+++ b/src/IPConfiguration/apply_lease_v6.c
@@ -285,7 +285,20 @@ install_v6_default_route(const struct in6_addr *gateway, unsigned ifindex)
 	msg.gw.sin6_family = AF_INET6;
 	msg.gw.sin6_len = sizeof(msg.gw);
 	msg.gw.sin6_addr = *gateway;
-	msg.gw.sin6_scope_id = ifindex;	/* required for link-local gw */
+	/*
+	 * FreeBSD's PF_ROUTE socket uses "embedded scope" for link-local
+	 * sockaddrs (sa6_embedscope): the ifindex goes into bytes 2-3 of
+	 * the address (network byte order), and sin6_scope_id stays 0.
+	 * Without this the kernel returns EINVAL on RTM_ADD. The same
+	 * embedding is visible in dmesg lines like `fe80:1::5054:ff:fe12:
+	 * 3456(em0)` — the `:1` IS the ifindex. RFC 2553 §4 plus FreeBSD-
+	 * specific routing-socket convention.
+	 */
+	if (IN6_IS_ADDR_LINKLOCAL(&msg.gw.sin6_addr)) {
+		msg.gw.sin6_addr.s6_addr[2] = (uint8_t)((ifindex >> 8) & 0xff);
+		msg.gw.sin6_addr.s6_addr[3] = (uint8_t)(ifindex & 0xff);
+	}
+	msg.gw.sin6_scope_id = 0;
 
 	msg.mask.sin6_family = AF_INET6;
 	msg.mask.sin6_len = sizeof(msg.mask);

--- a/src/IPConfiguration/apply_lease_v6.c
+++ b/src/IPConfiguration/apply_lease_v6.c
@@ -265,9 +265,8 @@ install_v6_address(const char *ifname, const struct in6_addr *addr,
  * is why apply_lease.c's IPv4 RTM_ADD works without padding.
  */
 #define RT_SIN6_WIRE	32
-#if RT_SIN6_WIRE < sizeof(struct sockaddr_in6)
-#error "RT_SIN6_WIRE smaller than struct sockaddr_in6"
-#endif
+_Static_assert(RT_SIN6_WIRE >= sizeof(struct sockaddr_in6),
+    "RT_SIN6_WIRE smaller than struct sockaddr_in6");
 
 static int
 install_v6_default_route(const struct in6_addr *gateway, unsigned ifindex)

--- a/src/IPConfiguration/apply_lease_v6.c
+++ b/src/IPConfiguration/apply_lease_v6.c
@@ -257,15 +257,28 @@ install_v6_address(const char *ifname, const struct in6_addr *addr,
 	return (rc);
 }
 
+/*
+ * SA_SIZE-equivalent rounding for sockaddr_in6 in a PF_ROUTE message:
+ * the kernel reads sockaddrs at sizeof(long)-aligned offsets, so each
+ * sin6 occupies 32 bytes on the wire (28-byte struct + 4 bytes
+ * padding). IPv4's sockaddr_in is 16 bytes — already aligned — which
+ * is why apply_lease.c's IPv4 RTM_ADD works without padding.
+ */
+#define RT_SIN6_WIRE	32
+#if RT_SIN6_WIRE < sizeof(struct sockaddr_in6)
+#error "RT_SIN6_WIRE smaller than struct sockaddr_in6"
+#endif
+
 static int
 install_v6_default_route(const struct in6_addr *gateway, unsigned ifindex)
 {
 	struct {
 		struct rt_msghdr	hdr;
-		struct sockaddr_in6	dst;
-		struct sockaddr_in6	gw;
-		struct sockaddr_in6	mask;
+		uint8_t			dst[RT_SIN6_WIRE];
+		uint8_t			gw[RT_SIN6_WIRE];
+		uint8_t			mask[RT_SIN6_WIRE];
 	} msg;
+	struct sockaddr_in6 sa;
 	int sock;
 	ssize_t n;
 
@@ -278,31 +291,35 @@ install_v6_default_route(const struct in6_addr *gateway, unsigned ifindex)
 	msg.hdr.rtm_pid = (int32_t)getpid();
 	msg.hdr.rtm_seq = 1;
 
-	msg.dst.sin6_family = AF_INET6;
-	msg.dst.sin6_len = sizeof(msg.dst);
-	/* ::/0 — zero-filled */
+	/* dst = ::/0 */
+	(void)memset(&sa, 0, sizeof(sa));
+	sa.sin6_family = AF_INET6;
+	sa.sin6_len = sizeof(sa);
+	(void)memcpy(msg.dst, &sa, sizeof(sa));
 
-	msg.gw.sin6_family = AF_INET6;
-	msg.gw.sin6_len = sizeof(msg.gw);
-	msg.gw.sin6_addr = *gateway;
 	/*
-	 * FreeBSD's PF_ROUTE socket uses "embedded scope" for link-local
-	 * sockaddrs (sa6_embedscope): the ifindex goes into bytes 2-3 of
-	 * the address (network byte order), and sin6_scope_id stays 0.
-	 * Without this the kernel returns EINVAL on RTM_ADD. The same
-	 * embedding is visible in dmesg lines like `fe80:1::5054:ff:fe12:
-	 * 3456(em0)` — the `:1` IS the ifindex. RFC 2553 §4 plus FreeBSD-
-	 * specific routing-socket convention.
+	 * gw — copy the LL gateway, then embed the ifindex into bytes
+	 * 2-3 of the address per FreeBSD's "embedded scope" convention
+	 * for PF_ROUTE sockaddrs (sa6_embedscope). sin6_scope_id stays
+	 * 0 — the kernel's rt_xaddrs path picks up scope from the
+	 * embedded form. The same encoding is visible in dmesg lines
+	 * like `fe80:1::5054:ff:fe12:3456(em0)` — the `:1` IS ifindex.
 	 */
-	if (IN6_IS_ADDR_LINKLOCAL(&msg.gw.sin6_addr)) {
-		msg.gw.sin6_addr.s6_addr[2] = (uint8_t)((ifindex >> 8) & 0xff);
-		msg.gw.sin6_addr.s6_addr[3] = (uint8_t)(ifindex & 0xff);
+	(void)memset(&sa, 0, sizeof(sa));
+	sa.sin6_family = AF_INET6;
+	sa.sin6_len = sizeof(sa);
+	sa.sin6_addr = *gateway;
+	if (IN6_IS_ADDR_LINKLOCAL(&sa.sin6_addr)) {
+		sa.sin6_addr.s6_addr[2] = (uint8_t)((ifindex >> 8) & 0xff);
+		sa.sin6_addr.s6_addr[3] = (uint8_t)(ifindex & 0xff);
 	}
-	msg.gw.sin6_scope_id = 0;
+	(void)memcpy(msg.gw, &sa, sizeof(sa));
 
-	msg.mask.sin6_family = AF_INET6;
-	msg.mask.sin6_len = sizeof(msg.mask);
-	/* ::/0 mask — zero-filled */
+	/* mask = ::/0 */
+	(void)memset(&sa, 0, sizeof(sa));
+	sa.sin6_family = AF_INET6;
+	sa.sin6_len = sizeof(sa);
+	(void)memcpy(msg.mask, &sa, sizeof(sa));
 
 	sock = socket(AF_ROUTE, SOCK_RAW, 0);
 	if (sock < 0) {

--- a/src/IPConfiguration/apply_lease_v6.c
+++ b/src/IPConfiguration/apply_lease_v6.c
@@ -1,0 +1,253 @@
+/*
+ * apply_lease_v6.c — install a SLAAC address + default route.
+ *
+ * Three sub-steps:
+ *   1. Compute the IID. RFC 4862 §5.5.3 modified-EUI-64: prefix(64)
+ *      || mac[0..3] || ff || fe || mac[3..6], with the universal/local
+ *      bit (mac[0] bit 1) inverted.
+ *   2. SIOCAIFADDR_IN6 with the prefix + lifetimes from the RA's PIO.
+ *      The kernel performs DAD in the background; iter 7a does not
+ *      wait for it.
+ *   3. RTM_ADD default IPv6 route via the RA's source link-local. The
+ *      gateway sockaddr_in6 carries sin6_scope_id = ifindex so the
+ *      kernel knows which interface the LL belongs to.
+ *
+ * Deferred for later iters: lifetime renewal, RDNSS, multiple
+ * prefixes, RFC 7217 stable privacy addresses (iter 7a uses
+ * deterministic EUI-64; the privacy mode is configurable in Apple's
+ * IPConfiguration but tied to per-interface policy that doesn't
+ * exist yet here).
+ */
+#include "apply_lease_v6.h"
+
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <net/route.h>
+#include <netinet/in.h>
+#include <netinet6/in6_var.h>
+#include <netinet6/nd6.h>
+
+#include <arpa/inet.h>
+
+#include <errno.h>
+#include <ifaddrs.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void
+xlog(const char *fmt, ...)
+{
+	va_list ap;
+
+	(void)fprintf(stderr, "ipconfigd[apply6] ");
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+static int
+get_iface_mac(const char *ifname, uint8_t mac[6])
+{
+	struct ifaddrs *ifa, *p;
+	int ok = -1;
+
+	if (getifaddrs(&ifa) != 0)
+		return (-1);
+	for (p = ifa; p != NULL; p = p->ifa_next) {
+		const struct sockaddr_dl *dl;
+
+		if (p->ifa_addr == NULL ||
+		    p->ifa_addr->sa_family != AF_LINK)
+			continue;
+		if (strcmp(p->ifa_name, ifname) != 0)
+			continue;
+		dl = (const struct sockaddr_dl *)(const void *)p->ifa_addr;
+		if (dl->sdl_alen != 6)
+			break;
+		(void)memcpy(mac, LLADDR(dl), 6);
+		ok = 0;
+		break;
+	}
+	freeifaddrs(ifa);
+	return (ok);
+}
+
+static void
+make_slaac_addr(const struct in6_addr *prefix, uint8_t prefix_len,
+    const uint8_t mac[6], struct in6_addr *out)
+{
+	uint8_t iid[8];
+
+	(void)prefix_len;	/* iter 7a requires /64; assert in caller */
+
+	iid[0] = mac[0] ^ 0x02;	/* flip universal/local */
+	iid[1] = mac[1];
+	iid[2] = mac[2];
+	iid[3] = 0xff;
+	iid[4] = 0xfe;
+	iid[5] = mac[3];
+	iid[6] = mac[4];
+	iid[7] = mac[5];
+
+	*out = *prefix;
+	(void)memcpy(&out->s6_addr[8], iid, 8);
+}
+
+static void
+make_prefix_mask(uint8_t prefix_len, struct in6_addr *mask)
+{
+	int i;
+
+	(void)memset(mask, 0, sizeof(*mask));
+	for (i = 0; i < prefix_len && i < 128; i++)
+		mask->s6_addr[i / 8] |= (uint8_t)(0x80 >> (i % 8));
+}
+
+static int
+install_v6_address(const char *ifname, const struct in6_addr *addr,
+    uint8_t prefix_len, uint32_t valid_lt, uint32_t preferred_lt)
+{
+	struct in6_aliasreq req;
+	int sock, rc;
+
+	(void)memset(&req, 0, sizeof(req));
+	(void)strlcpy(req.ifra_name, ifname, sizeof(req.ifra_name));
+
+	req.ifra_addr.sin6_family = AF_INET6;
+	req.ifra_addr.sin6_len = sizeof(struct sockaddr_in6);
+	req.ifra_addr.sin6_addr = *addr;
+
+	req.ifra_prefixmask.sin6_family = AF_INET6;
+	req.ifra_prefixmask.sin6_len = sizeof(struct sockaddr_in6);
+	make_prefix_mask(prefix_len, &req.ifra_prefixmask.sin6_addr);
+
+	/*
+	 * Apple's IPConfiguration sets ifra_flags=IN6_IFF_AUTOCONF here.
+	 * FreeBSD's in6_var.h exposes the same flag; treating an
+	 * RA-derived address as autoconf lets the kernel apply RFC 4862
+	 * lifetime semantics (auto-remove on valid expiry) if we ever
+	 * wire that. For iter 7a the daemon doesn't track expiry, but
+	 * setting the flag still matches the address's actual provenance.
+	 */
+	req.ifra_flags = IN6_IFF_AUTOCONF;
+
+	req.ifra_lifetime.ia6t_vltime = valid_lt;
+	req.ifra_lifetime.ia6t_pltime = preferred_lt;
+
+	sock = socket(AF_INET6, SOCK_DGRAM, 0);
+	if (sock < 0) {
+		xlog("socket(AF_INET6) failed: %s", strerror(errno));
+		return (-1);
+	}
+	rc = ioctl(sock, SIOCAIFADDR_IN6, &req);
+	if (rc != 0)
+		xlog("SIOCAIFADDR_IN6(%s) failed: %s", ifname, strerror(errno));
+	(void)close(sock);
+	return (rc);
+}
+
+static int
+install_v6_default_route(const struct in6_addr *gateway, unsigned ifindex)
+{
+	struct {
+		struct rt_msghdr	hdr;
+		struct sockaddr_in6	dst;
+		struct sockaddr_in6	gw;
+		struct sockaddr_in6	mask;
+	} msg;
+	int sock;
+	ssize_t n;
+
+	(void)memset(&msg, 0, sizeof(msg));
+	msg.hdr.rtm_msglen = sizeof(msg);
+	msg.hdr.rtm_version = RTM_VERSION;
+	msg.hdr.rtm_type = RTM_ADD;
+	msg.hdr.rtm_addrs = RTA_DST | RTA_GATEWAY | RTA_NETMASK;
+	msg.hdr.rtm_flags = RTF_UP | RTF_GATEWAY | RTF_STATIC;
+	msg.hdr.rtm_pid = (int32_t)getpid();
+	msg.hdr.rtm_seq = 1;
+
+	msg.dst.sin6_family = AF_INET6;
+	msg.dst.sin6_len = sizeof(msg.dst);
+	/* ::/0 — zero-filled */
+
+	msg.gw.sin6_family = AF_INET6;
+	msg.gw.sin6_len = sizeof(msg.gw);
+	msg.gw.sin6_addr = *gateway;
+	msg.gw.sin6_scope_id = ifindex;	/* required for link-local gw */
+
+	msg.mask.sin6_family = AF_INET6;
+	msg.mask.sin6_len = sizeof(msg.mask);
+	/* ::/0 mask — zero-filled */
+
+	sock = socket(AF_ROUTE, SOCK_RAW, 0);
+	if (sock < 0) {
+		xlog("socket(AF_ROUTE) failed: %s", strerror(errno));
+		return (-1);
+	}
+	n = write(sock, &msg, sizeof(msg));
+	if (n != (ssize_t)sizeof(msg)) {
+		if (errno == EEXIST) {
+			(void)close(sock);
+			return (0);
+		}
+		xlog("write(PF_ROUTE, RTM_ADD ::/0) failed: %s",
+		    strerror(errno));
+		(void)close(sock);
+		return (-1);
+	}
+	(void)close(sock);
+	return (0);
+}
+
+int
+apply_ra_lease(const char *ifname, const struct ra_info *info,
+    struct in6_addr *out_addr)
+{
+	uint8_t mac[6];
+	struct in6_addr slaac;
+	char abuf[INET6_ADDRSTRLEN];
+
+	if (info->prefix_len != 64) {
+		xlog("PIO prefix_len=%u != 64 — SLAAC requires /64 "
+		    "(RFC 4862 §5.5.3); skipping",
+		    (unsigned)info->prefix_len);
+		return (-1);
+	}
+	if (get_iface_mac(ifname, mac) != 0) {
+		xlog("get_iface_mac(%s) failed", ifname);
+		return (-1);
+	}
+
+	make_slaac_addr(&info->prefix, info->prefix_len, mac, &slaac);
+	(void)inet_ntop(AF_INET6, &slaac, abuf, sizeof(abuf));
+	xlog("SLAAC address: %s/%u (EUI-64 from %s MAC)",
+	    abuf, (unsigned)info->prefix_len, ifname);
+
+	if (install_v6_address(ifname, &slaac, info->prefix_len,
+	    info->valid_lifetime, info->preferred_lifetime) != 0)
+		return (-1);
+
+	*out_addr = slaac;
+
+	/*
+	 * Route install is best-effort. If it fails (e.g. EEXIST from a
+	 * stale ::/0 default) we still report success — the address is
+	 * up and reachable on-link.
+	 */
+	if (install_v6_default_route(&info->router_lladdr,
+	    info->router_scope_id) != 0)
+		xlog("default ::/0 route install failed (non-fatal)");
+
+	return (0);
+}

--- a/src/IPConfiguration/apply_lease_v6.h
+++ b/src/IPConfiguration/apply_lease_v6.h
@@ -12,6 +12,17 @@
 #include "ra_listen.h"
 
 /*
+ * Clear ND6_IFF_IFDISABLED on `ifname` and install an EUI-64
+ * link-local fe80::… address. This is the precondition for sending
+ * an ND_ROUTER_SOLICIT: ff02::2 is link-local scope, so the kernel
+ * needs an LL source on the egress interface. FreeBSD's per-image
+ * default for `net.inet6.ip6.auto_linklocal` in this build is 0 (the
+ * stack leaves IFDISABLED set on attach), so we cannot rely on the
+ * kernel to auto-configure the LL. Returns 0 on success.
+ */
+int bring_v6_up(const char *ifname);
+
+/*
  * Build the SLAAC unicast address from `info`'s prefix + an EUI-64
  * derived from `ifname`'s MAC, install it via SIOCAIFADDR_IN6, and
  * add a default route via info->router_lladdr. Returns 0 on success

--- a/src/IPConfiguration/apply_lease_v6.h
+++ b/src/IPConfiguration/apply_lease_v6.h
@@ -1,0 +1,27 @@
+/*
+ * apply_lease_v6.h — install an IPv6 SLAAC address + default route
+ * derived from a Router Advertisement.
+ *
+ * Iter 7a scope: one address, one default route, best-effort. No
+ * lifetime tracking, no DAD wait — kernel DAD runs in the background
+ * after SIOCAIFADDR_IN6 and we don't gate on it for the marker.
+ */
+#ifndef APPLY_LEASE_V6_H
+#define APPLY_LEASE_V6_H
+
+#include "ra_listen.h"
+
+/*
+ * Build the SLAAC unicast address from `info`'s prefix + an EUI-64
+ * derived from `ifname`'s MAC, install it via SIOCAIFADDR_IN6, and
+ * add a default route via info->router_lladdr. Returns 0 on success
+ * (address installed; route is best-effort and logged separately).
+ *
+ * `out_addr` receives the computed SLAAC address for the caller's
+ * SCDynamicStore publish; it is populated even if route install
+ * fails downstream.
+ */
+int apply_ra_lease(const char *ifname, const struct ra_info *info,
+    struct in6_addr *out_addr);
+
+#endif /* APPLY_LEASE_V6_H */

--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -303,7 +303,18 @@ main(int argc, char **argv)
 						 * means RA isn't configured;
 						 * we log IPCFG-RA-MISS and
 						 * continue with IPv4 only.
+						 *
+						 * Round-1 CI showed em0 has
+						 * ND6_IFF_IFDISABLED set (this
+						 * image's net.inet6.ip6.auto_
+						 * linklocal is 0, so the kernel
+						 * never auto-added a link-local).
+						 * bring_v6_up clears IFDISABLED
+						 * and installs fe80::EUI-64 so
+						 * the kernel can source-select
+						 * the link-local-scoped RS.
 						 */
+						(void)bring_v6_up(ifname);
 						rar = ra_acquire(ifname,
 						    15000, &ra);
 						if (rar == 0) {

--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -55,10 +55,12 @@
 #include <unistd.h>
 
 #include "apply_lease.h"
+#include "apply_lease_v6.h"
 #include "bound_state.h"
 #include "dhcp_discover.h"
 #include "lease_loop.h"
 #include "mach_service.h"
+#include "ra_listen.h"
 #include "sc_publish.h"
 
 /*
@@ -167,8 +169,8 @@ main(int argc, char **argv)
 	(void)argc;
 	(void)argv;
 
-	xlog("ipconfigd starting (iter 5b — MIG service + DHCPv4 + "
-	    "renewal CI gate)");
+	xlog("ipconfigd starting (iter 7a — MIG service + DHCPv4 + "
+	    "RFC 5227 ARP + IPv6 RA/SLAAC)");
 
 	lease_cap_secs = read_lease_cap_env();
 
@@ -286,7 +288,51 @@ main(int argc, char **argv)
 						xlog("IPCFG-STORE-FAIL: "
 						    "set State:/.../IPv4");
 					} else {
+						struct ra_info ra;
+						int rar;
+
 						xlog("IPCFG-STORE-OK");
+
+						/*
+						 * iter 7a: solicit + listen for
+						 * one RA, derive a SLAAC address,
+						 * install it + the v6 default
+						 * route, and publish State:/.../
+						 * IPv6. 15s budget — QEMU SLIRP
+						 * answers within ms, so a miss
+						 * means RA isn't configured;
+						 * we log IPCFG-RA-MISS and
+						 * continue with IPv4 only.
+						 */
+						rar = ra_acquire(ifname,
+						    15000, &ra);
+						if (rar == 0) {
+							struct in6_addr v6;
+
+							if (apply_ra_lease(
+							    ifname, &ra,
+							    &v6) == 0) {
+								(void)
+								sc_publish_ipv6(
+								    pub, ifname,
+								    &v6,
+								    ra.prefix_len,
+								    &ra.router_lladdr);
+								xlog("IPCFG-RA-OK");
+							} else {
+								xlog("IPCFG-RA-MISS: "
+								    "apply_ra_lease failed");
+							}
+						} else if (rar == 1) {
+							xlog("IPCFG-RA-MISS: "
+							    "no RA in 15s "
+							    "(SLIRP may not "
+							    "advertise IPv6)");
+						} else {
+							xlog("IPCFG-RA-MISS: "
+							    "ra_acquire fatal");
+						}
+
 						(void)lease_loop_run(ifname,
 						    &lease, pub,
 						    lease_cap_secs);

--- a/src/IPConfiguration/ra_listen.c
+++ b/src/IPConfiguration/ra_listen.c
@@ -1,0 +1,428 @@
+/*
+ * ra_listen.c — IPv6 Router Solicitation + Router Advertisement
+ * receive on a single interface.
+ *
+ * QEMU SLIRP (the CI target) sends unsolicited RAs only every 600s
+ * but responds to a solicitation within ~ms; iter 7a therefore
+ * actively solicits rather than waiting for the next unsolicited.
+ *
+ * Send path: ICMPv6 raw socket bound to `ifname`'s scope, sendto
+ * ff02::2 (all-routers multicast). Packet body = ND_ROUTER_SOLICIT
+ * (RFC 4861 §4.1): 8-byte ICMP6 header with reserved=0, followed by
+ * one source-link-layer-address option (type=1, len=1, our MAC).
+ * The kernel computes the ICMPv6 checksum automatically for
+ * IPPROTO_ICMPV6 raw sockets.
+ *
+ * Receive path: ICMP6_FILTER allows only ND_ROUTER_ADVERT, then
+ * recvmsg with IPV6_PKTINFO + IPV6_HOPLIMIT cmsgs. RFC 4861 §6.1.2
+ * requires hop-limit == 255 on the received frame (anti-spoofing).
+ * Walk options after the 16-byte RA header looking for the first
+ * Prefix Information Option (type=3, len=4) with on-link + autonomous
+ * flags set; copy out its prefix + lifetimes + the RA's source
+ * link-local address (the router for default-route purposes).
+ *
+ * One-shot for iter 7a — no lease loop, no expiry tracking. The
+ * post-iter productionisation backlog tracks the recurring listener.
+ */
+#include "ra_listen.h"
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <netinet/in.h>
+#include <netinet/icmp6.h>
+
+#include <arpa/inet.h>
+
+#include <errno.h>
+#include <ifaddrs.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+/*
+ * Daemon shutdown flag — let a long RA wait short-circuit on SIGTERM
+ * the same way dhcp_discover / arp_probe do.
+ */
+extern volatile sig_atomic_t got_term;
+
+static void
+xlog(const char *fmt, ...)
+{
+	va_list ap;
+
+	(void)fprintf(stderr, "ipconfigd[ra] ");
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+static int
+get_iface_mac(const char *ifname, uint8_t mac[6])
+{
+	struct ifaddrs *ifa, *p;
+	int ok = -1;
+
+	if (getifaddrs(&ifa) != 0)
+		return (-1);
+	for (p = ifa; p != NULL; p = p->ifa_next) {
+		const struct sockaddr_dl *dl;
+
+		if (p->ifa_addr == NULL ||
+		    p->ifa_addr->sa_family != AF_LINK)
+			continue;
+		if (strcmp(p->ifa_name, ifname) != 0)
+			continue;
+		dl = (const struct sockaddr_dl *)(const void *)p->ifa_addr;
+		if (dl->sdl_alen != 6)
+			break;
+		(void)memcpy(mac, LLADDR(dl), 6);
+		ok = 0;
+		break;
+	}
+	freeifaddrs(ifa);
+	return (ok);
+}
+
+/*
+ * Open a raw ICMPv6 socket configured for ND host operation:
+ *   - ICMP6_FILTER: pass only ND_ROUTER_ADVERT (we don't need to see
+ *     our own RS coming back).
+ *   - IPV6_RECVPKTINFO + IPV6_RECVHOPLIMIT: surface the ifindex and
+ *     hop limit on each recvmsg so we can enforce RFC 4861 §6.1.2
+ *     (hop-limit == 255 anti-spoof).
+ *   - IPV6_MULTICAST_HOPS + IPV6_UNICAST_HOPS = 255: required by RFC
+ *     4861 for both outbound RS and any unicast we emit.
+ *   - SO_RCVTIMEO = 1s: lets the recvmsg poll loop rotate through
+ *     got_term and the listen-window deadline.
+ */
+static int
+open_icmp6(const char *ifname)
+{
+	struct icmp6_filter filt;
+	int sock, on = 1, hops = 255;
+	struct timeval tv;
+
+	(void)ifname;	/* sendto carries the scope; nothing to bind here */
+
+	sock = socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
+	if (sock < 0) {
+		xlog("socket(AF_INET6, ICMPV6) failed: %s", strerror(errno));
+		return (-1);
+	}
+
+	ICMP6_FILTER_SETBLOCKALL(&filt);
+	ICMP6_FILTER_SETPASS(ND_ROUTER_ADVERT, &filt);
+	if (setsockopt(sock, IPPROTO_ICMPV6, ICMP6_FILTER, &filt,
+	    sizeof(filt)) != 0) {
+		xlog("ICMP6_FILTER: %s", strerror(errno));
+		(void)close(sock);
+		return (-1);
+	}
+	(void)setsockopt(sock, IPPROTO_IPV6, IPV6_RECVPKTINFO, &on, sizeof(on));
+	(void)setsockopt(sock, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, &on, sizeof(on));
+	(void)setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &hops,
+	    sizeof(hops));
+	(void)setsockopt(sock, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &hops,
+	    sizeof(hops));
+
+	tv.tv_sec = 1;
+	tv.tv_usec = 0;
+	(void)setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+	return (sock);
+}
+
+/*
+ * Send an ICMPv6 Router Solicitation to ff02::2 via `ifname`. The
+ * packet is 16 bytes: 8-byte RS header + 8-byte source-LL-addr
+ * option (type=1 len=1 + 6-byte MAC). Returns 0 on success.
+ */
+static int
+send_rs(int sock, const char *ifname, const uint8_t mac[6])
+{
+	struct sockaddr_in6 dst;
+	uint8_t pkt[16];
+	struct nd_router_solicit *rs;
+	uint8_t *opt;
+	unsigned ifindex;
+	ssize_t n;
+
+	ifindex = if_nametoindex(ifname);
+	if (ifindex == 0) {
+		xlog("if_nametoindex(%s) failed: %s", ifname, strerror(errno));
+		return (-1);
+	}
+
+	(void)memset(&dst, 0, sizeof(dst));
+	dst.sin6_family = AF_INET6;
+	dst.sin6_len = sizeof(dst);
+	if (inet_pton(AF_INET6, "ff02::2", &dst.sin6_addr) != 1) {
+		xlog("inet_pton(ff02::2) failed");
+		return (-1);
+	}
+	dst.sin6_scope_id = ifindex;
+
+	(void)memset(pkt, 0, sizeof(pkt));
+	rs = (struct nd_router_solicit *)(void *)pkt;
+	rs->nd_rs_type = ND_ROUTER_SOLICIT;
+	rs->nd_rs_code = 0;
+	rs->nd_rs_cksum = 0;	/* kernel fills */
+	rs->nd_rs_reserved = 0;
+
+	opt = pkt + 8;
+	opt[0] = ND_OPT_SOURCE_LINKADDR;
+	opt[1] = 1;	/* 8-byte units */
+	(void)memcpy(opt + 2, mac, 6);
+
+	n = sendto(sock, pkt, sizeof(pkt), 0,
+	    (struct sockaddr *)&dst, sizeof(dst));
+	if (n != (ssize_t)sizeof(pkt)) {
+		xlog("sendto(ff02::2 RS) failed: %s", strerror(errno));
+		return (-1);
+	}
+	return (0);
+}
+
+/*
+ * Walk RA options starting at `opts` for `len` bytes. On the first
+ * Prefix Information Option (type=3) with both on-link (L) and
+ * autonomous (A) flags set, copy out prefix + lifetimes and return 1.
+ * Returns 0 if no eligible PIO was found, -1 if the option chain is
+ * malformed (length=0 in any option, RFC 4861 §4.6).
+ */
+static int
+parse_options(const uint8_t *opts, size_t len, struct ra_info *out)
+{
+	size_t off = 0;
+
+	while (off + 2 <= len) {
+		uint8_t type = opts[off];
+		uint8_t olen = opts[off + 1];
+		size_t obytes;
+
+		if (olen == 0)
+			return (-1);
+		obytes = (size_t)olen * 8;
+		if (off + obytes > len)
+			return (-1);
+
+		if (type == ND_OPT_PREFIX_INFORMATION && obytes >= 32) {
+			const struct nd_opt_prefix_info *pi;
+
+			pi = (const struct nd_opt_prefix_info *)
+			    (const void *)(opts + off);
+			if ((pi->nd_opt_pi_flags_reserved &
+			    (ND_OPT_PI_FLAG_ONLINK |
+			     ND_OPT_PI_FLAG_AUTO)) ==
+			    (ND_OPT_PI_FLAG_ONLINK |
+			     ND_OPT_PI_FLAG_AUTO)) {
+				out->prefix = pi->nd_opt_pi_prefix;
+				out->prefix_len = pi->nd_opt_pi_prefix_len;
+				out->valid_lifetime =
+				    ntohl(pi->nd_opt_pi_valid_time);
+				out->preferred_lifetime =
+				    ntohl(pi->nd_opt_pi_preferred_time);
+				return (1);
+			}
+		}
+		off += obytes;
+	}
+	return (0);
+}
+
+/*
+ * Single recvmsg, validate hop-limit + ifindex, parse RA. Returns
+ *   1  — RA received and PIO extracted (out populated, including
+ *        router_lladdr from the source address).
+ *   0  — recv timed out (caller decides whether to keep waiting).
+ *  -1  — fatal (shutdown or unrecoverable error).
+ *
+ * Note: an RA with no eligible PIO is treated as "no result" (returns
+ * 0) — the caller's deadline loop will keep listening for another.
+ */
+static int
+recv_one(int sock, unsigned want_ifindex, struct ra_info *out)
+{
+	uint8_t buf[1500];
+	struct sockaddr_in6 from;
+	struct iovec iov;
+	struct msghdr mh;
+	uint8_t cmsgbuf[256];
+	struct cmsghdr *cm;
+	ssize_t n;
+	int hoplimit = -1;
+	unsigned got_ifindex = 0;
+	struct nd_router_advert *ra;
+
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	(void)memset(&mh, 0, sizeof(mh));
+	mh.msg_name = &from;
+	mh.msg_namelen = sizeof(from);
+	mh.msg_iov = &iov;
+	mh.msg_iovlen = 1;
+	mh.msg_control = cmsgbuf;
+	mh.msg_controllen = sizeof(cmsgbuf);
+
+	n = recvmsg(sock, &mh, 0);
+	if (n < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+			return (0);
+		if (errno == EINTR && got_term)
+			return (-1);
+		if (errno == EINTR)
+			return (0);
+		xlog("recvmsg(icmp6) failed: %s", strerror(errno));
+		return (-1);
+	}
+
+	for (cm = CMSG_FIRSTHDR(&mh); cm != NULL;
+	    cm = CMSG_NXTHDR(&mh, cm)) {
+		if (cm->cmsg_level != IPPROTO_IPV6)
+			continue;
+		if (cm->cmsg_type == IPV6_PKTINFO) {
+			struct in6_pktinfo pi;
+
+			(void)memcpy(&pi, CMSG_DATA(cm), sizeof(pi));
+			got_ifindex = (unsigned)pi.ipi6_ifindex;
+		} else if (cm->cmsg_type == IPV6_HOPLIMIT) {
+			int hl;
+
+			(void)memcpy(&hl, CMSG_DATA(cm), sizeof(hl));
+			hoplimit = hl;
+		}
+	}
+
+	/*
+	 * RFC 4861 §6.1.2: a host MUST silently discard an RA whose IP
+	 * hop limit is not 255, or whose source is not a link-local
+	 * address. Both protect against off-link spoofing.
+	 */
+	if (hoplimit != 255) {
+		xlog("RA rejected: hop-limit=%d (want 255)", hoplimit);
+		return (0);
+	}
+	if (!IN6_IS_ADDR_LINKLOCAL(&from.sin6_addr)) {
+		xlog("RA rejected: source not link-local");
+		return (0);
+	}
+	if (got_ifindex != 0 && got_ifindex != want_ifindex) {
+		xlog("RA rejected: arrived on ifindex=%u (want %u)",
+		    got_ifindex, want_ifindex);
+		return (0);
+	}
+	if (n < (ssize_t)sizeof(struct nd_router_advert)) {
+		xlog("RA rejected: short (%zd bytes)", n);
+		return (0);
+	}
+
+	ra = (struct nd_router_advert *)(void *)buf;
+	if (ra->nd_ra_type != ND_ROUTER_ADVERT) {
+		/* The ICMP6_FILTER should make this unreachable, but
+		 * defence-in-depth. */
+		return (0);
+	}
+
+	(void)memset(out, 0, sizeof(*out));
+	out->router_lladdr = from.sin6_addr;
+	out->router_scope_id = want_ifindex;
+
+	{
+		const uint8_t *opts = buf + sizeof(struct nd_router_advert);
+		size_t olen = (size_t)n - sizeof(struct nd_router_advert);
+		int r = parse_options(opts, olen, out);
+
+		if (r == 1)
+			return (1);
+		if (r < 0)
+			xlog("RA option chain malformed; ignoring");
+		else
+			xlog("RA with no eligible PIO (on-link+auto); waiting");
+		return (0);
+	}
+}
+
+int
+ra_acquire(const char *ifname, unsigned timeout_ms, struct ra_info *out)
+{
+	uint8_t mac[6];
+	int sock, r;
+	unsigned ifindex;
+	struct timespec deadline, now;
+
+	if (get_iface_mac(ifname, mac) != 0) {
+		xlog("get_iface_mac(%s) failed", ifname);
+		return (-1);
+	}
+	ifindex = if_nametoindex(ifname);
+	if (ifindex == 0) {
+		xlog("if_nametoindex(%s) failed: %s", ifname, strerror(errno));
+		return (-1);
+	}
+
+	sock = open_icmp6(ifname);
+	if (sock < 0)
+		return (-1);
+
+	if (send_rs(sock, ifname, mac) != 0) {
+		(void)close(sock);
+		return (-1);
+	}
+	xlog("sent ND_ROUTER_SOLICIT on %s (ifindex=%u) → ff02::2",
+	    ifname, ifindex);
+
+	(void)clock_gettime(CLOCK_MONOTONIC, &deadline);
+	deadline.tv_sec += timeout_ms / 1000;
+	deadline.tv_nsec += (long)(timeout_ms % 1000) * 1000000L;
+	if (deadline.tv_nsec >= 1000000000L) {
+		deadline.tv_nsec -= 1000000000L;
+		deadline.tv_sec++;
+	}
+
+	while (!got_term) {
+		(void)clock_gettime(CLOCK_MONOTONIC, &now);
+		if (now.tv_sec > deadline.tv_sec ||
+		    (now.tv_sec == deadline.tv_sec &&
+		     now.tv_nsec >= deadline.tv_nsec)) {
+			(void)close(sock);
+			return (1);	/* timed out, no RA */
+		}
+
+		r = recv_one(sock, ifindex, out);
+		if (r == 1) {
+			char pbuf[INET6_ADDRSTRLEN];
+			char rbuf[INET6_ADDRSTRLEN];
+
+			(void)inet_ntop(AF_INET6, &out->prefix, pbuf,
+			    sizeof(pbuf));
+			(void)inet_ntop(AF_INET6, &out->router_lladdr, rbuf,
+			    sizeof(rbuf));
+			xlog("RA: prefix=%s/%u router=%s%%%s "
+			    "valid=%us preferred=%us",
+			    pbuf, (unsigned)out->prefix_len, rbuf, ifname,
+			    (unsigned)out->valid_lifetime,
+			    (unsigned)out->preferred_lifetime);
+			(void)close(sock);
+			return (0);
+		}
+		if (r < 0) {
+			(void)close(sock);
+			return (-1);
+		}
+		/* r == 0: keep listening */
+	}
+	(void)close(sock);
+	return (-1);
+}

--- a/src/IPConfiguration/ra_listen.h
+++ b/src/IPConfiguration/ra_listen.h
@@ -1,0 +1,33 @@
+/*
+ * ra_listen.h — IPv6 Router Advertisement listener for iter 7a.
+ *
+ * Single-shot: send one ICMPv6 Router Solicitation to ff02::2 on
+ * `ifname`, wait up to `timeout_ms` for a Router Advertisement, parse
+ * the first Prefix Information Option whose on-link + autonomous
+ * flags are set, and return it.
+ *
+ * RFC 4861 §4.2 (RA format) + RFC 4862 §5.5.3 (SLAAC processing).
+ */
+#ifndef RA_LISTEN_H
+#define RA_LISTEN_H
+
+#include <netinet/in.h>
+#include <stdint.h>
+
+struct ra_info {
+	struct in6_addr	prefix;			/* /N from PIO */
+	uint8_t		prefix_len;
+	uint32_t	valid_lifetime;		/* seconds, RFC 4861 */
+	uint32_t	preferred_lifetime;	/* seconds */
+	struct in6_addr	router_lladdr;		/* fe80::… source of the RA */
+	uint32_t	router_scope_id;	/* ifindex for the LL gateway */
+};
+
+/*
+ * Acquire SLAAC parameters on `ifname`. Returns 0 on success (out
+ * populated), 1 on no-RA-within-timeout (out untouched), -1 on
+ * fatal error.
+ */
+int ra_acquire(const char *ifname, unsigned timeout_ms, struct ra_info *out);
+
+#endif /* RA_LISTEN_H */

--- a/src/IPConfiguration/sc_publish.c
+++ b/src/IPConfiguration/sc_publish.c
@@ -273,6 +273,96 @@ sc_publish_ipv4(struct sc_publish *p, const char *ifname,
 }
 
 int
+sc_publish_ipv6(struct sc_publish *p, const char *ifname,
+    const struct in6_addr *addr, uint8_t prefix_len,
+    const struct in6_addr *router_lladdr)
+{
+	CFMutableDictionaryRef dict;
+	CFStringRef key, k_addresses, k_prefixlen, k_router;
+	CFStringRef k_iface, k_flags;
+	CFStringRef iface_str, addr_str, router_str;
+	CFArrayRef addr_arr, plen_arr;
+	CFNumberRef plen_num, flags_num;
+	const void *addr_vals[1];
+	const void *plen_vals[1];
+	char abuf[INET6_ADDRSTRLEN];
+	char rbuf[INET6_ADDRSTRLEN + IFNAMSIZ + 2];
+	int plen_i, flags_i = 0;
+	Boolean ok;
+
+	if (p == NULL || p->store == NULL)
+		return (-1);
+
+	if (inet_ntop(AF_INET6, addr, abuf, sizeof(abuf)) == NULL)
+		return (-1);
+	{
+		char rbase[INET6_ADDRSTRLEN];
+
+		if (inet_ntop(AF_INET6, router_lladdr, rbase,
+		    sizeof(rbase)) == NULL)
+			return (-1);
+		(void)snprintf(rbuf, sizeof(rbuf), "%s%%%s", rbase, ifname);
+	}
+
+	dict = CFDictionaryCreateMutable(NULL, 0,
+	    &kCFTypeDictionaryKeyCallBacks,
+	    &kCFTypeDictionaryValueCallBacks);
+	if (dict == NULL)
+		return (-1);
+
+	k_addresses = mkstr("Addresses");
+	k_prefixlen = mkstr("PrefixLength");
+	k_router = mkstr("Router");
+	k_iface = mkstr("InterfaceName");
+	k_flags = mkstr("Flags");
+
+	addr_str = mkstr(abuf);
+	addr_vals[0] = addr_str;
+	addr_arr = CFArrayCreate(NULL, addr_vals, 1, &kCFTypeArrayCallBacks);
+	CFDictionarySetValue(dict, k_addresses, addr_arr);
+	CFRelease(addr_arr);
+	CFRelease(addr_str);
+
+	plen_i = prefix_len;
+	plen_num = CFNumberCreate(NULL, kCFNumberIntType, &plen_i);
+	plen_vals[0] = plen_num;
+	plen_arr = CFArrayCreate(NULL, plen_vals, 1, &kCFTypeArrayCallBacks);
+	CFDictionarySetValue(dict, k_prefixlen, plen_arr);
+	CFRelease(plen_arr);
+	CFRelease(plen_num);
+
+	router_str = mkstr(rbuf);
+	CFDictionarySetValue(dict, k_router, router_str);
+	CFRelease(router_str);
+
+	iface_str = mkstr(ifname);
+	CFDictionarySetValue(dict, k_iface, iface_str);
+	CFRelease(iface_str);
+
+	flags_num = CFNumberCreate(NULL, kCFNumberIntType, &flags_i);
+	CFDictionarySetValue(dict, k_flags, flags_num);
+	CFRelease(flags_num);
+
+	CFRelease(k_addresses);
+	CFRelease(k_prefixlen);
+	CFRelease(k_router);
+	CFRelease(k_iface);
+	CFRelease(k_flags);
+
+	key = make_key(ifname, "IPv6");
+	ok = SCDynamicStoreSetValue(p->store, key, dict);
+	CFRelease(key);
+	CFRelease(dict);
+
+	if (!ok) {
+		xlog("SCDynamicStoreSetValue(IPv6) failed: %s",
+		    SCErrorString(SCError()));
+		return (-1);
+	}
+	return (0);
+}
+
+int
 sc_publish_remove(struct sc_publish *p, const char *ifname)
 {
 	CFStringRef key;
@@ -287,6 +377,10 @@ sc_publish_remove(struct sc_publish *p, const char *ifname)
 	CFRelease(key);
 
 	key = make_key(ifname, "DNS");
+	(void)SCDynamicStoreRemoveValue(p->store, key);
+	CFRelease(key);
+
+	key = make_key(ifname, "IPv6");
 	(void)SCDynamicStoreRemoveValue(p->store, key);
 	CFRelease(key);
 

--- a/src/IPConfiguration/sc_publish.h
+++ b/src/IPConfiguration/sc_publish.h
@@ -18,6 +18,9 @@
 
 #include "dhcp_packet.h"
 
+#include <netinet/in.h>
+#include <stdint.h>
+
 struct sc_publish;
 
 /*
@@ -38,6 +41,18 @@ struct sc_publish	*sc_publish_open(const char *session_name);
  */
 int	sc_publish_ipv4(struct sc_publish *p, const char *ifname,
 	    const struct dhcp_lease *lease);
+
+/*
+ * Publish iter 7a SLAAC state under State:/Network/Service/<UUID>/IPv6.
+ * Mirrors Apple's IPv6 dict shape: Addresses (array of strings),
+ * PrefixLength (array of numbers), Router (link-local address with
+ * %ifname zone), InterfaceName, Flags=0 (SLAAC). Returns 0 on success.
+ *
+ * Single-address publish only; iter 7a doesn't track multiple PIOs.
+ */
+int	sc_publish_ipv6(struct sc_publish *p, const char *ifname,
+	    const struct in6_addr *addr, uint8_t prefix_len,
+	    const struct in6_addr *router_lladdr);
 
 /*
  * Remove the previously-published keys for `ifname`. Called on

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -744,6 +744,31 @@ expect {
     }
 }
 
+# IPCFG-RA — iter 7a IPv6 Router Advertisement + SLAAC. ipconfigd
+# sends an ND_ROUTER_SOLICIT to ff02::2 on em0, waits up to 15s for
+# an RA, derives a SLAAC address (EUI-64 over the PIO's prefix),
+# installs it + a default ::/0 route via the RA's source LL, and
+# publishes State:/Network/Service/.../IPv6.
+#
+# IPCFG-RA-MISS is the soft path: QEMU SLIRP's IPv6 RA support varies
+# by qemu version and CLI args. First-round CI accepts MISS so we can
+# see whether SLIRP actually responds; later rounds either keep MISS
+# acceptable (if SLIRP is silent) or upgrade to OK-required (if SLIRP
+# does answer). Either way, IPv6 not coming up does NOT fail the
+# overall boot — IPv4 already passed.
+expect {
+    timeout {
+        puts "\nFAIL: IPCFG-RA marker not seen (neither OK nor MISS)"
+        exit 1
+    }
+    "IPCFG-RA-OK" {
+        puts "\nOK: ipconfigd RA/SLAAC works (address + ::/0 route + State:/.../IPv6 published)"
+    }
+    "IPCFG-RA-MISS" {
+        puts "\nWARN: ipconfigd RA-MISS — SLIRP did not respond to RS (IPv4 still OK)"
+    }
+}
+
 expect {
     timeout {
         puts "\nFAIL: IPCFG-RENEW-OK marker not seen (iter 5b lease renewal CI gate)"


### PR DESCRIPTION
## Summary
- After IPCFG-STORE-OK, send `ND_ROUTER_SOLICIT` → `ff02::2` on the DHCP'd interface, listen up to 15s for a Router Advertisement, derive an EUI-64 SLAAC address from the first eligible PIO (`L` + `A` flags), install it via `SIOCAIFADDR_IN6` + `RTM_ADD ::/0` via the RA's source link-local, and publish `State:/Network/Service/<UUID>/IPv6` to configd. Marker `IPCFG-RA-OK`.
- ~520 LOC fresh BSD-licensed C in `src/IPConfiguration/{ra_listen,apply_lease_v6}.{c,h}` + a 90-LOC `sc_publish_ipv6` extension. Apple's `bootp/IPConfiguration.bproj/rtadv.c` is 2133 LOC of recurring listener / event-channel / configd-plugin state machine — too much for iter 7a's single-shot scope.
- `boot-test.sh` accepts `IPCFG-RA-OK` or `IPCFG-RA-MISS` (soft path): QEMU SLIRP's IPv6 RA behavior varies by version + CLI args; if SLIRP is silent we still pass (IPv4 already worked, v6 absence isn't a regression).

## Deferred to follow-up iters
- RDNSS option (RFC 8106) → State:/.../DNS IPv6 servers
- Multiple prefixes / multiple RAs
- RA lifetime tracking + address expiry (current iter installs once, never removes)
- RFC 7217 stable privacy addresses (deterministic EUI-64 only for iter 7a)
- DHCPv6 stateful (iter 7b — Apple's `DHCPv6Client.c` is 3717 LOC)
- `ipconfig(8)` CLI port (iter 8 — Apple's `bootp/ipconfig.tproj/client.c`)

## Test plan
- [ ] CI boot-test reaches IPCFG-RA-OK (preferred) or IPCFG-RA-MISS (acceptable) inside 15s after IPCFG-STORE-OK
- [ ] IPCFG-RENEW-OK still fires after the RA step (no regression on lease loop)
- [ ] IPCFG-RPC-OK still fires at the end (no regression on Mach service)
- [ ] On success path: SLAAC address visible on em0 via `ifconfig em0` (`inet6 …/64 autoconf`), `netstat -rn -f inet6` shows `default` via the RA's LL gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)