### PR TITLE
fix(mDNSResponder): unbreak main after iter 2 — .PATH + srp-features.h

### DIFF
--- a/src/mDNSResponder/DSO/srp-features.h
+++ b/src/mDNSResponder/DSO/srp-features.h
@@ -1,0 +1,62 @@
+/* srp-features.h
+ *
+ * Copyright (c) 2020-2025 Apple Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file contains compile time feature flag which enables or disables
+ * different behavior of srp-mdns-proxy.
+ */
+
+#ifndef __SRP_FEATURES_H__
+#define __SRP_FEATURES_H__
+
+// SRP_FEATURE_COMBINED_SRP_DNSSD_PROXY: controls whether to initialize dnssd-proxy in srp-mdns-proxy.
+#if defined(BUILD_SRP_MDNS_PROXY) && (BUILD_SRP_MDNS_PROXY == 1)
+
+// SRP_TEST_SERVER always builds a full (simulated) Thread border router
+#  if defined(SRP_TEST_SERVER)
+#    define SRP_TEST_SERVER_OVERRIDE 1
+#  else
+#    define SRP_TEST_SERVER_OVERRIDE 0
+#  endif
+
+// We can only have combined srp-dnssd-proxy if we are building srp-mdns-proxy
+#  define SRP_FEATURE_PUBLISH_SPECIFIC_ROUTES 0
+#  define SRP_FEATURE_DNSSD_PROXY_SHARED_CONNECTION 0
+#    define SRP_FEATURE_DYNAMIC_CONFIGURATION 1
+#else
+#  ifndef SRP_FEATURE_REPLICATION
+#    define SRP_FEATURE_REPLICATION 1
+#  endif
+#  ifndef SRP_FEATURE_COMBINED_SRP_DNSSD_PROXY
+#    define SRP_FEATURE_COMBINED_SRP_DNSSD_PROXY 1
+#  endif
+#  ifndef SRP_FEATURE_DYNAMIC_CONFIGURATION
+#    define SRP_FEATURE_DYNAMIC_CONFIGURATION 1
+#endif
+#endif
+
+// SRP_FEATURE_CAN_GENERATE_TLS_CERT: controls whether to let srp-mdns-proxy generate the TLS certificate internally.
+#if defined(__APPLE__)
+    // All the Apple platforms support security framework, so it can generate TLS certificate internally.
+#  define SRP_FEATURE_CAN_GENERATE_TLS_CERT 1
+#else
+#  define SRP_FEATURE_CAN_GENERATE_TLS_CERT 0
+#endif
+
+
+// At present we never want this, but we're keeping the code around.
+#define SRP_ALLOWS_MDNS_CONFLICTS 0
+
+#endif // __SRP_FEATURES_H__

--- a/src/mDNSResponder/Makefile
+++ b/src/mDNSResponder/Makefile
@@ -34,6 +34,7 @@ SRCS+=		dso.c dso-transport.c
 .PATH:		${.CURDIR}/mDNSCore
 .PATH:		${.CURDIR}/mDNSPosix
 .PATH:		${.CURDIR}/mDNSShared
+.PATH:		${.CURDIR}/mDNSShared/utilities
 .PATH:		${.CURDIR}/DSO
 
 # Vendored Apple code is not WARNS=6-clean (lots of -Wunused-but-set-
@@ -57,6 +58,7 @@ CFLAGS+=	-I${.CURDIR}
 CFLAGS+=	-I${.CURDIR}/mDNSCore
 CFLAGS+=	-I${.CURDIR}/mDNSPosix
 CFLAGS+=	-I${.CURDIR}/mDNSShared
+CFLAGS+=	-I${.CURDIR}/mDNSShared/utilities
 CFLAGS+=	-I${.CURDIR}/DSO
 
 # <servers/bootstrap.h> (bootstrap_check_in + bootstrap_port global)


### PR DESCRIPTION
## Background
PR #53 (mDNS iter 2) was inadvertently merged via \`gh pr merge --auto\` while CI was still in flight — and CI failed. main has been red since. Two known issues this PR fixes; more may surface during CI iteration here, in which case I'll push additional fixups to this same PR.

## Changes
1. **Makefile**: add \`.PATH\` + \`-I\` for \`mDNSShared/utilities/\` so \`mdns_addr_tailq.c\` and \`misc_utilities.c\` resolve (the original CI failure on round 1: *"make: don't know how to make mdns_addr_tailq.c"*).
2. **DSO/srp-features.h**: copy the upstream header from \`apple-oss-distributions/mDNSResponder/ServiceRegistration/\` into \`DSO/\` next to \`dso.h\`. ServiceRegistration isn't vendored (out of port scope), but \`srp-features.h\` is a self-contained feature-flag header (~60 LOC, zero dependencies) and DSO/dso.h includes it unconditionally.

## Test plan
- [ ] CI build green
- [ ] MDNS-BOOT-OK fires (no regression on Mach service registration from iter 1)
- [ ] MDNS-ENGINE-OK fires (mDNS_Init succeeds on FreeBSD)
- [ ] All IPCFG-* / SYSLOG-* / IOKIT-* markers green (no regression)
- [ ] /var/log/mDNSResponder.stderr post-boot shows engine init lines

**This PR will NOT be auto-merged.** I will wait for CI green AND verify every checkbox above before \`gh pr merge --merge\`. (Lesson learned: \`--auto\` doesn't gate on CI when branch protection lacks required-status-checks.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)