### PR TITLE
feat(hostnamed): iter 3a — consume DHCP option 12 from /DHCP (#90)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1920,7 +1920,27 @@ cc -fblocks \
    -lsystem_kernel -lpthread
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnameprefset" \
     || { echo "FAIL: hostnameprefset not built"; exit 1; }
-echo "==> hostnamed + hostnametest + hostnameprefset built"
+
+# hostnamedhcpset — iter 3a (issue #90) CI fixture. Discovers the live
+# State:/Network/Service/<UUID>/DHCP key (already published by
+# ipconfigd per #88) and overlays an Option_12=<argv[1]> entry via
+# SCDynamicStoreSetValue so the next hostnamed run exercises the
+# Tier-3a DHCP read path. Same -fblocks + CF/SC linkage as
+# hostnametest / hostnameprefset.
+echo "==> building hostnamedhcpset"
+cc -fblocks \
+   -I"$ROOT/src/launchd/liblaunch" \
+   -I"$ROOT/src/launchd/freebsd-shims" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnamedhcpset" \
+   "$ROOT/src/hostnamed/hostnamedhcpset.c" \
+   -lSystemConfiguration -lCoreFoundation -ldispatch -lBlocksRuntime \
+   -lsystem_kernel -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnamedhcpset" \
+    || { echo "FAIL: hostnamedhcpset not built"; exit 1; }
+echo "==> hostnamed + hostnametest + hostnameprefset + hostnamedhcpset built"
 
 #
 # 3z. purge build packages + clean pkg cache + tear down chroot.

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -996,4 +996,25 @@ else
     echo "HOSTNAMED-PREFS-FAIL: hostnameprefset binary not installed"
 fi
 
+# ROUND 3: DHCP Tier-3a read (issue #90). hostnamedhcpset injects
+# Option_12 into the existing State:/Network/Service/<UUID>/DHCP dict
+# that ipconfigd published; with prefs.plist cleared and no kenv
+# override, hostnamed's precedence chain falls through to try_dhcp(),
+# which finds Option_12 and uses it. SLIRP doesn't supply Option_12
+# itself, so the fixture is the only way to exercise this tier in CI.
+HOSTNAMED_DHCP_FIXTURE="hostnamed-iter3a-fixture"
+rm -f /Library/Preferences/SystemConfiguration/preferences.plist
+if [ -x /usr/tests/freebsd-launchd-mach/hostnamedhcpset ]; then
+    /usr/tests/freebsd-launchd-mach/hostnamedhcpset "$HOSTNAMED_DHCP_FIXTURE"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "HOSTNAMED-DHCP-FAIL: hostnamedhcpset exit=$rc"
+    else
+        run_hostnamed "iter 3a DHCP read"
+        /usr/tests/freebsd-launchd-mach/hostnametest "$HOSTNAMED_DHCP_FIXTURE" DHCP
+    fi
+else
+    echo "HOSTNAMED-DHCP-FAIL: hostnamedhcpset binary not installed"
+fi
+
 exit 0

--- a/src/hostnamed/hostnamed.c
+++ b/src/hostnamed/hostnamed.c
@@ -432,6 +432,91 @@ out:
 	return (rc);
 }
 
