### PR TITLE
feat(hostnamed): iter 2 — SCPreferences read awareness (#86)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1902,7 +1902,25 @@ cc -fblocks \
    -lsystem_kernel -lpthread
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnametest" \
     || { echo "FAIL: hostnametest not built"; exit 1; }
-echo "==> hostnamed + hostnametest built"
+
+# hostnameprefset — iter 2 (issue #86) CI fixture. Writes a known
+# ComputerName into SCPrefs via SCPreferencesPathSetValue +
+# SCPreferencesCommitChanges so the next hostnamed run exercises the
+# Tier-2 read path. Same -fblocks + CF/SC linkage as hostnametest.
+echo "==> building hostnameprefset"
+cc -fblocks \
+   -I"$ROOT/src/launchd/liblaunch" \
+   -I"$ROOT/src/launchd/freebsd-shims" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnameprefset" \
+   "$ROOT/src/hostnamed/hostnameprefset.c" \
+   -lSystemConfiguration -lCoreFoundation -ldispatch -lBlocksRuntime \
+   -lsystem_kernel -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnameprefset" \
+    || { echo "FAIL: hostnameprefset not built"; exit 1; }
+echo "==> hostnamed + hostnametest + hostnameprefset built"
 
 #
 # 3z. purge build packages + clean pkg cache + tear down chroot.

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -935,28 +935,65 @@ else
     esac
 fi
 
-# HOSTNAMED — issue #63 iter 1. The plist's RunAtLoad is intentionally
-# disabled (see com.apple.hostnamed.plist comment): the launchd-port
-# RunAtLoad scan race wedges pam_xdg's /var/run/xdg bring-up and
-# breaks root login. Invoke hostnamed directly here, same workaround
-# syslogd's run.sh-side spawn uses, then run hostnametest to verify
-# the publish round-trip. A later iter restores RunAtLoad after the
-# launchd MachServices/checkin race is properly fixed.
-echo "==> hostnamed: kernel hostname BEFORE run = '$(hostname 2>/dev/null)'"
-if [ -x /usr/sbin/hostnamed ]; then
-    /usr/sbin/hostnamed > /var/log/hostnamed.stderr 2>&1
-    rc=$?
-    echo "--- /var/log/hostnamed.stderr (hostnamed exit=$rc) ---"
-    cat /var/log/hostnamed.stderr
-    echo "--- end hostnamed.stderr ---"
-else
-    echo "HOSTNAMED-FAIL: /usr/sbin/hostnamed not installed"
-fi
-echo "==> hostnamed: kernel hostname AFTER run  = '$(hostname 2>/dev/null)'"
+# HOSTNAMED — issue #63 (iter 1) + #86 (iter 2). The plist's RunAtLoad
+# is intentionally disabled (see com.apple.hostnamed.plist comment):
+# the launchd-port RunAtLoad scan race wedges pam_xdg's /var/run/xdg
+# bring-up and breaks root login. Invoke hostnamed directly here, same
+# workaround syslogd's run.sh-side spawn uses. A later iter restores
+# RunAtLoad after the launchd MachServices/checkin race is fixed.
+#
+# Two test rounds prove the precedence chain:
+#   ROUND 1 (iter 1 regression): no SCPrefs ComputerName set; hostnamed
+#     synthesizes "${slug}-${suffix}" from SMBIOS+MAC. hostnametest
+#     (no arg) emits HOSTNAMED-OK / HOSTNAMED-FAIL.
+#   ROUND 2 (iter 2 Tier-2 read): hostnameprefset writes a fixture
+#     ComputerName into SCPrefs; hostnamed re-reads, finds the prefs
+#     value, sethostname()s to it (bypassing synthesis). hostnametest
+#     with the same expected fixture emits HOSTNAMED-PREFS-OK /
+#     HOSTNAMED-PREFS-FAIL.
+
+run_hostnamed() {
+    label="$1"
+    echo "==> hostnamed [$label]: kernel hostname BEFORE = '$(hostname 2>/dev/null)'"
+    if [ -x /usr/sbin/hostnamed ]; then
+        /usr/sbin/hostnamed > /var/log/hostnamed.stderr 2>&1
+        rc=$?
+        echo "--- /var/log/hostnamed.stderr ($label, exit=$rc) ---"
+        cat /var/log/hostnamed.stderr
+        echo "--- end hostnamed.stderr ---"
+    else
+        echo "HOSTNAMED-FAIL: /usr/sbin/hostnamed not installed"
+        return 1
+    fi
+    echo "==> hostnamed [$label]: kernel hostname AFTER  = '$(hostname 2>/dev/null)'"
+}
+
+# ROUND 1: synthesis regression. Make sure no leftover SCPrefs ComputerName
+# from any earlier test cycle pollutes the result — the iter 1 path
+# should reach the slug+suffix synthesis branch.
+rm -f /Library/Preferences/SystemConfiguration/preferences.plist
+run_hostnamed "iter 1 synthesis"
 if [ -x /usr/tests/freebsd-launchd-mach/hostnametest ]; then
     /usr/tests/freebsd-launchd-mach/hostnametest
 else
     echo "HOSTNAMED-FAIL: hostnametest binary not installed"
+fi
+
+# ROUND 2: SCPrefs Tier-2 read (issue #86). Write a fixture ComputerName
+# into preferences.plist via hostnameprefset, re-run hostnamed (one-shot
+# — fresh process), then verify the published value matches the fixture.
+HOSTNAMED_FIXTURE="hostnamed-iter2-fixture"
+if [ -x /usr/tests/freebsd-launchd-mach/hostnameprefset ]; then
+    /usr/tests/freebsd-launchd-mach/hostnameprefset "$HOSTNAMED_FIXTURE"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "HOSTNAMED-PREFS-FAIL: hostnameprefset exit=$rc"
+    else
+        run_hostnamed "iter 2 SCPrefs read"
+        /usr/tests/freebsd-launchd-mach/hostnametest "$HOSTNAMED_FIXTURE"
+    fi
+else
+    echo "HOSTNAMED-PREFS-FAIL: hostnameprefset binary not installed"
 fi
 
 exit 0

--- a/src/hostnamed/hostnamed.c
+++ b/src/hostnamed/hostnamed.c
@@ -25,6 +25,7 @@
  */
 
 #include <SystemConfiguration/SCDynamicStore.h>
+#include <SystemConfiguration/SCPreferences.h>
 #include <CoreFoundation/CoreFoundation.h>
 
 #include <sys/types.h>
@@ -319,31 +320,36 @@ derive_slug(char *out, size_t outsz)
 	xlog("slug fallback -> 'freebsd'");
 }
 
