### PR TITLE
feat(mDNSResponder): iter 3 — libdns_sd.so + end-to-end dnssdtest

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1762,7 +1762,36 @@ cc -I"$ROOT/src/launchd/liblaunch" \
    -llaunch -lsystem_kernel
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/mdnstest" \
     || { echo "FAIL: mdnstest not built"; exit 1; }
-echo "==> mDNSResponder + mdnstest built"
+
+# libdns_sd — iter 3 client library. Compiles the cross-platform
+# DNS-SD client stubs from mDNSShared/ into /usr/lib/system/
+# libdns_sd.so so Apple-shape apps can link -ldns_sd. Same shape as
+# libIOKit / libSystemConfiguration's Makefile.
+echo "==> Phase K iter 3: building libdns_sd (src/mDNSResponder/libdns_sd)"
+make -C "$ROOT/src/mDNSResponder/libdns_sd" \
+     DESTDIR="$WORK/rootfs" \
+     SYSROOT="$WORK/rootfs" \
+     all install
+test -f "$WORK/rootfs/usr/lib/system/libdns_sd.so.1" \
+    || { echo "FAIL: libdns_sd.so.1 not installed"; exit 1; }
+test -L "$WORK/rootfs/usr/lib/system/libdns_sd.so" \
+    || { echo "FAIL: libdns_sd.so symlink not installed"; exit 1; }
+test -f "$WORK/rootfs/usr/include/dns_sd.h" \
+    || { echo "FAIL: /usr/include/dns_sd.h not installed"; exit 1; }
+
+# dnssdtest — iter 3 end-to-end DNS-SD round-trip probe. Registers a
+# test service and browses for it via libdns_sd, expects the daemon
+# to round-trip the entry. Marker MDNS-DNSSD-OK on success.
+echo "==> building dnssdtest"
+cc -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/dnssdtest" \
+   "$ROOT/src/mDNSResponder/dnssdtest.c" \
+   -ldns_sd
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/dnssdtest" \
+    || { echo "FAIL: dnssdtest not built"; exit 1; }
+echo "==> mDNSResponder + mdnstest + libdns_sd + dnssdtest built"
 
 #
 # 3z. purge build packages + clean pkg cache + tear down chroot.

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -819,6 +819,18 @@ if [ -f /var/log/mDNSResponder.stderr ]; then
     echo "--- end mDNSResponder.stderr ---"
 fi
 
+# MDNS-DNSSD — iter 3 end-to-end round-trip via libdns_sd:
+# dnssdtest registers a service ("freebsd-launchd-mach-iter3" /
+# _iter3._tcp) and browses for it; on success the daemon round-trips
+# its own registration back through libdns_sd's AF_UNIX channel.
+# Proves the engine + uds_daemon + libdns_sd stubs all line up.
+dnssdtest=/usr/tests/freebsd-launchd-mach/dnssdtest
+if [ ! -x "$dnssdtest" ]; then
+    echo "MDNS-DNSSD-FAIL: $dnssdtest missing"
+else
+    "$dnssdtest" || true	# marker gates in boot-test.sh
+fi
+
 ipconfig_cli=/usr/sbin/ipconfig
 if [ ! -x "$ipconfig_cli" ]; then
     echo "IPCFG-IPCONFIG-FAIL: $ipconfig_cli missing"

