### PR TITLE
feat(IPConfiguration): iter 8 — Apple-shape ipconfig(8) CLI

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1707,7 +1707,28 @@ cc -I"$IPCFG_MIG" -I"$ROOT/src/IPConfiguration" \
    -llaunch -lsystem_kernel
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/ipconfigrpctest" \
     || { echo "FAIL: ipconfigrpctest not built"; exit 1; }
-echo "==> ipconfigd + ipconfigtest + ipconfigrpctest built"
+
+# ipconfig — iter 8 Apple-shape CLI. Same MIG-client-stub linkage as
+# ipconfigrpctest; subcommand table mirrors bootp/ipconfig.tproj/
+# client.c so future iters grow by appending rows. Installs at
+# Apple-canonical /usr/sbin/ipconfig (no FreeBSD conflict — FreeBSD
+# has no ipconfig tool; sibling /sbin/ifconfig is a different binary).
+echo "==> building ipconfig (CLI)"
+mkdir -p "$WORK/rootfs/usr/sbin"
+cc -I"$IPCFG_MIG" -I"$ROOT/src/IPConfiguration" \
+   -I"$ROOT/src/launchd/liblaunch" \
+   -I"$ROOT/src/launchd/freebsd-shims" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wno-macro-redefined \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/sbin/ipconfig" \
+   "$ROOT/src/IPConfiguration/ipconfig.c" \
+   "$IPCFG_MIG/ipconfigUser.c" \
+   -llaunch -lsystem_kernel
+test -x "$WORK/rootfs/usr/sbin/ipconfig" \
+    || { echo "FAIL: /usr/sbin/ipconfig not built"; exit 1; }
+echo "==> ipconfigd + ipconfigtest + ipconfigrpctest + ipconfig built"
 
 #
 # 3z. purge build packages + clean pkg cache + tear down chroot.

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -782,4 +782,36 @@ else
     "$ipconfigrpctest" || true	# marker gates in boot-test.sh
 fi
 
+# IPCFG-IPCONFIG — iter 8 Apple-shape CLI smoke. The same
+# ipconfig_if_count + ipconfig_if_addr MIG round-trip ipconfigrpctest
+# exercises, but driven via /usr/sbin/ipconfig at its Apple-canonical
+# path. Validates that the binary parses argv, looks up the service,
+# calls the MIG stub, and prints the result.
+#
+# Marker: IPCFG-IPCONFIG-OK on both subcommands returning the expected
+# values (em0=10.0.2.15 from SLIRP; ifcount>=1). -FAIL on any mismatch.
+ipconfig_cli=/usr/sbin/ipconfig
+if [ ! -x "$ipconfig_cli" ]; then
+    echo "IPCFG-IPCONFIG-FAIL: $ipconfig_cli missing"
+else
+    cli_count=$("$ipconfig_cli" ifcount 2>&1 || true)
+    cli_addr=$("$ipconfig_cli" getifaddr em0 2>&1 || true)
+    echo "  ipconfig ifcount -> $cli_count"
+    echo "  ipconfig getifaddr em0 -> $cli_addr"
+    case "$cli_count" in
+        ''|*[!0-9]*)
+            echo "IPCFG-IPCONFIG-FAIL: ifcount non-numeric '$cli_count'"
+            ;;
+        *)
+            if [ "$cli_count" -lt 1 ]; then
+                echo "IPCFG-IPCONFIG-FAIL: ifcount=$cli_count < 1"
+            elif [ "$cli_addr" != "10.0.2.15" ]; then
+                echo "IPCFG-IPCONFIG-FAIL: em0 addr '$cli_addr' != 10.0.2.15"
+            else
+                echo "IPCFG-IPCONFIG-OK: ipconfig ifcount=$cli_count em0=$cli_addr"
+            fi
+            ;;
+    esac
+fi
+
 exit 0

