### PR TITLE
ci: disable driverpkgs install to trim CI build time

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -121,17 +121,27 @@ env ABI="${PKG_ABI}" \
 # (the matrix shape vmactions expects) resolves to driverpkgs-15.0-
 # RELEASE.txt without the caller having to set FREEBSD_VARIANT.
 : "${FREEBSD_VARIANT:=${FREEBSD_VERSION}-RELEASE}"
-DRIVER_PKGS_FILE="$ROOT/driverpkgs-${FREEBSD_VARIANT}.txt"
-if [ ! -f "$DRIVER_PKGS_FILE" ]; then
-    echo "ERROR: driver pkglist for FREEBSD_VARIANT=$FREEBSD_VARIANT not found" >&2
-    echo "       expected: $DRIVER_PKGS_FILE" >&2
-    echo "       create one or set FREEBSD_VARIANT to an existing variant" >&2
-    ls -1 "$ROOT"/driverpkgs-*.txt 2>/dev/null | sed 's|.*/||; s|^|       available: |' >&2
-    exit 1
-fi
+
+# DRIVER_PKGS — driver kmod install path (drm-66-kmod, nvidia-drm-kmod,
+# gpu-firmware-kmod, realtek-re-kmod, utouch-kmod, wifi-firmware-kmod).
+# Temporarily disabled to trim CI build time — the firmware+kmod set
+# adds several minutes per run to the chroot pkg install, and CI's
+# QEMU/SLIRP target doesn't exercise any of them. hwregd still
+# kldload(2)s any module that happens to live in /boot/modules; the
+# missing packages just mean those modules aren't present in the
+# rootfs at all on CI builds. Real-hardware images can re-enable by
+# uncommenting the validation + grep block below.
+#DRIVER_PKGS_FILE="$ROOT/driverpkgs-${FREEBSD_VARIANT}.txt"
+#if [ ! -f "$DRIVER_PKGS_FILE" ]; then
+#    echo "ERROR: driver pkglist for FREEBSD_VARIANT=$FREEBSD_VARIANT not found" >&2
+#    echo "       expected: $DRIVER_PKGS_FILE" >&2
+#    echo "       create one or set FREEBSD_VARIANT to an existing variant" >&2
+#    ls -1 "$ROOT"/driverpkgs-*.txt 2>/dev/null | sed 's|.*/||; s|^|       available: |' >&2
+#    exit 1
+#fi
 
 RUNTIME_PKGS=$(grep -v '^[[:space:]]*#' "$ROOT/pkglist.txt"        2>/dev/null | grep -v '^[[:space:]]*$' || true)
-DRIVER_PKGS=$( grep -v '^[[:space:]]*#' "$DRIVER_PKGS_FILE"        2>/dev/null | grep -v '^[[:space:]]*$' || true)
+DRIVER_PKGS=""  # re-enable: grep -v '^[[:space:]]*#' "$DRIVER_PKGS_FILE" 2>/dev/null | grep -v '^[[:space:]]*$' || true
 BUILD_PKGS=$(  grep -v '^[[:space:]]*#' "$ROOT/buildpkgs.txt"      2>/dev/null | grep -v '^[[:space:]]*$' || true)
 
 if [ -n "$RUNTIME_PKGS" ] || [ -n "$DRIVER_PKGS" ] || [ -n "$BUILD_PKGS" ]; then


### PR DESCRIPTION
## Summary

Per the conversation on #84 — the 6-package driver kmod set adds several minutes per CI run (recent builds were trending ~25min, much of it fetching/extracting GPU firmware blobs and NVIDIA kmod sources). CI's QEMU/SLIRP target doesn't exercise any of these drivers (em0 NIC + virtio disk only), so the install is pure overhead.

- `DRIVER_PKGS` forced to `""` — downstream `[ -n "$DRIVER_PKGS" ]` branches skip naturally.
- Validation + grep block commented out (not deleted) so re-enabling for real-hardware images is a single uncomment.
- `hwregd`'s autoload path (`kldload(2)` on hot-plug + boot-backlog drain) is unaffected; it just won't find these modules in `/boot/modules` on CI-built images.

## Test plan

- [ ] CI build job completes noticeably faster than the previous ~25min baseline (target: closer to the ~9min from before driverpkgs landed).
- [ ] Boot test still green end-to-end (no driver-kmod boot dependency).
- [ ] Continuous release artifact size shrinks (no driver pkgs in rootfs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)