--- a/src/mDNSResponder/dnssdtest.c
+++ b/src/mDNSResponder/dnssdtest.c
@@ -1,0 +1,150 @@
+/*
+ * dnssdtest — iter 3 end-to-end DNS-SD round-trip probe for mDNSResponder.
+ *
+ * Uses libdns_sd to register a synthetic service ("freebsd-launchd-mach-
+ * iter3" of type "_iter3._tcp") and then browse for it. The Register
+ * goes through libdns_sd's AF_UNIX wire protocol to the daemon at
+ * /var/run/mDNSResponder; the daemon registers the record in its
+ * authoritative zone and announces it over multicast. The Browse
+ * goes through the same socket; the daemon's local-record cache
+ * returns our own registration. End-to-end proof that the iter-2
+ * engine + libdns_sd client + uds_daemon pipe all work.
+ *
+ * Marker: MDNS-DNSSD-OK on round-trip success, MDNS-DNSSD-FAIL on
+ * any libdns_sd error or 5s timeout. run.sh runs this after the
+ * MDNS-ENGINE-OK marker fires; boot-test.sh gates on the marker.
+ */
+#include "dns_sd.h"
+
+#include <arpa/inet.h>		/* htons */
+
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#define DNSSD_SVC_NAME		"freebsd-launchd-mach-iter3"
+#define DNSSD_SVC_TYPE		"_iter3._tcp"
+#define DNSSD_SVC_PORT		12345
+#define DNSSD_BROWSE_TIMEOUT	5	/* seconds */
+
+static volatile int got_browse_hit;
+
+static void DNSSD_API
+register_cb(DNSServiceRef sdRef, DNSServiceFlags flags,
+    DNSServiceErrorType errorCode, const char *name, const char *regtype,
+    const char *domain, void *context)
+{
+	(void)sdRef;
+	(void)flags;
+	(void)context;
+	(void)fprintf(stderr,
+	    "dnssdtest: register cb err=%d name=%s type=%s domain=%s\n",
+	    (int)errorCode, name ? name : "?",
+	    regtype ? regtype : "?", domain ? domain : "?");
+}
+
+static void DNSSD_API
+browse_cb(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t ifIdx,
+    DNSServiceErrorType err, const char *serviceName, const char *regtype,
+    const char *domain, void *context)
+{
+	(void)sdRef;
+	(void)context;
+	(void)fprintf(stderr,
+	    "dnssdtest: browse cb err=%d flags=0x%x ifidx=%u name=%s "
+	    "type=%s domain=%s\n",
+	    (int)err, (unsigned)flags, (unsigned)ifIdx,
+	    serviceName ? serviceName : "?",
+	    regtype ? regtype : "?", domain ? domain : "?");
+	if (err == kDNSServiceErr_NoError && serviceName != NULL &&
+	    strcmp(serviceName, DNSSD_SVC_NAME) == 0)
+		got_browse_hit = 1;
+}
+
+int
+main(void)
+{
+	DNSServiceRef reg_ref = NULL;
+	DNSServiceRef browse_ref = NULL;
+	DNSServiceErrorType err;
+	int reg_fd, browse_fd, max_fd;
+	time_t deadline;
+
+	err = DNSServiceRegister(&reg_ref, 0, 0,
+	    DNSSD_SVC_NAME, DNSSD_SVC_TYPE,
+	    NULL,			/* domain (= ".local.") */
+	    NULL,			/* host (= this host) */
+	    htons(DNSSD_SVC_PORT),
+	    0, NULL,			/* txt record */
+	    register_cb, NULL);
+	if (err != kDNSServiceErr_NoError) {
+		(void)printf("MDNS-DNSSD-FAIL: DNSServiceRegister returned "
+		    "%d\n", (int)err);
+		return (1);
+	}
+
+	err = DNSServiceBrowse(&browse_ref, 0, 0,
+	    DNSSD_SVC_TYPE, NULL,	/* domain (= ".local.") */
+	    browse_cb, NULL);
+	if (err != kDNSServiceErr_NoError) {
+		(void)printf("MDNS-DNSSD-FAIL: DNSServiceBrowse returned "
+		    "%d\n", (int)err);
+		DNSServiceRefDeallocate(reg_ref);
+		return (1);
+	}
+
+	reg_fd = DNSServiceRefSockFD(reg_ref);
+	browse_fd = DNSServiceRefSockFD(browse_ref);
+	if (reg_fd < 0 || browse_fd < 0) {
+		(void)printf("MDNS-DNSSD-FAIL: DNSServiceRefSockFD returned "
+		    "%d / %d\n", reg_fd, browse_fd);
+		DNSServiceRefDeallocate(browse_ref);
+		DNSServiceRefDeallocate(reg_ref);
+		return (1);
+	}
+	max_fd = reg_fd > browse_fd ? reg_fd : browse_fd;
+
+	/*
+	 * Drain both DNSServiceRef sockets until the browse callback sees
+	 * our own registration, or 5s elapses. Within the same daemon
+	 * the browse-of-own-registration is a local-cache lookup, so it
+	 * returns within ms in practice — the 5s budget is for boot
+	 * race when the daemon is still wiring up the engine.
+	 */
+	deadline = time(NULL) + DNSSD_BROWSE_TIMEOUT;
+	while (!got_browse_hit && time(NULL) < deadline) {
+		fd_set rfds;
+		struct timeval tv;
+		int r;
+
+		FD_ZERO(&rfds);
+		FD_SET(reg_fd, &rfds);
+		FD_SET(browse_fd, &rfds);
+		tv.tv_sec = 1;
+		tv.tv_usec = 0;
+		r = select(max_fd + 1, &rfds, NULL, NULL, &tv);
+		if (r > 0) {
+			if (FD_ISSET(reg_fd, &rfds))
+				(void)DNSServiceProcessResult(reg_ref);
+			if (FD_ISSET(browse_fd, &rfds))
+				(void)DNSServiceProcessResult(browse_ref);
+		}
+	}
+
+	if (got_browse_hit)
+		(void)printf("MDNS-DNSSD-OK: registered + browsed "
+		    DNSSD_SVC_TYPE " / " DNSSD_SVC_NAME "\n");
+	else
+		(void)printf("MDNS-DNSSD-FAIL: browse did not see our own "
+		    "registration within %ds\n", DNSSD_BROWSE_TIMEOUT);
+
+	DNSServiceRefDeallocate(browse_ref);
+	DNSServiceRefDeallocate(reg_ref);
+	return (got_browse_hit ? 0 : 1);
+}