-/* Tier 1: kenv override. Whitelist [A-Za-z0-9 _.-]{1,253}; replace ' '
- * with '-' so the result is a valid hostname. Returns 1 if applied. */
+/* Whitelist + normalize a candidate hostname in-place. Allows
+ * [A-Za-z0-9 _.-]{1,253}; replaces spaces with '-' so the result is a
+ * valid kernel hostname. Returns 1 if the value passed validation and
+ * is now stored in out (NUL-terminated); 0 if rejected (out is
+ * untouched). Shared by Tier 1 (kenv override) and Tier 2 (SCPrefs
+ * ComputerName) so both apply the same gate. */
 static int
-try_override(char *out, size_t outsz)
+validate_and_normalize(const char *src, const char *source_label,
+    char *out, size_t outsz)
 {
 	char buf[256];
-	int n;
-	size_t i;
+	size_t i, len;
 
-	n = read_kenv("hostname.override", buf, sizeof(buf));
-	if (n <= 0)
+	if (src == NULL)
 		return (0);
-	/* Whitelist gate. */
+	len = strlen(src);
+	if (len == 0 || len > sizeof(buf) - 1 || len > 253) {
+		xlog("%s rejected: bad length %zu", source_label, len);
+		return (0);
+	}
+	(void)memcpy(buf, src, len);
+	buf[len] = '\0';
 	for (i = 0; buf[i] != '\0'; i++) {
 		unsigned char c = (unsigned char)buf[i];
 		if (!isalnum(c) && c != ' ' && c != '_' &&
 		    c != '.' && c != '-') {
-			xlog("hostname.override rejected: invalid char 0x%02x",
-			    (unsigned)c);
+			xlog("%s rejected: invalid char 0x%02x",
+			    source_label, (unsigned)c);
 			return (0);
 		}
-	}
-	if (i == 0 || i > 253) {
-		xlog("hostname.override rejected: bad length %zu", i);
-		return (0);
 	}
 	for (i = 0; buf[i] != '\0'; i++) {
 		if (buf[i] == ' ')
@@ -351,8 +357,79 @@ try_override(char *out, size_t outsz)
 	}
 	(void)strncpy(out, buf, outsz - 1);
 	out[outsz - 1] = '\0';
+	return (1);
+}
+
+/* Tier 1: kenv hostname.override (operator pre-boot pin). */
+static int
+try_override(char *out, size_t outsz)
+{
+	char buf[256];
+
+	if (read_kenv("hostname.override", buf, sizeof(buf)) <= 0)
+		return (0);
+	if (!validate_and_normalize(buf, "kenv hostname.override",
+	    out, outsz))
+		return (0);
 	xlog("hostname from kenv hostname.override -> '%s'", out);
 	return (1);
+}
+
+/* Tier 2: SCPreferences /System/System/ComputerName (user-set name via
+ * UI / scutil — beats synthesis). Opens the default preferences.plist
+ * (/Library/Preferences/SystemConfiguration/preferences.plist),
+ * drills the /System/System dict, reads the ComputerName string.
+ * Returns 1 if a valid name was found and stored in out; 0 otherwise.
+ * On any SC error or missing/empty/invalid value, falls through to
+ * synthesis — never aborts the daemon. Issue: #86 */
+static int
+try_scprefs(char *out, size_t outsz)
+{
+	SCPreferencesRef prefs = NULL;
+	CFStringRef session = NULL, path = NULL, key = NULL;
+	CFDictionaryRef sysdict;
+	CFStringRef cf_name;
+	char buf[256];
+	int rc = 0;
+
+	session = mkstr("com.apple.hostnamed");
+	path = mkstr("/System/System");
+	key = mkstr("ComputerName");
+	if (session == NULL || path == NULL || key == NULL)
+		goto out;
+
+	/* SCPreferencesCreate is lazy — it doesn't fail just because the
+	 * prefs file is missing. SCPreferencesPathGetValue will return
+	 * NULL in that case, and we silently fall through. */
+	prefs = SCPreferencesCreate(NULL, session, NULL);
+	if (prefs == NULL) {
+		xlog("try_scprefs: SCPreferencesCreate failed: %s "
+		    "(falling through to synthesis)",
+		    SCErrorString(SCError()));
+		goto out;
+	}
+	sysdict = SCPreferencesPathGetValue(prefs, path);
+	if (sysdict == NULL ||
+	    CFGetTypeID(sysdict) != CFDictionaryGetTypeID())
+		goto out;
+	cf_name = CFDictionaryGetValue(sysdict, key);
+	if (cf_name == NULL || CFGetTypeID(cf_name) != CFStringGetTypeID())
+		goto out;
+	if (!CFStringGetCString(cf_name, buf, sizeof(buf),
+	    kCFStringEncodingUTF8))
+		goto out;
+	if (!validate_and_normalize(buf,
+	    "SCPrefs /System/System/ComputerName", out, outsz))
+		goto out;
+	xlog("hostname from SCPrefs /System/System/ComputerName -> '%s'",
+	    out);
+	rc = 1;
+out:
+	if (prefs != NULL) CFRelease(prefs);
+	if (key != NULL) CFRelease(key);
+	if (path != NULL) CFRelease(path);
+	if (session != NULL) CFRelease(session);
+	return (rc);
 }
 
 /* Compose the final hostname into out (HOSTNAMED_MAX chars). */
