### PR TITLE
feat(ipconfigd): publish DHCP Option 12 (host_name) to /DHCP key (#88)

### DIFF
--- a/src/IPConfiguration/dhcp_discover.c
+++ b/src/IPConfiguration/dhcp_discover.c
@@ -490,6 +490,20 @@ parse_dhcp_reply(const uint8_t *frame, size_t frame_len,
 		lease->dns_count = n;
 	}
 
+	/* 12 host name — server-supplied client name. Per RFC 2132 §3.14
+	 * this is a plain string (NOT NUL-terminated on the wire). Truncate
+	 * any over-length value to DHCP_LEASE_MAX_HOSTNAME - 1 so we keep
+	 * room for a terminator; sc_publish_dhcp converts to CFString.
+	 * Issue #88. */
+	v = dhcp_option(opts, opts_len, DHCP_OPT_HOST_NAME, &l);
+	if (v != NULL && l > 0) {
+		unsigned n = (l < DHCP_LEASE_MAX_HOSTNAME - 1)
+		    ? (unsigned)l : (DHCP_LEASE_MAX_HOSTNAME - 1);
+		(void)memcpy(lease->host_name, v, n);
+		lease->host_name[n] = '\0';
+		lease->host_name_len = n;
+	}
+
 	return (1);
 }
 