+/* Tier 3a: DHCP option 12 (host_name) — server-supplied name from the
+ * active lease. ipconfigd (issue #88) publishes
+ * State:/Network/Service/<UUID>/DHCP dicts; we enumerate via the regex
+ * pattern, read each dict's Option_12 (CFString), validate the first
+ * non-empty value via the shared whitelist, and use it. Returns 1 if
+ * a usable value was found, 0 otherwise. Any SC error / missing key /
+ * absent Option_12 / wrong type / rejected value falls through to
+ * synthesis — never aborts the daemon. Issue: #90 */
+static int
+try_dhcp(char *out, size_t outsz)
+{
+	SCDynamicStoreRef store = NULL;
+	CFStringRef session = NULL, pattern = NULL, k_opt12 = NULL;
+	CFArrayRef keys = NULL;
+	CFIndex i, n;
+	int rc = 0;
+
+	session = mkstr("com.apple.hostnamed");
+	/* POSIX-regex over the SCDynamicStore key namespace. Matches
+	 * any service UUID; iter 3a takes the first dict that carries a
+	 * non-empty Option_12. Iter 3b will use State:/Network/Global/IPv4
+	 * to identify the primary service and read only its /DHCP. */
+	pattern = mkstr("State:/Network/Service/[^/]+/DHCP");
+	k_opt12 = mkstr("Option_12");
+	if (session == NULL || pattern == NULL || k_opt12 == NULL)
+		goto out;
+
+	store = SCDynamicStoreCreate(NULL, session, NULL, NULL);
+	if (store == NULL) {
+		xlog("try_dhcp: SCDynamicStoreCreate failed: %s "
+		    "(falling through to synthesis)",
+		    SCErrorString(SCError()));
+		goto out;
+	}
+
+	keys = SCDynamicStoreCopyKeyList(store, pattern);
+	if (keys == NULL)
+		goto out;
+	n = CFArrayGetCount(keys);
+	for (i = 0; i < n; i++) {
+		CFStringRef key;
+		CFPropertyListRef plist;
+		CFStringRef cf_name;
+		char buf[256];
+
+		key = (CFStringRef)CFArrayGetValueAtIndex(keys, i);
+		if (key == NULL)
+			continue;
+		plist = SCDynamicStoreCopyValue(store, key);
+		if (plist == NULL)
+			continue;
+		if (CFGetTypeID(plist) != CFDictionaryGetTypeID()) {
+			CFRelease(plist);
+			continue;
+		}
+		cf_name = CFDictionaryGetValue((CFDictionaryRef)plist,
+		    k_opt12);
+		if (cf_name == NULL ||
+		    CFGetTypeID(cf_name) != CFStringGetTypeID()) {
+			CFRelease(plist);
+			continue;
+		}
+		if (!CFStringGetCString(cf_name, buf, sizeof(buf),
+		    kCFStringEncodingUTF8)) {
+			CFRelease(plist);
+			continue;
+		}
+		CFRelease(plist);
+		if (!validate_and_normalize(buf,
+		    "DHCP Option_12", out, outsz))
+			continue;
+		xlog("hostname from DHCP /Network/Service/.../DHCP/Option_12 "
+		    "-> '%s'", out);
+		rc = 1;
+		break;
+	}
+out:
+	if (keys != NULL) CFRelease(keys);
+	if (store != NULL) CFRelease(store);
+	if (k_opt12 != NULL) CFRelease(k_opt12);
+	if (pattern != NULL) CFRelease(pattern);
+	if (session != NULL) CFRelease(session);
+	return (rc);
+}
+
 /* Compose the final hostname into out (HOSTNAMED_MAX chars). */
 static void
 synthesize(char *out, size_t outsz)
@@ -442,6 +527,8 @@ synthesize(char *out, size_t outsz)
 	if (try_override(out, outsz))
 		return;
 	if (try_scprefs(out, outsz))
+		return;
+	if (try_dhcp(out, outsz))
 		return;
 
 	derive_slug(slug, sizeof(slug));