--- a/src/IPConfiguration/ipconfig.c
+++ b/src/IPConfiguration/ipconfig.c
@@ -1,0 +1,164 @@
+/*
+ * ipconfig — Apple's IPConfiguration CLI, ported to freebsd-launchd-mach.
+ *
+ * Iter 8 (the closer for the IPConfiguration port story): a small
+ * Mach RPC client of `com.apple.IPConfiguration` mirroring Apple's
+ * bootp/ipconfig.tproj/client.c shape — a `commands[]` lookup table
+ * with one tiny dispatch function per subcommand. Iter 8 ships the
+ * two subcommands the existing 2-routine MIG surface can serve:
+ *
+ *   ipconfig getifaddr <ifname>     →  ipconfig_if_addr
+ *   ipconfig ifcount                →  ipconfig_if_count
+ *
+ * Apple's client.c is 1630 LOC because it covers ~25 subcommands
+ * (waitall, getoption, getsummary, getpacket, getv6packet, getra,
+ * getdhcpduid, set, addService, BSDP, NetBoot, CLAT46, …). Every
+ * one of those needs a MIG routine our ipconfig.defs doesn't have
+ * yet; they grow in later iters by appending rows to commands[] +
+ * one routine each in ipconfig.defs. Fresh ~150 LOC keeps the
+ * binary clean and the path to "vendor-shape" growth obvious.
+ *
+ * Install: /usr/sbin/ipconfig.
+ */
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include "ipconfig_mig_types.h"
+#include "ipconfig.h"		/* MIG: ipconfig_* client stubs */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *progname = "ipconfig";
+
+static int
+S_getifaddr(mach_port_t svc, int argc, char **argv)
+{
+	InterfaceName name;
+	ip_address_t addr = 0;
+	ipconfig_status_t status = ipconfig_status_internal_error_e;
+	kern_return_t kr;
+	struct in_addr in_a;
+	char buf[INET_ADDRSTRLEN];
+
+	if (argc < 1) {
+		(void)fprintf(stderr, "usage: %s getifaddr <ifname>\n",
+		    progname);
+		return (1);
+	}
+
+	(void)memset(name, 0, sizeof(name));
+	(void)strlcpy(name, argv[0], sizeof(name));
+
+	kr = ipconfig_if_addr(svc, name, &addr, &status);
+	if (kr != KERN_SUCCESS) {
+		(void)fprintf(stderr, "%s: getifaddr %s: mach 0x%x\n",
+		    progname, name, (unsigned)kr);
+		return (1);
+	}
+	if (status != ipconfig_status_success_e) {
+		(void)fprintf(stderr, "%s: getifaddr %s: status %d\n",
+		    progname, name, (int)status);
+		return (1);
+	}
+
+	in_a.s_addr = addr;
+	if (inet_ntop(AF_INET, &in_a, buf, sizeof(buf)) == NULL) {
+		(void)fprintf(stderr, "%s: getifaddr %s: inet_ntop failed\n",
+		    progname, name);
+		return (1);
+	}
+	(void)printf("%s\n", buf);
+	return (0);
+}
+
+static int
+S_ifcount(mach_port_t svc, int argc, char **argv)
+{
+	int count = -1;
+	kern_return_t kr;
+
+	(void)argc;
+	(void)argv;
+
+	kr = ipconfig_if_count(svc, &count);
+	if (kr != KERN_SUCCESS) {
+		(void)fprintf(stderr, "%s: ifcount: mach 0x%x\n", progname,
+		    (unsigned)kr);
+		return (1);
+	}
+	(void)printf("%d\n", count);
+	return (0);
+}
+
+static const struct command_info {
+	const char	*name;
+	int		(*func)(mach_port_t, int, char **);
+	int		min_argc;
+	const char	*usage;
+} commands[] = {
+	{ "getifaddr",	S_getifaddr,	1, "<ifname>" },
+	{ "ifcount",	S_ifcount,	0, "" },
+	{ NULL,		NULL,		0, NULL },
+};
+
+static void
+usage(void)
+{
+	int i;
+
+	(void)fprintf(stderr, "usage: %s <command> [args]\n", progname);
+	(void)fprintf(stderr, "commands:\n");
+	for (i = 0; commands[i].name != NULL; i++) {
+		(void)fprintf(stderr, "  %s %s\n", commands[i].name,
+		    commands[i].usage);
+	}
+	exit(2);
+}
+
+int
+main(int argc, char **argv)
+{
+	mach_port_t svc = MACH_PORT_NULL;
+	kern_return_t kr;
+	int i;
+
+	if (argv[0] != NULL) {
+		const char *slash = strrchr(argv[0], '/');
+
+		progname = (slash != NULL) ? slash + 1 : argv[0];
+	}
+
+	if (argc < 2)
+		usage();
+
+	for (i = 0; commands[i].name != NULL; i++) {
+		if (strcasecmp(argv[1], commands[i].name) != 0)
+			continue;
+		if ((argc - 2) < commands[i].min_argc) {
+			(void)fprintf(stderr,
+			    "%s: %s needs %d arg(s): %s %s %s\n",
+			    progname, commands[i].name,
+			    commands[i].min_argc, progname,
+			    commands[i].name, commands[i].usage);
+			return (2);
+		}
+		kr = bootstrap_look_up(bootstrap_port,
+		    "com.apple.IPConfiguration", &svc);
+		if (kr != KERN_SUCCESS || svc == MACH_PORT_NULL) {
+			(void)fprintf(stderr,
+			    "%s: bootstrap_look_up failed: 0x%x\n",
+			    progname, (unsigned)kr);
+			return (1);
+		}
+		return (commands[i].func(svc, argc - 2, &argv[2]));
+	}
+
+	(void)fprintf(stderr, "%s: unknown command '%s'\n", progname, argv[1]);
+	usage();
+	return (2);
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -795,6 +795,25 @@ expect {
     }
 }
 
