### PR TITLE
feat(DiskArbitration): iter 1 — daemon skeleton + Mach service

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1794,6 +1794,40 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/dnssdtest" \
 echo "==> mDNSResponder + mdnstest + libdns_sd + dnssdtest built"
 
 #
+# 3w. Phase K DiskArbitration iter 1 — daemon skeleton.
+#     Apple's DiskArbitration daemon. iter 1 is the bootstrap_check_in
+#     shell (no hwregd subscription yet, no libgeom enrichment, no
+#     DA framework). Mirrors hwregd / ipconfigd / mDNSResponder iter 1
+#     shape: prove the Mach plumbing + launchd plist + build infra
+#     first, then layer real subsystem code. iter 2 subscribes to
+#     hwregd's storage device class events.
+#     Plan: pkgdemon.github.io/freebsd-disk-arbitration-plan.html
+#
+echo "==> Phase K: building diskarbitrationd (src/DiskArbitration)"
+make -C "$ROOT/src/DiskArbitration" \
+     DESTDIR="$WORK/rootfs" \
+     SYSROOT="$WORK/rootfs" \
+     all install
+test -x "$WORK/rootfs/usr/sbin/diskarbitrationd" \
+    || { echo "FAIL: /usr/sbin/diskarbitrationd not installed or not executable"; exit 1; }
+
+# datest — iter 1 liveness probe. bootstrap_look_up for
+# com.apple.DiskArbitration; prints DA-BOOT-OK on success. run.sh
+# runs it and the marker gates in tests/boot-test.sh.
+echo "==> building datest"
+cc -I"$ROOT/src/launchd/liblaunch" \
+   -I"$ROOT/src/launchd/freebsd-shims" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/datest" \
+   "$ROOT/src/DiskArbitration/datest.c" \
+   -llaunch -lsystem_kernel
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/datest" \
+    || { echo "FAIL: datest not built"; exit 1; }
+echo "==> diskarbitrationd + datest built"
+
+#
 # 3z. purge build packages + clean pkg cache + tear down chroot.
 #     Runs LAST in the build phase, after every chroot-side build
 #     (libdispatch) has used cmake/ninja/clang. Build pkgs (cmake/ninja

--- a/overlays/System/Library/LaunchDaemons/com.apple.DiskArbitration.plist
+++ b/overlays/System/Library/LaunchDaemons/com.apple.DiskArbitration.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.apple.DiskArbitration.plist
+
+  Boot-time launchd plist for diskarbitrationd (freebsd-launchd-mach
+  DiskArbitration daemon).
+
+  iter 1 is the daemon skeleton: diskarbitrationd claims the
+  com.apple.DiskArbitration Mach service via bootstrap_check_in and
+  sleeps until SIGTERM. iter 2 subscribes to hwregd's storage device
+  class events (ATTACH/DETACH for ada0/da0/nvd0/cd0); iter 3 adds
+  libgeom enrichment (partition table, UUID, label, FS-type); iter 4+
+  serves the DiskArbitration.framework client API via the da.defs
+  MIG IDL. RunAtLoad + KeepAlive so it starts at PID-1 launchd boot
+  and respawns on crash. StandardErrorPath / StandardOutPath route
+  the daemon's log to /var/log/diskarbitrationd.stderr — same
+  convention hwregd / configd / ipconfigd / mDNSResponder use; the
+  CI boot test dumps the file post-boot for verification.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.apple.DiskArbitration</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/sbin/diskarbitrationd</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>MachServices</key>
+    <dict>
+        <key>com.apple.DiskArbitration</key>
+        <true/>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/var/log/diskarbitrationd.stderr</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/diskarbitrationd.stderr</string>
+</dict>
+</plist>

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -831,6 +831,17 @@ else
     "$dnssdtest" || true	# marker gates in boot-test.sh
 fi
 
