### PR TITLE
feat(DiskArbitration): iter 2 — subscribe to hwregd pub/sub bus

### DIFF
--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -831,15 +831,34 @@ else
     "$dnssdtest" || true	# marker gates in boot-test.sh
 fi
 
-# DA-BOOT — DiskArbitration iter 1 liveness probe. bootstrap_look_up
-# for com.apple.DiskArbitration; prints DA-BOOT-OK on success. iter 1
-# is just the daemon skeleton (no hwregd subscription, no libgeom
-# enrichment, no DA framework). iter 2+ wires the real plumbing.
+# DA-BOOT + DA-WATCH — DiskArbitration iter 2. datest verifies the
+# Mach service (DA-BOOT-OK); the daemon itself subscribes to hwregd
+# at startup and emits DA-WATCH-OK to /var/log/diskarbitrationd.stderr
+# once the ack EVENT arrives. Cat the file so the marker reaches this
+# console for boot-test.sh's expect.
 datest=/usr/tests/freebsd-launchd-mach/datest
 if [ ! -x "$datest" ]; then
     echo "DA-BOOT-FAIL: $datest missing"
 else
     "$datest" || true	# marker gates in boot-test.sh
+fi
+if [ -f /var/log/diskarbitrationd.stderr ]; then
+    # Wait briefly for the hwregd subscription to complete — the daemon
+    # boots in parallel with hwregd; if DA starts first, the initial
+    # bootstrap_look_up may fail and the subscription will retry. iter 2
+    # has no retry; iter 3 will. For now just give it a few seconds.
+    i=0
+    while [ $i -lt 10 ]; do
+        if grep -q 'DA-WATCH-OK\|DA-WATCH-FAIL' \
+            /var/log/diskarbitrationd.stderr 2>/dev/null; then
+            break
+        fi
+        sleep 1
+        i=$((i+1))
+    done
+    echo "--- /var/log/diskarbitrationd.stderr ---"
+    cat /var/log/diskarbitrationd.stderr
+    echo "--- end diskarbitrationd.stderr ---"
 fi
 
 ipconfig_cli=/usr/sbin/ipconfig

--- a/src/DiskArbitration/Makefile
+++ b/src/DiskArbitration/Makefile
@@ -13,7 +13,7 @@
 
 PROG=		diskarbitrationd
 MAN=
-SRCS=		diskarbitrationd.c
+SRCS=		diskarbitrationd.c hwreg_subscribe.c
 
 NO_MAN=		yes
 WARNS=		6
@@ -39,7 +39,8 @@ LDFLAGS+=	-Wl,--allow-shlib-undefined
 
 # -llaunch: bootstrap_check_in + the bootstrap_port global.
 # -lsystem_kernel: mach_msg + the Mach port syscalls behind it.
-LDADD+=		-llaunch -lsystem_kernel
+# -lpthread: the hwregd subscription receive-loop runs on its own thread.
+LDADD+=		-llaunch -lsystem_kernel -lpthread
 
 BINDIR=		/usr/sbin
 

--- a/src/DiskArbitration/diskarbitrationd.c
+++ b/src/DiskArbitration/diskarbitrationd.c
@@ -25,6 +25,8 @@
  *             DADiskUnmount / DADiskEject.
  *   iter 5+ — mount-policy arbitration, per-user agent.
  */
+#include "hwreg_subscribe.h"
+
 #include <mach/mach.h>
 #include <servers/bootstrap.h>
 
@@ -103,10 +105,18 @@ main(int argc, char **argv)
 	    "(receive right=0x%x)", (unsigned)svc);
 
 	/*
+	 * iter 2: subscribe to org.freebsd.hwregd's pub/sub bus and log
+	 * incoming device events. Tag storage names (ada*, da*, nvd*,
+	 * cd*, mmcsd*) with STORAGE; emit DA-WATCH-OK on subscription
+	 * ack. Non-fatal — if hwregd isn't up yet, the daemon stays
+	 * alive without storage events.
+	 */
+	(void)hwreg_subscribe_start();
+
+	/*
 	 * iter-1 hold-alive loop. Spin on sleep(60) — SIGTERM/SIGHUP
-	 * short-circuit. iter 2 replaces this with a Mach receive loop
-	 * subscribing to hwregd's storage events (mirroring how
-	 * ipconfigd's mach_service.c demuxes ipconfig.defs).
+	 * short-circuit. iter 3+ replaces this with a Mach receive loop
+	 * demuxing the da.defs MIG IDL (DARegisterDisk*Callback etc.).
 	 */
 	while (!got_term)
 		(void)sleep(60);

