### PR TITLE
feat(IPConfiguration): iter 9 — react to NIC arrival via hwregd subscription

### DIFF
--- a/src/IPConfiguration/Makefile
+++ b/src/IPConfiguration/Makefile
@@ -19,6 +19,7 @@ SRCS+=		sc_publish.c lease_loop.c
 SRCS+=		bound_state.c mach_service.c ipconfigd_mig.c
 SRCS+=		arp_probe.c
 SRCS+=		ra_listen.c apply_lease_v6.c
+SRCS+=		hwreg_subscribe.c
 
 # ipconfigServer.c — MIG-generated server stub for ipconfig.defs
 # (iter 5a's two read-only routines). build.sh runs mig and passes

--- a/src/IPConfiguration/hwreg_subscribe.c
+++ b/src/IPConfiguration/hwreg_subscribe.c
@@ -1,0 +1,219 @@
+/*
+ * hwreg_subscribe.c — IPConfiguration iter 9 hwregd pub/sub client.
+ *
+ * Adapted from src/DiskArbitration/hwreg_subscribe.c (iter 2). Same
+ * wire protocol (HWREG_MSG_SUBSCRIBE / HWREG_MSG_EVENT raw mach_msg,
+ * no MIG); the differences from the DA version:
+ *   - Filter on kind == '+' attach (not '!' notify or '?' nomatch).
+ *   - Parse `dev=<name>` from publish_event's "attach: dev=X parent=Y
+ *     loc=[Z]" text (DA's `name=` only ever appears in MIG watch
+ *     events from notify_watchers, never in the bare pub/sub stream
+ *     — see src/hwregd/hwregd.c handle_attach_detach).
+ *   - Dispatch to a caller-supplied callback so ipconfigd can decide
+ *     whether to DHCP the named interface (typically: skip if a
+ *     binding already exists, else run dhcp_run_on_interface).
+ */
+#include "hwreg_subscribe.h"
+
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Wire protocol mirrors src/hwregd/hwregd.c + hwregtest.c. Keep in
+ * sync if hwregd's protocol bumps. Match the DA copy verbatim so the
+ * two clients can't drift out of step.
+ */
+#define HWREG_MSG_SUBSCRIBE	0x48575201
+#define HWREG_MSG_EVENT		0x48575202
+
+struct hwreg_event_msg {
+	mach_msg_header_t	hdr;
+	char			kind;	/* '+' attach, '-' detach, '?' nomatch, '!' notify */
+	char			text[479];
+};
+
+static mach_port_t			g_notify_port = MACH_PORT_NULL;
+static pthread_t			g_recv_thread;
+static hwreg_subscribe_attach_cb	g_cb;
+static uint32_t				g_lease_cap_secs;
+
+static void
+xlog(const char *fmt, ...)
+{
+	va_list ap;
+
+	(void)fprintf(stderr, "ipconfigd[hwreg] ");
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+/*
+ * Parse `dev=<name>` from a pub/sub attach/detach text like
+ * "attach: dev=em0 parent=pci0 loc=[slot=...]". Returns "" if absent.
+ * Output sized to IF_NAMESIZE in practice.
+ */
+static void
+parse_devname(const char *text, char *out, size_t out_len)
+{
+	const char *p, *q;
+	size_t n;
+
+	out[0] = '\0';
+	p = strstr(text, "dev=");
+	if (p == NULL)
+		return;
+	p += 4;	/* skip "dev=" */
+	q = strchr(p, ' ');
+	n = (q != NULL) ? (size_t)(q - p) : strlen(p);
+	if (n >= out_len)
+		n = out_len - 1;
+	(void)memcpy(out, p, n);
+	out[n] = '\0';
+}
+
+static void *
+recv_loop(void *arg)
+{
+	(void)arg;
+
+	for (;;) {
+		struct {
+			struct hwreg_event_msg	ev;
+			mach_msg_max_trailer_t	trailer;
+		} rcv;
+		mach_msg_return_t mr;
+		char name[32];
+
+		(void)memset(&rcv, 0, sizeof(rcv));
+		mr = mach_msg(&rcv.ev.hdr, MACH_RCV_MSG, 0, sizeof(rcv),
+		    g_notify_port, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
+		if (mr != MACH_MSG_SUCCESS) {
+			xlog("recv loop: mach_msg 0x%x — exiting thread",
+			    (unsigned)mr);
+			return (NULL);
+		}
+		if (rcv.ev.hdr.msgh_id != HWREG_MSG_EVENT)
+			continue;
+
+		rcv.ev.text[sizeof(rcv.ev.text) - 1] = '\0';
+
+		/*
+		 * Only '+' attach matters for the autoload path: a NIC
+		 * appears, get DHCP running on it. '-' detach, '?' nomatch,
+		 * '!' notify are logged at debug but not actioned (LINK_UP
+		 * reaction to hot-plug cable is a follow-up iter).
+		 */
+		if (rcv.ev.kind != '+')
+			continue;
+
+		parse_devname(rcv.ev.text, name, sizeof(name));
+		if (name[0] == '\0')
+			continue;
+
+		xlog("attach event for dev=%s — dispatching to callback",
+		    name);
+		if (g_cb != NULL)
+			g_cb(name, g_lease_cap_secs);
+		/*
+		 * Callback may have entered lease_loop_run and never
+		 * returned. If it did return, keep listening — a second
+		 * attach (different NIC) will still be delivered.
+		 */
+	}
+}
+
+int
+hwreg_subscribe_start(hwreg_subscribe_attach_cb cb, uint32_t lease_cap_secs)
+{
+	mach_port_t svc = MACH_PORT_NULL;
+	kern_return_t kr;
+	mach_msg_return_t mr;
+	mach_msg_header_t req;
+	struct {
+		struct hwreg_event_msg	ev;
+		mach_msg_max_trailer_t	trailer;
+	} rcv;
+
+	g_cb = cb;
+	g_lease_cap_secs = lease_cap_secs;
+
+	kr = bootstrap_look_up(bootstrap_port, "org.freebsd.hwregd", &svc);
+	if (kr != KERN_SUCCESS) {
+		xlog("IPCFG-AUTOLOAD-SUB-FAIL: bootstrap_look_up("
+		    "org.freebsd.hwregd): 0x%x", (unsigned)kr);
+		return (-1);
+	}
+
+	kr = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE,
+	    &g_notify_port);
+	if (kr != KERN_SUCCESS) {
+		xlog("IPCFG-AUTOLOAD-SUB-FAIL: mach_port_allocate: 0x%x",
+		    (unsigned)kr);
+		return (-1);
+	}
+	kr = mach_port_insert_right(mach_task_self(), g_notify_port,
+	    g_notify_port, MACH_MSG_TYPE_MAKE_SEND);
+	if (kr != KERN_SUCCESS) {
+		xlog("IPCFG-AUTOLOAD-SUB-FAIL: mach_port_insert_right: 0x%x",
+		    (unsigned)kr);
+		return (-1);
+	}
+
+	/*
+	 * SUBSCRIBE: remote = hwregd's service port, local = our notify
+	 * port with MAKE_SEND. hwregd inserts a send right and pushes
+	 * EVENTs to us. Same shape hwregtest.c uses.
+	 */
+	(void)memset(&req, 0, sizeof(req));
+	req.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND,
+	    MACH_MSG_TYPE_MAKE_SEND);
+	req.msgh_size = sizeof(req);
+	req.msgh_remote_port = svc;
+	req.msgh_local_port = g_notify_port;
+	req.msgh_id = HWREG_MSG_SUBSCRIBE;
+	mr = mach_msg(&req, MACH_SEND_MSG | MACH_SEND_TIMEOUT, sizeof(req),
+	    0, MACH_PORT_NULL, 2000, MACH_PORT_NULL);
+	if (mr != MACH_MSG_SUCCESS) {
+		xlog("IPCFG-AUTOLOAD-SUB-FAIL: SUBSCRIBE send: 0x%x",
+		    (unsigned)mr);
+		return (-1);
+	}
+
+	/* Subscription-ack EVENT. 5s budget is plenty for the round-trip. */
+	(void)memset(&rcv, 0, sizeof(rcv));
+	mr = mach_msg(&rcv.ev.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0,
+	    sizeof(rcv), g_notify_port, 5000, MACH_PORT_NULL);
+	if (mr != MACH_MSG_SUCCESS) {
+		xlog("IPCFG-AUTOLOAD-SUB-FAIL: ack receive: 0x%x",
+		    (unsigned)mr);
+		return (-1);
+	}
+	if (rcv.ev.hdr.msgh_id != HWREG_MSG_EVENT) {
+		xlog("IPCFG-AUTOLOAD-SUB-FAIL: unexpected ack msgh_id=%d",
+		    (int)rcv.ev.hdr.msgh_id);
+		return (-1);
+	}
+	rcv.ev.text[sizeof(rcv.ev.text) - 1] = '\0';
+	xlog("IPCFG-AUTOLOAD-SUB-OK: subscribed to org.freebsd.hwregd "
+	    "(ack kind=%c text=[%s])",
+	    rcv.ev.kind ? rcv.ev.kind : '?', rcv.ev.text);
+
+	if (pthread_create(&g_recv_thread, NULL, recv_loop, NULL) != 0) {
+		xlog("IPCFG-AUTOLOAD-SUB-WARN: pthread_create failed: %s — "
+		    "subscription is up but events won't be dispatched",
+		    strerror(errno));
+		/* subscription itself works — count it as success */
+	}
+	return (0);
+}