+# DA-BOOT — DiskArbitration iter 1 liveness probe. bootstrap_look_up
+# for com.apple.DiskArbitration; prints DA-BOOT-OK on success. iter 1
+# is just the daemon skeleton (no hwregd subscription, no libgeom
+# enrichment, no DA framework). iter 2+ wires the real plumbing.
+datest=/usr/tests/freebsd-launchd-mach/datest
+if [ ! -x "$datest" ]; then
+    echo "DA-BOOT-FAIL: $datest missing"
+else
+    "$datest" || true	# marker gates in boot-test.sh
+fi
+
 ipconfig_cli=/usr/sbin/ipconfig
 if [ ! -x "$ipconfig_cli" ]; then
     echo "IPCFG-IPCONFIG-FAIL: $ipconfig_cli missing"

--- a/src/DiskArbitration/Makefile
+++ b/src/DiskArbitration/Makefile
@@ -1,0 +1,46 @@
+# diskarbitrationd — freebsd-launchd-mach DiskArbitration daemon.
+#
+# iter 1: daemon skeleton. main + bootstrap_check_in for
+# com.apple.DiskArbitration + a sleep loop. Same shape as
+# src/IPConfiguration/Makefile (iter 1 state) and src/hwregd/Makefile
+# / src/mDNSResponder/Makefile (the iter-1 mDNS shell).
+#
+# iter 2+ adds hwregd subscription (Mach RPC), libgeom enrichment,
+# and the da.defs MIG IDL serving DiskArbitration.framework clients.
+#
+# Build:   cd src/DiskArbitration && make SYSROOT=/path/to/rootfs
+# Install: make DESTDIR=/path/to/rootfs install
+
+PROG=		diskarbitrationd
+MAN=
+SRCS=		diskarbitrationd.c
+
+NO_MAN=		yes
+WARNS=		6
+
+CFLAGS+=	-O2 -pipe
+CFLAGS+=	-Wall -Wextra -Wshadow -Wstrict-prototypes
+CFLAGS+=	-Wmissing-prototypes -Wpointer-arith
+
+# <servers/bootstrap.h> (bootstrap_check_in + bootstrap_port global)
+# comes from liblaunch; its bootstrap.h pulls in Apple shim headers
+# (AvailabilityMacros.h, ...) from launchd/freebsd-shims. Same -I
+# pair hwregd / configd / ipconfigd / mDNSResponder use.
+CFLAGS+=	-I${.CURDIR}/../launchd/liblaunch
+CFLAGS+=	-I${.CURDIR}/../launchd/freebsd-shims
+
+SYSROOT?=
+.if !empty(SYSROOT)
+CFLAGS+=	-I${SYSROOT}/usr/include
+LDFLAGS+=	-L${SYSROOT}/usr/lib/system
+LDFLAGS+=	-Wl,-rpath,/usr/lib/system
+LDFLAGS+=	-Wl,--allow-shlib-undefined
+.endif
+
+# -llaunch: bootstrap_check_in + the bootstrap_port global.
+# -lsystem_kernel: mach_msg + the Mach port syscalls behind it.
+LDADD+=		-llaunch -lsystem_kernel
+
+BINDIR=		/usr/sbin
+
+.include <bsd.prog.mk>

--- a/src/DiskArbitration/datest.c
+++ b/src/DiskArbitration/datest.c
@@ -1,0 +1,29 @@
+/*
+ * datest — iter 1 liveness probe for diskarbitrationd.
+ *
+ * bootstrap_look_up the service; print DA-BOOT-OK on success. Same
+ * shape as ipconfigtest / hwregtest / mdnstest. run.sh runs it and
+ * the marker gates in tests/boot-test.sh.
+ */
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <stdio.h>
+
+int
+main(void)
+{
+	mach_port_t svc = MACH_PORT_NULL;
+	kern_return_t kr;
+
+	kr = bootstrap_look_up(bootstrap_port,
+	    "com.apple.DiskArbitration", &svc);
+	if (kr != KERN_SUCCESS || svc == MACH_PORT_NULL) {
+		(void)printf("DA-BOOT-FAIL: bootstrap_look_up: 0x%x\n",
+		    (unsigned)kr);
+		return (1);
+	}
+	(void)printf("DA-BOOT-OK: com.apple.DiskArbitration reachable "
+	    "(send right=0x%x)\n", (unsigned)svc);
+	return (0);
+}