--- a/src/DiskArbitration/hwreg_subscribe.c
+++ b/src/DiskArbitration/hwreg_subscribe.c
@@ -1,0 +1,221 @@
+/*
+ * hwreg_subscribe.c — DiskArbitration iter 2 hwregd pub/sub client.
+ *
+ * Subscribe to org.freebsd.hwregd via the raw HWREG_MSG_SUBSCRIBE
+ * protocol (same wire shape as src/hwregd/hwregtest.c). Receive
+ * EVENTs in a background pthread, log every event, tag storage-
+ * looking names (ada*, da*, nvd*, cd*, mmcsd*) with STORAGE.
+ *
+ * iter 2 deliberately uses the raw protocol rather than the MIG-
+ * served hwreg_watch / hwreg_lookup — no MIG client stubs to vendor
+ * yet, no nvlist criteria packing. iter 3 moves to MIG so we can
+ * filter at the hwregd side (class="device") + enumerate the current
+ * registry state at startup.
+ */
+#include "hwreg_subscribe.h"
+
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Wire protocol mirrors src/hwregd/hwregd.c + src/hwregd/hwregtest.c.
+ * Keep these in sync if hwregd's protocol bumps.
+ */
+#define HWREG_MSG_SUBSCRIBE	0x48575201
+#define HWREG_MSG_EVENT		0x48575202
+
+struct hwreg_event_msg {
+	mach_msg_header_t	hdr;
+	char			kind;	/* '+' arrived, '-' departed */
+	char			text[479];
+};
+
+static mach_port_t	g_notify_port = MACH_PORT_NULL;
+static pthread_t	g_recv_thread;
+
+static void
+xlog(const char *fmt, ...)
+{
+	va_list ap;
+
+	(void)fprintf(stderr, "diskarbitrationd[hwreg] ");
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+/*
+ * "arrived id=N name=ada0 class=PCIDevice" or "departed id=N name=..."
+ * is the upstream format from hwregd's notify_watchers. Pull the name
+ * out by scanning for "name=" and the next space. Returns "" if not
+ * present. Output buffer is the caller's; sized 32 in practice (matches
+ * hwregd's want_name limit).
+ */
+static void
+parse_devname(const char *text, char *out, size_t out_len)
+{
+	const char *p, *q;
+	size_t n;
+
+	out[0] = '\0';
+	p = strstr(text, "name=");
+	if (p == NULL)
+		return;
+	p += 5;	/* skip "name=" */
+	q = strchr(p, ' ');
+	n = (q != NULL) ? (size_t)(q - p) : strlen(p);
+	if (n >= out_len)
+		n = out_len - 1;
+	(void)memcpy(out, p, n);
+	out[n] = '\0';
+}
+
+/*
+ * True if `name` looks like a FreeBSD storage device that DA cares
+ * about: ada* (AHCI/CAM ATA), da* (SCSI / USB), nvd* / nda* (NVMe),
+ * cd* (optical), mmcsd* (SD/eMMC). iter 3 will replace this with a
+ * registry class filter via hwreg_watch.
+ */
+static int
+is_storage_name(const char *name)
+{
+	static const char *prefixes[] = {
+		"ada", "da", "nvd", "nda", "cd", "mmcsd"
+	};
+	size_t i;
+
+	for (i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
+		size_t plen = strlen(prefixes[i]);
+		if (strncmp(name, prefixes[i], plen) != 0)
+			continue;
+		if (name[plen] >= '0' && name[plen] <= '9')
+			return (1);
+	}
+	return (0);
+}
+
+static void *
+recv_loop(void *arg)
+{
+	(void)arg;
+
+	for (;;) {
+		struct {
+			struct hwreg_event_msg	ev;
+			mach_msg_max_trailer_t	trailer;
+		} rcv;
+		mach_msg_return_t mr;
+		char name[32];
+		int is_storage;
+
+		(void)memset(&rcv, 0, sizeof(rcv));
+		mr = mach_msg(&rcv.ev.hdr, MACH_RCV_MSG, 0, sizeof(rcv),
+		    g_notify_port, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
+		if (mr != MACH_MSG_SUCCESS) {
+			xlog("recv loop: mach_msg 0x%x — exiting thread",
+			    (unsigned)mr);
+			return (NULL);
+		}
+		if (rcv.ev.hdr.msgh_id != HWREG_MSG_EVENT) {
+			xlog("recv loop: unexpected msgh_id=%d",
+			    (int)rcv.ev.hdr.msgh_id);
+			continue;
+		}
+
+		rcv.ev.text[sizeof(rcv.ev.text) - 1] = '\0';
+		parse_devname(rcv.ev.text, name, sizeof(name));
+		is_storage = (name[0] != '\0') && is_storage_name(name);
+
+		xlog("%s kind=%c %s", is_storage ? "STORAGE" : "event",
+		    rcv.ev.kind ? rcv.ev.kind : '?', rcv.ev.text);
+	}
+}
+
+int
+hwreg_subscribe_start(void)
+{
+	mach_port_t svc = MACH_PORT_NULL;
+	kern_return_t kr;
+	mach_msg_return_t mr;
+	mach_msg_header_t req;
+	struct {
+		struct hwreg_event_msg	ev;
+		mach_msg_max_trailer_t	trailer;
+	} rcv;
+
+	kr = bootstrap_look_up(bootstrap_port, "org.freebsd.hwregd", &svc);
+	if (kr != KERN_SUCCESS) {
+		xlog("DA-WATCH-FAIL: bootstrap_look_up(org.freebsd.hwregd): "
+		    "0x%x", (unsigned)kr);
+		return (-1);
+	}
+
+	kr = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE,
+	    &g_notify_port);
+	if (kr != KERN_SUCCESS) {
+		xlog("DA-WATCH-FAIL: mach_port_allocate: 0x%x", (unsigned)kr);
+		return (-1);
+	}
+	kr = mach_port_insert_right(mach_task_self(), g_notify_port,
+	    g_notify_port, MACH_MSG_TYPE_MAKE_SEND);
+	if (kr != KERN_SUCCESS) {
+		xlog("DA-WATCH-FAIL: mach_port_insert_right: 0x%x",
+		    (unsigned)kr);
+		return (-1);
+	}
+
+	/*
+	 * SUBSCRIBE: remote = hwregd's service port, local = our notify
+	 * port with MAKE_SEND — hwregd receives a send right and can
+	 * push EVENTs to us. Same shape hwregtest.c uses.
+	 */
+	(void)memset(&req, 0, sizeof(req));
+	req.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND,
+	    MACH_MSG_TYPE_MAKE_SEND);
+	req.msgh_size = sizeof(req);
+	req.msgh_remote_port = svc;
+	req.msgh_local_port = g_notify_port;
+	req.msgh_id = HWREG_MSG_SUBSCRIBE;
+	mr = mach_msg(&req, MACH_SEND_MSG | MACH_SEND_TIMEOUT, sizeof(req),
+	    0, MACH_PORT_NULL, 2000, MACH_PORT_NULL);
+	if (mr != MACH_MSG_SUCCESS) {
+		xlog("DA-WATCH-FAIL: SUBSCRIBE send: 0x%x", (unsigned)mr);
+		return (-1);
+	}
+
+	/* Receive the subscription-ack EVENT hwregd sends back. */
+	(void)memset(&rcv, 0, sizeof(rcv));
+	mr = mach_msg(&rcv.ev.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0,
+	    sizeof(rcv), g_notify_port, 5000, MACH_PORT_NULL);
+	if (mr != MACH_MSG_SUCCESS) {
+		xlog("DA-WATCH-FAIL: ack receive: 0x%x", (unsigned)mr);
+		return (-1);
+	}
+	if (rcv.ev.hdr.msgh_id != HWREG_MSG_EVENT) {
+		xlog("DA-WATCH-FAIL: unexpected ack msgh_id=%d",
+		    (int)rcv.ev.hdr.msgh_id);
+		return (-1);
+	}
+	rcv.ev.text[sizeof(rcv.ev.text) - 1] = '\0';
+	xlog("DA-WATCH-OK: subscribed to org.freebsd.hwregd "
+	    "(ack kind=%c text=[%s])",
+	    rcv.ev.kind ? rcv.ev.kind : '?', rcv.ev.text);
+
+	if (pthread_create(&g_recv_thread, NULL, recv_loop, NULL) != 0) {
+		xlog("DA-WATCH-WARN: pthread_create failed: %s — "
+		    "subscription is up but events won't be logged",
+		    strerror(errno));
+		/* still considered success — the subscription itself works */
+	}
+	return (0);
+}