@@ -363,6 +440,8 @@ synthesize(char *out, size_t outsz)
 	char suffix[SUFFIX_LEN + 1];
 
 	if (try_override(out, outsz))
+		return;
+	if (try_scprefs(out, outsz))
 		return;
 
 	derive_slug(slug, sizeof(slug));

--- a/src/hostnamed/hostnameprefset.c
+++ b/src/hostnamed/hostnameprefset.c
@@ -1,0 +1,92 @@
+/*
+ * hostnameprefset — CI fixture helper for hostnamed iter 2.
+ *
+ * Usage:  hostnameprefset <computer-name>
+ *
+ * Writes ComputerName=<computer-name> into the default
+ * SCPreferences file (/Library/Preferences/SystemConfiguration/
+ * preferences.plist) at path /System/System, commits, and exits.
+ * The next hostnamed run will read that value and use it instead
+ * of synthesizing — proving Tier 2 fires.
+ *
+ * Not shipped to real images (CI-only tool); lives next to
+ * hostnametest under /usr/tests/freebsd-launchd-mach/.
+ *
+ * Issue: #86
+ */
+
+#include <SystemConfiguration/SCPreferences.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int
+main(int argc, char **argv)
+{
+	SCPreferencesRef prefs = NULL;
+	CFStringRef session = NULL, path = NULL, key = NULL, value = NULL;
+	CFMutableDictionaryRef dict = NULL;
+	int rc = 1;
+
+	if (argc != 2 || argv[1][0] == '\0') {
+		(void)fprintf(stderr,
+		    "usage: %s <computer-name>\n", argv[0]);
+		return (2);
+	}
+
+	session = CFStringCreateWithCString(NULL, "hostnameprefset",
+	    kCFStringEncodingUTF8);
+	path = CFStringCreateWithCString(NULL, "/System/System",
+	    kCFStringEncodingUTF8);
+	key = CFStringCreateWithCString(NULL, "ComputerName",
+	    kCFStringEncodingUTF8);
+	value = CFStringCreateWithCString(NULL, argv[1],
+	    kCFStringEncodingUTF8);
+	if (session == NULL || path == NULL || key == NULL || value == NULL) {
+		(void)fprintf(stderr, "CFString allocation failed\n");
+		goto out;
+	}
+
+	prefs = SCPreferencesCreate(NULL, session, NULL);
+	if (prefs == NULL) {
+		(void)fprintf(stderr, "SCPreferencesCreate failed: %s\n",
+		    SCErrorString(SCError()));
+		goto out;
+	}
+
+	dict = CFDictionaryCreateMutable(NULL, 0,
+	    &kCFTypeDictionaryKeyCallBacks,
+	    &kCFTypeDictionaryValueCallBacks);
+	if (dict == NULL) {
+		(void)fprintf(stderr, "CFDictionaryCreateMutable failed\n");
+		goto out;
+	}
+	CFDictionarySetValue(dict, key, value);
+
+	if (!SCPreferencesPathSetValue(prefs, path, dict)) {
+		(void)fprintf(stderr,
+		    "SCPreferencesPathSetValue(%s) failed: %s\n",
+		    "/System/System", SCErrorString(SCError()));
+		goto out;
+	}
+	if (!SCPreferencesCommitChanges(prefs)) {
+		(void)fprintf(stderr,
+		    "SCPreferencesCommitChanges failed: %s\n",
+		    SCErrorString(SCError()));
+		goto out;
+	}
+	(void)printf("hostnameprefset: wrote ComputerName='%s' to "
+	    "/Library/Preferences/SystemConfiguration/preferences.plist\n",
+	    argv[1]);
+	rc = 0;
+out:
+	if (dict != NULL) CFRelease(dict);
+	if (prefs != NULL) CFRelease(prefs);
+	if (value != NULL) CFRelease(value);
+	if (key != NULL) CFRelease(key);
+	if (path != NULL) CFRelease(path);
+	if (session != NULL) CFRelease(session);
+	return (rc);
+}