--- a/src/DiskArbitration/diskarbitrationd.c
+++ b/src/DiskArbitration/diskarbitrationd.c
@@ -1,0 +1,116 @@
+/*
+ * diskarbitrationd — freebsd-launchd-mach DiskArbitration daemon.
+ *
+ * iter 1: daemon skeleton. main + signal handling +
+ * bootstrap_check_in for the com.apple.DiskArbitration Mach service
+ * + a sleep loop that holds the service port until SIGTERM. No
+ * storage subscription yet, no libgeom enrichment, no DA framework
+ * surface — iter 2+ wires those.
+ *
+ * Same shape as ipconfigd / hwregd / configd / mDNSResponder iter 1:
+ * stand the daemon up first, prove the Mach plumbing + launchd
+ * MachServices broker + plist + build infra all work, THEN bring in
+ * real subsystem code. iter-1 marker DA-BOOT-OK is emitted by the
+ * separate `datest` client (bootstrap_look_up against the service).
+ *
+ * Architecture (per the refactored plan,
+ * pkgdemon.github.io/freebsd-disk-arbitration-plan.html):
+ *   iter 2  — subscribe to hwregd's storage device class events
+ *             (system=DEVFS subsystem=ada0/da0/nvd0/cd0 ATTACH /
+ *             DETACH) via Mach RPC, log them.
+ *   iter 3  — libgeom enrichment: partition table, UUID, label,
+ *             FS-type detection.
+ *   iter 4  — DiskArbitration.framework + da.defs MIG IDL serving
+ *             DARegisterDisk*Callback / DADiskClaim / DADiskMount /
+ *             DADiskUnmount / DADiskEject.
+ *   iter 5+ — mount-policy arbitration, per-user agent.
+ */
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t got_term;
+
+static void
+on_signal(int sig)
+{
+	got_term = sig;
+}
+
+static void
+xlog(const char *fmt, ...)
+{
+	struct timespec ts;
+	struct tm tm;
+	char tbuf[32];
+	va_list ap;
+
+	(void)clock_gettime(CLOCK_REALTIME, &ts);
+	(void)gmtime_r(&ts.tv_sec, &tm);
+	(void)strftime(tbuf, sizeof(tbuf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+	(void)fprintf(stderr, "diskarbitrationd %s ", tbuf);
+
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+int
+main(int argc, char **argv)
+{
+	struct sigaction sa;
+	mach_port_t svc = MACH_PORT_NULL;
+	kern_return_t kr;
+
+	(void)argc;
+	(void)argv;
+
+	xlog("starting (iter 1 — daemon skeleton, no hwregd subscription "
+	    "or libgeom enrichment yet)");
+
+	(void)memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = on_signal;
+	(void)sigaction(SIGTERM, &sa, NULL);
+	(void)sigaction(SIGINT, &sa, NULL);
+	(void)sigaction(SIGHUP, &sa, NULL);
+
+	/*
+	 * Claim the Mach service. Same pattern hwregd / configd /
+	 * ipconfigd / mDNSResponder use: bootstrap_check_in returns the
+	 * receive right for the service port that launchd's plist-
+	 * declared MachServices broker has set up. Once we hold the
+	 * right, peer bootstrap_look_up calls route through launchd to
+	 * our receive port — even before we serve real RPC, the lookup
+	 * succeeds, which is what the iter-1 DA-BOOT marker proves.
+	 */
+	kr = bootstrap_check_in(bootstrap_port, "com.apple.DiskArbitration",
+	    &svc);
+	if (kr != KERN_SUCCESS || svc == MACH_PORT_NULL) {
+		xlog("DA-BOOT-FAIL: bootstrap_check_in: 0x%x", (unsigned)kr);
+		return (1);
+	}
+	xlog("DA-BOOT-OK: com.apple.DiskArbitration registered "
+	    "(receive right=0x%x)", (unsigned)svc);
+
+	/*
+	 * iter-1 hold-alive loop. Spin on sleep(60) — SIGTERM/SIGHUP
+	 * short-circuit. iter 2 replaces this with a Mach receive loop
+	 * subscribing to hwregd's storage events (mirroring how
+	 * ipconfigd's mach_service.c demuxes ipconfig.defs).
+	 */
+	while (!got_term)
+		(void)sleep(60);
+
+	xlog("exiting on signal %d", (int)got_term);
+	return (0);
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -851,6 +851,24 @@ expect {
     }
 }
 
+# DA-BOOT — DiskArbitration iter 1 liveness. bootstrap_look_up for
+# com.apple.DiskArbitration via datest. Iter 1 ships just the daemon
+# skeleton (no hwregd subscription / libgeom / framework yet); iter 2+
+# adds storage event subscription via Mach RPC to hwregd.
+expect {
+    timeout {
+        puts "\nFAIL: DA-BOOT marker not seen"
+        exit 1
+    }
+    "DA-BOOT-FAIL" {
+        puts "\nFAIL: diskarbitrationd did not register its Mach service"
+        exit 1
+    }
+    "DA-BOOT-OK" {
+        puts "\nOK: diskarbitrationd Mach service up (com.apple.DiskArbitration registered)"
+    }
+}
+
 # IPCFG-IPCONFIG — iter 8 Apple-shape CLI. Same MIG round-trip
 # ipconfigrpctest exercises, but driven through /usr/sbin/ipconfig.
 # Validates that the Apple-canonical CLI parses argv, looks up


### PR DESCRIPTION
## Summary
Opens the DiskArbitration workstream. Iter 1 is the bootstrap_check_in shell: a small \`diskarbitrationd.c\` claims the \`com.apple.DiskArbitration\` Mach service and sleeps until SIGTERM.

Mirrors the pattern hwregd / configd / ipconfigd / mDNSResponder iter 1 used: stand the daemon up first, prove the Mach plumbing + launchd MachServices broker + plist + build infra work, THEN bring in real subsystem code.

## Files
- \`src/DiskArbitration/diskarbitrationd.c\` — bootstrap_check_in + signal-safe sleep loop.
- \`src/DiskArbitration/datest.c\` — bootstrap_look_up liveness probe.
- \`src/DiskArbitration/Makefile\` — bsd.prog.mk shape (same as src/IPConfiguration/Makefile iter 1).
- \`overlays/.../com.apple.DiskArbitration.plist\` — KeepAlive + MachServices.
- \`build.sh\` Phase K step + \`run.sh\` + \`boot-test.sh\` marker expect.

## Roadmap (per the refactored plan)
- **iter 2** — subscribe to hwregd's storage device class events (\`system=DEVFS subsystem=ada0/da0/nvd0/cd0\` ATTACH/DETACH) via Mach RPC; log them.
- **iter 3** — libgeom enrichment in-process (partition table, UUID, label, FS-type).
- **iter 4** — DiskArbitration.framework client API via \`da.defs\` MIG IDL.
- **iter 5+** — mount-policy arbitration, per-user agent.

## Test plan (verify before manual merge — NO --auto)
- [ ] CI build green
- [ ] \`DA-BOOT-OK\` fires between MDNS-DNSSD-OK and IPCFG-IPCONFIG-OK
- [ ] No regression on any prior markers (MACH/SYSLOG/CONFIGD/IOKIT/IPCFG/MDNS)
- [ ] /var/log/diskarbitrationd.stderr post-boot shows the iter-1 banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)