### PR TITLE
feat(hwregd): kldload the boot backlog after settle window

### DIFF
--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -456,6 +456,36 @@ if [ ! -x "$hwregquery" ]; then
 fi
 "$hwregquery" || true	# marker (HWREG-RPC-OK/FAIL) gates in boot-test.sh
 
+# HWREG-AUTOLOAD — boot-backlog autoload drain: hwregd waits out a
+# 60s settle window before kldload(2)ing matched modules (avoids the
+# mid-boot lock contention that wedged earlier iters). At the flip to
+# live mode the queue is drained and the daemon logs HWREG-AUTOLOAD-OK
+# (even when the queue is empty — common in QEMU/SLIRP where every CI
+# device already has a built-in driver). Poll hwregd.stderr with a
+# generous timeout so a slow VM can still cross the 60s threshold.
+hwregd_log=/var/log/hwregd.stderr
+autoload_found=0
+i=0
+while [ "$i" -lt 90 ]; do
+    if grep -q "HWREG-AUTOLOAD-OK" "$hwregd_log" 2>/dev/null; then
+        autoload_found=1
+        break
+    fi
+    sleep 1
+    i=$((i + 1))
+done
+if [ "$autoload_found" -eq 1 ]; then
+    grep "HWREG-AUTOLOAD-OK" "$hwregd_log" | tail -1
+else
+    echo "=== HWREG-AUTOLOAD diagnostics ==="
+    echo "--- $hwregd_log (tail) ---"
+    tail -50 "$hwregd_log" 2>/dev/null || echo "(no $hwregd_log)"
+    echo "--- uptime ---"
+    uptime || true
+    echo "=== end diagnostics ==="
+    echo "HWREG-AUTOLOAD-FAIL: marker not seen within 90s"
+fi
+
 # CONFIGD-STORE — configd SCDynamicStore round-trip: open a session
 # with configd, set a key, read it back, remove it, all over the
 # config.defs Mach RPC. Proves the configd daemon + its store work

--- a/src/hwregd/hwregd.c
+++ b/src/hwregd/hwregd.c
@@ -17,16 +17,20 @@
  * receive EVENT messages. launchd HardwareMatch will be one client.
  *
  * Backlog vs. live: at startup the kernel hands hwregd a backlog of