--- a/src/mDNSResponder/libdns_sd/Makefile
+++ b/src/mDNSResponder/libdns_sd/Makefile
@@ -1,0 +1,53 @@
+# libdns_sd — client library for Apple's DNS Service Discovery API.
+#
+# iter 3 of the mDNSResponder port. Compiles the cross-platform DNS-SD
+# client stubs from mDNSShared/ into /usr/lib/system/libdns_sd.so so
+# Apple-shape apps (gershwin desktop, ported Cocoa apps) can link
+# -ldns_sd and call DNSServiceRegister / DNSServiceBrowse /
+# DNSServiceResolve / DNSServiceQueryRecord / etc. The stubs speak
+# the Apple AF_UNIX wire protocol against /var/run/mDNSResponder,
+# which the daemon (PosixDaemon.c + uds_daemon.c, shipped iter 2)
+# listens on.
+#
+# No Mach surface here — Apple's open-source mDNSResponder dropped
+# the legacy Mach RPC layer years ago in favour of the cross-platform
+# AF_UNIX protocol. The com.apple.mDNSResponder Mach service in our
+# repo is currently a presence beacon (bootstrap_check_in only),
+# not a DNS-SD endpoint. iter 4+ can revisit if a Mach-RPC client
+# surfaces.
+#
+# Public header: /usr/include/dns_sd.h. Shared lib: /usr/lib/system/
+# libdns_sd.so(.1). Same path scheme libIOKit / libSystemConfiguration
+# use.
+
+LIB=		dns_sd
+SHLIB_MAJOR=	1
+
+SRCS=		dnssd_clientlib.c dnssd_clientstub.c dnssd_ipc.c dnssd_errstring.c
+
+.PATH:		${.CURDIR}/../mDNSShared
+
+# WARNS=0: vendored Apple source isn't WARNS=6-clean (same trade
+# the daemon's Makefile makes).
+WARNS=		0
+NO_MAN=		yes
+
+# Mirror upstream's CFLAGS_COMMON + FreeBSD-specific defines.
+CFLAGS+=	-O2 -pipe -fwrapv
+CFLAGS+=	-DPOSIX_BUILD
+CFLAGS+=	-DMDNS_UDS_SERVERPATH=\"/var/run/mDNSResponder\"
+CFLAGS+=	-DMDNS_NO_STRICT=1
+CFLAGS+=	-DHAVE_IPV6
+CFLAGS+=	-D_THREAD_SAFE
+
+CFLAGS+=	-I${.CURDIR}/../mDNSShared
+CFLAGS+=	-I${.CURDIR}/../mDNSShared/utilities
+CFLAGS+=	-I${.CURDIR}/../mDNSCore
+
+INCS=		${.CURDIR}/../mDNSShared/dns_sd.h
+INCSDIR=	${PREFIX}/include
+LIBDIR=		${PREFIX}/lib/system
+
+PREFIX?=	/usr
+
+.include <bsd.lib.mk>

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -830,6 +830,27 @@ expect {
     }
 }
 