--- a/src/IPConfiguration/hwreg_subscribe.h
+++ b/src/IPConfiguration/hwreg_subscribe.h
@@ -1,0 +1,50 @@
+/*
+ * hwreg_subscribe.h — IPConfiguration iter 9 hwregd pub/sub client.
+ *
+ * Subscribe to org.freebsd.hwregd via the raw HWREG_MSG_SUBSCRIBE
+ * wire protocol (same shape DiskArbitration uses) so ipconfigd can
+ * react to NICs that hwregd autoloads after the boot-settle window.
+ * The path that motivates this: a NIC whose driver is neither built
+ * into the kernel nor preloaded in /boot/loader.conf isn't visible
+ * to getifaddrs at ipconfigd's startup; hwregd's iter "drain the
+ * deferred backlog" PR (#60) kldload(2)s the driver ~60s into boot,
+ * the kernel posts a +attach devctl line, hwregd republishes it on
+ * its pub/sub bus, and this subscriber kicks off DHCP on the new
+ * interface — closing the "first boot on autoloaded NICs" gap.
+ *
+ * iter 9 deliberately stays on the raw pub/sub (no MIG hwreg_watch
+ * + nvlist criteria) because the subscriber doesn't gain anything
+ * by filtering at hwregd: it has to re-run getifaddrs() to confirm
+ * the interface is an Ethernet anyway. Same call shape DA's iter 2
+ * uses (see src/DiskArbitration/hwreg_subscribe.{c,h}).
+ */
+#ifndef IPCONFIGURATION_HWREG_SUBSCRIBE_H
+#define IPCONFIGURATION_HWREG_SUBSCRIBE_H
+
+#include <stdint.h>
+
+/*
+ * Callback invoked from the subscriber thread when hwregd posts a
+ * `+` attach event whose dev=<ifname> looks plausibly like a NIC
+ * (getifaddrs filtering happens inside the callback, not here). The
+ * callback owns whether to actually run DHCP — typically it consults
+ * bound_state to skip already-bound interfaces, then runs the DHCP
+ * state machine + lease loop. The callback BLOCKS the subscriber
+ * thread until it returns; once it enters lease_loop_run no further
+ * events are processed (single-NIC focus — multi-NIC fan-out is a
+ * later iter). `lease_cap_secs` is forwarded from main.
+ */
+typedef void (*hwreg_subscribe_attach_cb)(const char *ifname,
+    uint32_t lease_cap_secs);
+
+/*
+ * Start the hwregd subscription. Emits IPCFG-AUTOLOAD-SUB-OK on a
+ * successful ack-receive, IPCFG-AUTOLOAD-SUB-FAIL otherwise. Returns
+ * 0 on success (subscription established + receive thread running),
+ * -1 on any error (logged inline). Non-fatal — the daemon stays up
+ * and keeps its Mach service registered, just without auto-react.
+ */
+int	hwreg_subscribe_start(hwreg_subscribe_attach_cb cb,
+	    uint32_t lease_cap_secs);
+
+#endif /* IPCONFIGURATION_HWREG_SUBSCRIBE_H */