- * `?` events buffered from early boot. kldload'ing for those wedged
- * the CI boot test — a matched driver's attach() then runs mid-boot
- * under kernel locks (the CI VM's offender was the ICH SMBus
- * controller -> ichsmb). So hwregd kldloads only for *live* events:
- * for HWREGD_SETTLE_SECONDS after startup it match-and-logs every
- * nomatch, then flips to live mode and kldloads on each subsequent
- * nomatch. The window is time-based, not "until devctl goes quiet" —
- * a chronically noisy devctl (e.g. a flaky drive spamming CAM error
- * events) must not pin hwregd in backlog mode forever. Boot-time
- * drivers are the loader's job; hot-plug is hwregd's.
+ * `?` events buffered from early boot. kldload'ing those mid-boot
+ * wedged the CI boot test — a matched driver's attach() then runs
+ * under kernel locks the boot probe still holds (the CI VM's
+ * offender was the ICH SMBus controller -> ichsmb). So hwregd waits
+ * out a settle window before touching the kernel: for the first
+ * HWREGD_SETTLE_SECONDS of uptime, each nomatch is match-and-logged
+ * and the claiming module is queued (deduped) in a small in-process
+ * list; on the flip to live mode the queue is drained with kldload(2)
+ * in one pass, then each subsequent nomatch is kldload'd inline.
+ * The window is time-based, not "until devctl goes quiet" — a
+ * chronically noisy devctl (e.g. a flaky drive spamming CAM error
+ * events) must not pin hwregd in backlog mode forever. By the time
+ * the window elapses the kernel's boot-time device probe is done,
+ * so the deferred attach()es no longer contend with it.
  *
  * The hints-matching machinery — read_linker_hints / search_hints
  * and the pnpinfo helpers (getint, getstr, pnpval_as_int,
@@ -170,10 +174,25 @@ static void *hints_end;
 
 /*
  * false for the first HWREGD_SETTLE_SECONDS of uptime (the boot-
- * settle window). hwregd kldloads only in live mode; matches during
- * the window are logged but not loaded — see act_on_match().
+ * settle window). hwregd kldloads inline only in live mode; matches
+ * during the window are logged + queued in deferred_mods[] and then
+ * drained in one pass at the flip — see act_on_match() and
+ * drain_deferred_loads().
  */
 static bool live_mode = false;
+
+/*
+ * Backlog-of-matches queue. During the settle window each module
+ * name a nomatch resolves to is appended here (deduped). At the flip
+ * to live mode drain_deferred_loads() walks the queue and kldload(2)s
+ * each entry. 64 slots × 32 bytes = 2 KiB — comfortably more than the
+ * handful of PCI/USB device classes typical hardware needs a driver
+ * for at boot.
+ */
+#define HWREGD_DEFERRED_MAX	64
+#define HWREGD_DEFERRED_MODLEN	32
+static char	deferred_mods[HWREGD_DEFERRED_MAX][HWREGD_DEFERRED_MODLEN];
+static int	n_deferred;
 
 static void
 on_signal(int sig)
@@ -364,12 +383,37 @@ notify_watchers(char kind, const char *devname)
 }
 
 /*
+ * Append `mod` to the deferred backlog queue, deduping by name. Used
+ * during the settle window so we don't kldload(2) mid-boot; the queue
+ * is drained at the flip to live mode by drain_deferred_loads().
+ */
+static void
+defer_match(const char *mod)
+{
+	int i;
+
+	for (i = 0; i < n_deferred; i++) {
+		if (strcmp(deferred_mods[i], mod) == 0)
+			return;
+	}
+	if (n_deferred >= HWREGD_DEFERRED_MAX) {
+		xlog("deferred backlog full (%d slots) — dropping '%s'",
+		    HWREGD_DEFERRED_MAX, mod);
+		return;
+	}
+	strlcpy(deferred_mods[n_deferred], mod,
+	    sizeof(deferred_mods[n_deferred]));
+	n_deferred++;
+}
+
+/*
  * Act on a module that linker.hints says claims a nomatched device.
  * "kernel" is the pseudo-module for built-in drivers — nothing to
- * load. In live mode (hot-plug) the module is kldload(2)ed; during
- * the boot backlog it is only logged — kldloading mid-boot wedges
- * the boot (a driver attach runs under kernel locks; see the file
- * header). EEXIST (already loaded) is a normal, expected outcome.
+ * load. In live mode (hot-plug) the module is kldload(2)ed inline;
+ * during the boot backlog the module name is queued for the drain
+ * at live-mode flip — kldloading mid-boot wedges the boot (a driver
+ * attach runs under kernel locks; see the file header). EEXIST
+ * (already loaded) is a normal, expected outcome.
  */
 static void
 act_on_match(const char *mod)
@@ -379,7 +423,8 @@ act_on_match(const char *mod)
 
 	if (!live_mode) {
 		xlog("match: module '%s' claims this device "
-		    "(boot backlog — not loaded)", mod);
+		    "(boot backlog — queued for autoload)", mod);
+		defer_match(mod);
 		return;
 	}
 
@@ -391,6 +436,43 @@ act_on_match(const char *mod)
 	} else {
 		xlog("kldload(%s): loaded", mod);
 	}