+# MDNS-DNSSD — iter 3 end-to-end DNS-SD round-trip via libdns_sd.
+# dnssdtest registers "_iter3._tcp" / "freebsd-launchd-mach-iter3"
+# through libdns_sd's AF_UNIX channel to the daemon, then browses
+# for the same type and waits up to 5s for its own registration to
+# show up in the browse callback. Proves the engine + uds_daemon +
+# libdns_sd stubs all wire correctly end-to-end — the first iter
+# that exercises a real DNS-SD round-trip from a client binary.
+expect {
+    timeout {
+        puts "\nFAIL: MDNS-DNSSD marker not seen"
+        exit 1
+    }
+    "MDNS-DNSSD-FAIL" {
+        puts "\nFAIL: dnssdtest could not round-trip Register + Browse via libdns_sd"
+        exit 1
+    }
+    "MDNS-DNSSD-OK" {
+        puts "\nOK: libdns_sd end-to-end (Register + Browse round-trip via /var/run/mDNSResponder)"
+    }
+}
+
 # IPCFG-IPCONFIG — iter 8 Apple-shape CLI. Same MIG round-trip
 # ipconfigrpctest exercises, but driven through /usr/sbin/ipconfig.
 # Validates that the Apple-canonical CLI parses argv, looks up


### PR DESCRIPTION
## Summary
Closes the mDNSResponder usability loop. Iter 2 brought up the engine + AF_UNIX uds_daemon; iter 3 ships the client library Apple-shape apps link against, plus an end-to-end Register+Browse test to prove the full stack works.

- **\`/usr/lib/system/libdns_sd.so\`** built from \`mDNSShared/{dnssd_clientlib,dnssd_clientstub,dnssd_ipc,dnssd_errstring}.c\`. Same bsd.lib.mk shape as libIOKit + libSystemConfiguration.
- **\`/usr/include/dns_sd.h\`** installed alongside.
- **\`dnssdtest\`** registers \`_iter3._tcp\` / \`freebsd-launchd-mach-iter3\` through libdns_sd, then browses for the type, drains both DNSServiceRef sockets via \`select()\` until the browse callback sees its own registration. Round-trip should be ms-scale (within-daemon local-cache lookup).

## Why no Mach RPC for iter 3
Apple's open-source mDNSResponder dropped the legacy Mach client API years ago — there's no upstream \`dnssd.defs\` to port. \`com.apple.mDNSResponder\` Mach service remains the iter-1/2 presence beacon (bootstrap_check_in only). A future iter can add Mach client RPC if a real consumer materializes.

## Test plan (verify before manual merge — NO --auto)
- [ ] CI build green (libdns_sd compiles, dnssdtest links)
- [ ] MDNS-BOOT-OK still fires (no regression)
- [ ] MDNS-ENGINE-OK still fires (no regression)
- [ ] MDNS-DNSSD-OK fires (the new end-to-end marker)
- [ ] No regression on IPCFG-* / SYSLOG-* / IOKIT-* / CONFIGD-* / MACH-SMOKE
- [ ] \`/usr/lib/system/libdns_sd.so.1\` + \`/usr/include/dns_sd.h\` present in the rootfs

🤖 Generated with [Claude Code](https://claude.com/claude-code)