--- a/src/DiskArbitration/hwreg_subscribe.h
+++ b/src/DiskArbitration/hwreg_subscribe.h
@@ -1,0 +1,23 @@
+/*
+ * hwreg_subscribe.h — DiskArbitration iter 2 hwregd pub/sub client.
+ *
+ * Mirrors hwregtest.c's pattern: bootstrap_look_up org.freebsd.hwregd,
+ * allocate a notify port, send a raw HWREG_MSG_SUBSCRIBE, wait for the
+ * ack EVENT, then spawn a pthread that loops on mach_msg(MACH_RCV_MSG)
+ * and logs every event hwregd pushes. Storage-looking device names
+ * (ada*, da*, nvd*, cd*, mmcsd*) are tagged STORAGE in the log; full
+ * registry filtering + initial enumeration are iter 3.
+ */
+#ifndef DISKARBITRATION_HWREG_SUBSCRIBE_H
+#define DISKARBITRATION_HWREG_SUBSCRIBE_H
+
+/*
+ * Start the hwregd subscription. Returns 0 on success (subscription
+ * established + ack received; receive thread running). Returns -1 on
+ * any error path (logged inline). Non-fatal in iter 2 — the daemon
+ * still keeps the Mach service registered, just without storage
+ * events.
+ */
+int hwreg_subscribe_start(void);
+
+#endif /* DISKARBITRATION_HWREG_SUBSCRIBE_H */

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -869,6 +869,27 @@ expect {
     }
 }
 