--- a/src/hostnamed/hostnamedhcpset.c
+++ b/src/hostnamed/hostnamedhcpset.c
@@ -1,0 +1,135 @@
+/*
+ * hostnamedhcpset — CI fixture helper for hostnamed iter 3a.
+ *
+ * Usage:  hostnamedhcpset <option-12-value>
+ *
+ * Finds the State:/Network/Service/<UUID>/DHCP dict that ipconfigd
+ * already published (issue #88), adds Option_12=<argv[1]> to it, and
+ * writes the augmented dict back to SCDynamicStore. The next hostnamed
+ * run will read that value via its DHCP tier (try_dhcp) and use it,
+ * proving Tier-3a fires.
+ *
+ * Why we modify ipconfigd's existing /DHCP key rather than minting our
+ * own: the live key is already shaped correctly (InterfaceName +
+ * LeaseStartTime) and has a real UUID derived from the active NIC MAC.
+ * Synthesizing one would duplicate sc_publish.c's UUID logic; piggy-
+ * backing keeps the fixture small and the test against a real surface.
+ *
+ * Not shipped to real images (CI-only tool); lives next to
+ * hostnametest + hostnameprefset under /usr/tests/freebsd-launchd-mach/.
+ *
+ * Issue: #90
+ */
+
+#include <SystemConfiguration/SCDynamicStore.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int
+main(int argc, char **argv)
+{
+	SCDynamicStoreRef store = NULL;
+	CFStringRef session = NULL, pattern = NULL, k_opt12 = NULL;
+	CFStringRef value = NULL, key = NULL;
+	CFArrayRef keys = NULL;
+	CFPropertyListRef plist = NULL;
+	CFMutableDictionaryRef dict = NULL;
+	CFIndex n;
+	int rc = 1;
+
+	if (argc != 2 || argv[1][0] == '\0') {
+		(void)fprintf(stderr,
+		    "usage: %s <option-12-value>\n", argv[0]);
+		return (2);
+	}
+
+	session = CFStringCreateWithCString(NULL, "hostnamedhcpset",
+	    kCFStringEncodingUTF8);
+	pattern = CFStringCreateWithCString(NULL,
+	    "State:/Network/Service/[^/]+/DHCP", kCFStringEncodingUTF8);
+	k_opt12 = CFStringCreateWithCString(NULL, "Option_12",
+	    kCFStringEncodingUTF8);
+	value = CFStringCreateWithCString(NULL, argv[1],
+	    kCFStringEncodingUTF8);
+	if (session == NULL || pattern == NULL || k_opt12 == NULL ||
+	    value == NULL) {
+		(void)fprintf(stderr, "CFString allocation failed\n");
+		goto out;
+	}
+
+	store = SCDynamicStoreCreate(NULL, session, NULL, NULL);
+	if (store == NULL) {
+		(void)fprintf(stderr, "SCDynamicStoreCreate failed: %s\n",
+		    SCErrorString(SCError()));
+		goto out;
+	}
+
+	keys = SCDynamicStoreCopyKeyList(store, pattern);
+	if (keys == NULL || (n = CFArrayGetCount(keys)) == 0) {
+		(void)fprintf(stderr,
+		    "no State:/Network/Service/<UUID>/DHCP key found "
+		    "(is ipconfigd running and BOUND?)\n");
+		goto out;
+	}
+
+	/* Use the first matching key. iter 3a doesn't yet pick the
+	 * primary service — fine for a CI environment with a single
+	 * em0 / virtio NIC; iter 3b will do State:/Network/Global/IPv4
+	 * lookup to pick the active service. */
+	key = (CFStringRef)CFArrayGetValueAtIndex(keys, 0);
+	if (key == NULL) {
+		(void)fprintf(stderr, "key list returned NULL entry\n");
+		goto out;
+	}
+	CFRetain(key);
+
+	plist = SCDynamicStoreCopyValue(store, key);
+	if (plist == NULL ||
+	    CFGetTypeID(plist) != CFDictionaryGetTypeID()) {
+		(void)fprintf(stderr, "existing /DHCP key has no dict value\n");
+		goto out;
+	}
+
+	dict = CFDictionaryCreateMutableCopy(NULL, 0,
+	    (CFDictionaryRef)plist);
+	if (dict == NULL) {
+		(void)fprintf(stderr,
+		    "CFDictionaryCreateMutableCopy failed\n");
+		goto out;
+	}
+	CFDictionarySetValue(dict, k_opt12, value);
+
+	if (!SCDynamicStoreSetValue(store, key, dict)) {
+		(void)fprintf(stderr,
+		    "SCDynamicStoreSetValue failed: %s\n",
+		    SCErrorString(SCError()));
+		goto out;
+	}
+
+	{
+		char keybuf[256];
+		if (CFStringGetCString(key, keybuf, sizeof(keybuf),
+		    kCFStringEncodingUTF8)) {
+			(void)printf("hostnamedhcpset: wrote Option_12='%s' "
+			    "into %s\n", argv[1], keybuf);
+		} else {
+			(void)printf("hostnamedhcpset: wrote Option_12='%s'\n",
+			    argv[1]);
+		}
+	}
+	rc = 0;
+out:
+	if (dict != NULL) CFRelease(dict);
+	if (plist != NULL) CFRelease(plist);
+	if (key != NULL) CFRelease(key);
+	if (keys != NULL) CFRelease(keys);
+	if (store != NULL) CFRelease(store);
+	if (value != NULL) CFRelease(value);
+	if (k_opt12 != NULL) CFRelease(k_opt12);
+	if (pattern != NULL) CFRelease(pattern);
+	if (session != NULL) CFRelease(session);
+	return (rc);
+}