--- a/src/IPConfiguration/dhcp_packet.h
+++ b/src/IPConfiguration/dhcp_packet.h
@@ -79,6 +79,10 @@ struct dhcp {
  */
 #define DHCP_LEASE_MAX_DNS	4
 
+/* DHCP option 12 max length per RFC 2132 §3.14. +1 for terminating NUL
+ * so the buffer is always safe to pass to printf / strncpy. */
+#define DHCP_LEASE_MAX_HOSTNAME	256
+
 struct dhcp_lease {
 	struct in_addr	addr;		/* yiaddr from the ACK */
 	struct in_addr	netmask;	/* option 1 (default 255.0.0.0) */
@@ -87,6 +91,12 @@ struct dhcp_lease {
 	uint32_t	lease_time;	/* option 51 (seconds) */
 	struct in_addr	dns[DHCP_LEASE_MAX_DNS];
 	unsigned	dns_count;
+	/* Option 12 host name — server-supplied client name. Issue #88;
+	 * hostnamed iter 3 reads State:/Network/Service/<UUID>/DHCP/Option_12
+	 * to fold this into its precedence chain. host_name_len = 0 means
+	 * the option was absent from the lease. */
+	char		host_name[DHCP_LEASE_MAX_HOSTNAME];
+	unsigned	host_name_len;
 };
 
 #endif /* _IPCFG_DHCP_PACKET_H_ */

--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -240,6 +240,23 @@ dhcp_run_on_interface(const char *ifname, uint32_t lease_cap_secs)
 	xlog("IPCFG-STORE-OK");
 
 	/*
+	 * Issue #88: publish State:/Network/Service/<UUID>/DHCP carrying
+	 * InterfaceName + LeaseStartTime, and Option_12 (host name) when
+	 * the lease supplied it. SLIRP doesn't ship Option_12 so the
+	 * marker proves the key/dict shape is correct; hostnamed iter 3
+	 * is the first consumer that reads it. Failure is non-fatal —
+	 * the IPv4 publish already succeeded.
+	 */
+	if (sc_publish_dhcp(pub, ifname, &lease) != 0) {
+		xlog("IPCFG-DHCP-FAIL: set State:/.../DHCP");
+	} else {
+		xlog("IPCFG-DHCP-OK: published /DHCP "
+		    "(Option_12 %s)",
+		    lease.host_name_len > 0
+		        ? lease.host_name : "absent");
+	}
+
+	/*
 	 * iter 7a: solicit + listen for one RA, derive a SLAAC address,
 	 * install it + the v6 default route, and publish
 	 * State:/.../IPv6. 15s budget — QEMU SLIRP answers within ms,

--- a/src/IPConfiguration/lease_loop.c
+++ b/src/IPConfiguration/lease_loop.c
@@ -116,9 +116,15 @@ lease_loop_run(const char *ifname, struct dhcp_lease *lease,
 			*lease = renewed;
 			lease_secs = cap_lease(lease->lease_time,
 			    lease_cap_secs);
-			if (pub != NULL &&
-			    sc_publish_ipv4(pub, ifname, lease) != 0)
-				xlog("RENEWING: re-publish failed (continuing)");
+			if (pub != NULL) {
+				if (sc_publish_ipv4(pub, ifname, lease) != 0)
+					xlog("RENEWING: re-publish failed (continuing)");
+				/* Issue #88: refresh /DHCP on renewal so
+				 * LeaseStartTime advances and Option_12
+				 * tracks any server-side change. */
+				if (sc_publish_dhcp(pub, ifname, lease) != 0)
+					xlog("RENEWING: /DHCP re-publish failed (continuing)");
+			}
 			xlog("RENEWING -> BOUND (server lease=%us, "
 			    "effective=%us)",
 			    (unsigned)lease->lease_time, lease_secs);
@@ -139,9 +145,12 @@ lease_loop_run(const char *ifname, struct dhcp_lease *lease,
 			*lease = renewed;
 			lease_secs = cap_lease(lease->lease_time,
 			    lease_cap_secs);
-			if (pub != NULL &&
-			    sc_publish_ipv4(pub, ifname, lease) != 0)
-				xlog("REBINDING: re-publish failed (continuing)");
+			if (pub != NULL) {
+				if (sc_publish_ipv4(pub, ifname, lease) != 0)
+					xlog("REBINDING: re-publish failed (continuing)");
+				if (sc_publish_dhcp(pub, ifname, lease) != 0)
+					xlog("REBINDING: /DHCP re-publish failed (continuing)");
+			}
 			xlog("REBINDING -> BOUND (server lease=%us, "
 			    "effective=%us)",
 			    (unsigned)lease->lease_time, lease_secs);

--- a/src/IPConfiguration/sc_publish.c
+++ b/src/IPConfiguration/sc_publish.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>		/* clock_gettime(CLOCK_MONOTONIC) for /DHCP LeaseStartTime */
 #include <string.h>
 
 struct sc_publish {
@@ -268,6 +269,77 @@ sc_publish_ipv4(struct sc_publish *p, const char *ifname,
 		if (!ok)
 			xlog("SCDynamicStoreSetValue(DNS) failed: %s",
 			    SCErrorString(SCError()));
+	}
+	return (0);
+}
+
+int
+sc_publish_dhcp(struct sc_publish *p, const char *ifname,
+    const struct dhcp_lease *lease)
+{
+	CFMutableDictionaryRef dict;
+	CFStringRef key, k_lease, k_iface, k_opt12;
+	CFStringRef iface_str, host_str;
+	CFNumberRef lease_num;
+	struct timespec ts;
+	int32_t lease_start;
+	Boolean ok;
+
+	if (p == NULL || p->store == NULL || lease == NULL)
+		return (-1);
+
+	dict = CFDictionaryCreateMutable(NULL, 0,
+	    &kCFTypeDictionaryKeyCallBacks,
+	    &kCFTypeDictionaryValueCallBacks);
+	if (dict == NULL)
+		return (-1);
+
+	/* InterfaceName + LeaseStartTime are always set so the dict is
+	 * never empty — observers can watch for the /DHCP key to appear
+	 * even on a lease that didn't carry Option_12. LeaseStartTime is
+	 * CLOCK_MONOTONIC seconds at bind, matching what bound_state.c
+	 * already tracks; SCPrefs / IPMonitor consumers don't depend on
+	 * absolute wall-clock here. */
+	k_iface = mkstr("InterfaceName");
+	k_lease = mkstr("LeaseStartTime");
+	iface_str = mkstr(ifname);
+	(void)clock_gettime(CLOCK_MONOTONIC, &ts);
+	lease_start = (int32_t)ts.tv_sec;
+	lease_num = CFNumberCreate(NULL, kCFNumberSInt32Type, &lease_start);
+
+	if (k_iface != NULL && k_lease != NULL && iface_str != NULL &&
+	    lease_num != NULL) {
+		CFDictionarySetValue(dict, k_iface, iface_str);
+		CFDictionarySetValue(dict, k_lease, lease_num);
+	}
+
+	/* Option_12 (host name) — only added when the lease carried it.
+	 * Stored as CFString rather than CFData since the option is
+	 * printable per RFC 2132 §3.14 and hostnamed iter 3 reads it as
+	 * a string. Issue #88. */
+	k_opt12 = mkstr("Option_12");
+	host_str = NULL;
+	if (lease->host_name_len > 0 && k_opt12 != NULL) {
+		host_str = mkstr(lease->host_name);
+		if (host_str != NULL)
+			CFDictionarySetValue(dict, k_opt12, host_str);
+	}
+
+	key = make_key(ifname, "DHCP");
+	ok = SCDynamicStoreSetValue(p->store, key, dict);
+	CFRelease(key);
+	CFRelease(dict);
+	if (host_str != NULL) CFRelease(host_str);
+	if (k_opt12 != NULL) CFRelease(k_opt12);
+	if (lease_num != NULL) CFRelease(lease_num);
+	if (iface_str != NULL) CFRelease(iface_str);
+	if (k_lease != NULL) CFRelease(k_lease);
+	if (k_iface != NULL) CFRelease(k_iface);
+
+	if (!ok) {
+		xlog("SCDynamicStoreSetValue(DHCP) failed: %s",
+		    SCErrorString(SCError()));
+		return (-1);
 	}
 	return (0);
 }

--- a/src/IPConfiguration/sc_publish.h
+++ b/src/IPConfiguration/sc_publish.h
@@ -55,6 +55,21 @@ int	sc_publish_ipv6(struct sc_publish *p, const char *ifname,
 	    const struct in6_addr *router_lladdr);
 
 /*
+ * Publish DHCP state under State:/Network/Service/<UUID>/DHCP. Mirrors
+ * Apple's IPMonitor DHCP-options dict shape: per-option entries keyed
+ * "Option_<N>" (CFData on Apple; CFString for printable options like
+ * 12 here so consumers — hostnamed iter 3, mDNSResponder — can read
+ * directly without re-decoding), plus LeaseStartTime (CFNumber,
+ * CLOCK_MONOTONIC seconds at bind). Issue #88.
+ *
+ * The /DHCP key is always set on BOUND (so observers can subscribe to
+ * its appearance), but Option_12 entries only land when the lease
+ * actually carried a server-supplied host name. Returns 0 on success.
+ */
+int	sc_publish_dhcp(struct sc_publish *p, const char *ifname,
+	    const struct dhcp_lease *lease);
+
+/*
  * Remove the previously-published keys for `ifname`. Called on
  * lease loss (REBINDING also fails) so observers see the service
  * transition to "no v4".

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -809,6 +809,25 @@ expect {
     }
 }
 
+# IPCFG-DHCP — issue #88. ipconfigd publishes State:/Network/Service/<UUID>/DHCP
+# carrying InterfaceName + LeaseStartTime (always), and Option_12
+# (host name, only when the lease supplied it). SLIRP doesn't ship
+# Option_12 so the marker just proves the dict shape is correct;
+# hostnamed iter 3 is the first consumer that reads the value.
+expect {
+    timeout {
+        puts "\nFAIL: IPCFG-DHCP marker not seen"
+        exit 1
+    }
+    "IPCFG-DHCP-FAIL" {
+        puts "\nFAIL: ipconfigd /DHCP publish failed"
+        exit 1
+    }
+    "IPCFG-DHCP-OK" {
+        puts "\nOK: ipconfigd published State:/Network/Service/.../DHCP (consumer surface for hostnamed iter 3)"
+    }
+}
+
 # IPCFG-RA — iter 7a IPv6 Router Advertisement + SLAAC. ipconfigd
 # sends an ND_ROUTER_SOLICIT to ff02::2 on em0, waits up to 15s for
 # an RA, derives a SLAAC address (EUI-64 over the PIO's prefix),


### PR DESCRIPTION
## Summary

Adds `State:/Network/Service/<UUID>/DHCP` to ipconfigd's SCDynamicStore publish surface. The dict always carries `InterfaceName` + `LeaseStartTime` (CLOCK_MONOTONIC seconds at bind/renewal), and adds `Option_12` (DHCP host_name) as a CFString when the lease supplied it.

This is the **dependency prerequisite for hostnamed iter 3**, which will read `/DHCP/Option_12` and slot it into the precedence chain between SCPrefs ComputerName and synthesis. Without ipconfigd publishing that surface, hostnamed iter 3 would have nothing to consume.

Closes #88.

### Why now

While scoping hostnamed iter 3 (vendoring Apple's `Plugins/IPMonitor/set-hostname.c`) I found the consumer-side plan assumes ipconfigd already publishes Option 12. It doesn't — the constant `DHCP_OPT_HOST_NAME = 12` exists in `dhcp_packet.h` but nothing extracts it from the lease. Shipping the producer side first as a small, self-contained PR keeps both halves reviewable.

### Code

- **`dhcp_packet.h`** — `struct dhcp_lease` grows `host_name[256]` + `host_name_len`. `DHCP_LEASE_MAX_HOSTNAME = 256` (RFC 2132 §3.14 max 255 bytes + NUL).
- **`dhcp_discover.c`** — `parse_dhcp_reply()` now extracts `DHCP_OPT_HOST_NAME` next to the other option parses, truncating to `DHCP_LEASE_MAX_HOSTNAME - 1` and NUL-terminating.
- **`sc_publish.{h,c}`** — new `sc_publish_dhcp()` mirrors `sc_publish_ipv4`'s shape. `Option_12` published as `CFString` rather than `CFData` (the option is printable per the RFC, and the iter-3 consumer reads it as a string).
- **`ipconfigd.c`** — BOUND path calls `sc_publish_dhcp` after `IPCFG-STORE-OK`, emits new `IPCFG-DHCP-OK` / `IPCFG-DHCP-FAIL` marker.
- **`lease_loop.c`** — RENEWING + REBINDING re-publish `/DHCP` alongside `/IPv4` so `LeaseStartTime` advances and `Option_12` stays fresh.
- **`tests/boot-test.sh`** — new `IPCFG-DHCP-OK` gate after `IPCFG-STORE-OK`.

### CI

SLIRP doesn't supply Option 12, so the CI marker reports `(Option_12 absent)` and proves only that the dict surface exists. Real-hardware DHCP servers that supply option 12 will light up `Option_12`.

## Test plan

- [ ] Build green.
- [ ] `IPCFG-DHCP-OK: published /DHCP (Option_12 absent)` appears after `IPCFG-STORE-OK`.
- [ ] No regression in `IPCFG-STORE-OK` / `IPCFG-RENEW-OK` / other markers.
- [ ] hostnamed iter 3 follow-up PR reads from this surface and adds a real readback test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)