--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -35,6 +35,19 @@
  * bound_state.{c,h}; the main thread (DHCP + lease loop) writes it
  * on BOUND. iter 5a vendors 2 read-only routines (if_count,
  * if_addr); the full ipconfig.defs surface grows in iter 6+.
+ *
+ * iter 9 — react to NIC arrival via hwregd subscription.
+ * hwreg_subscribe.c bootstrap_look_up's org.freebsd.hwregd and
+ * subscribes to its raw pub/sub stream; on a `+` attach event the
+ * subscriber thread invokes on_attach_event(), which (if no NIC is
+ * yet bound) re-runs dhcp_pick_interface and calls
+ * dhcp_run_on_interface on the newly-visible NIC. Closes the "first
+ * boot on a NIC whose driver hwregd autoloads ~60s into boot" gap
+ * left by the iter "drain the deferred backlog" PR (#60). Marker
+ * IPCFG-AUTOLOAD-SUB-OK fires when the subscription is established
+ * (the autoload-then-DHCP end-to-end path isn't exercised in CI yet
+ * because the CI kernel still has `device em` built in — a separate
+ * iter that slims the kernel proves the full chain).
  */
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -58,6 +71,7 @@
 #include "apply_lease_v6.h"
 #include "bound_state.h"
 #include "dhcp_discover.h"
+#include "hwreg_subscribe.h"
 #include "lease_loop.h"
 #include "mach_service.h"
 #include "ra_listen.h"
@@ -160,17 +174,155 @@ read_lease_cap_env(void)
 	return ((uint32_t)v);
 }
 