--- a/src/hostnamed/hostnametest.c
+++ b/src/hostnamed/hostnametest.c
@@ -90,25 +90,36 @@ main(int argc, char **argv)
 	char kn[KERN_LIMIT];
 	const char *expected;
 	const char *ok_marker, *fail_marker, *mode_label;
+	char ok_buf[64], fail_buf[64], mode_buf[64];
 	int rc = 1;
 
 	/*
-	 * Two modes:
-	 *   hostnametest                — iter 1 regression check: verify
-	 *                                 sources agree AND value isn't
-	 *                                 "Amnesiac". Emits HOSTNAMED-OK /
-	 *                                 HOSTNAMED-FAIL.
-	 *   hostnametest <expected>     — iter 2 (issue #86) Tier-2 read
-	 *                                 check: verify sources agree AND
-	 *                                 the published value equals
-	 *                                 <expected> (the fixture that
-	 *                                 hostnameprefset wrote to SCPrefs
-	 *                                 before hostnamed ran). Emits
-	 *                                 HOSTNAMED-PREFS-OK /
-	 *                                 HOSTNAMED-PREFS-FAIL.
+	 * Three modes:
+	 *   hostnametest
+	 *       iter-1 regression check: sources agree AND value isn't
+	 *       "Amnesiac". Emits HOSTNAMED-OK / HOSTNAMED-FAIL.
+	 *   hostnametest <expected>
+	 *       iter-2 (issue #86) SCPrefs Tier-2 check: sources agree AND
+	 *       value equals <expected> (the fixture hostnameprefset wrote
+	 *       before hostnamed ran). Emits HOSTNAMED-PREFS-OK / -FAIL.
+	 *   hostnametest <expected> <suffix>
+	 *       iter-3+ tier check: same as iter-2 verification but the
+	 *       marker label becomes HOSTNAMED-<SUFFIX>-OK / -FAIL. Used
+	 *       by iter-3a as `hostnametest <fixture> DHCP` to emit
+	 *       HOSTNAMED-DHCP-OK (issue #90).
 	 */
-	expected = (argc == 2) ? argv[1] : NULL;
-	if (expected != NULL) {
+	expected = (argc >= 2) ? argv[1] : NULL;
+	if (argc >= 3) {
+		(void)snprintf(ok_buf, sizeof(ok_buf),
+		    "HOSTNAMED-%s-OK", argv[2]);
+		(void)snprintf(fail_buf, sizeof(fail_buf),
+		    "HOSTNAMED-%s-FAIL", argv[2]);
+		(void)snprintf(mode_buf, sizeof(mode_buf),
+		    "iter 3+ %s read", argv[2]);
+		ok_marker   = ok_buf;
+		fail_marker = fail_buf;
+		mode_label  = mode_buf;
+	} else if (expected != NULL) {
 		ok_marker   = "HOSTNAMED-PREFS-OK";
 		fail_marker = "HOSTNAMED-PREFS-FAIL";
 		mode_label  = "iter 2 SCPrefs read";
@@ -175,8 +186,8 @@ main(int argc, char **argv)
 
 	if (expected != NULL && strcmp(cn, expected) != 0) {
 		(void)printf("%s: expected='%s' but published='%s' — "
-		    "Tier-2 SCPrefs read did not fire (synthesis still ran?)\n",
-		    fail_marker, expected, cn);
+		    "%s did not win (lower-precedence tier fired?)\n",
+		    fail_marker, expected, cn, mode_label);
 		goto out;
 	}
 

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -1036,6 +1036,28 @@ expect {
     }
 }
 