+}
+
+/*
+ * Drain the boot-backlog deferred-match queue: kldload(2) each unique
+ * module a settle-window nomatch resolved to. Called exactly once at
+ * the flip to live mode; the kernel's boot probe is done by then so
+ * the driver attach()es no longer contend with it. The function emits
+ * the HWREG-AUTOLOAD-OK marker unconditionally (even when the queue
+ * is empty — common in QEMU/SLIRP where every CI device already has
+ * a built-in driver) so CI can prove the drain ran.
+ */
+static void
+drain_deferred_loads(void)
+{
+	int i, loaded = 0, existing = 0, failed = 0;
+
+	xlog("draining %d deferred boot-backlog match(es)", n_deferred);
+	for (i = 0; i < n_deferred; i++) {
+		if (kldload(deferred_mods[i]) < 0) {
+			if (errno == EEXIST) {
+				xlog("kldload(%s): already loaded",
+				    deferred_mods[i]);
+				existing++;
+			} else {
+				xlog("kldload(%s) failed: %s",
+				    deferred_mods[i], strerror(errno));
+				failed++;
+			}
+		} else {
+			xlog("kldload(%s): loaded", deferred_mods[i]);
+			loaded++;
+		}
+	}
+	n_deferred = 0;
+	xlog("HWREG-AUTOLOAD-OK: drained queue "
+	    "(loaded=%d already=%d failed=%d)",
+	    loaded, existing, failed);
 }
 
 /* --- linker.hints reader (ported from devmatch.c) ----------------- */
@@ -1534,6 +1616,7 @@ main(int argc, char **argv)
 			live_mode = true;
 			xlog("boot-settle window (%ds) elapsed — live mode: "
 			    "hot-plug autoload enabled", HWREGD_SETTLE_SECONDS);
+			drain_deferred_loads();
 		}
 
 		fd_set rfds;

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -394,6 +394,22 @@ expect {
     "HWREG-RPC-OK" { puts "\nOK: hwregd Mach-RPC registry query works" }
 }
 
+# HWREG-AUTOLOAD — hwregd boot-backlog autoload: after a 60s settle
+# window the daemon drains its deferred-match queue with kldload(2)
+# and logs the marker. run.sh polls hwregd.stderr for up to 90s, so
+# the global 480s timeout above is plenty.
+expect {
+    timeout {
+        puts "\nFAIL: HWREG-AUTOLOAD marker not seen"
+        exit 1
+    }
+    "HWREG-AUTOLOAD-FAIL" {
+        puts "\nFAIL: hwregd boot-backlog autoload drain did not run"
+        exit 1
+    }
+    "HWREG-AUTOLOAD-OK" { puts "\nOK: hwregd boot-backlog autoload drain ran" }
+}
+
 expect {
     timeout {
         puts "\nFAIL: CONFIGD-STORE marker not seen"


### PR DESCRIPTION
## Summary

- hwregd has always **logged but never loaded** driver modules matched during its 60-second boot-settle window — the original wedge bug meant `kldload(2)` mid-boot deadlocked under kernel locks held by the still-running boot probe, so the safest fix was to skip the load entirely. Net effect: any hardware present at boot whose driver was neither built into the kernel nor listed in `/boot/loader.conf` never got a driver this boot. The *"first boot on new hardware just works"* story was broken.
- Fix: queue (deduped) the module names matched during settle in a small in-process list (`deferred_mods[64]`). At the flip to live mode `drain_deferred_loads()` walks the queue and `kldload(2)`s each entry in one pass — by then the kernel's boot probe is done so the attach()es no longer contend with it. Live-mode hot-plug behavior unchanged.
- The drain emits `HWREG-AUTOLOAD-OK` unconditionally (even when the queue is empty — common in QEMU/SLIRP where every CI device already has a built-in driver) so CI can prove the path ran.
- `run.sh` polls `/var/log/hwregd.stderr` for the marker with a 90s window (the daemon log dump in `run.sh` hits *before* the 60s settle elapses, so a polling loop is required). `boot-test.sh` adds an expect block to gate it under the existing global 480s timeout.

## Test plan

- [ ] CI boot test passes (HWREG-AUTOLOAD-OK seen within 90s of the polling loop start).
- [ ] In CI, hwregd.stderr shows either "drained queue (loaded=0 already=0 failed=0)" for a SLIRP boot with no nomatched devices, or a non-zero loaded/already count if any module matched.
- [ ] No regression in HWREG-PUBSUB / HWREG-RPC markers.
- [ ] The boot does not wedge — the 60s settle still outlasts the kernel's device probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)