+# IPCFG-IPCONFIG — iter 8 Apple-shape CLI. Same MIG round-trip
+# ipconfigrpctest exercises, but driven through /usr/sbin/ipconfig.
+# Validates that the Apple-canonical CLI parses argv, looks up
+# com.apple.IPConfiguration, calls ipconfig_if_count + ipconfig_if_addr,
+# and prints the expected results.
+expect {
+    timeout {
+        puts "\nFAIL: IPCFG-IPCONFIG marker not seen"
+        exit 1
+    }
+    "IPCFG-IPCONFIG-FAIL" {
+        puts "\nFAIL: /usr/sbin/ipconfig CLI did not return the expected ifcount + getifaddr"
+        exit 1
+    }
+    "IPCFG-IPCONFIG-OK" {
+        puts "\nOK: /usr/sbin/ipconfig CLI works (Apple-shape getifaddr + ifcount)"
+    }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary
- Closes the IPConfiguration port story. New \`/usr/sbin/ipconfig\` is a Mach RPC client of \`com.apple.IPConfiguration\` mirroring Apple's \`bootp/ipconfig.tproj/client.c\` shape (\`commands[]\` dispatch table). Iter 8 ships the two subcommands the existing 2-routine MIG surface serves: \`ipconfig getifaddr <ifname>\` → \`ipconfig_if_addr\` and \`ipconfig ifcount\` → \`ipconfig_if_count\`.
- Fresh ~160 LOC. Apple's \`client.c\` is 1630 LOC covering ~25 subcommands (waitall, getoption, getsummary, getpacket, getv6packet, getra, getdhcpduid, set, addService, BSDP, NetBoot, CLAT46, ...). Each needs a MIG routine our \`ipconfig.defs\` doesn't have yet; they grow in later iters by appending one row to \`commands[]\` + one routine to \`ipconfig.defs\`.

## No conflict with FreeBSD
- Install path: \`/usr/sbin/ipconfig\`. FreeBSD has no \`ipconfig\` tool — pure addition, no overwrite. Sibling \`/sbin/ifconfig\` is a different binary with a different name (one char difference). Matches the "pure addition" entries in [userland-cmds plan](https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html) §9 alongside \`mig\`, \`migcom\`, \`lsmp\`, \`hostinfo\`, \`nvram\`, \`stackshot\`.

## CI marker
\`IPCFG-IPCONFIG-OK\` after \`IPCFG-RPC-OK\`. \`run.sh\` runs \`ipconfig ifcount\` + \`ipconfig getifaddr em0\`, checks values (1, 10.0.2.15), emits OK on match.

## Test plan
- [ ] CI boot-test reaches IPCFG-IPCONFIG-OK
- [ ] No regression on earlier markers (IPCFG-BOOT/ARP/BOUND/STORE/RA/RENEW/RPC all green)
- [ ] On-image: \`/usr/sbin/ipconfig getifaddr em0\` prints the DHCPed v4 address; \`/usr/sbin/ipconfig ifcount\` prints \`1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)