+# HOSTNAMED-DHCP — issue #90 iter 3a gate. ROUND 3 in run.sh:
+# hostnamedhcpset injects Option_12="hostnamed-iter3a-fixture" into
+# the live State:/Network/Service/<UUID>/DHCP dict that ipconfigd
+# published (issue #88). With preferences.plist cleared and no kenv
+# override, hostnamed's precedence chain falls through to try_dhcp(),
+# which finds Option_12 and uses it. hostnametest verifies all three
+# publish surfaces + the kernel hostname carry the fixture value
+# (proving DHCP beats synthesis but loses to SCPrefs and kenv).
+expect {
+    timeout {
+        puts "\nFAIL: HOSTNAMED-DHCP marker not seen"
+        exit 1
+    }
+    "HOSTNAMED-DHCP-FAIL" {
+        puts "\nFAIL: hostnamed Tier-3a DHCP read did not override synthesis"
+        exit 1
+    }
+    "HOSTNAMED-DHCP-OK" {
+        puts "\nOK: hostnamed Tier-3a DHCP Option_12 beats synthesis (kernel + Setup:/System + Setup:/Network/HostNames all carry the fixture value)"
+    }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

Adds Tier-3a to hostnamed's precedence chain: a DHCP-supplied host name (now published by ipconfigd per #88, PR #89) beats synthesis but loses to the `kenv` override and SCPrefs ComputerName. Net order:

1. `kenv hostname.override`                                        (iter 1)
2. SCPreferences `/System/System/ComputerName`                     (iter 2)
3. **NEW:** DHCP `State:/Network/Service/<UUID>/DHCP/Option_12`    (iter 3a)
4. Synthesized `${slug}-${suffix}`                                 (iter 1)

Daemon stays one-shot — no plist change, no SCDS change subscription. Reverse-DNS PTR, mDNS local-name, vendored Apple `set-hostname.c`, and the `KeepAlive=true` persistent loop are all deferred to iter 3b/3c.

Closes #90.

### Why this is a small PR

The plan's "iter 3" bundles DHCP + PTR + mDNS + vendored Apple code + KeepAlive=true + libdispatch loop. That's ~1500+ LOC and a real architectural shift. Splitting along consumer-surface lines lets us close the loop on what just shipped (#89's `/DHCP` publish) without taking on the event-loop refactor — and gives iter 3b/3c a clean baseline to build on.

### Code

- **`src/hostnamed/hostnamed.c`** — new `try_dhcp()` enumerates keys matching POSIX regex `State:/Network/Service/[^/]+/DHCP` via `SCDynamicStoreCopyKeyList`, reads each dict's `Option_12` (CFString), passes the first non-empty value through the shared `validate_and_normalize` gate. Slots between `try_scprefs` and synthesis.
- **`src/hostnamed/hostnamedhcpset.c`** (new, ~125 LOC) — CI fixture. Discovers the live `/DHCP` key ipconfigd already published, overlays `Option_12=<argv[1]>` via `CFDictionaryCreateMutableCopy` + `SCDynamicStoreSetValue`. Same pattern as `hostnameprefset`.
- **`src/hostnamed/hostnametest.c`** — third arg `<suffix>` picks the marker label so iter 2/3+/future tier verifications share the same code path: `HOSTNAMED-<SUFFIX>-OK / -FAIL`.
- **`build.sh`** — compiles `hostnamedhcpset` standalone next to the other fixture helpers.
- **`run.sh`** — ROUND 3: `rm prefs.plist`, `hostnamedhcpset <fixture>`, re-run hostnamed (reads DHCP), `hostnametest <fixture> DHCP`.
- **`boot-test.sh`** — new `HOSTNAMED-DHCP-OK` gate after `HOSTNAMED-PREFS-OK`.

### Deferred to iter 3b/3c

- Vendor Apple's `Plugins/IPMonitor/set-hostname.c`.
- `KeepAlive=true` + libdispatch event loop (needs the [[launchd-runatload-race]] fixed first for proper boot-time spawning).
- Reverse-DNS PTR async resolver shim.
- mDNS local-name discovery.
- SCDS change-notification subscription.
- `State:/Network/Global/IPv4` primary-service lookup (iter 3a takes the first matching /DHCP — fine for single-NIC CI, but real multi-NIC machines need primary-service selection).

## Test plan

- [ ] CI build green.
- [ ] CI log shows `HOSTNAMED-OK: hostname='pc-q35-8-2-123456'` from ROUND 1 (synthesis regression).
- [ ] CI log shows `HOSTNAMED-PREFS-OK: hostname='hostnamed-iter2-fixture'` from ROUND 2 (SCPrefs regression).
- [ ] CI log shows `HOSTNAMED-DHCP-OK: hostname='hostnamed-iter3a-fixture'` from ROUND 3 (new DHCP tier fires).
- [ ] hostnamed.stderr for ROUND 3 shows `hostname from DHCP /Network/Service/.../DHCP/Option_12 -> 'hostnamed-iter3a-fixture'`.
- [ ] No regression in any prior marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)