+/*
+ * dhcp_run_on_interface — full DHCPv4 INIT → BOUND → publish → RA →
+ * lease loop on `ifname`. Extracted from main() so both the startup
+ * path and the hwregd subscriber callback (iter 9) can drive it.
+ *
+ * Blocks in lease_loop_run until SIGTERM; never returns from a fully
+ * successful path. On any failure the function returns cleanly and
+ * the caller decides what to do (typically: fall through to the
+ * sleep loop and wait for the next hwregd attach).
+ */
+static void
+dhcp_run_on_interface(const char *ifname, uint32_t lease_cap_secs)
+{
+	struct dhcp_lease lease;
+	struct sc_publish *pub;
+	char a[INET_ADDRSTRLEN], m[INET_ADDRSTRLEN];
+	char r[INET_ADDRSTRLEN], s[INET_ADDRSTRLEN];
+	struct ra_info ra;
+	int rar;
+
+	xlog("selected interface for DHCPv4: %s", ifname);
+	if (dhcp_lease_acquire(ifname, &lease) != 0) {
+		/* dhcp_lease_acquire logged IPCFG-BOUND-FAIL on its own line */
+		return;
+	}
+
+	if (apply_lease(ifname, &lease) != 0) {
+		xlog("apply_lease(%s) failed", ifname);
+		xlog("IPCFG-BOUND-FAIL");
+		return;
+	}
+
+	(void)inet_ntop(AF_INET, &lease.addr, a, sizeof(a));
+	(void)inet_ntop(AF_INET, &lease.netmask, m, sizeof(m));
+	(void)inet_ntop(AF_INET, &lease.router, r, sizeof(r));
+	(void)inet_ntop(AF_INET, &lease.server, s, sizeof(s));
+	xlog("bound: iface=%s addr=%s netmask=%s router=%s "
+	    "server=%s lease=%us",
+	    ifname, a, m, r, s, (unsigned)lease.lease_time);
+	/*
+	 * Make the lease visible to the Mach service worker before the
+	 * BOUND marker fires — so any client racing IPCFG-RPC-OK against
+	 * IPCFG-BOUND-OK sees the address it expects.
+	 */
+	bound_state_set(ifname, &lease);
+	xlog("IPCFG-BOUND-OK");
+
+	/*
+	 * Publish to configd. Failure is non-fatal: the daemon stays up,
+	 * the lease is already applied at the kernel level, but
+	 * observers watching State:/Network/Service/... won't see this
+	 * binding. CI marker IPCFG-STORE-FAIL flags it.
+	 */
+	pub = sc_publish_open("ipconfigd");
+	if (pub == NULL) {
+		xlog("IPCFG-STORE-FAIL: no configd session");
+		return;
+	}
+	if (sc_publish_ipv4(pub, ifname, &lease) != 0) {
+		xlog("IPCFG-STORE-FAIL: set State:/.../IPv4");
+		sc_publish_close(pub);
+		return;
+	}
+	xlog("IPCFG-STORE-OK");
+
+	/*
+	 * iter 7a: solicit + listen for one RA, derive a SLAAC address,
+	 * install it + the v6 default route, and publish
+	 * State:/.../IPv6. 15s budget — QEMU SLIRP answers within ms,
+	 * so a miss means RA isn't configured; we log IPCFG-RA-MISS and
+	 * continue with IPv4 only.
+	 *
+	 * Round-1 CI showed em0 has ND6_IFF_IFDISABLED set (this image's
+	 * net.inet6.ip6.auto_linklocal is 0, so the kernel never
+	 * auto-added a link-local). bring_v6_up clears IFDISABLED and
+	 * installs fe80::EUI-64 so the kernel can source-select the
+	 * link-local-scoped RS.
+	 */
+	(void)bring_v6_up(ifname);
+	rar = ra_acquire(ifname, 15000, &ra);
+	if (rar == 0) {
+		struct in6_addr v6;
+
+		if (apply_ra_lease(ifname, &ra, &v6) == 0) {
+			(void)sc_publish_ipv6(pub, ifname, &v6,
+			    ra.prefix_len, &ra.router_lladdr);
+			xlog("IPCFG-RA-OK");
+		} else {
+			xlog("IPCFG-RA-MISS: apply_ra_lease failed");
+		}
+	} else if (rar == 1) {
+		xlog("IPCFG-RA-MISS: no RA in 15s "
+		    "(SLIRP may not advertise IPv6)");
+	} else {
+		xlog("IPCFG-RA-MISS: ra_acquire fatal");
+	}
+
+	(void)lease_loop_run(ifname, &lease, pub, lease_cap_secs);
+	sc_publish_close(pub);
+}
+
+/*
+ * iter 9 hwregd-subscriber callback — invoked from the subscriber
+ * thread (hwreg_subscribe.c) when hwregd posts a `+` attach event.
+ * If we already have a binding (the startup-path picked an interface
+ * and is in lease_loop_run, or an earlier attach fired DHCP), skip:
+ * the iter is single-NIC-focused, multi-NIC fan-out is a later
+ * iter. Otherwise confirm the new device is an Ethernet (via
+ * dhcp_pick_interface which already filters AF_LINK + IFT_ETHER +
+ * !loopback — its "first match wins" rule means the just-attached
+ * NIC will be picked once it's in getifaddrs) and run the full
+ * DHCP+publish+lease loop on it.
+ */
+static void
+on_attach_event(const char *attached_ifname, uint32_t lease_cap_secs)
+{
+	char picked[IFNAMSIZ] = "";
+	char already[IFNAMSIZ] = "";
+
+	if (bound_state_any(already, sizeof(already))) {
+		xlog("attach(dev=%s): skipping — already bound on %s",
+		    attached_ifname, already);
+		return;
+	}
+
+	if (dhcp_pick_interface(picked, sizeof(picked)) != 0) {
+		xlog("attach(dev=%s): no Ethernet visible yet via "
+		    "getifaddrs — will retry on next event",
+		    attached_ifname);
+		return;
+	}
+
+	xlog("attach(dev=%s) — running DHCP on %s",
+	    attached_ifname, picked);
+	dhcp_run_on_interface(picked, lease_cap_secs);
+}
+
 int
 main(int argc, char **argv)
 {
 	struct sigaction sa;
 	uint32_t lease_cap_secs;
+	char ifname[IFNAMSIZ] = "";
 
 	(void)argc;
 	(void)argv;
 
-	xlog("ipconfigd starting (iter 7a — MIG service + DHCPv4 + "
-	    "RFC 5227 ARP + IPv6 RA/SLAAC)");
+	xlog("ipconfigd starting (iter 9 — MIG service + DHCPv4 + "
+	    "RFC 5227 ARP + IPv6 RA/SLAAC + hwregd attach subscriber)");
 
 	lease_cap_secs = read_lease_cap_env();
 
@@ -208,6 +360,17 @@ main(int argc, char **argv)
 		xlog("mach_service_start failed; RPC off");
 
 	/*
+	 * iter 9: start the hwregd attach subscriber BEFORE the initial
+	 * DHCP attempt so a NIC that hwregd autoloads while we're
+	 * starting up still goes through on_attach_event. The
+	 * subscription itself is unconditional (success on em0 → main
+	 * thread enters lease_loop_run and never returns; subscriber
+	 * thread idles but is harmless). Failure to subscribe is
+	 * non-fatal — DHCP on the startup-path NIC still runs.
+	 */
+	(void)hwreg_subscribe_start(on_attach_event, lease_cap_secs);
+
+	/*
 	 * iter 3: full DHCPv4 INIT → BOUND on the first non-loopback
 	 * Ethernet interface (em0 in CI). dhcp_lease_acquire runs the
 	 * SELECTING → REQUESTING → BOUND state machine; apply_lease
@@ -222,145 +385,21 @@ main(int argc, char **argv)
 	 * sleep until T1, RENEWING, on fail sleep to T2, REBINDING.
 	 *
 	 * Failure does NOT exit ipconfigd — the Mach service stays
-	 * registered (iter-1 IPCFG-BOOT still passes), and a future
-	 * iter's retry logic will pick up.
+	 * registered (iter-1 IPCFG-BOOT still passes), and iter 9's
+	 * hwregd subscriber will pick up if a NIC arrives later.
 	 */
-	{
-		char ifname[IFNAMSIZ] = "";
-
-		if (dhcp_pick_interface(ifname, sizeof(ifname)) != 0) {
-			xlog("no Ethernet interface found for DHCPv4");
-			xlog("IPCFG-BOUND-FAIL");
-		} else {
-			struct dhcp_lease lease;
-
-			xlog("selected interface for DHCPv4: %s", ifname);
-			if (dhcp_lease_acquire(ifname, &lease) == 0) {
-				char a[INET_ADDRSTRLEN], m[INET_ADDRSTRLEN];
-				char r[INET_ADDRSTRLEN], s[INET_ADDRSTRLEN];
-
-				if (apply_lease(ifname, &lease) != 0) {
-					xlog("apply_lease(%s) failed",
-					    ifname);
-					xlog("IPCFG-BOUND-FAIL");
-				} else {
-					struct sc_publish *pub;
-
-					(void)inet_ntop(AF_INET,
-					    &lease.addr, a, sizeof(a));
-					(void)inet_ntop(AF_INET,
-					    &lease.netmask, m, sizeof(m));
-					(void)inet_ntop(AF_INET,
-					    &lease.router, r, sizeof(r));
-					(void)inet_ntop(AF_INET,
-					    &lease.server, s, sizeof(s));
-					xlog("bound: iface=%s addr=%s "
-					    "netmask=%s router=%s "
-					    "server=%s lease=%us",
-					    ifname, a, m, r, s,
-					    (unsigned)lease.lease_time);
-					/*
-					 * Make the lease visible to the
-					 * Mach service worker before the
-					 * BOUND marker fires — so any
-					 * client racing IPCFG-RPC-OK
-					 * against IPCFG-BOUND-OK sees the
-					 * address it expects.
-					 */
-					bound_state_set(ifname, &lease);
-					xlog("IPCFG-BOUND-OK");
-
-					/*
-					 * Publish to configd. Failure is
-					 * non-fatal: the daemon stays up,
-					 * the lease is already applied at
-					 * the kernel level, but observers
-					 * watching State:/Network/Service/.
-					 * won't see this binding. CI marker
-					 * IPCFG-STORE-FAIL flags it.
-					 */
-					pub = sc_publish_open("ipconfigd");
-					if (pub == NULL) {
-						xlog("IPCFG-STORE-FAIL: "
-						    "no configd session");
-					} else if (sc_publish_ipv4(pub,
-					    ifname, &lease) != 0) {
-						xlog("IPCFG-STORE-FAIL: "
-						    "set State:/.../IPv4");
-					} else {
-						struct ra_info ra;
-						int rar;
-
-						xlog("IPCFG-STORE-OK");
-
-						/*
-						 * iter 7a: solicit + listen for
-						 * one RA, derive a SLAAC address,
-						 * install it + the v6 default
-						 * route, and publish State:/.../
-						 * IPv6. 15s budget — QEMU SLIRP
-						 * answers within ms, so a miss
-						 * means RA isn't configured;
-						 * we log IPCFG-RA-MISS and
-						 * continue with IPv4 only.
-						 *
-						 * Round-1 CI showed em0 has
-						 * ND6_IFF_IFDISABLED set (this
-						 * image's net.inet6.ip6.auto_
-						 * linklocal is 0, so the kernel
-						 * never auto-added a link-local).
-						 * bring_v6_up clears IFDISABLED
-						 * and installs fe80::EUI-64 so
-						 * the kernel can source-select
-						 * the link-local-scoped RS.
-						 */
-						(void)bring_v6_up(ifname);
-						rar = ra_acquire(ifname,
-						    15000, &ra);
-						if (rar == 0) {
-							struct in6_addr v6;
-
-							if (apply_ra_lease(
-							    ifname, &ra,
-							    &v6) == 0) {
-								(void)
-								sc_publish_ipv6(
-								    pub, ifname,
-								    &v6,
-								    ra.prefix_len,
-								    &ra.router_lladdr);
-								xlog("IPCFG-RA-OK");
-							} else {
-								xlog("IPCFG-RA-MISS: "
-								    "apply_ra_lease failed");
-							}
-						} else if (rar == 1) {
-							xlog("IPCFG-RA-MISS: "
-							    "no RA in 15s "
-							    "(SLIRP may not "
-							    "advertise IPv6)");
-						} else {
-							xlog("IPCFG-RA-MISS: "
-							    "ra_acquire fatal");
-						}
-
-						(void)lease_loop_run(ifname,
-						    &lease, pub,
-						    lease_cap_secs);
-					}
-					if (pub != NULL)
-						sc_publish_close(pub);
-				}
-			}
-			/* failure case: dhcp_lease_acquire already logged
-			 * the marker on its own line */
-		}
+	if (dhcp_pick_interface(ifname, sizeof(ifname)) != 0) {
+		xlog("no Ethernet interface found for DHCPv4 at startup "
+		    "— waiting for hwregd attach event");
+		xlog("IPCFG-BOUND-FAIL");
+	} else {
+		dhcp_run_on_interface(ifname, lease_cap_secs);
 	}
 
 	/*
-	 * Hold the daemon alive. iter 1/2 have no MIG demux; later
-	 * iters replace this loop with a mach_msg(MACH_RCV_MSG ...)
-	 * receive over the service port (the configd / hwregd shape).
+	 * Hold the daemon alive after a failed startup DHCP (or after
+	 * lease_loop_run unexpectedly returns). The hwregd subscriber
+	 * thread is still listening and will run DHCP if a NIC arrives.
 	 */
 	while (!got_term) {
 		(void)sleep(60);

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -714,6 +714,27 @@ expect {
     }
 }
 
+# IPCFG-AUTOLOAD-SUB — iter 9 hwregd attach subscription. ipconfigd
+# subscribes to org.freebsd.hwregd's raw pub/sub bus at startup so
+# NICs that hwregd autoloads ~60s into boot still get DHCP'd. The
+# full attach→DHCP path isn't exercised in CI (em is built into the
+# kernel here so it's present at startup, not later autoloaded), but
+# this marker proves the subscription wiring is up — when a slimmed
+# kernel ships in a later iter, the same wiring carries the chain.
+expect {
+    timeout {
+        puts "\nFAIL: IPCFG-AUTOLOAD-SUB marker not seen"
+        exit 1
+    }
+    "IPCFG-AUTOLOAD-SUB-FAIL" {
+        puts "\nFAIL: ipconfigd hwregd subscription did not establish"
+        exit 1
+    }
+    "IPCFG-AUTOLOAD-SUB-OK" {
+        puts "\nOK: ipconfigd subscribed to hwregd attach events"
+    }
+}
+
 # IPCFG-ARP — iter 6 RFC 5227 ARP probe on the DHCPOFFER. Fires
 # after 3 successful (= no-reply) probes of the offered address;
 # precedes IPCFG-BOUND-OK in the timeline (probe runs between


### PR DESCRIPTION
## Summary

- ipconfigd used to call `dhcp_pick_interface()` exactly once at startup and give up forever if no NIC was visible (`ipconfigd.c:231`). With PR #60 hwregd now `kldload(2)`s driver modules for boot-backlog nomatches ~60s into boot, so a NIC whose driver is neither built into the kernel nor preloaded in `/boot/loader.conf` attaches long after ipconfigd has already given up — the chain that should make *"first boot on new hardware just works"* was open on the DHCP side.
- This iter closes it. ipconfigd now subscribes to hwregd's raw pub/sub bus (same protocol DiskArbitration iter 2 consumes) at startup. On a `+` attach event the subscriber thread invokes `on_attach_event`, which (if nothing is yet bound) re-runs `dhcp_pick_interface` and `dhcp_run_on_interface` on the newly-visible NIC.
- Extracts the large inline DHCP+publish+RA+lease-loop block from `main()` into the shared `dhcp_run_on_interface(ifname, lease_cap_secs)` helper so the startup path and the subscriber path drive the same code.
- New file: `src/IPConfiguration/hwreg_subscribe.{c,h}` — adapted from `src/DiskArbitration/hwreg_subscribe.{c,h}`, but parses `dev=` (publish_event format) rather than `name=` (notify_watchers / MIG watch format — never reaches a bare-pubsub subscriber). Callback-driven so the daemon can decide what to do with each attach.
- iter scope is deliberately single-NIC — `bound_state_any` guards against re-binding when the startup path already covered em0; multi-NIC fan-out and LINK_UP reaction for hot-plug cable are later iters (per the IPConfiguration-port-state memory's deferred list).

## CI marker

`IPCFG-AUTOLOAD-SUB-OK` fires from `hwreg_subscribe_start` once the subscription is established. New expect block in `boot-test.sh` between `IPCFG-BOOT` and `IPCFG-ARP` gates it.

The full autoload→attach→DHCP chain is **not** exercised in CI yet because the GENERIC kernel still has `device em` built in — the NIC is present at startup, not later autoloaded by hwregd. A separate iter that slims the kernel (or a manual real-hardware test) proves the end-to-end chain. This PR proves the wiring is correct and ready.

## Test plan

- [ ] CI boot test passes (`IPCFG-AUTOLOAD-SUB-OK` seen between `IPCFG-BOOT-OK` and `IPCFG-ARP-OK`).
- [ ] No regression in IPCFG-BOOT / IPCFG-BOUND / IPCFG-STORE / IPCFG-RA / IPCFG-RENEW / IPCFG-RPC / IPCFG-IPCONFIG markers (the extracted helper is a behavior-preserving refactor of the startup path).
- [ ] `ipconfigd.stderr` shows the subscription log line: `subscribed to org.freebsd.hwregd (ack ...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)