+# DA-WATCH — iter 2 hwregd subscription. The daemon's hwreg_subscribe
+# layer sends a HWREG_MSG_SUBSCRIBE to org.freebsd.hwregd, waits for
+# the ack EVENT, then spawns a thread to log incoming attach/detach
+# events. Storage-device names (ada*/da*/nvd*/cd*/mmcsd*) are tagged
+# STORAGE in the log. iter 3+ will move to the MIG-served
+# hwreg_watch / hwreg_lookup so we can filter at the hwregd side and
+# enumerate the current registry state at startup.
+expect {
+    timeout {
+        puts "\nFAIL: DA-WATCH marker not seen"
+        exit 1
+    }
+    "DA-WATCH-FAIL" {
+        puts "\nFAIL: diskarbitrationd could not subscribe to org.freebsd.hwregd"
+        exit 1
+    }
+    "DA-WATCH-OK" {
+        puts "\nOK: diskarbitrationd subscribed to hwregd's pub/sub bus"
+    }
+}
+
 # IPCFG-IPCONFIG — iter 8 Apple-shape CLI. Same MIG round-trip
 # ipconfigrpctest exercises, but driven through /usr/sbin/ipconfig.
 # Validates that the Apple-canonical CLI parses argv, looks up


### PR DESCRIPTION
## Summary
diskarbitrationd now hooks into hwregd's device event stream. New \`hwreg_subscribe.{c,h}\` mirrors \`src/hwregd/hwregtest.c\`'s raw protocol:
1. \`bootstrap_look_up\` \`org.freebsd.hwregd\`
2. Allocate a notify port with \`MAKE_SEND\` for hwregd to push to us
3. Send \`HWREG_MSG_SUBSCRIBE\`
4. Wait for the ack EVENT
5. Spawn a pthread that loops on \`mach_msg(MACH_RCV_MSG)\` and logs every incoming attach/detach event

Storage-looking device names (\`ada*\`, \`da*\`, \`nvd*\`, \`nda*\`, \`cd*\`, \`mmcsd*\`) are tagged \`STORAGE\` in the log; everything else logs as a plain event.

## Why raw protocol, not MIG yet
iter 2 stays on the raw \`HWREG_MSG_SUBSCRIBE\`/\`HWREG_MSG_EVENT\` protocol so we don't have to vendor hwregd's MIG client stubs or pack nvlist criteria. iter 3 moves to MIG-served \`hwreg_watch\` (filter at hwregd's side with \`class="device"\`) + \`hwreg_lookup\` (enumerate the existing registry at startup so we see disks that attached before DA started, not just future hot-plug events).

## CI marker
\`DA-WATCH-OK\` after \`DA-BOOT-OK\`, before \`IPCFG-IPCONFIG-OK\`. \`run.sh\` cats \`/var/log/diskarbitrationd.stderr\` so the marker reaches the boot console.

Failure is non-fatal: if hwregd isn't yet up when DA starts (boot ordering race), DA logs \`DA-WATCH-FAIL\` and keeps its own Mach service registered. iter 3 will add a retry loop.

## Test plan (verify before manual merge — NO --auto)
- [ ] CI build green
- [ ] \`DA-BOOT-OK\` still fires (no regression on iter 1)
- [ ] \`DA-WATCH-OK\` fires (new)
- [ ] No regression on any prior markers (MACH/SYSLOG/CONFIGD/IOKIT/IPCFG/MDNS)
- [ ] \`/var/log/diskarbitrationd.stderr\` shows the iter-2 banner + subscription ack
- [ ] Storage-tagged events visible if QEMU's ada0/da0 attach generates devctl events (best-effort — events may have happened before DA subscribed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)