--- a/src/hostnamed/hostnametest.c
+++ b/src/hostnamed/hostnametest.c
@@ -82,72 +82,107 @@ out:
 }
 
 int
-main(void)
+main(int argc, char **argv)
 {
 	SCDynamicStoreRef store = NULL;
 	CFStringRef session = NULL;
 	char *cn = NULL, *hn = NULL, *lhn = NULL;
 	char kn[KERN_LIMIT];
+	const char *expected;
+	const char *ok_marker, *fail_marker, *mode_label;
 	int rc = 1;
+
+	/*
+	 * Two modes:
+	 *   hostnametest                — iter 1 regression check: verify
+	 *                                 sources agree AND value isn't
+	 *                                 "Amnesiac". Emits HOSTNAMED-OK /
+	 *                                 HOSTNAMED-FAIL.
+	 *   hostnametest <expected>     — iter 2 (issue #86) Tier-2 read
+	 *                                 check: verify sources agree AND
+	 *                                 the published value equals
+	 *                                 <expected> (the fixture that
+	 *                                 hostnameprefset wrote to SCPrefs
+	 *                                 before hostnamed ran). Emits
+	 *                                 HOSTNAMED-PREFS-OK /
+	 *                                 HOSTNAMED-PREFS-FAIL.
+	 */
+	expected = (argc == 2) ? argv[1] : NULL;
+	if (expected != NULL) {
+		ok_marker   = "HOSTNAMED-PREFS-OK";
+		fail_marker = "HOSTNAMED-PREFS-FAIL";
+		mode_label  = "iter 2 SCPrefs read";
+	} else {
+		ok_marker   = "HOSTNAMED-OK";
+		fail_marker = "HOSTNAMED-FAIL";
+		mode_label  = "iter 1 synthesis";
+	}
 
 	session = CFStringCreateWithCString(NULL, "hostnametest",
 	    kCFStringEncodingUTF8);
 	if (session == NULL) {
-		(void)printf("HOSTNAMED-FAIL: CFStringCreate(session)\n");
+		(void)printf("%s: CFStringCreate(session)\n", fail_marker);
 		goto out;
 	}
 	store = SCDynamicStoreCreate(NULL, session, NULL, NULL);
 	if (store == NULL) {
-		(void)printf("HOSTNAMED-FAIL: SCDynamicStoreCreate "
-		    "(configd unreachable?)\n");
+		(void)printf("%s: SCDynamicStoreCreate "
+		    "(configd unreachable?)\n", fail_marker);
 		goto out;
 	}
 
 	cn = read_dict_string(store, "Setup:/System", "ComputerName");
 	if (cn == NULL || cn[0] == '\0') {
-		(void)printf("HOSTNAMED-FAIL: Setup:/System missing "
-		    "ComputerName\n");
+		(void)printf("%s: Setup:/System missing ComputerName\n",
+		    fail_marker);
 		goto out;
 	}
 
 	hn = read_dict_string(store, "Setup:/Network/HostNames", "HostName");
 	if (hn == NULL || hn[0] == '\0') {
-		(void)printf("HOSTNAMED-FAIL: Setup:/Network/HostNames "
-		    "missing HostName\n");
+		(void)printf("%s: Setup:/Network/HostNames missing "
+		    "HostName\n", fail_marker);
 		goto out;
 	}
 
 	lhn = read_dict_string(store, "Setup:/Network/HostNames",
 	    "LocalHostName");
 	if (lhn == NULL || lhn[0] == '\0') {
-		(void)printf("HOSTNAMED-FAIL: Setup:/Network/HostNames "
-		    "missing LocalHostName\n");
+		(void)printf("%s: Setup:/Network/HostNames missing "
+		    "LocalHostName\n", fail_marker);
 		goto out;
 	}
 
 	if (gethostname(kn, sizeof(kn)) != 0 || kn[0] == '\0') {
-		(void)printf("HOSTNAMED-FAIL: gethostname(3) returned "
-		    "nothing\n");
+		(void)printf("%s: gethostname(3) returned nothing\n",
+		    fail_marker);
 		goto out;
 	}
-	if (strcmp(kn, "Amnesiac") == 0) {
-		(void)printf("HOSTNAMED-FAIL: gethostname(3) still "
-		    "'Amnesiac' — hostnamed did not run or sethostname(2) "
-		    "failed\n");
+	if (expected == NULL && strcmp(kn, "Amnesiac") == 0) {
+		(void)printf("%s: gethostname(3) still 'Amnesiac' — "
+		    "hostnamed did not run or sethostname(2) failed\n",
+		    fail_marker);
 		goto out;
 	}
 
 	if (strcmp(cn, hn) != 0 || strcmp(cn, lhn) != 0 ||
 	    strcmp(cn, kn) != 0) {
-		(void)printf("HOSTNAMED-FAIL: sources disagree "
-		    "(ComputerName='%s' HostName='%s' LocalHostName='%s' "
-		    "kernel='%s')\n", cn, hn, lhn, kn);
+		(void)printf("%s: sources disagree (ComputerName='%s' "
+		    "HostName='%s' LocalHostName='%s' kernel='%s')\n",
+		    fail_marker, cn, hn, lhn, kn);
 		goto out;
 	}
 
-	(void)printf("HOSTNAMED-OK: hostname='%s' "
-	    "(Setup:/System + Setup:/Network/HostNames + kernel all agree)\n",
-	    cn);
+	if (expected != NULL && strcmp(cn, expected) != 0) {
+		(void)printf("%s: expected='%s' but published='%s' — "
+		    "Tier-2 SCPrefs read did not fire (synthesis still ran?)\n",
+		    fail_marker, expected, cn);
+		goto out;
+	}
+
+	(void)printf("%s: hostname='%s' (%s; "
+	    "Setup:/System + Setup:/Network/HostNames + kernel all agree)\n",
+	    ok_marker, cn, mode_label);
 	rc = 0;
 out:
 	free(cn);

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -974,11 +974,13 @@ expect {
     }
 }
 
-# HOSTNAMED — issue #63 iter 1 gate. hostnametest reads ComputerName
-# back from Setup:/System, HostName + LocalHostName from
-# Setup:/Network/HostNames, and gethostname(3) from the kernel; emits
-# HOSTNAMED-OK only when all three agree AND the value isn't
-# "Amnesiac". HOSTNAMED-FAIL fires on any mismatch / unset / placeholder.
+# HOSTNAMED — issue #63 iter 1 gate. ROUND 1 in run.sh: no SCPrefs
+# ComputerName set, hostnamed synthesizes "${slug}-${suffix}" from
+# SMBIOS + NIC MAC. hostnametest (no arg) reads ComputerName back from
+# Setup:/System, HostName + LocalHostName from Setup:/Network/HostNames,
+# and gethostname(3) from the kernel; emits HOSTNAMED-OK only when all
+# three agree AND the value isn't "Amnesiac". HOSTNAMED-FAIL fires on
+# any mismatch / unset / placeholder.
 expect {
     timeout {
         puts "\nFAIL: HOSTNAMED marker not seen"
@@ -990,6 +992,28 @@ expect {
     }
     "HOSTNAMED-OK" {
         puts "\nOK: hostnamed synthesized + published (SCDynamicStore + kernel agree, value != Amnesiac)"
+    }
+}
+
+# HOSTNAMED-PREFS — issue #86 iter 2 gate. ROUND 2 in run.sh:
+# hostnameprefset writes ComputerName="hostnamed-iter2-fixture" into
+# /Library/Preferences/SystemConfiguration/preferences.plist via the
+# SCPreferences API; hostnamed re-reads and uses the prefs value
+# instead of synthesizing; hostnametest with the fixture arg verifies
+# that all three publish surfaces (Setup:/System + Setup:/Network/HostNames
+# + kernel) carry exactly that value. HOSTNAMED-PREFS-FAIL fires if
+# Tier-2 SCPrefs read didn't fire and synthesis ran anyway.
+expect {
+    timeout {
+        puts "\nFAIL: HOSTNAMED-PREFS marker not seen"
+        exit 1
+    }
+    "HOSTNAMED-PREFS-FAIL" {
+        puts "\nFAIL: hostnamed Tier-2 SCPrefs read did not override synthesis"
+        exit 1
+    }
+    "HOSTNAMED-PREFS-OK" {
+        puts "\nOK: hostnamed Tier-2 SCPrefs ComputerName beats synthesis (kernel + Setup:/System + Setup:/Network/HostNames all carry the fixture value)"
     }
 }
 


### PR DESCRIPTION
## Summary

Implements hostnamed iter 2 per the [published plan](https://pkgdemon.github.io/freebsd-hostnamed-plan.html). Adds a Tier-2 read of SCPreferences ComputerName so a user-set name (via UI / scutil — eventually) beats synthesis but still loses to the `kenv hostname.override` operator pin.

Closes #86.

### Precedence chain (new)

1. `kenv hostname.override`                       (operator pin — highest, iter 1)
2. **NEW:** SCPreferences `/System/System/ComputerName` (user-set, iter 2)
3. Synthesized `${slug}-${suffix}`                (fallback — lowest, iter 1)

### What's new

- **`src/hostnamed/hostnamed.c`** — factored the iter-1 override gate into `validate_and_normalize()`; new `try_scprefs()` opens the default `preferences.plist`, drills `/System/System` via `SCPreferencesPathGetValue`, reads `ComputerName`, runs it through the shared validator. Any SC error / missing path / missing key / wrong type / rejected value falls through to synthesis — never aborts the daemon.
- **`src/hostnamed/hostnameprefset.c`** (new, ~90 LOC) — CI fixture helper. Writes `ComputerName=<argv[1]>` into `/Library/Preferences/SystemConfiguration/preferences.plist` via `SCPreferencesPathSetValue` + `SCPreferencesCommitChanges`. Not shipped to real images.
- **`src/hostnamed/hostnametest.c`** — now accepts an optional expected hostname. No-arg mode = iter-1 regression (`HOSTNAMED-OK`/`HOSTNAMED-FAIL`). With-arg mode = iter-2 verification (`HOSTNAMED-PREFS-OK`/`HOSTNAMED-PREFS-FAIL`, requires the fixture value to equal what's published across all 4 surfaces).
- **`build.sh`** — compiles `hostnameprefset` next to `hostnametest` (same `-fblocks` + CF/SC linkage).
- **`run.sh`** — two test rounds: ROUND 1 clean state → synthesis → `HOSTNAMED-OK`; ROUND 2 fixture → prefs read → `HOSTNAMED-PREFS-OK`.
- **`boot-test.sh`** — new `HOSTNAMED-PREFS-OK`/`HOSTNAMED-PREFS-FAIL` gate after the existing `HOSTNAMED-OK` gate.

### Deferred to iter 3+

- DHCP option 12 + reverse-DNS PTR fallback (vendor Apple's `Plugins/IPMonitor/set-hostname.c`).
- Bonjour conflict rename feedback.
- SCPrefs change notification subscription (one-shot → persistent loop).
- Restore `RunAtLoad` once launchd's MachServices/checkin race is fixed.

## Test plan

- [ ] CI build green.
- [ ] CI log shows `HOSTNAMED-OK: hostname='pc-q35-8-2-123456'` from ROUND 1 (synthesis still works, iter 1 regression clean).
- [ ] CI log shows `HOSTNAMED-PREFS-OK: hostname='hostnamed-iter2-fixture'` from ROUND 2 (Tier-2 read fires).
- [ ] `/var/log/hostnamed.stderr` dump for ROUND 2 shows `hostname from SCPrefs /System/System/ComputerName -> 'hostnamed-iter2-fixture'`.
- [ ] No regression in any prior marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)