### PR TITLE
feat(pam): iter 2 — vendor 5 standalone Apple pam_modules (#95)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1989,6 +1989,38 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/pamframeworktest" \
     || { echo "FAIL: pamframeworktest not built"; exit 1; }
 
 #
+# 3y3. PAM port iter 2 — vendor 5 standalone Apple modules from
+#      apple-oss-distributions/pam_modules @ pam_modules-217.100.6
+#      (issue #95). Builds pam_self / pam_rootok / pam_uwtmp /
+#      pam_nologin / pam_env standalone modules, installs over
+#      FreeBSD-pam's same-named files at /usr/lib/pam_NAME.so.6.
+#      Iter 3 will swap /etc/pam.d/* and drop FreeBSD-pam.
+#
+echo "==> PAM iter 2: building 5 standalone Apple modules (src/pam_modules)"
+make -C "$ROOT/src/pam_modules" \
+     DESTDIR="$WORK/rootfs" \
+     PREFIX=/usr \
+     SYSROOT="$WORK/rootfs" \
+     all install
+for m in pam_self pam_rootok pam_uwtmp pam_nologin pam_env; do
+    test -f "$WORK/rootfs/usr/lib/$m.so.6" \
+        || { echo "FAIL: /usr/lib/$m.so.6 not installed"; exit 1; }
+done
+echo "==> 5 Apple PAM modules installed"
+
+# pammodulestest — iter 2 (issue #95) CI gate. dlopens each of the
+# 5 modules + verifies the canonical pam_sm_* entry point exists.
+# Emits PAM-MODULES-OK / PAM-MODULES-FAIL.
+echo "==> building pammodulestest"
+cc -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib" \
+   -Wl,-rpath,/usr/lib -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/pammodulestest" \
+   "$ROOT/src/pam_modules/pammodulestest.c"
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/pammodulestest" \
+    || { echo "FAIL: pammodulestest not built"; exit 1; }
+
+#
 # 3z. purge build packages + clean pkg cache + tear down chroot.
 #     Runs LAST in the build phase, after every chroot-side build
 #     (libdispatch) has used cmake/ninja/clang. Build pkgs (cmake/ninja

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -1033,4 +1033,20 @@ else
     echo "PAM-FRAMEWORK-FAIL: pamframeworktest binary not installed"
 fi
 
+# PAM-MODULES — PAM port iter 2 (issue #95). dlopens each of the 5
+# vendored Apple standalone modules from /usr/lib/pam_NAME.so.6 and
+# verifies the canonical pam_sm_* entry point is present. Indirectly
+# verifies the existing post-login marker chain that was already
+# green in iter 1 STILL works (login now using OUR pam_self.so.6 +
+# pam_uwtmp.so.6 instead of FreeBSD's, with our libpam.so.6).
+echo "==> PAM iter 2: ls -lh /usr/lib/pam_{self,rootok,uwtmp,nologin,env}.so.6"
+ls -lh /usr/lib/pam_self.so.6 /usr/lib/pam_rootok.so.6 \
+       /usr/lib/pam_uwtmp.so.6 /usr/lib/pam_nologin.so.6 \
+       /usr/lib/pam_env.so.6 2>/dev/null
+if [ -x /usr/tests/freebsd-launchd-mach/pammodulestest ]; then
+    /usr/tests/freebsd-launchd-mach/pammodulestest
+else
+    echo "PAM-MODULES-FAIL: pammodulestest binary not installed"
+fi
+
 exit 0

--- a/src/pam_modules/APPLE_LICENSE
+++ b/src/pam_modules/APPLE_LICENSE
@@ -1,0 +1,335 @@
+APPLE PUBLIC SOURCE LICENSE
+Version 2.0 -  August 6, 2003
+
+Please read this License carefully before downloading this software.  By
+downloading or using this software, you are agreeing to be bound by the terms
+of this License.  If you do not or cannot agree to the terms of this License,
+please do not download or use the software.
+
+Apple Note:  In January 2007, Apple changed its corporate name from "Apple
+Computer, Inc." to "Apple Inc."  This change has been reflected below and
+copyright years updated, but no other changes have been made to the APSL 2.0.
+
+1.	General; Definitions.  This License applies to any program or other
+work which Apple Inc. ("Apple") makes publicly available and which contains a
+notice placed by Apple identifying such program or work as "Original Code" and
+stating that it is subject to the terms of this Apple Public Source License
+version 2.0 ("License").  As used in this License:
+
+1.1	 "Applicable Patent Rights" mean:  (a) in the case where Apple is the
+grantor of rights, (i) claims of patents that are now or hereafter acquired,
+owned by or assigned to Apple and (ii) that cover subject matter contained in
+the Original Code, but only to the extent necessary to use, reproduce and/or
+distribute the Original Code without infringement; and (b) in the case where
+You are the grantor of rights, (i) claims of patents that are now or hereafter
+acquired, owned by or assigned to You and (ii) that cover subject matter in
+Your Modifications, taken alone or in combination with Original Code.
+
+1.2	"Contributor" means any person or entity that creates or contributes to
+the creation of Modifications.
+
+1.3	 "Covered Code" means the Original Code, Modifications, the combination
+of Original Code and any Modifications, and/or any respective portions thereof.
+
+1.4	"Externally Deploy" means: (a) to sublicense, distribute or otherwise
+make Covered Code available, directly or indirectly, to anyone other than You;
+and/or (b) to use Covered Code, alone or as part of a Larger Work, in any way
+to provide a service, including but not limited to delivery of content, through
+electronic communication with a client other than You.
+
+1.5	"Larger Work" means a work which combines Covered Code or portions
+thereof with code not governed by the terms of this License.
+
+1.6	"Modifications" mean any addition to, deletion from, and/or change to,
+the substance and/or structure of the Original Code, any previous
+Modifications, the combination of Original Code and any previous Modifications,
+and/or any respective portions thereof.  When code is released as a series of
+files, a Modification is:  (a) any addition to or deletion from the contents of
+a file containing Covered Code; and/or (b) any new file or other representation
+of computer program statements that contains any part of Covered Code. 
+
+1.7	"Original Code" means (a) the Source Code of a program or other work as
+originally made available by Apple under this License, including the Source
+Code of any updates or upgrades to such programs or works made available by
+Apple under this License, and that has been expressly identified by Apple as
+such in the header file(s) of such work; and (b) the object code compiled from
+such Source Code and originally made available by Apple under this License
+
+1.8	"Source Code" means the human readable form of a program or other work
+that is suitable for making modifications to it, including all modules it
+contains, plus any associated interface definition files, scripts used to
+control compilation and installation of an executable (object code).
+
+1.9	"You" or "Your" means an individual or a legal entity exercising rights
+under this License.  For legal entities, "You" or "Your" includes any entity
+which controls, is controlled by, or is under common control with, You, where
+"control" means (a) the power, direct or indirect, to cause the direction or
+management of such entity, whether by contract or otherwise, or (b) ownership
+of fifty percent (50%) or more of the outstanding shares or beneficial
+ownership of such entity.
+
+2.	Permitted Uses; Conditions & Restrictions.   Subject to the terms and
+conditions of this License, Apple hereby grants You, effective on the date You
+accept this License and download the Original Code, a world-wide, royalty-free,
+non-exclusive license, to the extent of Apple's Applicable Patent Rights and
+copyrights covering the Original Code, to do the following:
+
+2.1	Unmodified Code.  You may use, reproduce, display, perform, internally
+distribute within Your organization, and Externally Deploy verbatim, unmodified
+copies of the Original Code, for commercial or non-commercial purposes,
+provided that in each instance:
+
+(a)	You must retain and reproduce in all copies of Original Code the
+copyright and other proprietary notices and disclaimers of Apple as they appear
+in the Original Code, and keep intact all notices in the Original Code that
+refer to this License; and
+
+(b) 	You must include a copy of this License with every copy of Source Code
+of Covered Code and documentation You distribute or Externally Deploy, and You
+may not offer or impose any terms on such Source Code that alter or restrict
+this License or the recipients' rights hereunder, except as permitted under
+Section 6.
+
+2.2	Modified Code.  You may modify Covered Code and use, reproduce,
+display, perform, internally distribute within Your organization, and
+Externally Deploy Your Modifications and Covered Code, for commercial or
+non-commercial purposes, provided that in each instance You also meet all of
+these conditions:
+
+(a)	You must satisfy all the conditions of Section 2.1 with respect to the
+Source Code of the Covered Code; 
+
+(b)	You must duplicate, to the extent it does not already exist, the notice
+in Exhibit A in each file of the Source Code of all Your Modifications, and
+cause the modified files to carry prominent notices stating that You changed
+the files and the date of any change; and
+
+(c)	If You Externally Deploy Your Modifications, You must make Source Code
+of all Your Externally Deployed Modifications either available to those to whom
+You have Externally Deployed Your Modifications, or publicly available.  Source
+Code of Your Externally Deployed Modifications must be released under the terms
+set forth in this License, including the license grants set forth in Section 3
+below, for as long as you Externally Deploy the Covered Code or twelve (12)
+months from the date of initial External Deployment, whichever is longer. You
+should preferably distribute the Source Code of Your Externally Deployed
+Modifications electronically (e.g. download from a web site).
+
+2.3	Distribution of Executable Versions.  In addition, if You Externally
+Deploy Covered Code (Original Code and/or Modifications) in object code,
+executable form only, You must include a prominent notice, in the code itself
+as well as in related documentation, stating that Source Code of the Covered
+Code is available under the terms of this License with information on how and
+where to obtain such Source Code.  
+
+2.4	Third Party Rights.  You expressly acknowledge and agree that although
+Apple and each Contributor grants the licenses to their respective portions of
+the Covered Code set forth herein, no assurances are provided by Apple or any
+Contributor that the Covered Code does not infringe the patent or other
+intellectual property rights of any other entity. Apple and each Contributor
+disclaim any liability to You for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a condition to
+exercising the rights and licenses granted hereunder, You hereby assume sole
+responsibility to secure any other intellectual property rights needed, if any.
+For example, if a third party patent license is required to allow You to
+distribute the Covered Code, it is Your responsibility to acquire that license
+before distributing the Covered Code.
+
+3.	Your Grants.  In consideration of, and as a condition to, the licenses
+granted to You under this License, You hereby grant to any person or entity
+receiving or distributing Covered Code under this License a non-exclusive,
+royalty-free, perpetual, irrevocable license, under Your Applicable Patent
+Rights and other intellectual property rights (other than patent) owned or
+controlled by You, to use, reproduce, display, perform, modify, sublicense,
+distribute and Externally Deploy Your Modifications of the same scope and
+extent as Apple's licenses under Sections 2.1 and 2.2 above.  
+
+4.	Larger Works.  You may create a Larger Work by combining Covered Code
+with other code not governed by the terms of this License and distribute the
+Larger Work as a single product.  In each such instance, You must make sure the
+requirements of this License are fulfilled for the Covered Code or any portion
+thereof. 
+
+5.	Limitations on Patent License.   Except as expressly stated in Section
+2, no other patent rights, express or implied, are granted by Apple herein.
+Modifications and/or Larger Works may require additional patent licenses from
+Apple which Apple may grant in its sole discretion.  
+
+6.	Additional Terms.  You may choose to offer, and to charge a fee for,
+warranty, support, indemnity or liability obligations and/or other rights
+consistent with the scope of the license granted herein ("Additional Terms") to
+one or more recipients of Covered Code. However, You may do so only on Your own
+behalf and as Your sole responsibility, and not on behalf of Apple or any
+Contributor. You must obtain the recipient's agreement that any such Additional
+Terms are offered by You alone, and You hereby agree to indemnify, defend and
+hold Apple and every Contributor harmless for any liability incurred by or
+claims asserted against Apple or such Contributor by reason of any such
+Additional Terms. 
+
+7.	Versions of the License.  Apple may publish revised and/or new versions
+of this License from time to time.  Each version will be given a distinguishing
+version number.  Once Original Code has been published under a particular
+version of this License, You may continue to use it under the terms of that
+version. You may also choose to use such Original Code under the terms of any
+subsequent version of this License published by Apple.  No one other than Apple
+has the right to modify the terms applicable to Covered Code created under this
+License.  
+
+8.	NO WARRANTY OR SUPPORT.  The Covered Code may contain in whole or in
+part pre-release, untested, or not fully tested works.  The Covered Code may
+contain errors that could cause failures or loss of data, and may be incomplete
+or contain inaccuracies.  You expressly acknowledge and agree that use of the
+Covered Code, or any portion thereof, is at Your sole and entire risk.  THE
+COVERED CODE IS PROVIDED "AS IS" AND WITHOUT WARRANTY, UPGRADES OR SUPPORT OF
+ANY KIND AND APPLE AND APPLE'S LICENSOR(S) (COLLECTIVELY REFERRED TO AS "APPLE"
+FOR THE PURPOSES OF SECTIONS 8 AND 9) AND ALL CONTRIBUTORS EXPRESSLY DISCLAIM
+ALL WARRANTIES AND/OR CONDITIONS, EXPRESS OR IMPLIED, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES AND/OR CONDITIONS OF MERCHANTABILITY, OF
+SATISFACTORY QUALITY, OF FITNESS FOR A PARTICULAR PURPOSE, OF ACCURACY, OF
+QUIET ENJOYMENT, AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.  APPLE AND EACH
+CONTRIBUTOR DOES NOT WARRANT AGAINST INTERFERENCE WITH YOUR ENJOYMENT OF THE
+COVERED CODE, THAT THE FUNCTIONS CONTAINED IN THE COVERED CODE WILL MEET YOUR
+REQUIREMENTS, THAT THE OPERATION OF THE COVERED CODE WILL BE UNINTERRUPTED OR
+ERROR-FREE, OR THAT DEFECTS IN THE COVERED CODE WILL BE CORRECTED.  NO ORAL OR
+WRITTEN INFORMATION OR ADVICE GIVEN BY APPLE, AN APPLE AUTHORIZED
+REPRESENTATIVE OR ANY CONTRIBUTOR SHALL CREATE A WARRANTY.  You acknowledge
+that the Covered Code is not intended for use in the operation of nuclear
+facilities, aircraft navigation, communication systems, or air traffic control
+machines in which case the failure of the Covered Code could lead to death,
+personal injury, or severe physical or environmental damage.
+
+9.	LIMITATION OF LIABILITY. TO THE EXTENT NOT PROHIBITED BY LAW, IN NO
+EVENT SHALL APPLE OR ANY CONTRIBUTOR BE LIABLE FOR ANY INCIDENTAL, SPECIAL,
+INDIRECT OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR RELATING TO THIS LICENSE OR
+YOUR USE OR INABILITY TO USE THE COVERED CODE, OR ANY PORTION THEREOF, WHETHER
+UNDER A THEORY OF CONTRACT, WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCTS
+LIABILITY OR OTHERWISE, EVEN IF APPLE OR SUCH CONTRIBUTOR HAS BEEN ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGES AND NOTWITHSTANDING THE FAILURE OF ESSENTIAL
+PURPOSE OF ANY REMEDY. SOME JURISDICTIONS DO NOT ALLOW THE LIMITATION OF
+LIABILITY OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS LIMITATION MAY NOT
+APPLY TO YOU. In no event shall Apple's total liability to You for all damages
+(other than as may be required by applicable law) under this License exceed the
+amount of fifty dollars ($50.00).
+
+10.	Trademarks.  This License does not grant any rights to use the
+trademarks or trade names  "Apple", "Mac", "Mac OS", "QuickTime", "QuickTime
+Streaming Server" or any other trademarks, service marks, logos or trade names
+belonging to Apple (collectively "Apple Marks") or to any trademark, service
+mark, logo or trade name belonging to any Contributor.  You agree not to use
+any Apple Marks in or as part of the name of products derived from the Original
+Code or to endorse or promote products derived from the Original Code other
+than as expressly permitted by and in strict compliance at all times with
+Apple's third party trademark usage guidelines which are posted at
+http://www.apple.com/legal/guidelinesfor3rdparties.html.  
+
+11.	Ownership. Subject to the licenses granted under this License, each
+Contributor retains all rights, title and interest in and to any Modifications
+made by such Contributor.  Apple retains all rights, title and interest in and
+to the Original Code and any Modifications made by or on behalf of Apple
+("Apple Modifications"), and such Apple Modifications will not be automatically
+subject to this License.  Apple may, at its sole discretion, choose to license
+such Apple Modifications under this License, or on different terms from those
+contained in this License or may choose not to license them at all.  
+
+12.	Termination.  
+
+12.1	Termination.  This License and the rights granted hereunder will
+terminate:
+
+(a)	automatically without notice from Apple if You fail to comply with any
+term(s) of this License and fail to cure such breach within 30 days of becoming
+aware of such breach;
+(b)	immediately in the event of the circumstances described in Section
+13.5(b); or
+(c)	automatically without notice from Apple if You, at any time during the
+term of this License, commence an action for patent infringement against Apple;
+provided that Apple did not first commence an action for patent infringement
+against You in that instance.
+
+12.2	Effect of Termination.  Upon termination, You agree to immediately stop
+any further use, reproduction, modification, sublicensing and distribution of
+the Covered Code.  All sublicenses to the Covered Code which have been properly
+granted prior to termination shall survive any termination of this License.
+Provisions which, by their nature, should remain in effect beyond the
+termination of this License shall survive, including but not limited to
+Sections 3, 5, 8, 9, 10, 11, 12.2 and 13.  No party will be liable to any other
+for compensation, indemnity or damages of any sort solely as a result of
+terminating this License in accordance with its terms, and termination of this
+License will be without prejudice to any other right or remedy of any party.
+
+13. 	Miscellaneous.
+
+13.1	Government End Users.   The Covered Code is a "commercial item" as
+defined in FAR 2.101.  Government software and technical data rights in the
+Covered Code include only those rights customarily provided to the public as
+defined in this License. This customary commercial license in technical data
+and software is provided in accordance with FAR 12.211 (Technical Data) and
+12.212 (Computer Software) and, for Department of Defense purchases, DFAR
+252.227-7015 (Technical Data -- Commercial Items) and 227.7202-3 (Rights in
+Commercial Computer Software or Computer Software Documentation).  Accordingly,
+all U.S. Government End Users acquire Covered Code with only those rights set
+forth herein.
+
+13.2	Relationship of Parties.  This License will not be construed as
+creating an agency, partnership, joint venture or any other form of legal
+association between or among You, Apple or any Contributor, and You will not
+represent to the contrary, whether expressly, by implication, appearance or
+otherwise.
+
+13.3	Independent Development.   Nothing in this License will impair Apple's
+right to acquire, license, develop, have others develop for it, market and/or
+distribute technology or products that perform the same or similar functions
+as, or otherwise compete with, Modifications, Larger Works, technology or
+products that You may develop, produce, market or distribute.
+
+13.4	Waiver; Construction.  Failure by Apple or any Contributor to enforce
+any provision of this License will not be deemed a waiver of future enforcement
+of that or any other provision.  Any law or regulation which provides that the
+language of a contract shall be construed against the drafter will not apply to
+this License.
+
+13.5	Severability.  (a) If for any reason a court of competent jurisdiction
+finds any provision of this License, or portion thereof, to be unenforceable,
+that provision of the License will be enforced to the maximum extent
+permissible so as to effect the economic benefits and intent of the parties,
+and the remainder of this License will continue in full force and effect.  (b)
+Notwithstanding the foregoing, if applicable law prohibits or restricts You
+from fully and/or specifically complying with Sections 2 and/or 3 or prevents
+the enforceability of either of those Sections, this License will immediately
+terminate and You must immediately discontinue any use of the Covered Code and
+destroy all copies of it that are in your possession or control.
+
+13.6	Dispute Resolution.  Any litigation or other dispute resolution between
+You and Apple relating to this License shall take place in the Northern
+District of California, and You and Apple hereby consent to the personal
+jurisdiction of, and venue in, the state and federal courts within that
+District with respect to this License. The application of the United Nations
+Convention on Contracts for the International Sale of Goods is expressly
+excluded.
+
+13.7	Entire Agreement; Governing Law.  This License constitutes the entire
+agreement between the parties with respect to the subject matter hereof.  This
+License shall be governed by the laws of the United States and the State of
+California, except that body of California law concerning conflicts of law. 
+
+Where You are located in the province of Quebec, Canada, the following clause
+applies:  The parties hereby confirm that they have requested that this License
+and all related documents be drafted in English. Les parties ont exigé que le
+présent contrat et tous les documents connexes soient rédigés en anglais. 
+
+EXHIBIT A. 
+
+"Portions Copyright (c) 1999-2007 Apple Inc.  All Rights Reserved.
+
+This file contains Original Code and/or Modifications of Original Code as
+defined in and that are subject to the Apple Public Source License Version 2.0
+(the 'License').  You may not use this file except in compliance with the
+License.  Please obtain a copy of the License at
+http://www.opensource.apple.com/apsl/ and read it before using this file.
+
+The Original Code and all software distributed under the License are
+distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS
+OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES, INCLUDING WITHOUT
+LIMITATION, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.  Please see the License for the
+specific language governing rights and limitations under the License." 
+

--- a/src/pam_modules/Makefile
+++ b/src/pam_modules/Makefile
@@ -46,7 +46,8 @@ CFLAGS_COMMON =	-fPIC -O2 -pipe -fblocks \
 		-I${.CURDIR}/common \
 		-I${.CURDIR}/../OpenPAM/openpam/include \
 		-I${.CURDIR}/../OpenPAM/freebsd-shims \
-		-DLT_OBJDIR='"libs/"'
+		-DLT_OBJDIR='"libs/"' \
+		-DUTMPX_AUTOFILL_MASK=0
 
 SYSROOT ?=
 .if !empty(SYSROOT)

--- a/src/pam_modules/Makefile
+++ b/src/pam_modules/Makefile
@@ -1,0 +1,100 @@
+# pam_modules — Apple's PAM module set, vendored for freebsd-launchd-mach.
+#
+# Vendored from apple-oss-distributions/pam_modules @ pam_modules-217.100.6.
+# Upstream tree preserved (modules/, common/, tests/,
+# test_pam_localauthentication/, pam_modules.xcodeproj/) for traceability.
+# Apple's xcodeproj is kept but unused by this build.
+#
+# Iter 2 deliverable (issue #95): build 5 standalone modules that don't
+# depend on OD / SecurityServer / SmartCard / OS-private subsystems
+# we don't have:
+#
+#   /usr/lib/pam_self.so.6      — allow root to su to anyone
+#   /usr/lib/pam_rootok.so.6    — allow root without password
+#   /usr/lib/pam_uwtmp.so.6     — utmp/wtmp accounting
+#   /usr/lib/pam_nologin.so.6   — respect /etc/nologin
+#   /usr/lib/pam_env.so.6       — set environment variables
+#
+# All 5 install over FreeBSD-pam's same-named files (same flat
+# /usr/lib/ layout iter 1 established for pam_unix/pam_deny/pam_permit).
+#
+# The other 12 modules in Apple's tarball (pam_aks, pam_basesystem,
+# pam_group, pam_krb5, pam_launchd, pam_localauthentication, pam_mount,
+# pam_ntlm, pam_opendirectory, pam_sacl, pam_smartcard, pam_tid)
+# require Apple-private substrate we don't have — left in the source
+# tree for future iters but not compiled.
+#
+# Build:   make SYSROOT=/path/to/rootfs
+# Install: make DESTDIR=/path/to/rootfs PREFIX=/usr install
+
+CC ?=		cc
+
+DESTDIR ?=
+PREFIX ?=	/usr
+PAMDIR =	${DESTDIR}${PREFIX}/lib
+
+# common/Logging.h is included by every module. By default (without
+# -DPAM_USE_OS_LOG) it falls through to a syslog-based path with no
+# Apple-private deps.
+#
+# OpenPAM headers (security/pam_*.h) and our codesign.h / dyld_priv.h
+# shims live in the sibling src/OpenPAM/ tree (iter 1).
+CFLAGS_COMMON =	-fPIC -O2 -pipe -fblocks \
+		-Wno-deprecated-declarations \
+		-Wno-unused-parameter \
+		-Wno-unused-result \
+		-I${.CURDIR}/common \
+		-I${.CURDIR}/../OpenPAM/openpam/include \
+		-I${.CURDIR}/../OpenPAM/freebsd-shims \
+		-DLT_OBJDIR='"libs/"'
+
+SYSROOT ?=
+.if !empty(SYSROOT)
+CFLAGS_COMMON +=	-I${SYSROOT}/usr/include
+LDFLAGS_COMMON +=	-L${SYSROOT}/usr/lib \
+			-L${SYSROOT}/usr/lib/system \
+			-Wl,-rpath,/usr/lib \
+			-Wl,-rpath,/usr/lib/system \
+			-Wl,--allow-shlib-undefined
+.endif
+
+# Module link deps. Same as OpenPAM iter 1's bundled modules:
+# -lpam for OpenPAM helper symbols; -lcrypt for any module that
+# happens to call crypt(3) (FreeBSD keeps crypt in libcrypt, not
+# libc). pam_self/pam_rootok/pam_nologin don't actually call crypt
+# but linking it is harmless and keeps the build uniform.
+PAM_MOD_LIBS =	-lpam -lcrypt
+
+all:	pam_self.so pam_rootok.so pam_uwtmp.so pam_nologin.so pam_env.so
+
+pam_self.so:	${.CURDIR}/modules/pam_self/pam_self.c
+	${CC} ${CFLAGS_COMMON} ${LDFLAGS_COMMON} \
+	    -shared -o ${.TARGET} ${.ALLSRC} ${PAM_MOD_LIBS}
+
+pam_rootok.so:	${.CURDIR}/modules/pam_rootok/pam_rootok.c
+	${CC} ${CFLAGS_COMMON} ${LDFLAGS_COMMON} \
+	    -shared -o ${.TARGET} ${.ALLSRC} ${PAM_MOD_LIBS}
+
+pam_uwtmp.so:	${.CURDIR}/modules/pam_uwtmp/pam_uwtmp.c
+	${CC} ${CFLAGS_COMMON} ${LDFLAGS_COMMON} \
+	    -shared -o ${.TARGET} ${.ALLSRC} ${PAM_MOD_LIBS}
+
+pam_nologin.so:	${.CURDIR}/modules/pam_nologin/pam_nologin.c
+	${CC} ${CFLAGS_COMMON} ${LDFLAGS_COMMON} \
+	    -shared -o ${.TARGET} ${.ALLSRC} ${PAM_MOD_LIBS}
+
+pam_env.so:	${.CURDIR}/modules/pam_env/pam_env.c
+	${CC} ${CFLAGS_COMMON} ${LDFLAGS_COMMON} \
+	    -shared -o ${.TARGET} ${.ALLSRC} ${PAM_MOD_LIBS}
+
+install: all
+	install -d ${PAMDIR}
+	install -m 0755 pam_self.so ${PAMDIR}/pam_self.so.6
+	install -m 0755 pam_rootok.so ${PAMDIR}/pam_rootok.so.6
+	install -m 0755 pam_uwtmp.so ${PAMDIR}/pam_uwtmp.so.6
+	install -m 0755 pam_nologin.so ${PAMDIR}/pam_nologin.so.6
+	install -m 0755 pam_env.so ${PAMDIR}/pam_env.so.6
+
+clean:
+	rm -f pam_self.so pam_rootok.so pam_uwtmp.so \
+	      pam_nologin.so pam_env.so

--- a/src/pam_modules/common/Common.c
+++ b/src/pam_modules/common/Common.c
@@ -1,0 +1,722 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <security/openpam.h>
+
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <DirectoryService/DirectoryService.h>
+#include <OpenDirectory/OpenDirectory.h>
+#include <OpenDirectory/OpenDirectoryPriv.h>
+#include <ServerInformation/ServerInformation.h>
+
+#include "Common.h"
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(Common)
+#define PAM_LOG PAM_LOG_Common()
+#endif
+
+enum {
+	kWaitSeconds       =  1,
+	kMaxIterationCount = 30,
+	kMaxSeconds        = 20,
+};
+
+int
+cstring_to_cfstring(const char *val, CFStringRef *buffer)
+{
+	int retval = PAM_BUF_ERR;
+
+	if (NULL == val || NULL == buffer) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	*buffer = CFStringCreateWithCString(kCFAllocatorDefault, val, kCFStringEncodingUTF8);
+	if (NULL == *buffer) {
+		_LOG_DEBUG("CFStringCreateWithCString() failed");
+		retval = PAM_BUF_ERR;
+		goto cleanup;
+	}
+
+	retval =  PAM_SUCCESS;
+
+cleanup:
+	if (PAM_SUCCESS != retval)
+		_LOG_ERROR("failed: %d", retval);
+
+	return retval;
+}
+
+int
+cfstring_to_cstring(const CFStringRef val, char **buffer)
+{
+	CFIndex maxlen = 0;
+	int retval = PAM_BUF_ERR;
+
+	if (NULL == val || NULL == buffer) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	maxlen = CFStringGetMaximumSizeForEncoding(CFStringGetLength(val), kCFStringEncodingUTF8);
+	*buffer = calloc(maxlen + 1, sizeof(char));
+	if (NULL == *buffer) {
+		_LOG_DEBUG("malloc() failed");
+		retval = PAM_BUF_ERR;
+		goto cleanup;
+	}
+
+	if (CFStringGetCString(val, *buffer, maxlen + 1, kCFStringEncodingUTF8)) {
+		retval =  PAM_SUCCESS;
+	} else {
+		_LOG_DEBUG("CFStringGetCString failed.");
+		free(*buffer);
+		*buffer = NULL;
+	}
+
+cleanup:
+	if (PAM_SUCCESS != retval)
+		_LOG_ERROR("failed: %d", retval);
+
+	return retval;
+}
+
+int
+od_record_create(pam_handle_t *pamh, ODRecordRef *record, CFStringRef cfUser)
+{
+	int retval = PAM_SERVICE_ERR;
+	const int attr_num = 5;
+
+	ODNodeRef cfNode = NULL;
+	CFErrorRef cferror = NULL;
+	CFArrayRef attrs = NULL;
+	CFTypeRef cfVals[attr_num];
+
+	if (NULL == record || NULL == cfUser) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	int current_iterations = 0;
+
+	cfNode = ODNodeCreateWithNodeType(kCFAllocatorDefault,
+					  kODSessionDefault,
+					  eDSAuthenticationSearchNodeName,
+					  &cferror);
+	if (NULL == cfNode || NULL != cferror) {
+		_LOG_ERROR("ODNodeCreateWithNodeType failed.");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	cfVals[0] = kODAttributeTypeAuthenticationAuthority;
+	cfVals[1] = kODAttributeTypeHomeDirectory;
+	cfVals[2] = kODAttributeTypeNFSHomeDirectory;
+	cfVals[3] = kODAttributeTypeUserShell;
+	cfVals[4] = kODAttributeTypeUniqueID;
+	attrs = CFArrayCreate(kCFAllocatorDefault, cfVals, (CFIndex)attr_num, &kCFTypeArrayCallBacks);
+	if (NULL == attrs) {
+		_LOG_DEBUG("CFArrayCreate() failed");
+		retval = PAM_BUF_ERR;
+		goto cleanup;
+	}
+
+	time_t seconds = time(NULL);
+	while (current_iterations <= kMaxIterationCount) {
+		CFIndex unreachable_count = 0;
+		CFArrayRef unreachable_nodes = ODNodeCopyUnreachableSubnodeNames(cfNode, NULL);
+		if (unreachable_nodes) {
+			unreachable_count = CFArrayGetCount(unreachable_nodes);
+			CFRelease(unreachable_nodes);
+			_LOG_DEBUG("%lu OD nodes unreachable.", unreachable_count);
+		}
+
+		*record = ODNodeCopyRecord(cfNode, kODRecordTypeUsers, cfUser, attrs, &cferror);
+		if (*record) {
+			break;
+		}
+		if (0 == unreachable_count) {
+			break;
+		}
+		if (time(NULL) > (seconds + kMaxSeconds)) {
+            _LOG_ERROR("Timeout when waiting for the unreachable nodes");
+			break;
+		}
+
+		_LOG_DEBUG("Waiting %d seconds for nodes to become reachable", kWaitSeconds);
+		sleep(kWaitSeconds);
+		++current_iterations;
+	}
+
+	if (*record) {
+		retval = PAM_SUCCESS;
+	} else {
+		retval = PAM_USER_UNKNOWN;
+	}
+
+cleanup:
+	CFReleaseSafe(attrs);
+	CFReleaseSafe(cferror);
+	CFReleaseSafe(cfNode);
+
+	if (PAM_SUCCESS != retval) {
+		_LOG_ERROR("failed: %d", retval);
+		if (record != NULL)
+			CFReleaseNull(*record);
+	}
+
+	return retval;
+}
+
+int
+od_record_create_cstring(pam_handle_t *pamh, ODRecordRef *record, const char *user)
+{
+	int retval = PAM_SUCCESS;
+	CFStringRef cfUser = NULL;
+
+	if (NULL == record || NULL == user) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	if (PAM_SUCCESS != (retval = cstring_to_cfstring(user, &cfUser)) ||
+	    PAM_SUCCESS != (retval = od_record_create(pamh, record, cfUser))) {
+		_LOG_DEBUG("od_record_create() failed");
+		goto cleanup;
+	}
+
+cleanup:
+	if (PAM_SUCCESS != retval) {
+		_LOG_ERROR("failed: %d", retval);
+		if (record != NULL)
+			CFReleaseNull(*record);
+	}
+
+	CFReleaseSafe(cfUser);
+
+	return retval;
+}
+
+/* Can return NULL */
+int
+od_record_attribute_create_cfarray(ODRecordRef record, CFStringRef attrib,  CFArrayRef *out)
+{
+	int retval = PAM_SUCCESS;
+
+	if (NULL == record || NULL == attrib || NULL == out) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	*out = ODRecordCopyValues(record, attrib, NULL);
+
+cleanup:
+	if (PAM_SUCCESS != retval) {
+		CFReleaseSafe(out);
+	}
+	return retval;
+}
+
+/* Can return NULL */
+int
+od_record_attribute_create_cfstring(ODRecordRef record, CFStringRef attrib,  CFStringRef *out)
+{
+	int retval = PAM_SERVICE_ERR;
+	CFTypeRef cval = NULL;
+	CFArrayRef vals = NULL;
+	CFIndex i = 0, count = 0;
+
+	if (NULL == record || NULL == attrib || NULL == out) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	*out = NULL;
+	retval = od_record_attribute_create_cfarray(record, attrib, &vals);
+	if (PAM_SUCCESS != retval) {
+		_LOG_DEBUG("od_record_attribute_create_cfarray() failed");
+		goto cleanup;
+	}
+	if (NULL == vals) {
+		retval = PAM_SUCCESS;
+		goto cleanup;
+	}
+
+	count = CFArrayGetCount(vals);
+	if (1 != count) {
+		char *attr_cstr = NULL;
+		cfstring_to_cstring(attrib, &attr_cstr);
+		_LOG_DEBUG("returned %lx attributes for %s", count, attr_cstr);
+		free(attr_cstr);
+	}
+
+	for (i = 0; i < count; ++i) {
+		cval = CFArrayGetValueAtIndex(vals, i);
+		if (NULL == cval) {
+			continue;
+		}
+		if (CFGetTypeID(cval) == CFStringGetTypeID()) {
+			*out = CFStringCreateCopy(kCFAllocatorDefault, cval);
+			if (NULL == *out) {
+				_LOG_DEBUG("CFStringCreateCopy() failed");
+				retval = PAM_BUF_ERR;
+				goto cleanup;
+			}
+			break;
+		} else {
+			_LOG_DEBUG("attribute is not a cfstring");
+			retval = PAM_PERM_DENIED;
+			goto cleanup;
+		}
+	}
+	retval = PAM_SUCCESS;
+
+cleanup:
+	if (PAM_SUCCESS != retval) {
+		CFReleaseSafe(out);
+	}
+	CFReleaseSafe(vals);
+
+	return retval;
+}
+
+/* Can return NULL */
+int
+od_record_attribute_create_cstring(ODRecordRef record, CFStringRef attrib,  char **out)
+{
+	int retval = PAM_SERVICE_ERR;
+	CFStringRef val = NULL;
+
+	if (NULL == record || NULL == attrib || NULL == out) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	retval = od_record_attribute_create_cfstring(record, attrib, &val);
+	if (PAM_SUCCESS != retval) {
+		_LOG_DEBUG("od_record_attribute_create_cfstring() failed");
+		goto cleanup;
+	}
+
+	if (NULL != val) {
+		retval = cfstring_to_cstring(val, out);
+		if (PAM_SUCCESS != retval) {
+			_LOG_DEBUG("cfstring_to_cstring() failed");
+			goto cleanup;
+		}
+	}
+
+cleanup:
+	if (PAM_SUCCESS != retval) {
+		free(out);
+	}
+
+	CFReleaseSafe(val);
+
+	return retval;
+}
+
+int
+od_record_check_pwpolicy(ODRecordRef record, CFErrorRef *odError)
+{
+    CFErrorRef localerr = NULL;
+	int retval = PAM_SERVICE_ERR;
+
+	if (NULL == record) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+    if (!ODRecordAuthenticationAllowed(record, &localerr)) {
+        switch (CFErrorGetCode(localerr)) {
+			case kODErrorCredentialsAccountNotFound:
+				retval = PAM_USER_UNKNOWN;
+				break;
+			case kODErrorCredentialsAccountDisabled:
+			case kODErrorCredentialsAccountInactive:
+				retval = PAM_PERM_DENIED;
+				break;
+			case kODErrorCredentialsPasswordExpired:
+			case kODErrorCredentialsPasswordChangeRequired:
+				retval = PAM_NEW_AUTHTOK_REQD;
+				break;
+			case kODErrorCredentialsInvalid:
+				retval = PAM_AUTH_ERR;
+				break;
+			case kODErrorCredentialsAccountTemporarilyLocked :
+				retval = PAM_APPLE_ACCT_TEMP_LOCK;
+				break;
+			case kODErrorCredentialsAccountLocked :
+				retval = PAM_APPLE_ACCT_LOCKED;
+				break;
+			default:
+				retval = PAM_AUTH_ERR;
+				break;
+		}
+
+    } else {
+        retval = PAM_SUCCESS;
+    }
+
+cleanup:
+	_LOG_DEBUG("retval: %d", retval);
+    if (odError) {
+        *odError = localerr;
+    }
+	return retval;
+}
+
+int
+od_record_check_authauthority(ODRecordRef record)
+{
+	int retval = PAM_PERM_DENIED;
+	CFStringRef authauth = NULL;
+
+	if (NULL == record) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	retval = od_record_attribute_create_cfstring(record, kODAttributeTypeAuthenticationAuthority, &authauth);
+	if (PAM_SUCCESS != retval) {
+		_LOG_DEBUG("od_record_attribute_create_cfstring() failed");
+		goto cleanup;
+	}
+	if (NULL == authauth) {
+		retval = PAM_SUCCESS;
+		goto cleanup;
+	}
+	if (!CFStringHasPrefix(authauth, CFSTR(kDSValueAuthAuthorityDisabledUser))) {
+		retval = PAM_SUCCESS;
+	}
+
+cleanup:
+	if (PAM_SUCCESS != retval) {
+		_LOG_ERROR("failed: %d", retval);
+	}
+
+	CFReleaseSafe(authauth);
+
+	return retval;
+}
+
+int
+od_record_check_homedir(ODRecordRef record)
+{
+	int retval = PAM_SERVICE_ERR;
+	CFStringRef tmp = NULL;
+
+	if (NULL == record) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	retval = od_record_attribute_create_cfstring(record, kODAttributeTypeNFSHomeDirectory, &tmp);
+	if (PAM_SUCCESS != retval) {
+		_LOG_DEBUG("od_record_attribute_create_cfstring() failed");
+		goto cleanup;
+	}
+
+	/* Allow NULL home directories */
+	if (NULL == tmp) {
+		retval = PAM_SUCCESS;
+		goto cleanup;
+	}
+
+	/* Do not allow login with '/dev/null' home */
+	if (kCFCompareEqualTo == CFStringCompare(tmp, CFSTR("/dev/null"), 0)) {
+		_LOG_DEBUG("home directory is /dev/null");
+		retval = PAM_PERM_DENIED;
+		goto cleanup;
+	}
+
+	if (kCFCompareEqualTo == CFStringCompare(tmp, CFSTR("99"), 0)) {
+		_LOG_DEBUG("home directory is 99");
+		retval = PAM_PERM_DENIED;
+		goto cleanup;
+	}
+
+	retval = PAM_SUCCESS;
+
+cleanup:
+	if (PAM_SUCCESS != retval)
+		_LOG_ERROR("failed: %d", retval);
+
+	CFReleaseSafe(tmp);
+
+	return retval;
+}
+
+int
+od_record_check_shell(ODRecordRef record)
+{
+	int retval = PAM_PERM_DENIED;
+	CFStringRef cfstr = NULL;
+
+	if (NULL == record) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	retval = od_record_attribute_create_cfstring(record, kODAttributeTypeUserShell, &cfstr);
+	if (PAM_SUCCESS != retval) {
+		_LOG_DEBUG("od_record_attribute_create_cfstring() failed");
+		goto cleanup;
+	}
+
+	if (NULL == cfstr) {
+		retval = PAM_SUCCESS;
+		goto cleanup;
+	}
+
+	if (CFStringCompare(cfstr, CFSTR("/usr/bin/false"), 0) == kCFCompareEqualTo) {
+		_LOG_DEBUG("user shell is /bin/false");
+		retval = PAM_PERM_DENIED;
+	}
+
+cleanup:
+	if (PAM_SUCCESS != retval)
+		_LOG_ERROR("failed: %d", retval);
+
+	CFReleaseSafe(cfstr);
+
+	return retval;
+}
+
+int
+od_string_from_record(ODRecordRef record, CFStringRef attrib,  char **out)
+{
+	int retval = PAM_SERVICE_ERR;
+	CFStringRef val = NULL;
+
+	if (NULL == record) {
+		_LOG_DEBUG("%s - NULL ODRecord passed.", __func__);
+		goto cleanup;
+	}
+
+	retval = od_record_attribute_create_cfstring(record, attrib, &val);
+	if (PAM_SUCCESS != retval) {
+		goto cleanup;
+	}
+
+	if (val)
+		retval = cfstring_to_cstring(val, out);
+
+cleanup:
+	CFReleaseSafe(val);
+
+	return retval;
+}
+
+int
+extract_homemount(char *in, char **out_url, char **out_path)
+{
+	// Directory Services people have assured me that this won't change
+	static const char URL_OPEN[] = "<url>";
+	static const char URL_CLOSE[] = "</url>";
+	static const char PATH_OPEN[] = "<path>";
+	static const char PATH_CLOSE[] = "</path>";
+
+	char *server_URL = NULL;
+	char *path = NULL;
+	char *record_start = NULL;
+	char *record_end = NULL;
+
+	int retval = PAM_SERVICE_ERR;
+
+	if (NULL == in)
+		goto fin;
+
+	record_start = in;
+	server_URL = strstr(record_start, URL_OPEN);
+	if (NULL == server_URL)
+		goto fin;
+	server_URL += sizeof(URL_OPEN)-1;
+	while ('\0' != *server_URL && isspace(*server_URL))
+		server_URL++;
+	record_end = strstr(server_URL, URL_CLOSE);
+	if (NULL == record_end)
+		goto fin;
+	while (record_end >= server_URL && '\0' != *record_end && isspace(*(record_end-1)))
+		record_end--;
+	if (NULL == record_end)
+		goto fin;
+	*record_end = '\0';
+	if (NULL == (*out_url = strdup(server_URL)))
+		goto fin;
+
+	record_start = record_end+1;
+	path = strstr(record_start, PATH_OPEN);
+	if (NULL == path)
+		goto ok;
+	path += sizeof(PATH_OPEN)-1;
+	while ('\0' != *path && isspace(*path))
+		path++;
+	record_end = strstr(path, PATH_CLOSE);
+	if (NULL == record_end)
+		goto fin;
+	while (record_end >= path && '\0' != *record_end && isspace(*(record_end-1)))
+		record_end--;
+	if (NULL == record_end)
+		goto fin;
+	*record_end = '\0';
+	if (NULL == (*out_path = strdup(path)))
+		goto fin;
+
+ok:
+	retval = PAM_SUCCESS;
+fin:
+	return retval;
+}
+
+int
+od_extract_home(pam_handle_t *pamh, const char *username, char **server_URL, char **path, char **homedir)
+{
+	int retval = PAM_SERVICE_ERR;
+	char *tmp = NULL;
+	ODRecordRef record = NULL;
+
+	retval = od_record_create_cstring(pamh, &record, username);
+	if (PAM_SUCCESS != retval) {
+		goto cleanup;
+	}
+
+	retval = od_string_from_record(record, kODAttributeTypeHomeDirectory, &tmp);
+	if (retval) {
+		_LOG_DEBUG("%s - get kODAttributeTypeHomeDirectory  : %d",
+			    __func__, retval);
+		goto cleanup;
+	}
+	extract_homemount(tmp, server_URL, path);
+	_LOG_DEBUG("%s - Server URL   : %s", __func__, *server_URL);
+	_LOG_DEBUG("%s - Path to mount: %s", __func__, *path);
+
+	retval = od_string_from_record(record, kODAttributeTypeNFSHomeDirectory, homedir);
+	_LOG_DEBUG("%s - Home dir     : %s", __func__, *homedir);
+	if (retval)
+		goto cleanup;
+
+	retval = PAM_SUCCESS;
+
+cleanup:
+	if (tmp)
+		free(tmp);
+	CFReleaseSafe(record);
+
+	return retval;
+}
+
+/* extract the principal from OpenDirectory */
+int
+od_principal_for_user(pam_handle_t *pamh, const char *user, char **od_principal)
+{
+	int retval = PAM_SERVICE_ERR;
+	ODRecordRef record = NULL;
+	CFStringRef principal = NULL;
+	CFArrayRef authparts = NULL, vals = NULL;
+	CFIndex i = 0, count = 0;
+
+	if (NULL == user || NULL == od_principal) {
+		_LOG_DEBUG("NULL argument passed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+	retval = od_record_create_cstring(pamh, &record, user);
+	if (PAM_SUCCESS != retval) {
+		_LOG_DEBUG("od_record_attribute_create_cfstring() failed");
+		goto cleanup;
+	}
+
+	retval = od_record_attribute_create_cfarray(record, kODAttributeTypeAuthenticationAuthority, &vals);
+	if (PAM_SUCCESS != retval) {
+		_LOG_DEBUG("od_record_attribute_create_cfarray() failed");
+		goto cleanup;
+	}
+	if (NULL == vals) {
+		_LOG_DEBUG("no authauth availale for user.");
+		retval = PAM_PERM_DENIED;
+		goto cleanup;
+	}
+
+	count = CFArrayGetCount(vals);
+	for (i = 0; i < count; i++)
+	{
+		const void *val = CFArrayGetValueAtIndex(vals, i);
+		if (NULL == val || CFGetTypeID(val) != CFStringGetTypeID())
+			break;
+
+		authparts = CFStringCreateArrayBySeparatingStrings(kCFAllocatorDefault, val, CFSTR(";"));
+		if (NULL == authparts)
+			continue;
+
+		if ((CFArrayGetCount(authparts) < 5) ||
+		    (CFStringCompare(CFArrayGetValueAtIndex(authparts, 1), CFSTR("Kerberosv5"), kCFCompareEqualTo)) ||
+		    (CFStringHasPrefix(CFArrayGetValueAtIndex(authparts, 4), CFSTR("LKDC:")))) {
+			if (NULL != authparts) {
+				CFRelease(authparts);
+				authparts = NULL;
+			}
+			continue;
+		} else {
+			break;
+		}
+	}
+
+	if (NULL == authparts) {
+		_LOG_DEBUG("No authentication authority returned");
+		retval = PAM_PERM_DENIED;
+		goto cleanup;
+	}
+
+	principal = CFArrayGetValueAtIndex(authparts, 3);
+	if (NULL == principal) {
+		_LOG_DEBUG("no principal found in authentication authority");
+		retval = PAM_PERM_DENIED;
+		goto cleanup;
+	}
+
+	retval = cfstring_to_cstring(principal, od_principal);
+	if (PAM_SUCCESS != retval) {
+		_LOG_DEBUG("cfstring_to_cstring() failed");
+		goto cleanup;
+	}
+
+
+cleanup:
+	if (PAM_SUCCESS != retval) {
+		_LOG_DEBUG("failed: %d", retval);
+	}
+
+	CFReleaseSafe(record);
+	CFReleaseSafe(authparts);
+	CFReleaseSafe(vals);
+
+	return retval;
+}
+
+void
+pam_cf_cleanup(__unused pam_handle_t *pamh, void *data, __unused int pam_end_status)
+{
+	if (data) {
+		CFStringRef *cfstring = data;
+		CFRelease(*cfstring);
+	}
+}

--- a/src/pam_modules/common/Common.h
+++ b/src/pam_modules/common/Common.h
@@ -1,0 +1,38 @@
+#include <OpenDirectory/OpenDirectory.h>
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+
+#ifndef _COMMON_H_
+#define _COMMON_H_
+
+int od_record_create(pam_handle_t*, ODRecordRef*, CFStringRef);
+int od_record_create_cstring(pam_handle_t*, ODRecordRef*, const char*);
+int od_record_attribute_create_cfstring(ODRecordRef record, CFStringRef attrib,  CFStringRef *out);
+int od_record_attribute_create_cfarray(ODRecordRef record, CFStringRef attrib,  CFArrayRef *out);
+int od_record_attribute_create_cstring(ODRecordRef record, CFStringRef attrib,  char **out);
+
+int od_record_check_pwpolicy(ODRecordRef, CFErrorRef *);
+int od_record_check_authauthority(ODRecordRef);
+int od_record_check_homedir(ODRecordRef);
+int od_record_check_shell(ODRecordRef);
+
+int od_extract_home(pam_handle_t*, const char *, char **, char **, char **);
+int od_principal_for_user(pam_handle_t*, const char *, char **);
+
+void pam_cf_cleanup(__unused pam_handle_t *, void *, __unused int );
+
+int cfstring_to_cstring(const CFStringRef val, char **buffer);
+
+#ifndef CFReleaseSafe
+#define CFReleaseSafe(CF) { CFTypeRef _cf = (CF); if (_cf) CFRelease(_cf); }
+#endif
+
+#ifndef CFReleaseNull
+#define CFReleaseNull(CF) { CFTypeRef _cf = (CF); \
+if (_cf) { (CF) = NULL; CFRelease(_cf); } }
+#endif
+
+CF_RETURNS_RETAINED
+CFStringRef    GetPrincipalFromUser(CFDictionaryRef inUserRecord);
+
+#endif /* _COMMON_H_ */

--- a/src/pam_modules/common/ForkSafeLogging.h
+++ b/src/pam_modules/common/ForkSafeLogging.h
@@ -1,0 +1,35 @@
+//
+//  ForkSafeLogging.h
+//  pam_modules
+//
+//  Fork detection to disable framework logging after fork
+//
+
+#ifndef ForkSafeLogging_h
+#define ForkSafeLogging_h
+
+#include <pthread.h>
+#include <stdbool.h>
+#import <os/trace_private.h>
+
+static bool _pam_is_forked = false;
+
+// Fork handlers using pthread_atfork pattern from Heimdal
+static void _pam_fork_child_handler(void) {
+    _pam_is_forked = true;
+    // Disable os_trace to prevent OpenDirectory and other framework crashes
+    os_trace_set_mode(OS_TRACE_MODE_DISABLE);
+}
+
+// Library constructor to register fork handlers
+__attribute__((constructor))
+static void _pam_init_fork_detection(void) {
+    pthread_atfork(NULL, NULL, _pam_fork_child_handler);
+}
+
+// Check if we're running after fork
+static inline bool pam_is_after_fork(void) {
+    return _pam_is_forked;
+}
+
+#endif /* ForkSafeLogging_h */

--- a/src/pam_modules/common/Logging.h
+++ b/src/pam_modules/common/Logging.h
@@ -1,0 +1,39 @@
+//
+//  Logging.h
+//  pam_modules
+//
+
+#ifndef Logging_h
+#define Logging_h
+
+// to turn on os_logs, uncomment following line
+// #define PAM_USE_OS_LOG
+
+#ifdef PAM_USE_OS_LOG
+#include <os/log.h>
+#include <os/activity.h>
+
+#define PAM_DEFINE_LOG(category) \
+static os_log_t PAM_LOG_ ## category () { \
+static dispatch_once_t once; \
+static os_log_t log; \
+dispatch_once(&once, ^{ log = os_log_create("com.apple.pam", #category); }); \
+return log; \
+};
+
+#define _LOG_DEBUG(...) os_log_debug(PAM_LOG, __VA_ARGS__)
+#define _LOG_VERBOSE(...) os_log_debug(PAM_LOG, __VA_ARGS__)
+#define _LOG_INFO(...) os_log_info(PAM_LOG, __VA_ARGS__)
+#define _LOG_DEFAULT(...) os_log(PAM_LOG, __VA_ARGS__)
+#define _LOG_ERROR(...) os_log_error(PAM_LOG, __VA_ARGS__)
+
+#else
+
+#define _LOG_DEBUG(...) openpam_log(PAM_LOG_DEBUG, __VA_ARGS__)
+#define _LOG_VERBOSE(...) openpam_log(PAM_LOG_VERBOSE, __VA_ARGS__)
+#define _LOG_INFO(...) openpam_log(PAM_LOG_VERBOSE, __VA_ARGS__)
+#define _LOG_DEFAULT(...) openpam_log(PAM_LOG_NOTICE, __VA_ARGS__)
+#define _LOG_ERROR(...) openpam_log(PAM_LOG_ERROR, __VA_ARGS__)
+#endif
+
+#endif /* Logging_h */

--- a/src/pam_modules/common/SharedMem.h
+++ b/src/pam_modules/common/SharedMem.h
@@ -1,0 +1,61 @@
+#ifndef PAM_SHARED_MEMORY_H
+#define PAM_SHARED_MEMORY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Write data into the shared memory.
+ *
+ * @param data Buffer with data to write
+ * @param size Number of bytes to write
+ * @return 0 on success, -1 on error
+ */
+const char *pam_shm_write(const void* data, size_t size);
+
+/**
+ * Read data from the shared memory.
+ *
+ * @param handle Handle from pam_shm_write
+ * @param buffer Buffer to receive data (can be NULL to query data length)
+ * @param size Number of bytes to read
+ * @return Number of bytes read, or -1 on failure
+ */
+ssize_t pam_shm_read(const char *handle, void* buffer, size_t size);
+
+/**
+ * Close the shared memory and release resources.
+ *
+ * @param handle Handle from pam_shm_open
+ */
+void pam_shm_close(const char *handle);
+
+/**
+ * Returns shared secret based on the environment name and releases shm
+ *
+ * @param pamh Handle to the PAM session
+ * @param env_name Handle from pam_shm_open
+ * @return secret value, or NULL on failure. Caller is responsible for releasing the memory
+ */
+char *pam_copy_secret_from_shm(struct pam_handle *pamh, const char *env_name);
+
+/**
+ * Returns shared secret with backward compatibility support
+ * First tries to get the secret directly from the original PAM environment variable,
+ * then falls back to shared memory approach using the new environment variable name
+ *
+ * @param pamh Handle to the PAM session
+ * @param original_env_name Original PAM environment variable name (for backward compatibility)
+ * @param shm_env_name New PAM environment variable name containing shared memory handle
+ * @return secret value, or NULL on failure. Caller is responsible for releasing the memory
+ */
+char *pam_copy_secret_with_fallback(struct pam_handle *pamh, const char *original_env_name, const char *shm_env_name);
+
+void pam_safe_string_release(char *str);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PAM_SHARED_MEMORY_H

--- a/src/pam_modules/common/SharedMem.m
+++ b/src/pam_modules/common/SharedMem.m
@@ -1,0 +1,209 @@
+// Copyright (c) 2025 Apple Inc. All Rights Reserved.
+
+#import <Foundation/Foundation.h>
+#import <sys/mman.h>
+#import <sys/stat.h>
+#import <fcntl.h>
+#import <unistd.h>
+#import <security/pam_types.h>
+#import <security/pam_appl.h>
+#import <security/pam_modules.h>
+#import "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(SharedMem)
+#define PAM_LOG PAM_LOG_SharedMem()
+#endif
+
+#define PAM_SHM_PATH_PREFIX @"/pam"
+
+const char *pam_shm_write(const void *data, size_t len) {
+    // Check for NULL data or excessive length
+    if (data == NULL || len == 0) {
+        _LOG_ERROR("Invalid data or length");
+        return NULL;
+    }
+    
+    // Check for potential overflow and maximum size (consistent with existing PATH_MAX usage)
+    if (len > PATH_MAX || len > SIZE_MAX - sizeof(uint32_t)) {
+        _LOG_ERROR("Data too large for shared memory");
+        return NULL;
+    }
+    
+    NSUUID *uuid = [NSUUID UUID];
+    NSString *segmentName = [[PAM_SHM_PATH_PREFIX stringByAppendingString:[[uuid.UUIDString componentsSeparatedByString:@"-"] componentsJoinedByString:@""]] substringToIndex:16];
+
+    size_t totalSize = sizeof(uint32_t) + len;
+
+    int fd = shm_open([segmentName UTF8String], O_CREAT | O_RDWR, 0600);
+    if (fd == -1) {
+        _LOG_ERROR("createSegmentWithName: createSegmentWithName shm_open %s", segmentName.UTF8String);
+        return nil;
+    }
+
+    if (ftruncate(fd, totalSize) == -1) {
+        _LOG_ERROR("createSegmentWithName: ftruncate");
+        close(fd);
+        shm_unlink([segmentName UTF8String]);
+        return nil;
+    }
+
+    void *ptr = mmap(NULL, totalSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (ptr == MAP_FAILED) {
+        _LOG_ERROR("createSegmentWithName: mmap");
+        close(fd);
+        shm_unlink([segmentName UTF8String]);
+        return nil;
+    }
+
+    memcpy(ptr, &len, sizeof(uint32_t));
+    memcpy((char *)ptr + sizeof(uint32_t), data, len);
+
+    munmap(ptr, totalSize);
+    close(fd);
+    _LOG_DEBUG("Data written to SHM");
+
+    return segmentName.UTF8String;
+}
+
+ssize_t pam_shm_read(const char *segName, void *buf, size_t bufLen) {
+    if (segName == NULL) {
+        _LOG_ERROR("readSegmentWithName: NULL segment name");
+        return -1;
+    }
+    
+    int fd = shm_open(segName, O_RDONLY, 0);
+    if (fd == -1) {
+        _LOG_ERROR("readSegmentWithName: shm_open");
+        return -1;
+    }
+
+    uint32_t len;
+    void *ptr = mmap(NULL, sizeof(uint32_t), PROT_READ, MAP_SHARED, fd, 0);
+    if (ptr == MAP_FAILED) {
+        _LOG_ERROR("readSegmentWithName: mmap");
+        close(fd);
+        return -1;
+    }
+    memcpy(&len, ptr, sizeof(uint32_t));
+    munmap(ptr, sizeof(uint32_t));
+    
+    // Check for excessive size (consistent with existing PATH_MAX usage)
+    if (len > PATH_MAX) {
+        _LOG_ERROR("readSegmentWithName: excessive data length %u", len);
+        close(fd);
+        return -1;
+    }
+    
+    // Check for potential overflow
+    if (len > SIZE_MAX - sizeof(uint32_t)) {
+        _LOG_ERROR("readSegmentWithName: potential integer overflow");
+        close(fd);
+        return -1;
+    }
+    
+    size_t totalSize = sizeof(uint32_t) + len;
+    ptr = mmap(NULL, totalSize, PROT_READ, MAP_SHARED, fd, 0);
+    if (ptr == MAP_FAILED) {
+        _LOG_ERROR("readSegmentWithName: mmap");
+        close(fd);
+        return -1;
+    }
+
+    // Get pointer to the actual data (skip the length prefix)
+    const char *dataPtr = (const char *)ptr + sizeof(uint32_t);
+
+    // If buf is NULL, caller just wants the data length
+    if (!buf) {
+        munmap(ptr, totalSize);
+        close(fd);
+        _LOG_DEBUG("Data length read from SHM");
+        return (ssize_t)len;
+    }
+
+    // Copy data directly to the output buffer
+    size_t toCopy = MIN(bufLen, len);
+    memcpy(buf, dataPtr, toCopy);
+
+    munmap(ptr, totalSize);
+    close(fd);
+    _LOG_DEBUG("Data read from SHM");
+
+    return (ssize_t)toCopy;
+}
+
+void pam_shm_cleanup(const char *segName) {
+    shm_unlink(segName);
+    _LOG_DEBUG("Unlinked SHM");
+}
+
+char *pam_copy_secret_from_shm(struct pam_handle *pamh, const char *env_name) {
+    char *retval = NULL;
+    const char *shm_handle = pam_getenv(pamh, env_name);
+    if (NULL == shm_handle) {
+        _LOG_ERROR("Unable to retrieve the ENV value %s.", env_name);
+        goto fin;
+    }
+    
+    size_t secret_len = pam_shm_read(shm_handle, NULL, 0);
+    if (secret_len == 0) {
+        _LOG_ERROR("Unable to retrieve the secret length.");
+        goto fin;
+    }
+    
+    if (secret_len > PATH_MAX) {
+        _LOG_ERROR("Wrong secret len %zu.", secret_len);
+        goto fin;
+    }
+    
+    retval = malloc(secret_len + 1);
+    if (retval == NULL) {
+        _LOG_ERROR("Failed to allocate memory for secret.");
+        goto fin;
+    }
+    
+    ssize_t read_bytes = pam_shm_read(shm_handle, retval, secret_len);
+    if (read_bytes < 0 || (size_t)read_bytes != secret_len) {
+        _LOG_ERROR("Failed to read secret from shared memory.");
+        free(retval);
+        retval = NULL;
+        goto fin;
+    }
+    
+    retval[secret_len] = '\0';
+    
+    _LOG_DEBUG("Read secret");
+
+fin:
+    if (shm_handle) {
+        pam_shm_cleanup(shm_handle);
+    }
+    return retval;
+}
+
+char *pam_copy_secret_with_fallback(struct pam_handle *pamh, const char *original_env_name, const char *shm_env_name) {
+    char *retval = NULL;
+    
+    // First try to get the secret directly from the original PAM environment (backward compatibility)
+    const char *direct_secret = pam_getenv(pamh, original_env_name);
+    if (direct_secret != NULL) {
+        _LOG_DEBUG("Found secret in original PAM environment %s", original_env_name);
+        retval = strdup(direct_secret);
+        return retval;
+    }
+    
+    // Fall back to shared memory approach using the new environment variable
+    _LOG_DEBUG("Original PAM environment %s not found, trying shared memory approach with %s", original_env_name, shm_env_name);
+    retval = pam_copy_secret_from_shm(pamh, shm_env_name);
+    
+    return retval;
+}
+
+void pam_safe_string_release(char *str) {
+    if (!str) {
+        return;
+    }
+    size_t len = strlen(str);
+    memset_s(str, len, 0, len);
+    free(str);
+}

--- a/src/pam_modules/modules/pam_aks/authorization_aks
+++ b/src/pam_modules/modules/pam_aks/authorization_aks
@@ -1,0 +1,3 @@
+# localauthentication: auth 
+auth       required       pam_aks.so
+account    required       pam_opendirectory.so

--- a/src/pam_modules/modules/pam_aks/pam_aks.8
+++ b/src/pam_modules/modules/pam_aks/pam_aks.8
@@ -1,0 +1,75 @@
+.\"
+.\" Copyright (c) 2009 Apple Inc. All rights reserved.
+.\"
+.\" @APPLE_LICENSE_HEADER_START@
+.\" 
+.\" This file contains Original Code and/or Modifications of Original Code
+.\" as defined in and that are subject to the Apple Public Source License
+.\" Version 2.0 (the 'License'). You may not use this file except in
+.\" compliance with the License. Please obtain a copy of the License at
+.\" http://www.opensource.apple.com/apsl/ and read it before using this
+.\" file.
+.\" 
+.\" The Original Code and all software distributed under the License are
+.\" distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+.\" EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+.\" INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+.\" Please see the License for the specific language governing rights and
+.\" limitations under the License.
+.\" 
+.\" @APPLE_LICENSE_HEADER_END@
+.\"
+.Dd February 7, 2009
+.Dt pam_opendirectory 8
+.Os
+.Sh NAME
+.Nm pam_opendirectory
+.Nd OpenDirectory PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_opendirectory
+.Op Ar options
+.Sh DESCRIPTION
+The OpenDirectory PAM module supports the authentication, account management and password management function classes.  In terms of the
+.Ar function-class
+parameter, these are
+.Dq Li auth ,
+.Dq Li account
+and
+.Dq Li password
+respectively.
+.Ss The OpenDirectory Authentication Module
+The OpenDirectory authentication module permits or denies users based on OpenDirectory password authentication.
+.Pp
+The following option may be passed to this authentication module:
+.Bl -tag
+.It Cm nullok
+Allow null passwords.
+.El
+.Ss The OpenDirectory Account Management Module
+The OpenDirectory account management module permits or denies users based whether the account is enabled in OpenDirectory.
+.Pp
+The following option may be passed to this account management module:
+.Bl -tag
+.It Cm no_check_shell
+Skip validating the user's shell.
+.It Cm no_check_home
+Skip validating the user's home directory.
+.It Cm refresh Ns = Ns Ar min
+Sets the mbr_check_membership(3) cache timeout to
+.Ar min
+minutes.  When this option is used, the
+.Ar min
+value must be specified, and it must be an integer.
+.El
+.Ss The OpenDirectory Password Management Module
+The OpenDirectory password management module supports password changing and enforces the OpenDirectory password policy.
+.Sh SEE ALSO
+.Xr mbr_check_membership 3 ,
+.Xr pam.conf 5 ,
+.Xr pam 8 ,
+.Xr pwpolicy 8 ,
+.Xr DirectoryService 8

--- a/src/pam_modules/modules/pam_aks/pam_aks.c
+++ b/src/pam_modules/modules/pam_aks/pam_aks.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ * Portions Copyright (c) 2001 PADL Software Pty Ltd. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * Portions Copyright (c) 2000 Apple Computer, Inc.  All Rights
+ * Reserved.  This file contains Original Code and/or Modifications of
+ * Original Code as defined in and that are subject to the Apple Public
+ * Source License Version 1.1 (the "License").  You may not use this file
+ * except in compliance with the License.  Please obtain a copy of the
+ * License at http://www.apple.com/publicsource and read it before using
+ * this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON- INFRINGEMENT.  Please see the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/******************************************************************
+ * The purpose of this module is to provide an aks based 
+ * authentication module for Mac OS X.
+ ******************************************************************/
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <spawn.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <os/log.h>
+#include <libproc.h>
+#include "Logging.h"
+
+#define PAM_SM_AUTH
+#define PAM_SM_ACCOUNT
+
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(aks)
+#define PAM_LOG PAM_LOG_aks()
+#endif
+
+extern char **environ;
+
+PAM_EXTERN int
+pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    _LOG_DEBUG("pam_sm_authenticate");
+    
+    int retval = PAM_AUTH_ERR;
+
+    const char *user = NULL;
+    struct passwd *pwd = NULL;
+    struct passwd pwdbuf;
+    char buffer[2 * PATH_MAX];
+
+    /* get information about user to authenticate for */
+    if (pam_get_user(pamh, &user, NULL) != PAM_SUCCESS || !user ||
+        getpwnam_r(user, &pwdbuf, buffer, sizeof(buffer), &pwd) != 0 || !pwd) {
+        _LOG_ERROR("unable to obtain the username.");
+        retval = PAM_AUTHINFO_UNAVAIL;
+        goto cleanup;
+    }
+
+	char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
+	int status = proc_pidpath(getpid(), pathbuf, sizeof(pathbuf));
+	if (status <= 0) {
+		_LOG_ERROR("unable to get the path.");
+		goto cleanup;
+	}
+
+	snprintf(buffer, sizeof(buffer), "%d", pwd->pw_uid);
+	pid_t spawn_pid;
+	char *args[] = {pathbuf, buffer, NULL};
+	status = posix_spawn(&spawn_pid, "/System/Library/Frameworks/LocalAuthentication.framework/Support/lastatus", NULL, NULL, args, environ);
+	if (status == 0) {
+		_LOG_DEBUG("helper pid %d", spawn_pid);
+		if (waitpid(spawn_pid, &status, 0) != -1) {
+            if (status == 0) {
+                _LOG_DEBUG("helper return value %d", status);
+            } else {
+                _LOG_DEFAULT("helper return value %d", status);
+            }
+			if (status == 0)
+				retval = PAM_SUCCESS;
+		} else {
+			_LOG_ERROR("wait failed %d", status);
+		}
+	} else {
+        _LOG_ERROR("launch failed %d", status);
+	}
+
+cleanup:
+    _LOG_DEFAULT("pam_sm_authenticate for %s[%d] returned %d", user, pwd ? pwd->pw_uid : -1, retval);
+    return retval;
+}
+
+
+PAM_EXTERN int 
+pam_sm_setcred(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    _LOG_DEBUG("pam_sm_setcred");
+	return PAM_SUCCESS;
+}
+
+
+PAM_EXTERN int 
+pam_sm_acct_mgmt(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    _LOG_DEBUG("pam_sm_acct_mgmt");
+    return PAM_SUCCESS;
+}

--- a/src/pam_modules/modules/pam_aks/screensaver_aks
+++ b/src/pam_modules/modules/pam_aks/screensaver_aks
@@ -1,0 +1,6 @@
+# localauthentication: auth 
+auth       required       pam_aks.so
+account    required       pam_opendirectory.so
+account    sufficient     pam_self.so
+account    required       pam_group.so no_warn group=admin,wheel fail_safe
+account    required       pam_group.so no_warn deny group=admin,wheel ruser fail_safe

--- a/src/pam_modules/modules/pam_aks/screensaver_new_aks
+++ b/src/pam_modules/modules/pam_aks/screensaver_new_aks
@@ -1,0 +1,3 @@
+# localauthentication: auth 
+auth       required       pam_aks.so
+account    required       pam_opendirectory.so

--- a/src/pam_modules/modules/pam_basesystem/pam_basesystem.8
+++ b/src/pam_modules/modules/pam_basesystem/pam_basesystem.8
@@ -1,0 +1,37 @@
+.\"
+.\" Copyright (c) 2025 Apple Inc. All rights reserved.
+.\"
+.\" @APPLE_LICENSE_HEADER_START@
+.\" 
+.\" This file contains Original Code and/or Modifications of Original Code
+.\" as defined in and that are subject to the Apple Public Source License
+.\" Version 2.0 (the 'License'). You may not use this file except in
+.\" compliance with the License. Please obtain a copy of the License at
+.\" http://www.opensource.apple.com/apsl/ and read it before using this
+.\" file.
+.\" 
+.\" The Original Code and all software distributed under the License are
+.\" distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+.\" EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+.\" INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+.\" Please see the License for the specific language governing rights and
+.\" limitations under the License.
+.\" 
+.\" @APPLE_LICENSE_HEADER_END@
+.\"
+.Dd October 8, 2025
+.Dt pam_basesystem 8
+.Os
+.Sh NAME
+.Nm pam_basesystem
+.Nd BaseSystem PAM module
+.Sh DESCRIPTION
+The BaseSystem PAM module facilitates unlocking FileVault in BaseSystem.
+This allows technologies like OpenSSH to unlock the FileVault protected
+data volumes using a username and password.
+.Sh HISTORY
+This module first appeared in macOS 26 Tahoe.
+.Sh SEE ALSO
+.Xr sshd 8
+.Xr apple_ssh_and_filevault 7

--- a/src/pam_modules/modules/pam_basesystem/pam_basesystem.m
+++ b/src/pam_modules/modules/pam_basesystem/pam_basesystem.m
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2025 Apple Computer, Inc. All rights reserved.
+ * Portions Copyright (c) 2001 PADL Software Pty Ltd. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * Portions Copyright (c) 2025 Apple Computer, Inc.  All Rights
+ * Reserved.  This file contains Original Code and/or Modifications of
+ * Original Code as defined in and that are subject to the Apple Public
+ * Source License Version 1.1 (the "License").  You may not use this file
+ * except in compliance with the License.  Please obtain a copy of the
+ * License at http://www.apple.com/publicsource and read it before using
+ * this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON- INFRINGEMENT.  Please see the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <unistd.h>
+#import <pwd.h>
+#import <spawn.h>
+#import <os/log.h>
+#import <sysexits.h>
+#import "Logging.h"
+#import <reboot2.h>
+
+#define PAM_SM_AUTH
+#define PAM_SM_ACCOUNT
+
+#import <security/pam_modules.h>
+#import <security/pam_appl.h>
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(aks)
+#define PAM_LOG PAM_LOG_aks()
+#endif
+
+extern char **environ;
+
+#define LIBEXEC_SSHD_FVUNLOCK "/usr/libexec/sshd-fvunlock"
+#define PIVOT_MOUNT_PATH "/System/Volumes/macOS"
+
+PAM_EXTERN int
+pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    _LOG_DEBUG("pam_sm_authenticate");
+
+    static const char password_prompt[] = "Password:";
+    int retval = PAM_AUTH_ERR;
+
+    const char *user = NULL;
+    const char *password = NULL;
+    char *resp = NULL;
+    
+    int rd = -1;
+    int wr = -1;
+    pid_t pid = 0;
+    posix_spawn_file_actions_t file_actions = NULL;
+    posix_spawnattr_t spawn_attr = NULL;
+
+    /* get information about user to authenticate for */
+    if ((retval = pam_get_user(pamh, &user, NULL)) != PAM_SUCCESS || !user) {
+        _LOG_ERROR("basesystem: unable to obtain the username.");
+        if (retval == PAM_SUCCESS && !user) {
+            retval = PAM_AUTHINFO_UNAVAIL;
+        }
+        goto cleanup;
+    }
+    _LOG_DEBUG("basesystem: obtained username %s", user);
+
+    if ((retval = pam_get_authtok(pamh, PAM_AUTHTOK, &password, password_prompt)) != PAM_SUCCESS) {
+        _LOG_ERROR("basesystem: unable to obtain authtok.");
+        goto cleanup;
+    }
+    _LOG_DEBUG("basesystem: got password");
+
+    const char *const child_argv[] = {
+        LIBEXEC_SSHD_FVUNLOCK,
+        "--no-reboot",
+        user,
+        NULL
+    };
+    const char *const envp[] = {
+        NULL
+    };
+
+    int rc = 0;
+    if ((rc = posix_spawn_file_actions_init(&file_actions)) != 0) {
+        _LOG_ERROR("posix_spawn_file_actions_init() failed: %d", rc);
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+
+    if ((rc = posix_spawnattr_init(&spawn_attr)) != 0) {
+        _LOG_ERROR("posix_spawnattr_init() failed; %d", rc);
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+
+    int pipefd[2];
+    if ((rc = pipe(pipefd)) != 0) {
+        _LOG_ERROR("pipe() failed: %d", rc);
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+    
+    rd = pipefd[0];
+    wr = pipefd[1];
+
+    if ((rc = posix_spawn_file_actions_adddup2(&file_actions, rd, STDIN_FILENO)) != 0) {
+        _LOG_ERROR("posix_spawn_file_actions_adddup2() failed: %d", rc);
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+    
+    if ((rc = posix_spawn_file_actions_addclose(&file_actions, wr))) {
+        _LOG_ERROR("posix_spawn_file_actions_addclose() for write fd failed: %d", rc);
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+
+    if ((rc = posix_spawn_file_actions_addclose(&file_actions, rd))) {
+        _LOG_ERROR("posix_spawn_file_actions_addclose(rd) for read fd failed: %d", rc);
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+
+    rc = posix_spawn(&pid, LIBEXEC_SSHD_FVUNLOCK, &file_actions, &spawn_attr, (char *const *)child_argv, (char *const *)envp);
+    if (rc != 0) {
+        _LOG_ERROR("posix_spawn() failed: %d", rc);
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+    close(rd);
+    rd = -1;
+    
+    // write password over pipe, with null terminator
+    size_t datalen = strlen(password)+1;
+    size_t written = write(wr, password, datalen);
+    if (written != datalen) {
+        _LOG_ERROR("short write");
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+    
+    close(wr);
+    wr = -1;
+    
+    int status = 0;
+    if ((rc = waitpid(pid, &status, 0)) == -1) {
+        _LOG_ERROR("waitpid() failed: %d (status: %d)", rc, status);
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+    
+    // check status to see if we exited normally.
+    if (!WIFEXITED(status)) {
+        // child exited in an abnormal way
+        _LOG_ERROR(LIBEXEC_SSHD_FVUNLOCK " exited abnormally (status: %d)", status);
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+    
+    int exitcode = WEXITSTATUS(status);
+    if (exitcode != 0) {
+        _LOG_ERROR(LIBEXEC_SSHD_FVUNLOCK " exited normally with code: %d", exitcode);
+        switch (exitcode) {
+            case EX_NOPERM:
+                _LOG_ERROR(LIBEXEC_SSHD_FVUNLOCK " failed due to incorrect password");
+                retval = PAM_AUTH_ERR;
+                break;
+            case EX_TEMPFAIL:
+                _LOG_ERROR(LIBEXEC_SSHD_FVUNLOCK " failed because %s is temporarily unavailable", user);
+                pam_prompt(pamh, PAM_ERROR_MSG, &resp, "Account %s is temporarily unavailable.", user);
+                retval = PAM_MAXTRIES;
+                break;
+            case EX_SOFTWARE:
+            default:
+                _LOG_INFO(LIBEXEC_SSHD_FVUNLOCK " failed due to a system error");
+                retval = PAM_SYSTEM_ERR;
+                break;
+        }
+        goto cleanup;
+    }
+    
+    // Prompt for reboot
+    if (pam_prompt(pamh, PAM_TEXT_INFO, &resp, "System successfully unlocked.\nYou may now use SSH to authenticate normally.") != PAM_SUCCESS) {
+        _LOG_ERROR("failed to message for userspace reboot, continuing anyway");
+    }
+    
+    int pivotcode = 0;
+    if ((pivotcode = reboot3(RB3_PIVOTROOT, PIVOT_MOUNT_PATH)) != 0) {
+        _LOG_ERROR("userspace reboot failed: %d", pivotcode);
+        retval = PAM_SYSTEM_ERR;
+        goto cleanup;
+    }
+
+    // may not ever be reached since we userspace reobot.
+    retval = PAM_SUCCESS;
+cleanup:
+    if (spawn_attr) {
+        posix_spawnattr_destroy(&spawn_attr);
+    }
+    if (file_actions) {
+        posix_spawn_file_actions_destroy(&file_actions);
+    }
+    
+    if (rd != -1) {
+        close(rd);
+    }
+    if (wr != -1) {
+        close(wr);
+    }
+    
+    if (resp != NULL) {
+        free(resp);
+    }
+    
+    if (retval != PAM_SUCCESS) {
+        _LOG_ERROR("basesystem: pam_sm_authenticate for %s returned %d", user, retval);
+    }
+    return retval;
+}
+
+
+PAM_EXTERN int 
+pam_sm_setcred(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    _LOG_DEBUG("pam_sm_setcred");
+	return PAM_SUCCESS;
+}
+
+
+PAM_EXTERN int 
+pam_sm_acct_mgmt(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    _LOG_DEBUG("pam_sm_acct_mgmt");
+    return PAM_SUCCESS;
+}

--- a/src/pam_modules/modules/pam_env/README
+++ b/src/pam_modules/modules/pam_env/README
@@ -1,0 +1,72 @@
+# $Date: 2002/03/27 02:36:24 $
+# $Author: bbraun $
+# $Id: README,v 1.4 2002/03/27 02:36:24 bbraun Exp $
+#
+# This is the configuration file for pam_env, a PAM module to load in 
+# a configurable list of environment variables for a 
+# 
+# The original idea for this came from Andrew G. Morgan ...
+#<quote>
+#   Mmm. Perhaps you might like to write a pam_env module that reads a
+#   default environment from a file? I can see that as REALLY
+#   useful... Note it would be an "auth" module that returns PAM_IGNORE
+#   for the auth part and sets the environment returning PAM_SUCCESS in
+#   the setcred function...
+#</quote>
+#
+# What I wanted was the REMOTEHOST variable set, purely for selfish
+# reasons, and AGM didn't want it added to the SimpleApps login
+# program (which is where I added the patch). So, my first concern is
+# that variable, from there there are numerous others that might/would
+# be useful to be set: NNTPSERVER, LESS, PATH, PAGER, MANPAGER .....
+#
+# Of course, these are a different kind of variable than REMOTEHOST in
+# that they are things that are likely to be configured by
+# administrators rather than set by logging in, how to treat them both
+# in the same config file?
+#
+# Here is my idea: 
+#
+# Each line starts with the variable name, there are then two possible
+# options for each variable DEFAULT and OVERRIDE. 
+# DEFAULT allows and administrator to set the value of the
+# variable  to some default value, if none is supplied then the empty
+# string is assumed. The OVERRIDE option tells pam_env that it should
+# enter in its value (overriding the default value) if there is one
+# to use. OVERRIDE is not used, "" is assumed and no override will be
+# done. 
+#
+# VARIABLE   [DEFAULT=[value]]  [OVERRIDE=[value]]
+#
+# (Possibly non-existent) environment variables may be used in values
+# using the ${string} syntax and (possibly non-existent) PAM_ITEMs may
+# be used in values using the @{string} syntax. Both the $ and @
+# characters can be backslash escaped to be used as literal values
+# values can be delimited with "", escaped " not supported.
+#
+#
+# First, some special variables
+#
+# Set the REMOTEHOST variable for any hosts that are remote, default
+# to "localhost" rather than not being set at all
+REMOTEHOST	DEFAULT=localhost OVERRIDE=@{PAM_RHOST}
+#
+# Set the DISPLAY variable if it seems reasonable 
+DISPLAY		DEFAULT=${REMOTEHOST}:0.0 OVERRIDE=${DISPLAY}
+#
+#
+#  Now some simple variables
+#
+PAGER		DEFAULT=less
+MANPAGER	DEFAULT=less
+LESS		DEFAULT="M q e h15 z23 b80"
+NNTPSERVER	DEFAULT=localhost
+PATH		DEFAULT=${HOME}/bin:/usr/local/bin:/bin\
+:/usr/bin:/usr/local/bin/X11:/usr/bin/X11
+#
+# silly examples of escaped variables, just to show how they work.
+#
+DOLLAR		DEFAULT=\$
+DOLLARDOLLAR	DEFAULT=	OVERRIDE=\$${DOLLAR}
+DOLLARPLUS	DEFAULT=\${REMOTEHOST}${REMOTEHOST}
+ATSIGN		DEFAULT=""	OVERRIDE=\@

--- a/src/pam_modules/modules/pam_env/pam_env.8
+++ b/src/pam_modules/modules/pam_env/pam_env.8
@@ -1,0 +1,95 @@
+.\"
+.\" $Id: pam_env.c,v 1.5 2002/03/27 02:36:24 bbraun Exp $
+.\"
+.\" Written by Dave Kinchlea <kinch@kinch.ark.com> 1997/01/31
+.\" Inspired by Andrew Morgan <morgan@kernel.org>, who also supplied the 
+.\" template for this file (via pam_mail)
+.\"
+.\" Portions Copyright (C) 2002-2009 Apple Inc.  All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms of Linux-PAM, with
+.\" or without modification, are permitted provided that the following
+.\" conditions are met:
+.\" 
+.\" 1. Redistributions of source code must retain any existing copyright
+.\" notice, and this entire permission notice in its entirety,
+.\" including the disclaimer of warranties.
+.\" 
+.\" 2. Redistributions in binary form must reproduce all prior and current
+.\" copyright notices, this list of conditions, and the following
+.\" disclaimer in the documentation and/or other materials provided
+.\" with the distribution.
+.\" 
+.\" 3. The name of any author may not be used to endorse or promote
+.\" products derived from this software without their specific prior
+.\" written permission.
+.\"
+.\" THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+.\" WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+.\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+.\" IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+.\" INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+.\" BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+.\" OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+.\" ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+.\" TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+.\" USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+.\" DAMAGE. 
+.\"
+.Dd February 7, 2009
+.Dt pam_env 8
+.Os
+.Sh NAME
+.Nm pam_env
+.Nd The Environment PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_env
+.Op Ar options
+.Sh DESCRIPTION
+The Environment PAM module supports the authentication and session management function classes.  In terms of the
+.Ar function-class
+parameter, these are
+.Dq Li auth
+and
+.Dq Li session
+respectively.  The Environment PAM module has identical support for both supported function classes.
+.Pp
+The Environment PAM module allows the setting and unsetting of environment variables.  The use of previously set environment variables as well as PAM_ITEMs such as PAM_RHOST is supported.
+.Pp
+This module can also parse a file with simple KEY=VAL pairs on separate lines
+.Pq /etc/environment by default .
+You can change the default file to parse, with the
+.Cm envfile
+flag and turn it on or off by setting the
+.Cm readenv
+flag to 1 or 0 respectively.
+.Pp
+The following options may be passed to this module:
+.Bl -tag
+.It Cm conffile=/path/to/pam_env.conf
+Indicate an alternative pam_env.conf style configuration file to override the default. This can be useful when different services need different environments.
+.It Cm debug
+A lot of debug information will be printed to the system log.
+.It Cm envfile=/path/to/environment
+Indicate an alternative environment file to override the default. This can be useful when different services need different environments.
+.It Cm readenv=0|1
+Turns on or off the reading of the file specified by envfile (0 is off, 1 is on). By default this option is on.
+.El
+.Sh FILES
+.Bl -tag
+.It Pa /etc/security/pam_env.conf
+The default configuration file.
+.It Pa /etc/environment
+The default environment file.
+.El
+.Sh SEE ALSO
+.Xr environ 7 ,
+.Xr pam.conf 5 ,
+.Xr pam 8
+.Sh AUTHORS
+The
+.Nm
+module was written by Dave Kinchlea <kinch@kinch.ark.com>.

--- a/src/pam_modules/modules/pam_env/pam_env.c
+++ b/src/pam_modules/modules/pam_env/pam_env.c
@@ -1,0 +1,850 @@
+/*
+ * $Id: pam_env.c,v 1.5 2002/03/27 02:36:24 bbraun Exp $
+ *
+ * Written by Dave Kinchlea <kinch@kinch.ark.com> 1997/01/31
+ * Inspired by Andrew Morgan <morgan@kernel.org>, who also supplied the 
+ * template for this file (via pam_mail)
+ *
+ * Portions Copyright (C) 2002-2009 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms of Linux-PAM, with
+ * or without modification, are permitted provided that the following
+ * conditions are met:
+ * 
+ * 1. Redistributions of source code must retain any existing copyright
+ * notice, and this entire permission notice in its entirety,
+ * including the disclaimer of warranties.
+ * 
+ * 2. Redistributions in binary form must reproduce all prior and current
+ * copyright notices, this list of conditions, and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * 
+ * 3. The name of any author may not be used to endorse or promote
+ * products derived from this software without their specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE. 
+ */
+
+#ifndef DEFAULT_CONF_FILE
+#define DEFAULT_CONF_FILE       "/etc/security/pam_env.conf"
+#endif
+
+#define DEFAULT_ETC_ENVFILE     "/etc/environment"
+#define DEFAULT_READ_ENVFILE    1
+
+#include <ctype.h>
+#include <errno.h>
+#include <pwd.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "Logging.h"
+
+#ifdef __APPLE__
+#include <System/sys/codesign.h>
+#endif /* __APPLE__ */
+
+/*
+ * here, we make a definition for the externally accessible function
+ * in this file (this definition is required for static a module
+ * but strongly encouraged generally) it is used to instruct the
+ * modules include file to define the function prototypes.
+ */
+
+#define PAM_SM_AUTH         /* This is primarily a AUTH_SETCRED module */
+#define PAM_SM_SESSION      /* But I like to be friendly */
+#define PAM_SM_PASSWORD     /*        ""                 */
+#define PAM_SM_ACCOUNT      /*        ""                 */
+
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+
+/* This little structure makes it easier to keep variables together */
+
+typedef struct var {
+  char *name;
+  char *value;
+  char *defval;
+  char *override;
+} VAR;
+
+#define BUF_SIZE 1024
+#define MAX_ENV  8192
+
+#define GOOD_LINE    0
+#define BAD_LINE     100       /* This must be > the largest PAM_* error code */
+
+#define DEFINE_VAR   101     
+#define UNDEFINE_VAR 102
+#define ILLEGAL_VAR  103
+
+static int  _assemble_line(pam_handle_t *, FILE *, char *, int);
+static int  _parse_line(pam_handle_t *, char *, VAR *);
+static int  _check_var(pam_handle_t *, VAR *);           /* This is the real meat */
+static void _clean_var(pam_handle_t *, VAR *);        
+static int  _expand_arg(pam_handle_t *, char **);
+static const char * _pam_get_item_byname(pam_handle_t *, const char *);
+static int  _define_var(pam_handle_t *, VAR *);
+static int  _undefine_var(pam_handle_t *, VAR *);
+
+/* This is a flag used to designate an empty string */
+static char quote='Z';         
+
+/* argument parsing */
+
+#define PAM_DEBUG_ARG       0x01
+#define PAM_NEW_CONF_FILE   0x02
+#define PAM_ENV_SILENT      0x04
+#define PAM_NEW_ENV_FILE    0x10
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(env)
+#define PAM_LOG PAM_LOG_env()
+#endif
+
+static int _pam_parse(pam_handle_t *pamh, int flags, int argc, const char **argv, char **conffile,
+	char **envfile, int *readenv)
+{
+    int ctrl=0;
+	const char *readenvchar = NULL;
+
+	/* generic options */
+
+	if (NULL != openpam_get_option(pamh, "debug")) {
+		_LOG_DEBUG("debugging on");
+		ctrl |= PAM_DEBUG_ARG;
+	}
+	if (NULL != (*conffile = (char *)openpam_get_option(pamh, "conffile"))) {
+		_LOG_DEBUG("new Configuration File: %s", *conffile);
+		ctrl |= PAM_NEW_CONF_FILE;
+	}
+	if (NULL != (*envfile = (char *)openpam_get_option(pamh, "conffile"))) {
+		_LOG_DEBUG("new Env File: %s", *envfile);
+		ctrl |= PAM_NEW_ENV_FILE;
+	}
+	readenvchar = (char *)openpam_get_option(pamh, "readenv");
+	if (NULL != readenvchar && 0 != (*readenv = atoi(readenvchar))) {
+		_LOG_DEBUG("readenv: %d", *readenv);
+	}
+
+    return ctrl;
+}
+
+static int _parse_config_file(pam_handle_t *pamh, int ctrl, char **conffile)
+{
+    int retval;
+    const char *file;
+    char buffer[BUF_SIZE];
+    FILE *conf;
+    VAR Var, *var=&Var;   
+
+    var->name=NULL; var->defval=NULL; var->override=NULL;
+    _LOG_DEBUG("Called.");
+
+    if (ctrl & PAM_NEW_CONF_FILE) {
+	file = *conffile;
+    } else {
+	file = DEFAULT_CONF_FILE;
+    }
+
+    _LOG_DEBUG("Config file name is: %s", file);
+
+    /* 
+     * Lets try to open the config file, parse it and process 
+     * any variables found.
+     */
+
+    if ((conf = fopen(file,"r")) == NULL) {
+      _LOG_ERROR("Unable to open config file: %s",
+	       strerror(errno));
+      return PAM_IGNORE;
+    }
+
+    /* _pam_assemble_line will provide a complete line from the config file, with all 
+     * comments removed and any escaped newlines fixed up
+     */
+
+    while (( retval = _assemble_line(pamh, conf, buffer, BUF_SIZE)) > 0) {
+      _LOG_DEBUG("Read line: %s", buffer);
+
+      if ((retval = _parse_line(pamh, buffer, var)) == GOOD_LINE) {
+	retval = _check_var(pamh, var);
+
+	if (DEFINE_VAR == retval) {
+	  retval = _define_var(pamh, var);     
+
+	} else if (UNDEFINE_VAR == retval) {
+	  retval = _undefine_var(pamh, var);   
+	} 
+      } 
+      if (PAM_SUCCESS != retval && ILLEGAL_VAR != retval 
+	  && BAD_LINE != retval) break;
+      
+      _clean_var(pamh, var);    
+
+    }  /* while */
+    
+    (void) fclose(conf);
+
+    /* tidy up */
+    _clean_var(pamh, var);        /* We could have got here prematurely, this is safe though */
+    if (NULL != conffile) {
+        memset(conffile, 0, sizeof(*conffile));
+        *conffile = NULL;
+    }
+    file = NULL;
+    _LOG_DEBUG("Exit.");
+    return (retval<0?PAM_ABORT:PAM_SUCCESS);
+}
+
+static int _parse_env_file(pam_handle_t *pamh, int ctrl, char **env_file)
+{
+    int retval=PAM_SUCCESS, i, t;
+    const char *file;
+    char buffer[BUF_SIZE], *key, *mark;
+    FILE *conf;
+
+    if (ctrl & PAM_NEW_ENV_FILE)
+	file = *env_file;
+    else
+	file = DEFAULT_ETC_ENVFILE;
+
+    _LOG_DEBUG("Env file name is: %s", file);
+
+    if ((conf = fopen(file,"r")) == NULL) {
+      _LOG_DEBUG("Unable to open env file: %s", strerror(errno));
+      return PAM_ABORT;
+    }
+
+    while (_assemble_line(pamh, conf, buffer, BUF_SIZE) > 0) {
+	_LOG_DEBUG("Read line: %s", buffer);
+	key = buffer;
+
+	/* skip leading white space */
+	key += strspn(key, " \n\t");
+
+	/* skip blanks lines and comments */
+	if (!key || key[0] == '#')
+	    continue;
+
+	/* skip over "export " if present so we can be compat with
+	   bash type declerations */
+	if (strncmp(key, "export ", (size_t) 7) == 0)
+	    key += 7;
+
+	/* now find the end of value */
+	mark = key;
+	while(mark[0] != '\n' && mark[0] != '#' && mark[0] != '\0')
+	    mark++;
+	if (mark[0] != '\0')
+	    mark[0] = '\0';
+
+       /*
+	* sanity check, the key must be alpha-numeric
+	*/
+
+	for ( i = 0 ; key[i] != '=' && key[i] != '\0' ; i++ )
+	if (!isalnum(key[i]) && key[i] != '_') {
+		_LOG_DEBUG("key is not alpha numeric - '%s', ignoring", key);
+		continue;
+	    }
+
+	/* now we try to be smart about quotes around the value,
+	   but not too smart, we can't get all fancy with escaped
+	   values like bash */
+	if (key[i] == '=' && (key[++i] == '\"' || key[i] == '\'')) {
+	    for ( t = i+1 ; key[t] != '\0' ; t++)
+		if (key[t] != '\"' && key[t] != '\'')
+		    key[i++] = key[t];
+		else if (key[t+1] != '\0')
+		    key[i++] = key[t];
+	    key[i] = '\0';
+	}
+
+	/* set the env var, if it fails, we break out of the loop */
+	retval = pam_putenv(pamh, key);
+	if (retval != PAM_SUCCESS) {
+	    _LOG_DEBUG("error setting env \"%s\"", key);
+	    break;
+	}
+    }
+    
+    (void) fclose(conf);
+
+    /* tidy up */
+	if (NULL != env_file) {
+        memset(env_file, 0, sizeof(*env_file));
+        *env_file = NULL;
+    }
+    file = NULL;
+    _LOG_DEBUG("Exit.");
+    return (retval<0?PAM_IGNORE:PAM_SUCCESS);
+}
+
+/*
+ * This is where we read a line of the PAM config file. The line may be
+ * preceeded by lines of comments and also extended with "\\\n"
+ */
+
+static int _assemble_line(pam_handle_t *pamh, FILE *f, char *buffer, int buf_len)
+{
+    char *p = buffer;
+    char *s, *os;
+    int used = 0;
+
+    /* loop broken with a 'break' when a non-'\\n' ended line is read */
+
+    _LOG_DEBUG("called.");
+    for (;;) {
+	if (used >= buf_len) {
+	    /* Overflow */
+	    _LOG_DEBUG("_assemble_line: overflow");
+	    return -1;
+	}
+	if (fgets(p, buf_len - used, f) == NULL) {
+	    if (used) {
+		/* Incomplete read */
+		return -1;
+	    } else {
+		/* EOF */
+		return 0;
+	    }
+	}
+
+	/* skip leading spaces --- line may be blank */
+
+	s = p + strspn(p, " \n\t");
+	if (*s && (*s != '#')) {
+	    os = s;
+
+	    /*
+	     * we are only interested in characters before the first '#'
+	     * character
+	     */
+
+	    while (*s && *s != '#')
+		 ++s;
+	    if (*s == '#') {
+		 *s = '\0';
+		 used += strlen(os);
+		 break;                /* the line has been read */
+	    }
+
+	    s = os;
+
+	    /*
+	     * Check for backslash by scanning back from the end of
+	     * the entered line, the '\n' has been included since
+	     * normally a line is terminated with this
+	     * character. fgets() should only return one though!
+	     */
+
+	    s += strlen(s);
+	    while (s > os && ((*--s == ' ') || (*s == '\t')
+			      || (*s == '\n')));
+
+	    /* check if it ends with a backslash */
+	    if (*s == '\\') {
+		*s = '\0';              /* truncate the line here */
+		used += strlen(os);
+		p = s;                  /* there is more ... */
+	    } else {
+		/* End of the line! */
+		used += strlen(os);
+		break;                  /* this is the complete line */
+	    }
+
+	} else {
+	    /* Nothing in this line */
+	    /* Don't move p         */
+	}
+    }
+
+    return used;
+}
+
+static int _parse_line(pam_handle_t *pamh, char *buffer, VAR *var)
+{
+  /* 
+   * parse buffer into var, legal syntax is 
+   * VARIABLE [DEFAULT=[[string]] [OVERRIDE=[value]]
+   *
+   * Any other options defined make this a bad line, 
+   * error logged and no var set
+   */
+  
+  long length, quoteflg=0;
+  char *ptr, **valptr, *tmpptr; 
+  
+  _LOG_DEBUG("Called buffer = <%s>", buffer);
+
+  length = strcspn(buffer," \t\n");
+  
+  if ((var->name = malloc(length + 1)) == NULL) {
+      _LOG_ERROR("Couldn't malloc %ld bytes", length+1);
+    return PAM_BUF_ERR;
+  }
+  
+  /* 
+   * The first thing on the line HAS to be the variable name, 
+   * it may be the only thing though.
+   */
+  strncpy(var->name, buffer, length);
+  var->name[length] = '\0';
+    _LOG_DEBUG("var->name = <%s>, length = %ld", var->name, length);
+
+  /* 
+   * Now we check for arguments, we only support two kinds and ('cause I am lazy)
+   * each one can actually be listed any number of times
+   */
+  
+  ptr = buffer+length;
+  while ((length = strspn(ptr, " \t")) > 0) { 
+    ptr += length;                              /* remove leading whitespace */
+    _LOG_DEBUG("ptr: %s", ptr);
+    if (strncmp(ptr,"DEFAULT=",8) == 0) {
+      ptr+=8;
+      _LOG_DEBUG("Default arg found: <%s>", ptr);
+      valptr=&(var->defval);
+    } else if (strncmp(ptr, "OVERRIDE=", 9) == 0) {
+      ptr+=9;
+      _LOG_DEBUG("Override arg found: <%s>", ptr);
+      valptr=&(var->override);
+    } else {
+      _LOG_ERROR("Unrecognized option: %s - ignoring line", ptr);
+      return BAD_LINE;
+    }
+    
+    if ('"' != *ptr) {       /* Escaped quotes not supported */
+      length = strcspn(ptr, " \t\n");
+      tmpptr = ptr+length;
+    } else {
+      tmpptr = strchr(++ptr, '"');   
+      if (!tmpptr) {
+	_LOG_ERROR("Unterminated quoted string: %s", ptr-1);
+	return BAD_LINE;
+      }
+      length = tmpptr - ptr;        
+      if (*++tmpptr && ' ' != *tmpptr && '\t' != *tmpptr && '\n' != *tmpptr) {
+	_LOG_ERROR("Quotes must cover the entire string: <%s>", ptr);
+	return BAD_LINE;
+      }
+      quoteflg++;
+    }
+    if (length) {
+      if ((*valptr = malloc(length + 1)) == NULL) {
+          _LOG_ERROR("Couldn't malloc %ld bytes", length+1);
+	return PAM_BUF_ERR;
+      }
+      (void)strncpy(*valptr,ptr,length);
+      (*valptr)[length]='\0';
+    } else if (quoteflg--) {
+      *valptr = &quote;      /* a quick hack to handle the empty string */
+    }
+    ptr = tmpptr;         /* Start the search where we stopped */
+  } /* while */
+  
+  /* 
+   * The line is parsed, all is well.
+   */
+  
+  _LOG_DEBUG("Exit.");
+  ptr = NULL; tmpptr = NULL; valptr = NULL;
+  return GOOD_LINE;
+}
+
+static int _check_var(pam_handle_t *pamh, VAR *var)
+{
+  /* 
+   * Examine the variable and determine what action to take. 
+   * Returns DEFINE_VAR, UNDEFINE_VAR depending on action to take
+   * or a PAM_* error code if passed back from other routines
+   *
+   * if no DEFAULT provided, the empty string is assumed
+   * if no OVERRIDE provided, the empty string is assumed
+   * if DEFAULT=  and OVERRIDE evaluates to the empty string, 
+   *    this variable should be undefined
+   * if DEFAULT=""  and OVERRIDE evaluates to the empty string, 
+   *    this variable should be defined with no value
+   * if OVERRIDE=value   and value turns into the empty string, DEFAULT is used
+   *
+   * If DEFINE_VAR is to be returned, the correct value to define will
+   * be pointed to by var->value
+   */
+
+  int retval;
+
+  _LOG_DEBUG("Called.");
+
+  /*
+   * First thing to do is to expand any arguments, but only
+   * if they are not the special quote values (cause expand_arg
+   * changes memory).
+   */
+
+  if (var->defval && (&quote != var->defval) &&
+      ((retval = _expand_arg(pamh, &(var->defval))) != PAM_SUCCESS)) {
+      return retval;
+  }
+  if (var->override && (&quote != var->override) &&
+      ((retval = _expand_arg(pamh, &(var->override))) != PAM_SUCCESS)) {
+    return retval;
+  }
+
+  /* Now its easy */
+  
+  if (var->override && *(var->override) && &quote != var->override) { 
+    /* if there is a non-empty string in var->override, we use it */
+    _LOG_DEBUG("OVERRIDE variable <%s> being used: <%s>", var->name, var->override);
+    var->value = var->override;
+    retval = DEFINE_VAR;
+  } else {
+    
+    var->value = var->defval;
+    if (&quote == var->defval) {
+      /* 
+       * This means that the empty string was given for defval value 
+       * which indicates that a variable should be defined with no value
+       */
+      *var->defval = '\0';
+      _LOG_DEBUG("An empty variable: <%s>", var->name);
+      retval = DEFINE_VAR;
+    } else if (var->defval) {
+      _LOG_DEBUG("DEFAULT variable <%s> being used: <%s>", var->name, var->defval);
+      retval = DEFINE_VAR;
+    } else {
+      _LOG_DEBUG("UNDEFINE variable <%s>", var->name);
+      retval = UNDEFINE_VAR;
+    }
+  }
+
+  _LOG_DEBUG("Exit.");
+  return retval;
+}
+
+static int _expand_arg(pam_handle_t *pamh, char **value)
+{
+  const char *orig=*value, *tmpptr=NULL;
+  char *ptr;       /* 
+		    * Sure would be nice to use tmpptr but it needs to be 
+		    * a constant so that the compiler will shut up when I
+		    * call pam_getenv and _pam_get_item_byname -- sigh
+		    */
+		      
+  /* No unexpanded variable can be bigger than BUF_SIZE */
+  char type, tmpval[BUF_SIZE];
+
+  /* I know this shouldn't be hard-coded but it's so much easier this way */
+  char tmp[MAX_ENV];
+
+  _LOG_DEBUG("Remember to initialize tmp!");
+  memset(tmp, 0, MAX_ENV);
+
+  /* 
+   * (possibly non-existent) environment variables can be used as values
+   * by prepending a "$" and wrapping in {} (ie: ${HOST}), can escape with "\"
+   * (possibly non-existent) PAM items can be used as values 
+   * by prepending a "@" and wrapping in {} (ie: @{PAM_RHOST}, can escape 
+   *
+   */
+  _LOG_DEBUG("Expanding <%s>",orig);
+  while (*orig) {     /* while there is some input to deal with */
+    if ('\\' == *orig) {
+      ++orig;
+      if ('$' != *orig && '@' != *orig) {
+          _LOG_DEFAULT("Unrecognized escaped character: <%c> - ignoring", *orig);
+      } else if ((strlen(tmp) + 1) < MAX_ENV) {
+	tmp[strlen(tmp)] = *orig++;        /* Note the increment */
+      } else {
+          /* is it really a good idea to try to log this? */
+          _LOG_DEBUG("Variable buffer overflow: <%s> + <%s>", tmp, tmpptr);
+      }
+      continue;
+    } 
+    if ('$' == *orig || '@' == *orig) {
+      if ('{' != *(orig+1)) {
+	_LOG_DEFAULT("Expandable variables must be wrapped in {}"
+	   " <%s> - ignoring", orig);
+	if ((strlen(tmp) + 1) < MAX_ENV) {
+	  tmp[strlen(tmp)] = *orig++;        /* Note the increment */
+	}
+	continue;
+      } else {
+	_LOG_DEBUG("Expandable argument: <%s>", orig);
+	type = *orig;
+	orig+=2;     /* skip the ${ or @{ characters */
+	ptr = strchr(orig, '}');
+	if (ptr) { 
+	  *ptr++ = '\0';
+	} else {
+	  _LOG_ERROR("Unterminated expandable variable: <%s>", orig-2);
+	  return PAM_ABORT;
+	}
+	strncpy(tmpval, orig, sizeof(tmpval));
+	tmpval[sizeof(tmpval)-1] = '\0';
+	orig=ptr;
+	/* 
+	 * so, we know we need to expand tmpval, it is either 
+	 * an environment variable or a PAM_ITEM. type will tell us which
+	 */
+	switch (type) {
+	  
+	case '$':
+	  _LOG_DEBUG("Expanding env var: <%s>",tmpval);
+	  tmpptr = pam_getenv(pamh, tmpval);
+	  _LOG_DEBUG("Expanded to <%s>", tmpptr);
+	  break;
+	  
+	case '@':
+	  _LOG_DEBUG("Expanding pam item: <%s>",tmpval);
+	  tmpptr = _pam_get_item_byname(pamh, tmpval);
+	  _LOG_DEBUG("Expanded to <%s>", tmpptr);
+	  break;
+
+	default:
+	  _LOG_ERROR("Impossible error, type == <%c>", type);
+	  return PAM_ABORT;
+	}         /* switch */
+	
+	if (tmpptr) {
+	  if (strlcat(tmp, tmpptr, MAX_ENV) >= MAX_ENV) {
+	    /* is it really a good idea to try to log this? */
+	    _LOG_ERROR("Variable buffer overflow: <%s> + <%s>", tmp, tmpptr);
+	  }
+	}
+      }           /* if ('{' != *orig++) */
+    } else {      /* if ( '$' == *orig || '@' == *orig) */
+      if ((strlen(tmp) + 1) < MAX_ENV) {
+	tmp[strlen(tmp)] = *orig++;        /* Note the increment */
+      } else {
+	/* is it really a good idea to try to log this? */
+	_LOG_ERROR("Variable buffer overflow: <%s> + <%s>", tmp, tmpptr);
+      }
+    }
+  }              /* for (;*orig;) */
+
+  size_t tmp_len = strlen(tmp);
+  if (tmp_len > strlen(*value)) {
+    free(*value);
+    if ((*value = malloc(tmp_len+1)) == NULL) {
+        _LOG_ERROR("Couldn't malloc %lu bytes for expanded var",
+	       tmp_len+1);
+      return PAM_BUF_ERR;
+    }
+  }
+  strlcpy(*value, tmp, tmp_len+1);
+  _LOG_DEBUG("Exit.");
+
+  return PAM_SUCCESS;
+}
+
+static const char * _pam_get_item_byname(pam_handle_t *pamh, const char *name)
+{
+  /* 
+   * This function just allows me to use names as given in the config
+   * file and translate them into the appropriate PAM_ITEM macro
+   */
+
+  int item;
+  const char *itemval;
+
+  _LOG_DEBUG("Called.");
+  if (strcmp(name, "PAM_USER") == 0) {
+    item = PAM_USER;
+  } else if (strcmp(name, "PAM_USER_PROMPT") == 0) {
+    item = PAM_USER_PROMPT;
+  } else if (strcmp(name, "PAM_TTY") == 0) {
+    item = PAM_TTY;
+  } else if (strcmp(name, "PAM_RUSER") == 0) {
+    item = PAM_RUSER;
+  } else if (strcmp(name, "PAM_RHOST") == 0) {
+    item = PAM_RHOST;
+  } else {
+    _LOG_ERROR("Unknown PAM_ITEM: <%s>", name);
+    return NULL;
+  }
+  
+  if (pam_get_item(pamh, item, (const void **)&itemval) != PAM_SUCCESS) {
+    _LOG_DEBUG("pam_get_item failed");
+    return NULL;     /* let pam_get_item() log the error */
+  }
+  _LOG_DEBUG("Exit.");
+  return itemval;
+}
+
+static int _define_var(pam_handle_t *pamh, VAR *var)
+{
+  /* We have a variable to define, this is a simple function */
+  
+  char *envvar;
+  long size;
+  int retval=PAM_SUCCESS;
+  
+  _LOG_DEBUG("Called.");
+  size = strlen(var->name)+strlen(var->value)+2;
+  if ((envvar = malloc(size)) == NULL) {
+      _LOG_ERROR("Malloc fail, size = %ld", size);
+    return PAM_BUF_ERR;
+  }
+  (void) snprintf(envvar,size,"%s=%s",var->name,var->value);
+  retval = pam_putenv(pamh, envvar);
+  free(envvar); envvar=NULL;
+  _LOG_DEBUG("Exit.");
+  return retval;
+}
+
+static int _undefine_var(pam_handle_t *pamh, VAR *var)
+{
+  /* We have a variable to undefine, this is a simple function */
+  
+  _LOG_DEBUG("Called and exit.");
+  return pam_putenv(pamh, var->name);
+}
+
+static void   _clean_var(pam_handle_t *pamh, VAR *var)
+{
+    if (var->name) {
+      free(var->name); 
+    }
+    if (var->defval && (&quote != var->defval)) {
+      free(var->defval); 
+    }
+    if (var->override && (&quote != var->override)) {
+      free(var->override); 
+    }
+    var->name = NULL;
+    var->value = NULL;    /* never has memory specific to it */
+    var->defval = NULL;
+    var->override = NULL;
+    return;
+}
+
+
+
+/* --- authentication management functions (only) --- */
+
+PAM_EXTERN
+int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
+			const char **argv)
+{ 
+  return PAM_IGNORE;
+}
+
+PAM_EXTERN 
+int pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, 
+		   const char **argv)
+{
+  int retval, ctrl, readenv=DEFAULT_READ_ENVFILE;
+  char *conf_file=NULL, *env_file=NULL;
+
+  /*
+   * this module sets environment variables read in from a file
+   */
+  
+  _LOG_DEBUG("Called.");
+  ctrl = _pam_parse(pamh, flags, argc, argv, &conf_file, &env_file, &readenv);
+
+  retval = _parse_config_file(pamh, ctrl, &conf_file);
+
+  if(readenv)
+    _parse_env_file(pamh, ctrl, &env_file);
+
+  /* indicate success or failure */
+  
+  _LOG_DEBUG("Exit.");
+  return retval;
+}
+
+PAM_EXTERN 
+int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, 
+		     const char **argv)
+{
+  _LOG_ERROR("pam_sm_acct_mgmt called inappropriatly");
+  return PAM_SERVICE_ERR;
+}
+ 
+PAM_EXTERN
+int pam_sm_open_session(pam_handle_t *pamh,int flags,int argc
+			,const char **argv)
+{
+  int retval, ctrl, readenv=DEFAULT_READ_ENVFILE;
+  char *conf_file=NULL, *env_file=NULL;
+  
+  /*
+   * this module sets environment variables read in from a file
+   */
+    
+#ifdef __APPLE__
+  int csflags = 0;
+  int rv = 0;
+  pid_t pid = getpid();
+  rv = csops(pid, CS_OPS_STATUS, &csflags, sizeof(csflags));
+  if (rv != 0 ||  (rv == 0 && (csflags & CS_INSTALLER) != 0)) {
+    _LOG_ERROR("Disallowed due to CS_INSTALLER, rv %d", rv);
+    return PAM_SERVICE_ERR;
+  }
+#endif // __APPLE__
+  
+  _LOG_DEBUG("Called.");
+  ctrl = _pam_parse(pamh, flags, argc, argv, &conf_file, &env_file, &readenv);
+  
+  retval = _parse_config_file(pamh, ctrl, &conf_file);
+  
+  if(readenv)
+    _parse_env_file(pamh, ctrl, &env_file);
+
+  /* indicate success or failure */
+  
+  _LOG_DEBUG("Exit.");
+  return retval;
+}
+
+PAM_EXTERN
+int pam_sm_close_session(pam_handle_t *pamh,int flags,int argc,
+			 const char **argv)
+{
+  _LOG_DEBUG("Called and Exit");
+  return PAM_SUCCESS;
+}
+
+PAM_EXTERN 
+int pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, 
+		     const char **argv)
+{
+  _LOG_ERROR("pam_sm_chauthtok called inappropriatly");
+  return PAM_SERVICE_ERR;
+}
+
+#ifdef PAM_STATIC
+
+/* static module data */
+
+struct pam_module _pam_env_modstruct = {
+     "pam_env",
+     pam_sm_authenticate,
+     pam_sm_setcred,
+     pam_sm_acct_mgmt,
+     pam_sm_open_session,
+     pam_sm_close_session,
+     pam_sm_chauthtok,
+};
+
+#endif
+
+/* end of module definition */

--- a/src/pam_modules/modules/pam_env/pam_env.conf-example
+++ b/src/pam_modules/modules/pam_env/pam_env.conf-example
@@ -1,0 +1,72 @@
+# $Date: 2002/03/27 02:36:24 $
+# $Author: bbraun $
+# $Id: pam_env.conf-example,v 1.4 2002/03/27 02:36:24 bbraun Exp $
+#
+# This is the configuration file for pam_env, a PAM module to load in 
+# a configurable list of environment variables for a 
+# 
+# The original idea for this came from Andrew G. Morgan ...
+#<quote>
+#   Mmm. Perhaps you might like to write a pam_env module that reads a
+#   default environment from a file? I can see that as REALLY
+#   useful... Note it would be an "auth" module that returns PAM_IGNORE
+#   for the auth part and sets the environment returning PAM_SUCCESS in
+#   the setcred function...
+#</quote>
+#
+# What I wanted was the REMOTEHOST variable set, purely for selfish
+# reasons, and AGM didn't want it added to the SimpleApps login
+# program (which is where I added the patch). So, my first concern is
+# that variable, from there there are numerous others that might/would
+# be useful to be set: NNTPSERVER, LESS, PATH, PAGER, MANPAGER .....
+#
+# Of course, these are a different kind of variable than REMOTEHOST in
+# that they are things that are likely to be configured by
+# administrators rather than set by logging in, how to treat them both
+# in the same config file?
+#
+# Here is my idea: 
+#
+# Each line starts with the variable name, there are then two possible
+# options for each variable DEFAULT and OVERRIDE. 
+# DEFAULT allows and administrator to set the value of the
+# variable  to some default value, if none is supplied then the empty
+# string is assumed. The OVERRIDE option tells pam_env that it should
+# enter in its value (overriding the default value) if there is one
+# to use. OVERRIDE is not used, "" is assumed and no override will be
+# done. 
+#
+# VARIABLE   [DEFAULT=[value]]  [OVERRIDE=[value]]
+#
+# (Possibly non-existent) environment variables may be used in values
+# using the ${string} syntax and (possibly non-existent) PAM_ITEMs may
+# be used in values using the @{string} syntax. Both the $ and @
+# characters can be backslash escaped to be used as literal values
+# values can be delimited with "", escaped " not supported.
+#
+#
+# First, some special variables
+#
+# Set the REMOTEHOST variable for any hosts that are remote, default
+# to "localhost" rather than not being set at all
+#REMOTEHOST	DEFAULT=localhost OVERRIDE=@{PAM_RHOST}
+#
+# Set the DISPLAY variable if it seems reasonable 
+#DISPLAY		DEFAULT=${REMOTEHOST}:0.0 OVERRIDE=${DISPLAY}
+#
+#
+#  Now some simple variables
+#
+#PAGER		DEFAULT=less
+#MANPAGER	DEFAULT=less
+#LESS		DEFAULT="M q e h15 z23 b80"
+#NNTPSERVER	DEFAULT=localhost
+#PATH		DEFAULT=${HOME}/bin:/usr/local/bin:/bin\
+#:/usr/bin:/usr/local/bin/X11:/usr/bin/X11
+#
+# silly examples of escaped variables, just to show how they work.
+#
+#DOLLAR		DEFAULT=\$
+#DOLLARDOLLAR	DEFAULT=	OVERRIDE=\$${DOLLAR}
+#DOLLARPLUS	DEFAULT=\${REMOTEHOST}${REMOTEHOST}
+#ATSIGN		DEFAULT=""	OVERRIDE=\@

--- a/src/pam_modules/modules/pam_group/pam_group.8
+++ b/src/pam_modules/modules/pam_group/pam_group.8
@@ -1,0 +1,97 @@
+.\" Copyright (c) 2003 Networks Associates Technology, Inc.
+.\" All rights reserved.
+.\" Copyright (c) 2008-2009 Apple Inc. All rights reserved.
+.\"
+.\" Portions of this software were developed for the FreeBSD Project by
+.\" ThinkSec AS and NAI Labs, the Security Research Division of Network
+.\" Associates, Inc.  under DARPA/SPAWAR contract N66001-01-C-8035
+.\" ("CBOSS"), as part of the DARPA CHATS research program.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\" 3. The name of the author may not be used to endorse or promote
+.\"    products derived from this software without specific prior written
+.\"    permission.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
+.\"
+.\" $FreeBSD: src/lib/libpam/modules/pam_group/pam_group.8,v 1.3 2004/07/02 23:52:17 ru Exp $
+.\"
+.\" Protions copyright (c) 2009 Apple Inc. All rights reserved.
+.\"
+.Dd February 7, 2009
+.Dt pam_group 8
+.Os
+.Sh NAME
+.Nm pam_group
+.Nd Group PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_group
+.Op Ar options
+.Sh DESCRIPTION
+The Group PAM module supports the account management function class.  In terms of the
+.Ar function-class
+parameter, this is the
+.Dq Li account
+class.
+.Pp
+The Group account management module permits or denies users based on their membership to a particular group
+.Pq or groups
+specified with the 
+.Cm group
+option.  If no groups are specified the default group
+.Pq Dq wheel
+will be used.
+.Pp
+The following options may be passed to this account management module:
+.Bl -tag
+.It Cm deny
+Reverse the meaning of the test, i.e., reject the applicant if and only if he or she is a member of the specified group.  This can be useful to exclude certain groups of users from certain services.
+.It Cm fail_safe
+If the specified group does not exist, or has no members, act as if it does exist and the applicant is a member.
+.It Cm group=groupname
+Specify the name of the group to check.  This can be a comma-separated list 
+.Pq i.e. Dq group=admin,wheel .
+.It Cm root_only
+Skip this module entirely if the target account is not the superuser account.
+.It Cm ruser
+Check the membership of the applicant
+.Pq PAM_RUSER ,
+rather than the target account 
+.Pq PAM_USER
+.
+.El
+.Sh SEE ALSO
+.Xr pam_get_item 3 ,
+.Xr pam.conf 5 ,
+.Xr pam 8 ,
+.Xr DirectoryService 8
+.Sh AUTHORS
+The
+.Nm
+module and this manual page were developed for the
+.Fx
+Project by
+ThinkSec AS and NAI Labs, the Security Research Division of Network
+Associates, Inc.\& under DARPA/SPAWAR contract N66001-01-C-8035
+.Pq Dq CBOSS ,
+as part of the DARPA CHATS research program.

--- a/src/pam_modules/modules/pam_group/pam_group.c
+++ b/src/pam_modules/modules/pam_group/pam_group.c
@@ -1,0 +1,178 @@
+/*-
+ * Copyright (c) 2003 Networks Associates Technology, Inc.
+ * All rights reserved.
+ * Copyright (c) 2008-2009 Apple Inc. All rights reserved.
+ *
+ * Portions of this software were developed for the FreeBSD Project by
+ * ThinkSec AS and NAI Labs, the Security Research Division of Network
+ * Associates, Inc.  under DARPA/SPAWAR contract N66001-01-C-8035
+ * ("CBOSS"), as part of the DARPA CHATS research program.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior written
+ *    permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#include <sys/types.h>
+#include <sys/syslimits.h>
+
+#include <grp.h>
+#include <pwd.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#ifdef __APPLE__
+#include <membership.h>
+#include <stdlib.h>
+#include "Logging.h"
+#endif /* __APPLE__ */
+
+#define PAM_SM_AUTH
+
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <security/openpam.h>
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(group)
+#define PAM_LOG PAM_LOG_group()
+#endif
+
+PAM_EXTERN int
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags __unused,
+    int argc __unused, const char *argv[] __unused)
+{
+	const char *group, *user;
+	const void *ruser;
+#ifndef __APPLE__
+	char *const *list;
+#endif /* !__APPLE__ */
+	struct passwd *pwd;
+	struct passwd pwdbuf;
+	char pwbuffer[2 * PATH_MAX];
+	struct group *grp;
+#ifdef __APPLE__
+	char *str1, *str, *p;
+	int found_group = 0;
+	uuid_t u_uuid, g_uuid;
+	int ismember;
+#endif /* __APPLE__ */
+
+	/* get target account */
+	if (pam_get_user(pamh, &user, NULL) != PAM_SUCCESS ||
+	    user == NULL || getpwnam_r(user, &pwdbuf, pwbuffer, sizeof(pwbuffer), &pwd) != 0 || pwd == NULL) {
+		_LOG_ERROR("Unable to obtain the username.");
+		return (PAM_AUTH_ERR);
+	}
+	if (pwd->pw_uid != 0 && openpam_get_option(pamh, "root_only")) {
+		_LOG_DEBUG("The root_only option means root only.");
+		return (PAM_IGNORE);
+	}
+
+	/* get applicant */
+	if (openpam_get_option(pamh, "ruser") &&
+		(pam_get_item(pamh, PAM_RUSER, &ruser) != PAM_SUCCESS || ruser == NULL || 
+		 getpwnam_r(ruser, &pwdbuf, pwbuffer, sizeof(pwbuffer), &pwd) != 0 || pwd == NULL)) {
+		_LOG_ERROR("Unable to obtain the remote username.");
+		return (PAM_AUTH_ERR);
+	}
+
+	/* get regulating group */
+	if ((group = openpam_get_option(pamh, "group")) == NULL) {
+		group = "wheel";
+		_LOG_DEBUG("With no group specfified, I am defaulting to wheel.");
+	}
+#ifdef __APPLE__
+	str1 = str = strdup(group);
+	while ((p = strsep(&str, ",")) != NULL) {
+		if ((grp = getgrnam(p)) == NULL || grp->gr_mem == NULL)
+			continue;
+
+		/* check if the group is empty */
+		if (*grp->gr_mem == NULL)
+			continue;
+
+		found_group = 1;
+
+		/* check membership */
+		if (mbr_uid_to_uuid(pwd->pw_uid, u_uuid) != 0)
+			continue;
+		if (mbr_gid_to_uuid(grp->gr_gid, g_uuid) != 0)
+			continue;
+		if (mbr_check_membership(u_uuid, g_uuid, &ismember) != 0)
+			continue;
+		if (ismember)
+			goto found;
+	}
+	if (!found_group) {
+		_LOG_ERROR("The specified group (%s) could not be found.", group);
+		goto failed;
+	}
+#else /* !__APPLE__ */
+	if ((grp = getgrnam(group)) == NULL || grp->gr_mem == NULL) {
+		_LOG_ERROR("The specified group (%s) is NULL.", group);
+		goto failed;
+	}
+
+	/* check if the group is empty */
+	if (*grp->gr_mem == NULL) {
+		_LOG_ERROR("The specified group (%s) is empty.", group);
+		goto failed;
+	}
+
+	/* check membership */
+	if (pwd->pw_gid == grp->gr_gid)
+		goto found;
+	for (list = grp->gr_mem; *list != NULL; ++list)
+		if (strcmp(*list, pwd->pw_name) == 0)
+			goto found;
+#endif /* __APPLE__ */
+
+ not_found:
+	_LOG_DEBUG("The group check failed.");
+#ifdef __APPLE__
+	free(str1);
+#endif /* __APPLE__ */
+	if (openpam_get_option(pamh, "deny"))
+		return (PAM_SUCCESS);
+	return (PAM_AUTH_ERR);
+ found:
+	_LOG_DEBUG("The group check succeeded.");
+#ifdef __APPLE__
+	free(str1);
+#endif /* __APPLE__ */
+	if (openpam_get_option(pamh, "deny"))
+		return (PAM_AUTH_ERR);
+	return (PAM_SUCCESS);
+ failed:
+	if (openpam_get_option(pamh, "fail_safe"))
+		goto found;
+	else
+		goto not_found;
+}
+
+
+PAM_MODULE_ENTRY("pam_group");

--- a/src/pam_modules/modules/pam_krb5/pam_krb5.8
+++ b/src/pam_modules/modules/pam_krb5/pam_krb5.8
@@ -1,0 +1,218 @@
+.\"
+.\" $Id: pam_krb5.5,v 1.5 2000/01/05 00:59:56 fcusack Exp $
+.\" $FreeBSD: src/lib/libpam/modules/pam_krb5/pam_krb5.8,v 1.1.2.3 2001/12/17 10:08:31 ru Exp $
+.\"
+.\" Portions Copyright (c) 2008-2009 Apple Inc. All rights reserved.
+.\"
+.Dd January 15, 1999
+.Dt PAM_KRB5 8
+.Os
+.Sh NAME
+.Nm pam_krb5
+.Nd Kerberos 5 PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_krb5
+.Op Ar options
+.Sh DESCRIPTION
+The Kerberos 5 PAM module supports the authentication, account management and password management function classes.
+In terms of the
+.Ar function-class
+parameter, these are
+.Dq Li auth
+,
+.Dq Li account
+and
+.Dq Li password
+respectively.
+.Ss Kerberos 5 Authentication Module
+The Kerberos 5 authentication component
+provides functions to verify the identity of a user
+.Pq Fn pam_sm_authenticate
+and to set user specific credentials
+.Pq Fn pam_sm_setcred .
+.Fn pam_sm_authenticate
+converts the supplied username into a Kerberos principal,
+by appending the default local realm name.
+It also supports usernames with explicit realm names.
+If a realm name is supplied, then upon a successful return, it
+changes the username by mapping the principal name into a local username
+(calling
+.Fn krb5_aname_to_localname ) .
+This typically just means
+the realm name is stripped.
+.Pp
+It prompts the user for a password and obtains a new Kerberos TGT for
+the principal.
+The TGT is verified by obtaining a service
+ticket for the local host.
+.Pp
+When prompting for the current password, the authentication
+module will use the prompt
+.Dq Li "Password for <principal>:" .
+.Pp
+The
+.Fn pam_sm_setcred
+function stores the newly acquired credentials in a credentials cache,
+and sets the environment variable
+.Ev KRB5CCNAME
+appropriately.
+The credentials cache should be destroyed by the user at logout with
+.Xr kdestroy 1 .
+.Pp
+The following options may be passed to this authentication module:
+.Bl -tag -width ".Cm default_principal"
+.It Cm debug
+.Xr openpam_log 3
+debugging information at
+.Dv _LOG_DEBUG
+level.
+.It Cm use_first_pass
+If the authentication module is not the first in the stack,
+and a previous module obtained the user's password, that password is
+used to authenticate the user.
+If this fails, the authentication
+module returns failure without prompting the user for a password.
+This option has no effect if the authentication module is
+the first in the stack, or if no previous modules obtained the
+user's password.
+.It Cm try_first_pass
+This option is similar to the
+.Cm use_first_pass
+option, except that if the previously obtained password fails, the
+user is prompted for another password.
+.It Cm forwardable
+Obtain forwardable Kerberos credentials for the user.
+.It Cm no_auth_ccache
+Do not save obtained credentials in a credentials cache during authorization.
+.It Cm no_ccache
+Do not save the obtained credentials in a credentials cache.
+This is a
+useful option if the authentication module is used for services such
+as ftp or pop, where the user would not be able to destroy them.
+[This
+is not a recommendation to use the module for those services.]
+.It Cm ccache Ns = Ns Ar name
+Use
+.Ar name
+as the credentials cache.
+.Ar name
+must be in the form
+.Ar type : Ns Ar residual .
+The special tokens
+.Ql %u ,
+to designate the decimal UID of the user;
+and
+.Ql %p ,
+to designate the current process ID; can be used in
+.Ar name .
+.It Cm default_principal
+Construct the principal from the authenticating user's username, rather
+than obtaining it from the AuthenticationAuthority of the  user's
+OpenDirectory record.
+.It Cm use_kcminit
+Don't verify password, instead store the password in kcm and return
+success in the pam chain.  So when used in this mode, the pam_krb5
+module needs to be configured to be
+.Ql optional
+and some other module
+.Ql required .
+.El
+.Ss Kerberos 5 Account Management Module
+The Kerberos 5 account management component
+provides a function to perform account management,
+.Fn pam_sm_acct_mgmt .
+The function verifies that the authenticated principal is allowed
+to login to the local user account by calling
+.Fn krb5_kuserok
+(which checks the user's
+.Pa .k5login
+file).
+.Ss Kerberos 5 Password Management Module
+The Kerberos 5 password management component
+provides a function to change passwords
+.Pq Fn pam_sm_chauthtok .
+The username supplied (the
+user running the
+.Xr passwd 1
+command, or the username given as an argument) is mapped into
+a Kerberos principal name, using the same technique as in
+the authentication module.
+Note that if a realm name was
+explicitly supplied during authentication, but not during
+a password change, the mapping
+done by the password management module may not result in the
+same principal as was used for authentication.
+.Pp
+Unlike when
+changing a
+.Ux
+password, the password management module will
+allow any user to change any principal's password (if the user knows
+the principal's old password, of course).
+Also unlike
+.Ux ,
+root
+is always prompted for the principal's old password.
+.Pp
+The password management module uses the same heuristics as
+.Xr kpasswd 1
+to determine how to contact the Kerberos password server.
+.Pp
+The following options may be passed to this password management
+module:
+.Bl -tag -width ".Cm use_first_pass"
+.It Cm debug
+.Xr syslog 3
+debugging information at
+.Dv LOG_DEBUG
+level.
+.It Cm use_first_pass
+If the password management module is not the first in the stack,
+and a previous module obtained the user's old password, that password is
+used to authenticate the user.
+If this fails, the password
+management
+module returns failure without prompting the user for the old password.
+If successful, the new password entered to the previous module is also
+used as the new Kerberos password.
+If the new password fails,
+the password management module returns failure without
+prompting the user for a new password.
+.It Cm try_first_pass
+This option is similar to the
+.Cm use_first_pass
+option, except that if the previously obtained old or new passwords fail,
+the user is prompted for them.
+.El
+.Sh ENVIRONMENT
+.Bl -tag -width "KRB5CCNAME"
+.It Ev KRB5CCNAME
+Location of the credentials cache.
+.El
+.Sh FILES
+.Bl -tag -width ".Pa /tmp/krb5cc_ Ns Ar uid" -compact
+.It Pa /tmp/krb5cc_ Ns Ar uid
+default credentials cache
+.Ar ( uid
+is the decimal UID of the user).
+.It Pa $HOME/.k5login
+file containing Kerberos principals that are allowed access.
+.El
+.Sh SEE ALSO
+.Xr kdestroy 1 ,
+.Xr passwd 1 ,
+.Xr syslog 3 ,
+.Xr pam.conf 5 ,
+.Xr DirectoryService 8 ,
+.Xr pam 8
+.Sh NOTES
+Applications should not call
+.Fn pam_authenticate
+more than once between calls to
+.Fn pam_start
+and
+.Fn pam_end
+when using the Kerberos 5 PAM module.

--- a/src/pam_modules/modules/pam_krb5/pam_krb5.c
+++ b/src/pam_modules/modules/pam_krb5/pam_krb5.c
@@ -1,0 +1,1174 @@
+/*-
+ * This pam_krb5 module contains code that is:
+ *   Copyright (c) Derrick J. Brashear, 1996. All rights reserved.
+ *   Copyright (c) Frank Cusack, 1999-2001. All rights reserved.
+ *   Copyright (c) Jacques A. Vidrine, 2000-2001. All rights reserved.
+ *   Copyright (c) Nicolas Williams, 2001. All rights reserved.
+ *   Copyright (c) Perot Systems Corporation, 2001. All rights reserved.
+ *   Copyright (c) Mark R V Murray, 2001.  All rights reserved.
+ *   Copyright (c) Networks Associates Technology, Inc., 2002-2005.
+ *       All rights reserved.
+ *   Copyright (c) 2008-2009 Apple Inc. All rights reserved.
+ *
+ * Portions of this software were developed for the FreeBSD Project by
+ * ThinkSec AS and NAI Labs, the Security Research Division of Network
+ * Associates, Inc.  under DARPA/SPAWAR contract N66001-01-C-8035
+ * ("CBOSS"), as part of the DARPA CHATS research program.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notices, and the entire permission notice in its entirety,
+ *    including the disclaimer of warranties.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * ALTERNATIVELY, this product may be distributed under the terms of
+ * the GNU Public License, in which case the provisions of the GPL are
+ * required INSTEAD OF the above restrictions.  (This clause is
+ * necessary due to a potential bad interaction between the GPL and
+ * the restrictions contained in a BSD-style copyright.)
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <limits.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define KRB5_DEPRECATED_FUNCTION(x) /* no warnings for now :`( */
+
+#include <Heimdal/krb5.h>
+#include <Heimdal/com_err.h>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <OpenDirectory/OpenDirectory.h>
+
+#define	PAM_SM_AUTH
+#define	PAM_SM_ACCOUNT
+#define	PAM_SM_PASSWORD
+
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <security/openpam.h>
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(krb5)
+#define PAM_LOG PAM_LOG_krb5()
+#endif
+
+/* _krb5_kcm_get_initial_ticket is SPI, so define it here for now */
+krb5_error_code _krb5_kcm_get_initial_ticket(krb5_context context,
+					     krb5_ccache id,
+					     krb5_principal client,
+					     krb5_principal server,
+					     const char *password);
+
+
+#define	COMPAT_HEIMDAL
+/* #define	COMPAT_MIT  */
+
+static int	verify_krb_v5_tgt(krb5_context, krb5_ccache, char *, int);
+static const	char *compat_princ_component(krb5_context, krb5_principal, int);
+static void	compat_free_data_contents(krb5_context, krb5_data *);
+
+#define USER_PROMPT		"Username: "
+#define PASSWORD_PROMPT		"Password:"
+#define NEW_PASSWORD_PROMPT	"New Password:"
+
+#define PAM_OPT_CCACHE		"ccache"
+#define PAM_OPT_NO_AUTH_CCACHE        "no_auth_ccache"
+#define PAM_OPT_DEBUG		"debug"
+#define PAM_OPT_DEFAULT_PRINCIPAL	"default_principal"
+#define PAM_OPT_FORWARDABLE	"forwardable"
+#define PAM_OPT_NO_FORWARDABLE	"noforward"
+#define PAM_OPT_NO_CCACHE	"no_ccache"
+#define PAM_OPT_USE_KCMINIT	"use_kcminit"
+#define PAM_OPT_REUSE_CCACHE	"reuse_ccache"
+#define PAM_OPT_USE_FIRST_PASS	"use_first_pass"
+
+#define PAM_OPT_AUTH_AS_SELF	"auth_as_self"
+#define PAM_OPT_DEBUG		"debug"
+
+#ifdef COMPAT_MIT
+#define krb5_get_err_text(c,e) error_message(e)
+#endif
+
+#include "Common.h"
+
+static const char *password_key = "KRB5PWD";
+static const char *user_key = "KRB5USER";
+
+
+/*
+ * authentication management
+ */
+PAM_EXTERN int
+pam_sm_authenticate(pam_handle_t *pamh, int flags __unused,
+    int argc __unused, const char *argv[] __unused)
+{
+	krb5_error_code krbret;
+	krb5_context pam_context;
+	krb5_creds creds;
+	krb5_principal princ;
+	krb5_ccache ccache;
+	krb5_get_init_creds_opt *opts = NULL;
+	struct passwd *pwd;
+	struct passwd pwdbuf;
+	char pwbuffer[2 * PATH_MAX];
+	int retval, have_tickets = 0;
+	const void *ccache_data;
+	const char *user;
+	char *pass;
+	const void *sourceuser, *service;
+	char *principal = NULL, *princ_name = NULL, *ccache_name, luser[32], *srvdup;
+
+	retval = pam_get_user(pamh, &user, USER_PROMPT);
+	if (retval != PAM_SUCCESS)
+		return (retval);
+
+    _LOG_DEBUG("Got user: %s", user);
+
+	retval = pam_get_item(pamh, PAM_RUSER, &sourceuser);
+	if (retval != PAM_SUCCESS)
+		return (retval);
+
+    _LOG_DEBUG("Got ruser: %s", (const char *)sourceuser);
+
+	service = NULL;
+	pam_get_item(pamh, PAM_SERVICE, &service);
+	if (service == NULL)
+		service = "unknown";
+
+    _LOG_DEBUG("Got service: %s", (const char *)service);
+
+	krbret = krb5_init_context(&pam_context);
+	if (krbret != 0) {
+        _LOG_ERROR("Kerberos 5 error");
+		return (PAM_SERVICE_ERR);
+	}
+
+	/* Get principal name */
+	if (openpam_get_option(pamh, PAM_OPT_AUTH_AS_SELF))
+		asprintf(&principal, "%s/%s", (const char *)sourceuser, user);
+	else if (NULL == openpam_get_option(pamh, PAM_OPT_DEFAULT_PRINCIPAL))
+		od_principal_for_user(pamh, user, &principal);
+	else
+		principal = strdup(user);
+	if (principal == NULL) {
+        _LOG_ERROR("Failed to determine Kerberos principal name.");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup3;
+	}
+
+    _LOG_DEBUG("Context initialised");
+
+	/* if we are running with KCMINIT, just store the password in the kcm cache */
+	if (openpam_get_option(pamh, PAM_OPT_USE_KCMINIT)) {
+		_LOG_DEBUG("Stashing kcm credentials in enviroment for kcminit: %s", principal);
+
+		retval = pam_get_authtok(pamh, PAM_AUTHTOK, (const char **)&pass, PASSWORD_PROMPT);
+		if (retval != PAM_SUCCESS) {
+            _LOG_ERROR("no password: %s", principal);
+			goto cleanup3;
+		}
+
+		retval = pam_setenv(pamh, user_key, principal, 1);
+		if (retval != PAM_SUCCESS)
+			goto cleanup3;
+
+		retval = pam_setenv(pamh, password_key, pass, 1);
+		if (retval != PAM_SUCCESS) {
+			goto cleanup3;
+		}
+
+		free(principal);
+		krb5_free_context(pam_context);
+
+		return (PAM_IGNORE);
+	}
+
+	krbret = krb5_get_init_creds_opt_alloc(pam_context, &opts);
+	if (krbret) {
+		retval = PAM_SERVICE_ERR;
+		goto cleanup3;
+	}
+
+	if (NULL != openpam_get_option(pamh, PAM_OPT_NO_FORWARDABLE) &&
+		NULL != openpam_get_option(pamh, PAM_OPT_FORWARDABLE)) {
+        _LOG_ERROR("Do not set both \"%s\" and \"%s\".", PAM_OPT_FORWARDABLE, PAM_OPT_NO_FORWARDABLE);
+		retval = PAM_SERVICE_ERR;
+		goto cleanup3;
+	}
+
+	_LOG_DEBUG("Created principal: %s", principal);
+
+	krbret = krb5_parse_name(pam_context, principal, &princ);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_parse_name(): %s",
+		    krb5_get_err_text(pam_context, krbret));
+		retval = PAM_SERVICE_ERR;
+		goto cleanup3;
+	}
+
+    _LOG_DEBUG("Done krb5_parse_name()");
+
+	/* Now convert the principal name into something human readable */
+	princ_name = NULL;
+	krbret = krb5_unparse_name(pam_context, princ, &princ_name);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_unparse_name(): %s",
+		    krb5_get_err_text(pam_context, krbret));
+		retval = PAM_SERVICE_ERR;
+		goto cleanup2;
+	}
+
+    _LOG_DEBUG("Got principal: %s", princ_name);
+
+	/* Get password */
+	retval = pam_get_authtok(pamh, PAM_AUTHTOK, (const char **)&pass, PASSWORD_PROMPT);
+	if (retval != PAM_SUCCESS)
+		goto cleanup2;
+
+    _LOG_DEBUG("Got password");
+
+	/* Verify the local user exists (AFTER getting the password) */
+	if (strchr(user, '@')) {
+		/* get a local account name for this principal */
+		krbret = krb5_aname_to_localname(pam_context, princ,
+		    sizeof(luser), luser);
+		if (krbret != 0) {
+            _LOG_ERROR("Error krb5_aname_to_localname(): %s",
+			    krb5_get_err_text(pam_context, krbret));
+			retval = PAM_USER_UNKNOWN;
+			goto cleanup2;
+		}
+
+		retval = pam_set_item(pamh, PAM_USER, luser);
+		if (retval != PAM_SUCCESS)
+			goto cleanup2;
+
+        _LOG_DEBUG("PAM_USER Redone");
+	}
+
+	if (getpwnam_r(user, &pwdbuf, pwbuffer, sizeof(pwbuffer), &pwd) != 0 || pwd == NULL) {
+		retval = PAM_USER_UNKNOWN;
+		goto cleanup2;
+	}
+
+    _LOG_DEBUG("Done getpwnam()");
+
+	/* Get a TGT */
+	if (NULL == openpam_get_option(pamh, PAM_OPT_NO_FORWARDABLE)) {
+		krb5_get_init_creds_opt_set_forwardable(opts, 1);
+		krb5_get_init_creds_opt_set_proxiable(opts, 1);
+
+        _LOG_DEBUG("Attempting to get forwardable TGT.");
+		memset(&creds, 0, sizeof(krb5_creds));
+		krbret = krb5_get_init_creds_password(pam_context, &creds, princ,
+			pass, NULL, pamh, 0, NULL, opts);
+		if (krbret != 0) {
+			krb5_get_init_creds_opt_set_forwardable(opts, 0);
+			krb5_get_init_creds_opt_set_proxiable(opts, 0);
+		} else {
+            _LOG_DEBUG("Have a forwardable TGT.");
+			have_tickets = 1;
+		}
+	}
+
+	if (!have_tickets) {
+        _LOG_DEBUG("Attempting to get non-forwardable TGT.");
+		memset(&creds, 0, sizeof(krb5_creds));
+		krbret = krb5_get_init_creds_password(pam_context, &creds, princ,
+			pass, NULL, pamh, 0, NULL, opts);
+		if (krbret != 0) {
+            _LOG_ERROR("Error krb5_get_init_creds_password(): %s",
+				krb5_get_err_text(pam_context, krbret));
+			retval = PAM_AUTH_ERR;
+			goto cleanup2;
+		}
+	}
+
+    _LOG_DEBUG("Got TGT");
+
+	/* Generate a temporary cache */
+	krbret = krb5_cc_new_unique(pam_context, "FILE", NULL, &ccache);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_cc_gen_new(): %s",
+		    krb5_get_err_text(pam_context, krbret));
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+	krbret = krb5_cc_initialize(pam_context, ccache, creds.client);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_cc_initialize(): %s",
+		    krb5_get_err_text(pam_context, krbret));
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+	krbret = krb5_cc_store_cred(pam_context, ccache, &creds);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_cc_store_cred(): %s",
+		    krb5_get_err_text(pam_context, krbret));
+		krb5_cc_destroy(pam_context, ccache);
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+	if (0 == strcmp("FILE", krb5_cc_get_type(pam_context, ccache)))
+		chown(krb5_cc_get_name(pam_context, ccache), pwd->pw_uid, pwd->pw_gid);
+
+    _LOG_DEBUG("Credentials stashed");
+
+	/* Verify them */
+	if ((srvdup = strdup(service)) == NULL) {
+		retval = PAM_BUF_ERR;
+		goto cleanup;
+	}
+	krbret = verify_krb_v5_tgt(pam_context, ccache, srvdup,
+	    openpam_get_option(pamh, PAM_OPT_DEBUG) ? 1 : 0);
+	free(srvdup);
+	if (krbret == -1) {
+        _LOG_ERROR("Kerberos 5 error");
+		krb5_cc_destroy(pam_context, ccache);
+		retval = PAM_AUTH_ERR;
+		goto cleanup;
+	}
+
+    _LOG_DEBUG("Credentials stash verified");
+
+	retval = pam_get_data(pamh, "ccache", &ccache_data);
+	if (retval == PAM_SUCCESS) {
+		krb5_cc_destroy(pam_context, ccache);
+        _LOG_ERROR("Kerberos 5 error");
+		retval = PAM_AUTH_ERR;
+		goto cleanup;
+	}
+
+    _LOG_DEBUG("Credentials stash not pre-existing");
+
+	asprintf(&ccache_name, "%s:%s", krb5_cc_get_type(pam_context,
+		ccache), krb5_cc_get_name(pam_context, ccache));
+	if (ccache_name == NULL) {
+        _LOG_ERROR("Kerberos 5 error");
+		retval = PAM_BUF_ERR;
+		goto cleanup;
+	}
+	retval = pam_setenv(pamh, "krb5_ccache", ccache_name, 1);
+	if (retval != 0) {
+		krb5_cc_destroy(pam_context, ccache);
+        _LOG_ERROR("Kerberos 5 error");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup;
+	}
+
+    _LOG_DEBUG("Credentials stash saved");
+
+cleanup:
+	krb5_free_cred_contents(pam_context, &creds);
+    _LOG_DEBUG("Done cleanup");
+cleanup2:
+	krb5_free_principal(pam_context, princ);
+    _LOG_DEBUG("Done cleanup2");
+cleanup3:
+    if (principal)
+        free(principal);
+
+	if (princ_name)
+		free(princ_name);
+
+	if (opts)
+		krb5_get_init_creds_opt_free(pam_context, opts);
+
+	krb5_free_context(pam_context);
+
+    _LOG_DEBUG("Done cleanup3");
+
+	if (retval != PAM_SUCCESS)
+        _LOG_DEBUG("Kerberos 5 refuses you");
+
+	return (retval);
+}
+
+PAM_EXTERN int
+pam_sm_setcred(pam_handle_t *pamh, int flags,
+    int argc __unused, const char *argv[] __unused)
+{
+#ifdef _FREEFALL_CONFIG
+	return (PAM_SUCCESS);
+#else
+
+	krb5_error_code krbret;
+	krb5_context pam_context = NULL;
+	krb5_principal princ = NULL;
+	krb5_creds creds;
+	krb5_ccache ccache_temp, ccache_perm = NULL;
+	krb5_cc_cursor cursor;
+	struct passwd *pwd = NULL;
+	struct passwd pwdbuf;
+	char pwbuffer[2 * PATH_MAX];
+	int retval;
+	const char *cache_type, *cache_name, *q;
+	const void *user;
+    const void *login;
+	const void *cache_data;
+	char *cache_name_buf = NULL, *p = NULL, *cache_type_colon_name = NULL;
+	int use_kcminit;
+    
+	uid_t euid;
+	gid_t egid;
+
+	if (flags & PAM_DELETE_CRED) {
+		krb5_cccol_cursor cursor;
+
+		krbret = krb5_init_context(&pam_context);
+		if (krbret != 0) {
+            _LOG_DEBUG("Error krb5_init_secure_context() failed");
+			retval = PAM_SERVICE_ERR;
+			goto cleanup4;
+		}
+
+		krbret = krb5_cccol_cursor_new (pam_context, &cursor);
+		if (krbret) {
+			retval = PAM_SUCCESS;
+			goto cleanup4;
+		}
+
+		while (krb5_cccol_cursor_next (pam_context, cursor, &ccache_temp) == 0 && ccache_temp != NULL) {
+			krbret = krb5_cc_destroy (pam_context, ccache_temp);
+			if (krbret)
+				krb5_warn(pam_context, krbret, "krb5_cc_destroy");
+		}
+		krb5_cccol_cursor_free(pam_context, &cursor);
+
+		retval = PAM_SUCCESS;
+		goto cleanup4;
+	}
+
+	if (flags & PAM_REFRESH_CRED) {
+		retval = PAM_SUCCESS;
+		goto cleanup4;
+	}
+
+	if (flags & PAM_REINITIALIZE_CRED) {
+		retval = PAM_SUCCESS;
+		goto cleanup4;
+	}
+
+	if (!(flags & PAM_ESTABLISH_CRED)) {
+		retval = PAM_SERVICE_ERR;
+		goto cleanup4;
+	}
+
+	/* If a persistent cache isn't desired, stop now. */
+	if (openpam_get_option(pamh, PAM_OPT_NO_CCACHE)) {
+		retval = PAM_SUCCESS;
+		goto cleanup4;
+	}
+    
+    pam_get_data(pamh, "login", &login);
+    if (!login && openpam_get_option(pamh, PAM_OPT_NO_AUTH_CCACHE)) {
+        retval = PAM_SUCCESS;
+        _LOG_DEBUG("no_auth_ccache is set");
+        goto cleanup4;
+    }
+
+    _LOG_DEBUG("Establishing credentials");
+
+	/* Get username */
+	retval = pam_get_item(pamh, PAM_USER, &user);
+	if (retval != PAM_SUCCESS)
+		goto cleanup4;
+
+    _LOG_DEBUG("Got user: %s", (const char *)user);
+
+	krbret = krb5_init_context(&pam_context);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_init_secure_context() failed");
+		retval = PAM_SERVICE_ERR;
+		goto cleanup4;
+	}
+
+    _LOG_DEBUG("Context initialised");
+
+	euid = geteuid();	/* Usually 0 */
+	egid = getegid();
+
+    _LOG_DEBUG("Got euid, egid: %d %d", euid, egid);
+
+	use_kcminit = (openpam_get_option(pamh, PAM_OPT_USE_KCMINIT) != NULL);
+
+	if (!use_kcminit) {
+		/* Retrieve the temporary cache */
+		if ((cache_data = pam_getenv(pamh, "krb5_ccache")) == NULL) {
+            _LOG_DEBUG("Error pam_getenv failed.");
+			retval = PAM_IGNORE;
+			goto cleanup3;
+		}
+		krbret = krb5_cc_resolve(pam_context, cache_data, &ccache_temp);
+		if (krbret != 0) {
+            _LOG_DEBUG("Error krb5_cc_resolve(\"%s\"): %s", (const char *)cache_data,
+				krb5_get_err_text(pam_context, krbret));
+			retval = PAM_SERVICE_ERR;
+			goto cleanup3;
+		}
+	}
+	/* Get the uid. This should exist. */
+	if (getpwnam_r(user, &pwdbuf, pwbuffer, sizeof(pwbuffer), &pwd) != 0 || pwd == NULL) {
+		retval = PAM_USER_UNKNOWN;
+		goto cleanup3;
+	}
+
+    _LOG_DEBUG("Done getpwnam()");
+
+	/* Avoid following a symlink as root */
+	if (0 == egid && 0 != setegid(pwd->pw_gid)) {
+		retval = PAM_SERVICE_ERR;
+		goto cleanup3;
+	}
+	if (0 == euid && 0 != seteuid(pwd->pw_uid)) {
+		retval = PAM_SERVICE_ERR;
+		goto cleanup3;
+	}
+
+    _LOG_DEBUG("Done setegid() & seteuid()");
+
+
+	if (use_kcminit) {
+		const char *principal, *password;
+		krb5_principal princ = NULL;
+
+		principal = pam_getenv(pamh, user_key);
+		if (principal == NULL) {
+            _LOG_ERROR("pam_sm_setcred: krb5 user %s doesn't have a principal", (char *)user);
+			retval = PAM_SERVICE_ERR;
+			goto cleanup3;
+		}
+
+		password = pam_getenv(pamh, password_key);
+		if (password == NULL) {
+            _LOG_ERROR("pam_sm_setcred: krb5 user %s doesn't have a password", (char *)user);
+			retval = PAM_SERVICE_ERR;
+			goto cleanup3;
+		}
+
+		krbret = krb5_parse_name(pam_context, principal, &princ);
+		if (krbret != 0) {
+			retval = PAM_SERVICE_ERR;
+			goto cleanup3;
+		}
+
+        krbret = krb5_cc_cache_match(pam_context, princ, &ccache_perm);
+        if (krbret) {
+            krbret = krb5_cc_new_unique(pam_context, "API", NULL, &ccache_perm);
+            if (krbret) {
+                krb5_free_principal(pam_context, princ);
+                retval = PAM_SERVICE_ERR;
+                goto cleanup3;
+            }
+            _LOG_DEBUG("pam_sm_setcred: init credential cache");
+
+            krbret = krb5_cc_initialize(pam_context, ccache_perm, princ);
+            if (krbret) {
+                krb5_free_principal(pam_context, princ);
+                krb5_cc_close(pam_context, ccache_perm);
+                retval = PAM_SERVICE_ERR;
+                goto cleanup3;
+            }
+        }
+
+        _LOG_DEBUG("pam_sm_setcred: storing credential for: %s", principal);
+		krbret = _krb5_kcm_get_initial_ticket(pam_context, ccache_perm, princ, NULL, password);
+		krb5_free_principal(pam_context, princ);
+		if (krbret) {
+            _LOG_ERROR("kcm init failed: %d", krbret);
+			retval = PAM_SERVICE_ERR;
+			goto cleanup3;
+		}
+		retval = PAM_SUCCESS;
+	} else {
+
+		/* Initialize the new ccache */
+		krbret = krb5_cc_get_principal(pam_context, ccache_temp, &princ);
+		if (krbret != 0) {
+            _LOG_ERROR("Error krb5_cc_get_principal(): %s",
+				krb5_get_err_text(pam_context, krbret));
+			retval = PAM_SERVICE_ERR;
+			goto cleanup3;
+		}
+
+		/* Get the cache name */
+		cache_name = openpam_get_option(pamh, PAM_OPT_CCACHE);
+		if (cache_name == NULL) {
+			krbret = krb5_cc_default(pam_context, &ccache_perm);
+		}
+		else {
+			size_t len = (PATH_MAX + 16);
+			p = calloc(len, sizeof(char));
+			q = cache_name;
+
+			if (p == NULL) {
+                _LOG_ERROR("Error malloc(): failure");
+				retval = PAM_BUF_ERR;
+				goto cleanup3;
+			}
+			cache_name = cache_name_buf = p;
+
+			/* convert %u and %p */
+			while (*q) {
+				if (*q == '%') {
+					q++;
+					if (*q == 'u') {
+						len -= snprintf(p, len, "%d", pwd->pw_uid);
+						p += strlen(p);
+					}
+					else if (*q == 'p') {
+						len -= snprintf(p, len, "%d", getpid());
+						p += strlen(p);
+					}
+					else {
+						/* Not a special token */
+						*p++ = '%';
+						len--;
+						q--;
+					}
+					q++;
+				}
+				else {
+					*p++ = *q++;
+					len--;
+				}
+			}
+
+            _LOG_DEBUG("Got cache_name: %s", cache_name);
+
+			krbret = krb5_cc_resolve(pam_context, cache_name, &ccache_perm);
+			if (krbret != 0) {
+                _LOG_ERROR("Error krb5_cc_resolve(): %s",
+					krb5_get_err_text(pam_context, krbret));
+				retval = PAM_SERVICE_ERR;
+				goto cleanup2;
+			}
+		}
+		krbret = krb5_cc_initialize(pam_context, ccache_perm, princ);
+		if (krbret != 0) {
+            _LOG_ERROR("Error krb5_cc_initialize(): %s",
+				krb5_get_err_text(pam_context, krbret));
+			retval = PAM_SERVICE_ERR;
+			goto cleanup2;
+		}
+
+        _LOG_DEBUG("Cache initialised");
+
+		/* Prepare for iteration over creds */
+		krbret = krb5_cc_start_seq_get(pam_context, ccache_temp, &cursor);
+		if (krbret != 0) {
+            _LOG_ERROR("Error krb5_cc_start_seq_get(): %s",
+				krb5_get_err_text(pam_context, krbret));
+			krb5_cc_destroy(pam_context, ccache_perm);
+			retval = PAM_SERVICE_ERR;
+			goto cleanup2;
+		}
+
+        _LOG_DEBUG("Prepared for iteration");
+
+		/* Copy the creds (should be two of them) */
+		while ((krbret = krb5_cc_next_cred(pam_context, ccache_temp,
+						   &cursor, &creds) == 0)) {
+			krbret = krb5_cc_store_cred(pam_context, ccache_perm, &creds);
+			if (krbret != 0) {
+                _LOG_ERROR("Error krb5_cc_store_cred(): %s",
+					krb5_get_err_text(pam_context, krbret));
+				krb5_cc_destroy(pam_context, ccache_perm);
+				krb5_free_cred_contents(pam_context, &creds);
+				retval = PAM_SERVICE_ERR;
+				goto cleanup2;
+			}
+			krb5_free_cred_contents(pam_context, &creds);
+            _LOG_DEBUG("Iteration");
+		}
+		krb5_cc_end_seq_get(pam_context, ccache_temp, &cursor);
+
+        _LOG_DEBUG("Done iterating");
+
+		krbret = krb5_cc_destroy(pam_context, ccache_temp);
+		if (krbret != 0) {
+            _LOG_ERROR("Error krb5_cc_destroy(): %s",
+					krb5_get_err_text(pam_context, krbret));
+			krb5_cc_destroy(pam_context, ccache_perm);
+			retval = PAM_SERVICE_ERR;
+			goto cleanup2;
+		}
+        _LOG_DEBUG("Temporary FILE cache destroyed");
+	}
+
+	/* Get the cache type and name */
+	cache_type = krb5_cc_get_type(pam_context, ccache_perm);
+	cache_name = krb5_cc_get_name(pam_context, ccache_perm);
+    _LOG_DEBUG("Got cache_name: %s:%s", cache_type, cache_name);
+
+	if (0 == strcmp(cache_type, "FILE")) {
+		if (chown(cache_name, pwd->pw_uid, pwd->pw_gid) == -1) {
+            _LOG_ERROR("Error chown(): %s", strerror(errno));
+			krb5_cc_destroy(pam_context, ccache_perm);
+			retval = PAM_SERVICE_ERR;
+			goto cleanup2;
+		}
+        _LOG_DEBUG("Done chown()");
+
+		if (chmod(cache_name, (S_IRUSR | S_IWUSR)) == -1) {
+            _LOG_ERROR("Error chmod(): %s", strerror(errno));
+			krb5_cc_destroy(pam_context, ccache_perm);
+			retval = PAM_SERVICE_ERR;
+			goto cleanup2;
+		}
+        _LOG_DEBUG("Done chmod()");
+	} else {
+		(void)krb5_cc_switch(pam_context, ccache_perm);
+	}
+
+	asprintf(&cache_type_colon_name, "%s:%s", cache_type, cache_name);
+	if (NULL == cache_type_colon_name)
+		goto cleanup2;
+	retval = pam_setenv(pamh, "KRB5CCNAME", cache_type_colon_name, 1);
+	free(cache_type_colon_name);
+	if (retval != PAM_SUCCESS) {
+        _LOG_ERROR("Error pam_setenv(): %s", pam_strerror(pamh, retval));
+		krb5_cc_destroy(pam_context, ccache_perm);
+		retval = PAM_SERVICE_ERR;
+		goto cleanup2;
+	}
+
+    _LOG_DEBUG("Environment done: KRB5CCNAME=%s", cache_name);
+
+	krb5_cc_close(pam_context, ccache_perm);
+
+    _LOG_DEBUG("Cache closed");
+
+cleanup2:
+	if (NULL != princ)
+		krb5_free_principal(pam_context, princ);
+    _LOG_DEBUG("Done cleanup2");
+cleanup3:
+    _LOG_DEBUG("Done cleanup3");
+
+	seteuid(euid);
+	setegid(egid);
+
+    _LOG_DEBUG("Done seteuid() & setegid()");
+
+	if (cache_name_buf != NULL)
+		free(cache_name_buf);
+cleanup4:
+	if (pam_context)
+		krb5_free_context(pam_context);
+	pam_unsetenv(pamh, user_key);
+	pam_unsetenv(pamh, password_key);
+    _LOG_DEBUG("Done cleanup4");
+
+	return (retval);
+#endif
+}
+
+/*
+ * account management
+ */
+PAM_EXTERN int
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags __unused,
+    int argc __unused, const char *argv[] __unused)
+{
+	krb5_error_code krbret;
+	krb5_context pam_context;
+	krb5_ccache ccache;
+	krb5_principal princ;
+	int retval;
+	const void *user;
+	const void *ccache_name;
+
+	if (openpam_get_option(pamh, PAM_OPT_USE_KCMINIT))
+		return (PAM_SUCCESS);
+
+	retval = pam_get_item(pamh, PAM_USER, &user);
+	if (retval != PAM_SUCCESS)
+		return (retval);
+
+    _LOG_DEBUG("Got user: %s", (const char *)user);
+
+	retval = pam_get_data(pamh, "ccache", &ccache_name);
+	if (retval != PAM_SUCCESS)
+		return (PAM_SUCCESS);
+
+    _LOG_DEBUG("Got credentials");
+
+	krbret = krb5_init_context(&pam_context);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_init_secure_context() failed");
+		return (PAM_PERM_DENIED);
+	}
+
+    _LOG_DEBUG("Context initialised");
+
+	krbret = krb5_cc_resolve(pam_context, (const char *)ccache_name, &ccache);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_cc_resolve(\"%s\"): %s", (const char *)ccache_name,
+		    krb5_get_err_text(pam_context, krbret));
+		krb5_free_context(pam_context);
+		return (PAM_PERM_DENIED);
+	}
+
+    _LOG_DEBUG("Got ccache %s", (const char *)ccache_name);
+
+
+	krbret = krb5_cc_get_principal(pam_context, ccache, &princ);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_cc_get_principal(): %s",
+		    krb5_get_err_text(pam_context, krbret));
+		retval = PAM_PERM_DENIED;;
+		goto cleanup;
+	}
+
+    _LOG_DEBUG("Got principal");
+
+	if (krb5_kuserok(pam_context, princ, (const char *)user))
+		retval = PAM_SUCCESS;
+	else
+		retval = PAM_PERM_DENIED;
+	krb5_free_principal(pam_context, princ);
+
+    _LOG_DEBUG("Done kuserok()");
+
+cleanup:
+	krb5_free_context(pam_context);
+    _LOG_DEBUG("Done cleanup");
+
+	return (retval);
+
+}
+
+/*
+ * password management
+ */
+PAM_EXTERN int
+pam_sm_chauthtok(pam_handle_t *pamh, int flags,
+    int argc __unused, const char *argv[] __unused)
+{
+	krb5_error_code krbret;
+	krb5_context pam_context;
+	krb5_creds creds;
+	krb5_principal princ;
+	krb5_get_init_creds_opt *opts = NULL;
+	krb5_data result_code_string, result_string;
+	int result_code, retval;
+	char *pass;
+	const void *user;
+	char *princ_name = NULL, *passdup;
+
+	if (!(flags & PAM_UPDATE_AUTHTOK))
+		return (PAM_AUTHTOK_ERR);
+
+	retval = pam_get_item(pamh, PAM_USER, &user);
+	if (retval != PAM_SUCCESS)
+		return (retval);
+
+    _LOG_DEBUG("Got user: %s", (const char *)user);
+
+	krbret = krb5_init_context(&pam_context);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_init_secure_context() failed");
+		return (PAM_SERVICE_ERR);
+	}
+
+    _LOG_DEBUG("Context initialised");
+
+	krb5_get_init_creds_opt_alloc(pam_context, &opts);
+
+    _LOG_DEBUG("Credentials options initialised");
+
+	/* Get principal name */
+	krbret = krb5_parse_name(pam_context, (const char *)user, &princ);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_parse_name(): %s",
+		    krb5_get_err_text(pam_context, krbret));
+		retval = PAM_USER_UNKNOWN;
+		goto cleanup3;
+	}
+
+	/* Now convert the principal name into something human readable */
+	princ_name = NULL;
+	krbret = krb5_unparse_name(pam_context, princ, &princ_name);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_unparse_name(): %s",
+		    krb5_get_err_text(pam_context, krbret));
+		retval = PAM_SERVICE_ERR;
+		goto cleanup2;
+	}
+
+    _LOG_DEBUG("Got principal: %s", princ_name);
+
+	/* Get password */
+	retval = pam_get_authtok(pamh, PAM_OLDAUTHTOK, (const char **)&pass, PASSWORD_PROMPT);
+	if (retval != PAM_SUCCESS)
+		goto cleanup2;
+
+    _LOG_DEBUG("Got password");
+
+	memset(&creds, 0, sizeof(krb5_creds));
+	krbret = krb5_get_init_creds_password(pam_context, &creds, princ,
+	    pass, NULL, pamh, 0, "kadmin/changepw", opts);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_get_init_creds_password(): %s",
+		    krb5_get_err_text(pam_context, krbret));
+		retval = PAM_AUTH_ERR;
+		goto cleanup2;
+	}
+
+    _LOG_DEBUG("Credentials established");
+
+	/* Now get the new password */
+	for (;;) {
+		retval = pam_get_authtok(pamh,
+		    PAM_AUTHTOK, (const char **)&pass, NEW_PASSWORD_PROMPT);
+		if (retval != PAM_TRY_AGAIN)
+			break;
+		pam_error(pamh, "Mismatch; try again, EOF to quit.");
+	}
+	if (retval != PAM_SUCCESS)
+		goto cleanup;
+
+	_LOG_DEBUG("Got new password");
+
+	/* Change it */
+	if ((passdup = strdup(pass)) == NULL) {
+		retval = PAM_BUF_ERR;
+		goto cleanup;
+	}
+	krbret = krb5_set_password(pam_context, &creds, passdup, NULL,
+	    &result_code, &result_code_string, &result_string);
+	free(passdup);
+	if (krbret != 0) {
+        _LOG_ERROR("Error krb5_change_password(): %s",
+		    krb5_get_err_text(pam_context, krbret));
+		retval = PAM_AUTHTOK_ERR;
+		goto cleanup;
+	}
+	if (result_code) {
+        _LOG_ERROR("Error krb5_change_password(): (result_code)");
+		retval = PAM_AUTHTOK_ERR;
+		goto cleanup;
+	}
+
+    _LOG_DEBUG("Password changed");
+
+	if (result_string.data)
+		free(result_string.data);
+	if (result_code_string.data)
+		free(result_code_string.data);
+
+cleanup:
+	krb5_free_cred_contents(pam_context, &creds);
+    _LOG_DEBUG("Done cleanup");
+cleanup2:
+	krb5_free_principal(pam_context, princ);
+    _LOG_DEBUG("Done cleanup2");
+cleanup3:
+	if (princ_name)
+		free(princ_name);
+
+	if (opts)
+		krb5_get_init_creds_opt_free(pam_context, opts);
+
+	krb5_free_context(pam_context);
+
+    _LOG_DEBUG("Done cleanup3");
+
+	return (retval);
+}
+
+PAM_MODULE_ENTRY("pam_krb5");
+
+/*
+ * This routine with some modification is from the MIT V5B6 appl/bsd/login.c
+ * Modified by Sam Hartman <hartmans@mit.edu> to support PAM services
+ * for Debian.
+ *
+ * Verify the Kerberos ticket-granting ticket just retrieved for the
+ * user.  If the Kerberos server doesn't respond, assume the user is
+ * trying to fake us out (since we DID just get a TGT from what is
+ * supposedly our KDC).  If the host/<host> service is unknown (i.e.,
+ * the local keytab doesn't have it), and we cannot find another
+ * service we do have, let her in.
+ *
+ * Returns 1 for confirmation, -1 for failure, 0 for uncertainty.
+ */
+/* ARGSUSED */
+static int
+verify_krb_v5_tgt(krb5_context context, krb5_ccache ccache,
+    char *pam_service, int debug)
+{
+	krb5_error_code retval;
+	krb5_principal princ;
+	krb5_keyblock *keyblock;
+	krb5_data packet;
+	krb5_auth_context auth_context;
+	char phost[BUFSIZ];
+	const char *services[3], **service;
+
+	packet.data = 0;
+
+	/* If possible we want to try and verify the ticket we have
+	 * received against a keytab.  We will try multiple service
+	 * principals, including at least the host principal and the PAM
+	 * service principal.  The host principal is preferred because access
+	 * to that key is generally sufficient to compromise root, while the
+	 * service key for this PAM service may be less carefully guarded.
+	 * It is important to check the keytab first before the KDC so we do
+	 * not get spoofed by a fake KDC.
+	 */
+	services[0] = "host";
+	services[1] = pam_service;
+	services[2] = NULL;
+	keyblock = 0;
+	retval = -1;
+	for (service = &services[0]; *service != NULL; service++) {
+		retval = krb5_sname_to_principal(context, NULL, *service,
+		    KRB5_NT_SRV_HST, &princ);
+		if (retval != 0) {
+			if (debug)
+                _LOG_DEBUG("pam_krb5: verify_krb_v5_tgt(): %s: %s",
+				    "krb5_sname_to_principal()",
+				    krb5_get_err_text(context, retval));
+			return -1;
+		}
+
+		/* Extract the name directly. */
+		strncpy(phost, compat_princ_component(context, princ, 1),
+		    BUFSIZ);
+		phost[BUFSIZ - 1] = '\0';
+
+		/*
+		 * Do we have service/<host> keys?
+		 * (use default/configured keytab, kvno IGNORE_VNO to get the
+		 * first match, and ignore enctype.)
+		 */
+		retval = krb5_kt_read_service_key(context, NULL, princ, 0, 0,
+		    &keyblock);
+		if (retval != 0) {
+			krb5_free_principal(context, princ);
+			princ = NULL;
+			continue;
+		}
+		break;
+	}
+	if (retval != 0) {	/* failed to find key */
+		/* Keytab or service key does not exist */
+		if (debug)
+            _LOG_DEBUG("pam_krb5: verify_krb_v5_tgt(): %s: %s",
+			    "krb5_kt_read_service_key()",
+			    krb5_get_err_text(context, retval));
+		retval = 0;
+		goto cleanup;
+	}
+	if (keyblock)
+		krb5_free_keyblock(context, keyblock);
+
+	/* Talk to the kdc and construct the ticket. */
+	auth_context = NULL;
+	retval = krb5_mk_req(context, &auth_context, 0, (char *)*service, phost,
+		NULL, ccache, &packet);
+	if (auth_context) {
+		krb5_auth_con_free(context, auth_context);
+		auth_context = NULL;	/* setup for rd_req */
+	}
+	if (retval) {
+		if (debug)
+            _LOG_DEBUG("pam_krb5: verify_krb_v5_tgt(): %s: %s",
+			    "krb5_mk_req()",
+			    krb5_get_err_text(context, retval));
+		retval = -1;
+		goto cleanup;
+	}
+
+	/* Try to use the ticket. */
+	retval = krb5_rd_req(context, &auth_context, &packet, princ, NULL,
+	    NULL, NULL);
+	if (retval) {
+		if (debug)
+            _LOG_DEBUG("pam_krb5: verify_krb_v5_tgt(): %s: %s",
+			    "krb5_rd_req()",
+			    krb5_get_err_text(context, retval));
+		retval = -1;
+	}
+	else
+		retval = 1;
+
+cleanup:
+	if (packet.data)
+		compat_free_data_contents(context, &packet);
+	krb5_free_principal(context, princ);
+	return retval;
+}
+
+#ifdef COMPAT_HEIMDAL
+#ifdef COMPAT_MIT
+#error This cannot be MIT and Heimdal compatible!
+#endif
+#endif
+
+#ifndef COMPAT_HEIMDAL
+#ifndef COMPAT_MIT
+#error One of COMPAT_MIT and COMPAT_HEIMDAL must be specified!
+#endif
+#endif
+
+#ifdef COMPAT_HEIMDAL
+/* ARGSUSED */
+static const char *
+compat_princ_component(krb5_context context __unused, krb5_principal princ, int n)
+{
+	return princ->name.name_string.val[n];
+}
+
+/* ARGSUSED */
+static void
+compat_free_data_contents(krb5_context context __unused, krb5_data * data)
+{
+	krb5_xfree(data->data);
+}
+#endif
+
+#ifdef COMPAT_MIT
+static const char *
+compat_princ_component(krb5_context context, krb5_principal princ, int n)
+{
+	return krb5_princ_component(context, princ, n)->data;
+}
+
+static void
+compat_free_data_contents(krb5_context context, krb5_data * data)
+{
+	krb5_free_data_contents(context, data);
+}
+#endif

--- a/src/pam_modules/modules/pam_launchd/pam_launchd.8
+++ b/src/pam_modules/modules/pam_launchd/pam_launchd.8
@@ -1,0 +1,57 @@
+.\"
+.\" Copyright (c) 2009 Apple Inc. All rights reserved.
+.\"
+.\" @APPLE_LICENSE_HEADER_START@
+.\" 
+.\" This file contains Original Code and/or Modifications of Original Code
+.\" as defined in and that are subject to the Apple Public Source License
+.\" Version 2.0 (the 'License'). You may not use this file except in
+.\" compliance with the License. Please obtain a copy of the License at
+.\" http://www.opensource.apple.com/apsl/ and read it before using this
+.\" file.
+.\" 
+.\" The Original Code and all software distributed under the License are
+.\" distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+.\" EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+.\" INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+.\" Please see the License for the specific language governing rights and
+.\" limitations under the License.
+.\" 
+.\" @APPLE_LICENSE_HEADER_END@
+.\"
+.Dd February 7, 2009
+.Dt pam_launchd 8
+.Os
+.Sh NAME
+.Nm pam_launchd
+.Nd launchd PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_launchd
+.Op Ar options
+.Sh DESCRIPTION
+The launchd PAM module supports the session management function class.  In terms of the
+.Ar function-class
+parameter, this is the
+.Dq Li session
+class.
+.Pp
+The launchd session module is used to move the authenticated session to the correct, per-user, launchd namespace.
+.Pp
+The following option may be passed to this session management module:
+.Bl -tag
+.It Cm launchd_session_type=SESSION_TYPE
+Move this session to the launchd session type specified.
+.El
+.Sh ENVIRONMENT
+.Bl -tag
+.It Ev launchd_session_type=SESSION_TYPE
+Move this session to the launchd session type specified.
+.El
+.Sh SEE ALSO
+.Xr launchd 8 ,
+.Xr pam.conf 5 ,
+.Xr pam 8

--- a/src/pam_modules/modules/pam_launchd/pam_launchd.c
+++ b/src/pam_modules/modules/pam_launchd/pam_launchd.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2007-2009 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+#define _PAM_EXTERN_FUNCTIONS
+#define PAM_SM_SESSION
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <vproc.h>
+#include <vproc_priv.h>
+#include <servers/bootstrap.h>
+#include <bootstrap_priv.h>
+#include <pwd.h>
+#include <sys/syslimits.h>
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(launchd)
+#define PAM_LOG PAM_LOG_launchd()
+#endif
+
+#define SESSION_TYPE_OPT "launchd_session_type"
+#define DEFAULT_SESSION_TYPE VPROCMGR_SESSION_BACKGROUND
+#define NULL_SESSION_TYPE "NullSession"
+
+/* An application may modify the default behavior as follows:
+ * (1) Choose a specific session type:
+ *     pam_putenv(pamh, "launchd_session_type=Aqua");
+ * (2) Choose to not start a new session:
+ *     pam_putenv(pamh, "launchd_session_type=NullSession");
+ * Otherwise, if launchd_session_type is not set, a new session of the
+ * default type will be created.
+ */
+
+extern vproc_err_t _vproc_post_fork_ping(void);
+
+static mach_port_t
+get_root_bootstrap_port(void)
+{
+	mach_port_t parent_port = MACH_PORT_NULL;
+	mach_port_t previous_port = MACH_PORT_NULL;
+	do {
+		if (previous_port) {
+			if (previous_port != bootstrap_port) {
+				mach_port_deallocate(mach_task_self(), previous_port);
+			}
+			previous_port = parent_port;
+		} else {
+			previous_port = bootstrap_port;
+		}
+		if (bootstrap_parent(previous_port, &parent_port) != 0) {
+			return MACH_PORT_NULL;
+		}
+	} while (parent_port != previous_port);
+	
+	return parent_port;
+}
+
+PAM_EXTERN int
+pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	char buffer[2*PATH_MAX];
+	const char* default_session_type = DEFAULT_SESSION_TYPE;
+	const char* session_type = pam_getenv(pamh, SESSION_TYPE_OPT);
+	const char* username;
+	struct passwd *pwd;
+	struct passwd pwdbuf;
+	uid_t uid, suid;
+
+	/* Deterine the launchd session type. */
+	if (NULL == (default_session_type = openpam_get_option(pamh, SESSION_TYPE_OPT))) {
+		_LOG_DEBUG("No session type specified.");
+		default_session_type = DEFAULT_SESSION_TYPE;
+	}
+	if (NULL == session_type) {
+		session_type = default_session_type;
+	} else if (0 == strcmp(session_type, NULL_SESSION_TYPE)) {
+		_LOG_DEBUG("Skipping due to NULL session type.");
+		return PAM_IGNORE;
+	}
+	
+	/* Get the username (and UID). */
+	if (PAM_SUCCESS != pam_get_item(pamh, PAM_USER, (void *)&username) || NULL == username) {
+		_LOG_DEBUG("The username could not be obtained.");
+		return PAM_IGNORE;
+	}
+	if (0 != getpwnam_r(username, &pwdbuf, buffer, sizeof(buffer), &pwd) || NULL == pwd) {
+		_LOG_DEBUG("The pwd for %s could not be obtained.", username);
+		return PAM_IGNORE;
+	}
+	uid = pwd->pw_uid;
+	_LOG_DEBUG("Going to switch to (%s) %u's %s session", username, uid, session_type);
+	
+	/* If we're running as root, set the root Mach bootstrap as our bootstrap port. If not, we fail. */
+	if (geteuid() == 0) {
+		mach_port_t rbs = get_root_bootstrap_port();
+		if (rbs) {
+			mach_port_mod_refs(mach_task_self(), bootstrap_port, MACH_PORT_RIGHT_SEND, -1);
+			task_set_bootstrap_port(mach_task_self(), rbs);
+			bootstrap_port = rbs;
+		}
+	} else {
+		_LOG_DEBUG("We are not running as root.");
+		return PAM_IGNORE;
+	}
+
+	/* We need to set the UID to appease launchd, then lookup the per-user bootstrap. */
+	suid = getuid();
+	setreuid(0, 0);
+	mach_port_t puc = MACH_PORT_NULL;
+	kern_return_t kr = bootstrap_look_up_per_user(bootstrap_port, NULL, uid, &puc);
+	setreuid(suid, 0);
+	if (BOOTSTRAP_SUCCESS != kr) {
+		_LOG_ERROR("Could not look up per-user bootstrap for UID %u.", uid);
+		return PAM_IGNORE;
+	} else if (BOOTSTRAP_NOT_PRIVILEGED == kr) {
+		_LOG_ERROR("Permission denied to look up per-user bootstrap for UID %u.", uid);
+		/* If this happens, bootstrap_port is probably already set appropriately anyway. */
+		return PAM_IGNORE;
+	}
+
+	/* Set our bootstrap port to be that of the Background session of the per-user launchd. */
+	mach_port_mod_refs(mach_task_self(), bootstrap_port, MACH_PORT_RIGHT_SEND, -1);
+	task_set_bootstrap_port(mach_task_self(), puc);
+	bootstrap_port = puc;
+	
+	/* Now move ourselves into the appropriate session. */
+	if (strncmp(session_type, VPROCMGR_SESSION_BACKGROUND, sizeof(VPROCMGR_SESSION_BACKGROUND)) != 0) {
+		vproc_err_t verr = NULL;
+		if (NULL != (verr = _vprocmgr_switch_to_session(session_type, 0))) {
+			_LOG_ERROR("Unable to switch to %u's %s session (0x%p).", uid, session_type, verr);
+			return PAM_SESSION_ERR;
+		}
+	}
+	if (NULL != _vproc_post_fork_ping()) {
+		_LOG_ERROR("Calling _vproc_post_fork_ping failed.");
+		return PAM_SESSION_ERR;
+	}
+	
+	return PAM_SUCCESS;
+}
+
+PAM_EXTERN int
+pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	return PAM_SUCCESS;
+}

--- a/src/pam_modules/modules/pam_localauthentication/authorization_la
+++ b/src/pam_modules/modules/pam_localauthentication/authorization_la
@@ -1,0 +1,4 @@
+# localauthentication: auth 
+auth       required       pam_localauthentication.so
+auth       required       pam_aks.so
+account    required       pam_opendirectory.so

--- a/src/pam_modules/modules/pam_localauthentication/authorization_lacont
+++ b/src/pam_modules/modules/pam_localauthentication/authorization_lacont
@@ -1,0 +1,4 @@
+# localauthentication: auth 
+auth       required       pam_localauthentication.so continuityunlock
+auth       required       pam_aks.so
+account    required       pam_opendirectory.so

--- a/src/pam_modules/modules/pam_localauthentication/pam_localauthentication.8
+++ b/src/pam_modules/modules/pam_localauthentication/pam_localauthentication.8
@@ -1,0 +1,70 @@
+.\"
+.\" Copyright (c) 2009 Apple Inc. All rights reserved.
+.\"
+.\" @APPLE_LICENSE_HEADER_START@
+.\" 
+.\" This file contains Original Code and/or Modifications of Original Code
+.\" as defined in and that are subject to the Apple Public Source License
+.\" Version 2.0 (the 'License'). You may not use this file except in
+.\" compliance with the License. Please obtain a copy of the License at
+.\" http://www.opensource.apple.com/apsl/ and read it before using this
+.\" file.
+.\" 
+.\" The Original Code and all software distributed under the License are
+.\" distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+.\" EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+.\" INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+.\" Please see the License for the specific language governing rights and
+.\" limitations under the License.
+.\" 
+.\" @APPLE_LICENSE_HEADER_END@
+.\"
+.Dd March 20, 2023
+.Dt pam_localauthentication 8
+.Os
+.Sh NAME
+.Nm pam_localauthentication
+.Nd LocalAuthentication PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_localauthentication
+.Op Ar options
+.Sh DESCRIPTION
+The LocalAuthentication PAM module supports the authentication function class,
+.Ar function-class
+parameter is
+.Dq auth .
+.Ss The LocalAuthentication Authentication Module
+The LocalAuthentication authentication module permits or denies authentication based on LAContext policy evaluation.
+.Pp
+The module will try to create LAContext from the externalized blob returned by previous invocation of
+.Dq LAContext.externalizedContext .
+The blob will be queried by
+.Xr pam_get_data 3
+as data named
+.Dq token_la .
+.Pp
+When the LAContext instance is successfully created, the module will try to evaluate
+.Dq LAPolicyDeviceOwnerAuthenticationWithBiometrics
+on it with user interaction disabled. The expectation is that the policy was already successfully evaluated before. If so, then the authentication performed by this module will succeed as well.
+.Pp
+The following options may be passed to this authentication module:
+.Bl -tag
+.It Cm continuityunlock
+Use the alternative LAContext for AppleWatch unlock. The LAContext blob will be queried by
+.Xr pam_get_data 3
+as data named
+.Dq token_lacont
+and the policy evaluated will be
+.Dq LAPolicyContinuityUnlock .
+
+.El
+.Sh SEE ALSO
+.Xr mbr_check_membership 3 ,
+.Xr pam.conf 5 ,
+.Xr pam 8 ,
+.Xr pwpolicy 8 ,
+.Xr pam_get_data 3

--- a/src/pam_modules/modules/pam_localauthentication/pam_localauthentication.c
+++ b/src/pam_modules/modules/pam_localauthentication/pam_localauthentication.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ * Portions Copyright (c) 2001 PADL Software Pty Ltd. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * Portions Copyright (c) 2000 Apple Computer, Inc.  All Rights
+ * Reserved.  This file contains Original Code and/or Modifications of
+ * Original Code as defined in and that are subject to the Apple Public
+ * Source License Version 1.1 (the "License").  You may not use this file
+ * except in compliance with the License.  Please obtain a copy of the
+ * License at http://www.apple.com/publicsource and read it before using
+ * this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON- INFRINGEMENT.  Please see the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/******************************************************************
+ * The purpose of this module is to provide a LocalAuthentication 
+ * based authentication module for Mac OS X.
+ ******************************************************************/
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <coreauthd_spi.h>
+#include <pwd.h>
+#include <LocalAuthentication/LAPrivateDefines.h>
+#include <stdbool.h>
+
+#define PAM_SM_AUTH
+#define PAM_SM_ACCOUNT
+
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(LA)
+#define PAM_LOG PAM_LOG_LA()
+#endif
+
+#define CONTINUITY_UNLOCK_PARAM "continuityunlock"
+
+PAM_EXTERN int
+pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    _LOG_DEBUG("pam_sm_authenticate");
+
+    int retval = PAM_AUTH_ERR;
+    int tmpval = 0;
+    CFDataRef *externalized_context = NULL;
+    CFTypeRef context = NULL;
+    CFErrorRef error = NULL;
+    CFMutableDictionaryRef options = NULL;
+    CFNumberRef key = NULL;
+    CFNumberRef value = NULL;
+    int tmp;
+    bool isContinuityUnlock = openpam_get_option(pamh, CONTINUITY_UNLOCK_PARAM) != NULL;
+
+    const char *user = NULL;
+    struct passwd *pwd = NULL;
+    struct passwd pwdbuf;
+    
+    /* determine the required bufsize for getpwnam_r */
+    long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (bufsize == -1) {
+        bufsize = 2 * PATH_MAX;
+    }
+    
+    /* get information about user to authenticate for */
+    char *buffer = malloc(bufsize);
+    if (pam_get_user(pamh, &user, NULL) != PAM_SUCCESS || !user ||
+        getpwnam_r(user, &pwdbuf, buffer, bufsize, &pwd) != 0 || !pwd) {
+        _LOG_ERROR("unable to obtain the username.");
+        retval = PAM_AUTHINFO_UNAVAIL;
+        goto cleanup;
+    }
+    
+    /* get the externalized context */
+    tmpval = pam_get_data(pamh, isContinuityUnlock ? "token_lacont" : "token_la", (void *)&externalized_context);
+    if (tmpval != PAM_SUCCESS) {
+        _LOG_ERROR("error obtaining the token: %d", tmpval);
+        retval = PAM_AUTHINFO_UNAVAIL;
+        goto cleanup;
+    }
+
+    /* check that the externalized context is valid */
+    if (!*externalized_context) {
+        _LOG_ERROR("invalid token");
+        retval = PAM_AUTHTOK_ERR;
+        goto cleanup;
+    }
+
+    /* create a new LA context from the externalized context */
+    context = LACreateNewContextWithACMContext(*externalized_context, &error);
+    if (!context) {
+        _LOG_ERROR("context creation failed: %ld", CFErrorGetCode(error));
+        retval = PAM_AUTHTOK_ERR;
+        goto cleanup;
+    }
+
+    /* prepare the options dictionary, aka rewrite @{ @(LAOptionNotInteractive) : @YES } without Foundation */
+    tmp = kLAOptionNotInteractive;
+    key = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &tmp);
+
+    tmp = 1;
+    value = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &tmp);
+
+    options = CFDictionaryCreateMutable(kCFAllocatorDefault, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFDictionarySetValue(options, key, value);
+
+    /* evaluate policy */
+    int policy = isContinuityUnlock ? kLAPolicyContinuityUnlock : kLAPolicyDeviceOwnerAuthenticationWithBiometrics;
+    if (!LAEvaluatePolicy(context, policy, options, &error)) {
+        _LOG_ERROR("policy %d evaluation failed: %ld", policy, CFErrorGetCode(error));
+        retval = PAM_AUTH_ERR;
+        goto cleanup;
+    }
+
+    /* verify that M8 is not spoofed */
+    if (!isContinuityUnlock && !LAVerifySEP(pwd->pw_uid, &error)) {
+        _LOG_ERROR("LAVerifySEP failed: %ld", CFErrorGetCode(error));
+        retval = PAM_AUTH_ERR;
+        goto cleanup;
+    }
+    
+    /* we passed the authentication successfully */
+    retval = PAM_SUCCESS;
+    
+cleanup:
+    if (context) {
+        CFRelease(context);
+    }
+
+    if (key) {
+        CFRelease(key);
+    }
+
+    if (value) {
+        CFRelease(value);
+    }
+
+    if (options) {
+        CFRelease(options);
+    }
+    
+    if (error) {
+        CFRelease(error);
+    }
+
+    if (buffer) {
+        free(buffer);
+    }
+    
+    _LOG_DEFAULT("pam_sm_authenticate(cont:%d) returned %d", isContinuityUnlock, retval);
+    return retval;
+}
+
+
+PAM_EXTERN int
+pam_sm_setcred(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    _LOG_DEBUG("pam_sm_setcred");
+
+    return PAM_SUCCESS;
+}
+
+
+PAM_EXTERN int
+pam_sm_acct_mgmt(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    _LOG_DEBUG("pam_sm_acct_mgmt");
+
+    return PAM_SUCCESS;
+}

--- a/src/pam_modules/modules/pam_localauthentication/screensaver_la
+++ b/src/pam_modules/modules/pam_localauthentication/screensaver_la
@@ -1,0 +1,7 @@
+# localauthentication: auth 
+auth       required       pam_localauthentication.so
+auth       required       pam_aks.so
+account    required       pam_opendirectory.so
+account    sufficient     pam_self.so
+account    required       pam_group.so no_warn group=admin,wheel fail_safe
+account    required       pam_group.so no_warn deny group=admin,wheel ruser fail_safe

--- a/src/pam_modules/modules/pam_localauthentication/screensaver_new_la
+++ b/src/pam_modules/modules/pam_localauthentication/screensaver_new_la
@@ -1,0 +1,4 @@
+# localauthentication: auth 
+auth       required       pam_localauthentication.so
+auth       required       pam_aks.so
+account    required       pam_opendirectory.so

--- a/src/pam_modules/modules/pam_mount/pam_mount.8
+++ b/src/pam_modules/modules/pam_mount/pam_mount.8
@@ -1,0 +1,52 @@
+.\"
+.\" Copyright (c) 2009 Apple Inc. All rights reserved.
+.\"
+.\" @APPLE_LICENSE_HEADER_START@
+.\" 
+.\" This file contains Original Code and/or Modifications of Original Code
+.\" as defined in and that are subject to the Apple Public Source License
+.\" Version 2.0 (the 'License'). You may not use this file except in
+.\" compliance with the License. Please obtain a copy of the License at
+.\" http://www.opensource.apple.com/apsl/ and read it before using this
+.\" file.
+.\" 
+.\" The Original Code and all software distributed under the License are
+.\" distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+.\" EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+.\" INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+.\" Please see the License for the specific language governing rights and
+.\" limitations under the License.
+.\" 
+.\" @APPLE_LICENSE_HEADER_END@
+.\"
+.Dd February 7, 2009
+.Dt pam_mount 8
+.Os
+.Sh NAME
+.Nm pam_mount
+.Nd Home Folder Mounting PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_mount
+.Op Ar options
+.Sh DESCRIPTION
+The Home Folder Mounting PAM module supports the authentication and session management function classes.  In terms of the
+.Ar function-class
+parameter, these are
+.Dq Li auth
+and
+.Dq Li session
+respectively.
+.Ss The Home Folder Mounting Authentication Module
+The Home Folder Mounting authentication module reads the mount authenticator from the PAM authentication context and caches it in the PAM environment.  The Home Folder Mounting Session Management Module must be used in conjunction with this module to remove the authenticator from the PAM environment. 
+.Ss The Home Folder Mounting Session Management Module
+The Home Folder Mounting session management module copies the mount authenticator from the PAM environment, removes it from the PAM environment, and uses its copy to mount the user's home folder if the user's OpenDirectory record indicates that an AFP, SMB, NFS or FileVault home folder is to be used.
+.Pp
+When the session is closed, the Home Folder Mounting session management module unmounts the user's home folder if it was mounted by this module when the session was opened.
+.Sh SEE ALSO
+.Xr pam.conf 5 ,
+.Xr pam 8 ,
+.Xr DirectoryService 8

--- a/src/pam_modules/modules/pam_mount/pam_mount.c
+++ b/src/pam_modules/modules/pam_mount/pam_mount.c
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2009 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <security/openpam.h>
+
+#include <sys/mount.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <limits.h>
+#include <string.h>
+#include <pwd.h>
+#include <utmpx.h>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <OpenDirectory/OpenDirectory.h>
+#include <NetFS/URLMount.h>
+
+#include "SharedMem.h"
+#include "Common.h"
+#include "Logging.h"
+
+#define PM_DISPLAY_NAME "mount"
+#define PM_AUTHENTICATOR_ENV "mount_authenticator"
+#define PM_AUTHENTICATOR_SHM_ENV "mount_authenticator_shm"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(Mount)
+#define PAM_LOG PAM_LOG_Mount()
+#endif
+
+PAM_EXTERN int
+pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	static const char password_prompt[] = "Password:";
+	char *authenticator = NULL;
+
+	if (PAM_SUCCESS != pam_get_authtok(pamh, PAM_AUTHTOK, (void *)&authenticator, password_prompt)) {
+        _LOG_ERROR("Unable to obtain the authtok.");
+		return PAM_IGNORE;
+	}
+    
+    const char *shared_mem_id = pam_shm_write(authenticator, strlen(authenticator));
+    if (shared_mem_id == NULL) {
+        _LOG_ERROR("Unable to store to shm.");
+        return PAM_IGNORE;
+    }
+    
+	if (PAM_SUCCESS != pam_setenv(pamh, PM_AUTHENTICATOR_SHM_ENV, shared_mem_id, 1)) {
+		_LOG_ERROR("Unable to set the authtok in the environment.");
+		return PAM_IGNORE;
+	}
+    _LOG_DEBUG("Stored shm with id %s", shared_mem_id);
+    
+	return PAM_SUCCESS;
+}
+
+PAM_EXTERN int
+pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	return PAM_SUCCESS;
+}
+
+PAM_EXTERN int
+pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	int retval = PAM_SUCCESS;
+	char *server_URL = NULL;
+	char *path = NULL;
+	char *homedir = NULL;
+	int mountdirlen = PATH_MAX;
+	char *mountdir = NULL;
+	const char *username = NULL;
+    char *authenticator = NULL;
+	struct passwd *pwd = NULL;
+	struct passwd pwdbuf;
+	char pwbuffer[2 * PATH_MAX];
+	unsigned int was_remounted = 0;
+
+	/* get the username */
+	if (PAM_SUCCESS != (retval = pam_get_user(pamh, &username, NULL))) {
+		_LOG_ERROR("Unable to get the username: %s", pam_strerror(pamh, retval));
+		goto fin;
+	}
+	if (username == NULL || *username == '\0') {
+		_LOG_ERROR("Username is invalid.");
+		retval = PAM_PERM_DENIED;
+		goto fin;
+	}
+
+	/* get the uid */
+	if (0 != getpwnam_r(username, &pwdbuf, pwbuffer, sizeof(pwbuffer), &pwd) || NULL == pwd) {
+		_LOG_ERROR("Unknown user \"%s\".", username);
+		retval = PAM_SYSTEM_ERR;
+		goto fin;
+	}
+
+	/* get the authenticator */
+	authenticator = pam_copy_secret_with_fallback(pamh, PM_AUTHENTICATOR_ENV, PM_AUTHENTICATOR_SHM_ENV);
+	if (NULL == authenticator) {
+		_LOG_ERROR("Unable to retrieve the authenticator.");
+		retval = PAM_IGNORE;
+		goto fin;
+	}
+    
+	/* get the server_URL, path and homedir from OD */
+	if (PAM_SUCCESS != (retval = od_extract_home(pamh, username, &server_URL, &path, &homedir))) {
+		_LOG_ERROR("Error retrieve data from OpenDirectory: %s", pam_strerror(pamh, retval));
+		goto fin;
+	}
+
+	_LOG_DEBUG("           UID: %d", pwd->pw_uid);
+	_LOG_DEBUG("    server_URL: %s", server_URL);
+	_LOG_DEBUG("          path: %s", path);
+	_LOG_DEBUG("       homedir: %s", homedir);
+	_LOG_DEBUG("      username: %s", username);
+	//_LOG_DEBUG(" authenticator: %s", authenticator);  // We don't want to log user's passwords.
+
+
+	/* determine if we need to mount the home folder */
+	// this triggers the automounting for nfs
+	if (0 == access(homedir, F_OK) || EACCES == errno) {
+		_LOG_DEBUG("The home folder share is already mounted.");
+	}
+	if (NULL == (mountdir = malloc(mountdirlen+1))) {
+		_LOG_DEBUG("Failed to malloc the mountdir.");
+		retval = PAM_IGNORE;
+		goto fin;
+	}
+
+	/* mount the home folder */
+	if (NULL != server_URL && retval == PAM_SUCCESS) {
+		// for an afp or smb home folder
+		if (NULL != path) {
+			if (0 != NetFSMountHomeDirectoryWithAuthentication(server_URL,
+									   homedir,
+									   path,
+									   pwd->pw_uid,
+									   mountdirlen,
+									   mountdir,
+									   username,
+									   authenticator,
+									   kNetFSAllowKerberos,
+									   &was_remounted)) {
+				_LOG_DEBUG("Unable to mount the home folder.");
+				retval = PAM_SESSION_ERR;
+				goto fin;
+			}
+			else {
+				if (0 != was_remounted) {
+					_LOG_DEBUG("Remounted home folder.");
+				}
+				else {
+					_LOG_DEBUG("Mounted home folder.");
+				}
+				/* cache the homedir and path for close_session */
+				pam_set_data(pamh, "homedir", homedir, openpam_free_data);
+				pam_set_data(pamh, "path", path, openpam_free_data);
+				homedir = NULL;
+				path = NULL;
+			}
+		}
+	}
+	else {
+		// skip unmount for local homes
+		pam_set_data(pamh, "path", strdup(""), openpam_free_data);
+	}
+
+
+fin:
+	free(homedir);
+	free(mountdir);
+	free(server_URL);
+	free(path);
+    pam_safe_string_release(authenticator);
+
+	return retval;
+}
+
+
+PAM_EXTERN int
+pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	int retval = PAM_SUCCESS;
+	const char *username;
+	char *server_URL = NULL;
+	char *path = NULL;
+	char *homedir = NULL;
+	struct passwd *pwd = NULL;
+	struct passwd pwdbuf;
+	char pwbuffer[2 * PATH_MAX];
+	CFStringRef cfhomedir = NULL;
+	CFURLRef home_url = NULL;
+
+	/* get the username */
+	retval = pam_get_user(pamh, &username, NULL);
+	if (retval != PAM_SUCCESS) {
+		_LOG_ERROR("Unable to get the username: %s", pam_strerror(pamh, retval));
+		return retval;
+	}
+	if (username == NULL || *username == '\0') {
+		_LOG_ERROR("Username is invalid.");
+		return PAM_PERM_DENIED;
+	}
+
+	/* determine if we need to unmount the home folder */
+	struct utmpx *x;
+	setutxent();
+	while (NULL != (x = getutxent())) {
+		if (USER_PROCESS == x->ut_type && 0 == strcmp(x->ut_user, username) && x->ut_pid != getpid()) {
+			_LOG_DEBUG("User is still logged in elsewhere (%s), skipping home folder unmount.", x->ut_line);
+			return PAM_IGNORE;
+		}
+	}
+	endutxent();
+
+	/* try to retrieve the cached homedir */
+	if (PAM_SUCCESS != pam_get_data(pamh, "homedir", (void *)&homedir)) {
+		_LOG_DEBUG("No cached homedir in the PAM context.");
+	}
+	if (NULL != homedir) {
+		if (NULL == (homedir = strdup(homedir))) {
+			_LOG_ERROR("Failed to duplicate the homedir.");
+			retval = PAM_BUF_ERR;
+			goto fin;
+		}
+	}
+
+	/* try to retrieve the cached path */
+	if (PAM_SUCCESS != pam_get_data(pamh, "path", (void *)&path)) {
+		_LOG_DEBUG("No cached path in the PAM context.");
+	}
+	if (NULL != path) {
+		if (NULL == (path = strdup(path))) {
+			_LOG_ERROR("Failed to duplicate the path.");
+			retval = PAM_BUF_ERR;
+			goto fin;
+		}
+	}
+
+	/* skip unmount for local homes */
+	if (NULL != path && 0 == strcmp("", path)) {
+		_LOG_DEBUG("Skipping unmount.");
+		goto fin;
+	}
+
+	/* get the homedir and path or devicepath if needed */
+	if (NULL == homedir || NULL == path) {
+		if (PAM_SUCCESS != (retval = od_extract_home(pamh, username, &server_URL, &path, &homedir))) {
+			_LOG_ERROR("Error retrieve data from OpenDirectory: %s", pam_strerror(pamh, retval));
+			goto fin;
+		}
+	}
+
+	/* attempt to unmount the home folder */
+	if (NULL != homedir && NULL != path) {
+		// not FileVault
+		if (0 != getpwnam_r(username, &pwdbuf, pwbuffer, sizeof(pwbuffer), &pwd) || NULL == pwd) {
+			_LOG_ERROR("Unknown user \"%s\".", username);
+			retval = PAM_SYSTEM_ERR;
+			goto fin;
+		}
+		if (0 != NetFSUnmountHomeDirectory(homedir, path, pwd->pw_uid, 0)) {
+			_LOG_DEBUG("Unable to unmount the home folder: %s.", strerror(errno));
+			retval = PAM_IGNORE;
+		}
+		else {
+			_LOG_DEBUG("Unmounted home folder.");
+		}
+	}
+	else {
+		// nothing
+		_LOG_DEBUG("There is nothing to unmount.");
+		retval = PAM_IGNORE;
+	}
+
+fin:
+	free(server_URL);
+	free(path);
+	free(homedir);
+
+	if (home_url)
+		CFRelease(home_url);
+	if (cfhomedir)
+		CFRelease(cfhomedir);
+
+	return retval;
+}

--- a/src/pam_modules/modules/pam_nologin/README
+++ b/src/pam_modules/modules/pam_nologin/README
@@ -1,0 +1,12 @@
+# $Id: README,v 1.4 2002/03/27 02:36:30 bbraun Exp $
+#
+
+This module always lets root in; it lets other users in only if the file
+/etc/nologin doesn't exist.  In any case, if /etc/nologin exists, it's
+contents are displayed to the user.
+
+module services provided:
+
+	auth		_authentication and _setcred (blank)
+
+Michael K. Johnson

--- a/src/pam_modules/modules/pam_nologin/pam_nologin.8
+++ b/src/pam_modules/modules/pam_nologin/pam_nologin.8
@@ -1,0 +1,64 @@
+.\" Copyright (c) 2001 Mark R V Murray
+.\" All rights reserved.
+.\"
+.\" Portions Copyright (C) 2002-2009 Apple Inc.  All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
+.\"
+.\" $FreeBSD: src/lib/libpam/modules/pam_nologin/pam_nologin.8,v 1.5 2001/08/26 18:05:35 markm Exp $
+.\"
+.\" Protions copyright (c) 2009 Apple Inc. All rights reserved.
+.\"
+.Dd February 7, 2009
+.Dt pam_nologin 8
+.Os
+.Sh NAME
+.Nm pam_nologin
+.Nd No Login PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_nologin
+.Op Ar options
+.Sh DESCRIPTION
+The No Login PAM module supports the account management function class.  In terms of the
+.Ar function-class
+parameter, this is the
+.Dq Li account
+class.
+.Pp
+The No Login authentication module always returns success for the superuser, and returns success for all other users if the file
+.Pa /etc/nologin
+does not exist.  If
+.Pa /etc/nologin
+does exist, then its contents are echoed to non-superusers before failure is returned.
+.Sh FILES
+.Bl -tag
+.It Pa /etc/nologin
+A message to denied users.
+.El
+.Sh SEE ALSO
+.Xr nologin 8 ,
+.Xr pam.conf 5 ,
+.Xr pam 8 ,
+.Xr pwpolicy 8

--- a/src/pam_modules/modules/pam_nologin/pam_nologin.c
+++ b/src/pam_modules/modules/pam_nologin/pam_nologin.c
@@ -1,0 +1,156 @@
+/* pam_nologin module */
+
+/*
+ * $Id: pam_nologin.c,v 1.5 2002/03/27 19:20:24 bbraun Exp $
+ *
+ * Written by Michael K. Johnson <johnsonm@redhat.com> 1996/10/24
+ *
+ * Portions Copyright (C) 2002-2009 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms of Linux-PAM, with
+ * or without modification, are permitted provided that the following
+ * conditions are met:
+ * 
+ * 1. Redistributions of source code must retain any existing copyright
+ * notice, and this entire permission notice in its entirety,
+ * including the disclaimer of warranties.
+ * 
+ * 2. Redistributions in binary form must reproduce all prior and current
+ * copyright notices, this list of conditions, and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * 
+ * 3. The name of any author may not be used to endorse or promote
+ * products derived from this software without their specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE. 
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/syslimits.h>
+#include <pwd.h>
+#include <string.h>
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(nologin)
+#define PAM_LOG PAM_LOG_nologin()
+#endif
+
+/*
+ * here, we make a definition for the externally accessible function
+ * in this file (this definition is required for static a module
+ * but strongly encouraged generally) it is used to instruct the
+ * modules include file to define the function prototypes.
+ */
+
+#define PAM_SM_ACCOUNT
+
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+
+
+/* --- account management function (only) --- */
+
+PAM_EXTERN
+int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc,
+                        const char **argv)
+{
+     int retval = PAM_SUCCESS;
+     int fd;
+     const char *username;
+     char *mtmp=NULL;
+     struct passwd *user_pwd;
+     struct passwd pwdbuf;
+     char pwbuffer[2 * PATH_MAX];
+     struct pam_conv *conversation;
+     struct pam_message message;
+     struct pam_message *pmessage = &message;
+     struct pam_response *resp = NULL;
+     struct stat st;
+
+     if ((fd = open("/etc/nologin", O_RDONLY, 0)) >= 0) {
+       /* root can still log in; lusers cannot */
+       if ((pam_get_user(pamh, &username, NULL) != PAM_SUCCESS)
+           || !username) {
+		   _LOG_ERROR("Failed to obtain the username.");
+         return PAM_SERVICE_ERR;
+       }
+       if (getpwnam_r(username, &pwdbuf, pwbuffer, sizeof(pwbuffer), &user_pwd) != 0) {
+         _LOG_ERROR("The getpwnam_r call failed.");
+         user_pwd = NULL;
+       }
+       if (user_pwd && user_pwd->pw_uid == 0) {
+         message.msg_style = PAM_TEXT_INFO;
+       } else {
+	   if (!user_pwd) {
+		   _LOG_ERROR("The user is invalid.");
+	       retval = PAM_USER_UNKNOWN;
+	   } else {
+		   _LOG_ERROR("Denying non-root login.");
+	       retval = PAM_AUTH_ERR;
+	   }
+	   message.msg_style = PAM_ERROR_MSG;
+       }
+
+       /* fill in message buffer with contents of /etc/nologin */
+	   if (fstat(fd, &st) < 0) {/* give up trying to display message */
+           _LOG_ERROR("Failure displaying the message.");
+		   return retval;
+	   }
+       message.msg = mtmp = malloc(st.st_size+1);
+       /* if malloc failed... */
+	   if (!message.msg){
+           _LOG_ERROR("The message is empty.");
+		   return retval;
+	   }
+       read(fd, mtmp, st.st_size);
+       mtmp[st.st_size] = '\000';
+
+       /* Use conversation function to give user contents of /etc/nologin */
+       pam_get_item(pamh, PAM_CONV, (const void **)&conversation);
+       conversation->conv(1, (const struct pam_message **)&pmessage,
+			  &resp, conversation->appdata_ptr);
+       free(mtmp);
+       if (NULL != resp && NULL != resp->resp) {
+         memset(resp->resp, 0, strlen(resp->resp));
+       }
+     }
+
+     return retval;
+}
+
+
+#ifdef PAM_STATIC
+
+/* static module data */
+
+struct pam_module _pam_nologin_modstruct = {
+     "pam_nologin",
+     pam_sm_authenticate,
+     pam_sm_setcred,
+     NULL,
+     NULL,
+     NULL,
+     NULL,
+};
+
+#endif
+
+/* end of module definition */

--- a/src/pam_modules/modules/pam_ntlm/pam_ntlm.8
+++ b/src/pam_modules/modules/pam_ntlm/pam_ntlm.8
@@ -1,0 +1,31 @@
+.\"
+.\" Copyright (c) 2008-2009 Apple Inc. All rights reserved.
+.\"
+.Dd January 15, 1999
+.Dt PAM_KRB5 8
+.Os
+.Sh NAME
+.Nm pam_ntlm
+.Nd NTLM PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_krb5
+.Op Ar options
+.Sh DESCRIPTION
+The NTLM PAM module supports the storing NTLM credentials as part of pam_setcred(), add pam_ntlm as an auth parameter.
+In terms of the
+.Ar function-class
+parameter, its are
+.Dq Li auth .
+.Ss NTLM Authentication Module
+The NTLM component
+provides functions to store the NTLM credentials as a side effect of login
+.Pq Fn pam_sm_setcred .
+.Pp
+.Fn pam_sm_setcred
+function stores the credentials in a credentials cache.
+.Sh SEE ALSO
+.Xr pam.conf 5 ,
+.Xr pam 8

--- a/src/pam_modules/modules/pam_ntlm/pam_ntlm.c
+++ b/src/pam_modules/modules/pam_ntlm/pam_ntlm.c
@@ -1,0 +1,236 @@
+/*-
+ * Copyright 2010 Apple Inc
+ */
+
+#include <sys/cdefs.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/param.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pwd.h>
+
+#include <OpenDirectory/OpenDirectory.h>
+
+#include <GSS/gssapi_ntlm.h>
+#include <GSS/gssapi_spi.h>
+
+#define	PAM_SM_AUTH
+#define	PAM_SM_ACCOUNT
+#define	PAM_SM_PASSWORD
+
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <security/openpam.h>
+#include "SharedMem.h"
+
+#include "Common.h"
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(NTLM)
+#define PAM_LOG PAM_LOG_NTLM()
+#endif
+
+#define PAM_OPT_DEBUG		"debug"
+
+static const char *password_key = "NTLMPWD";
+static const char *password_shm_key = "NTLMPWD_shm";
+
+
+/*
+ * authentication management
+ */
+
+PAM_EXTERN int
+pam_sm_authenticate(pam_handle_t *pamh, int flags __unused,
+    int argc __unused, const char *argv[] __unused)
+{
+	int retval;
+	const char *password;
+
+    _LOG_DEBUG("pam_sm_authenticate: ntlm");
+
+	/* get password */
+	retval = pam_get_authtok(pamh, PAM_AUTHTOK, &password, NULL);
+	if (retval != PAM_SUCCESS)
+		return retval;
+    
+    const char *shared_mem_id = pam_shm_write(password, strlen(password));
+    if (shared_mem_id == NULL) {
+        _LOG_ERROR("Unable to store to shm.");
+        return PAM_IGNORE;
+    }
+    
+    if (PAM_SUCCESS != pam_setenv(pamh, password_shm_key, shared_mem_id, 1)) {
+        _LOG_ERROR("Unable to set the authtok in the environment.");
+        return PAM_IGNORE;
+    }
+    
+	return PAM_IGNORE;
+}
+
+static void
+ac_complete(void *ctx, OM_uint32 major, gss_status_id_t status,
+			gss_cred_id_t cred, gss_OID_set oids, OM_uint32 time_rec)
+{
+    OM_uint32 junk;
+    gss_release_cred(&junk, &cred);
+    gss_release_oid_set(&junk, &oids);
+    _LOG_DEBUG("ac_complete returned: %d for %d", major, geteuid());
+}
+
+PAM_EXTERN int
+pam_sm_setcred(pam_handle_t *pamh, int flags,
+    int argc __unused, const char *argv[] __unused)
+{
+	gss_auth_identity_desc identity;
+    const char *user;
+    char *password = NULL;
+	struct passwd *pwd;
+	struct passwd pwdbuf;
+	char pwbuffer[2 * PATH_MAX];
+	int retval;
+	uid_t euid = geteuid();
+	gid_t egid = getegid();
+	ODRecordRef record = NULL;
+	CFArrayRef array = NULL;
+	CFIndex i, count;
+
+    _LOG_DEBUG("pam_sm_setcred: ntlm");
+
+	memset(&identity, 0, sizeof(identity));
+
+	/* Get username */
+	retval = pam_get_item(pamh, PAM_USER, (const void **)&user);
+	if (retval != PAM_SUCCESS) {
+        _LOG_ERROR("pam_sm_setcred: ntlm user can't be found");
+		goto cleanup;
+	}
+
+	if (getpwnam_r(user, &pwdbuf, pwbuffer, sizeof(pwbuffer), &pwd) != 0 || pwd == NULL) {
+        _LOG_ERROR("pam_sm_setcred: ntlm user %s doesn't exists", user);
+		retval = PAM_USER_UNKNOWN;
+		goto cleanup;
+	}
+
+ password = pam_copy_secret_with_fallback(pamh, password_key, password_shm_key);
+ if (password == NULL) {
+  _LOG_ERROR("pam_sm_setcred: ntlm user %s doesn't have a password", user);
+  retval = PAM_IGNORE;
+  goto cleanup;
+ }
+    
+	retval = od_record_create_cstring(pamh, &record, user);
+	if (retval || record == NULL) {
+		retval = PAM_IGNORE;
+		goto cleanup;
+	}
+
+	array = ODRecordCopyValues(record, kODAttributeTypeAuthenticationAuthority, NULL);
+	if (array == NULL) {
+        _LOG_ERROR("pam_sm_setcred: ntlm user %s doesn't have auth authority", user);
+		retval = PAM_IGNORE;
+		goto cleanup;
+	}
+
+	identity.username = (char *)user;
+	identity.password = (char *)password;
+
+	count = CFArrayGetCount(array);
+	for (i = 0; i < count && identity.realm == NULL; i++) {
+		CFStringRef val = CFArrayGetValueAtIndex(array, i);
+		if (NULL == val || CFGetTypeID(val) != CFStringGetTypeID())
+			break;
+
+		if (!CFStringHasPrefix(val, CFSTR(";NetLogon;")))
+			continue;
+
+		CFArrayRef parts = CFStringCreateArrayBySeparatingStrings(kCFAllocatorDefault, val, CFSTR(";"));
+		if (parts == NULL)
+			continue;
+
+		if (CFArrayGetCount(parts) < 4) {
+			CFRelease(parts);
+			continue;
+		}
+
+		CFStringRef domain = CFArrayGetValueAtIndex(parts, 3);
+
+		retval = cfstring_to_cstring(domain, &identity.realm);
+		CFRelease(parts);
+		if (retval)
+			goto cleanup;
+	}
+
+	if (identity.realm == NULL) {
+        _LOG_DEBUG("pam_sm_setcred: no domain found skipping");
+		retval = PAM_IGNORE;
+		goto cleanup;
+	}
+
+	if (euid == 0) {
+		if (setegid(pwd->pw_gid) != 0) {
+			retval = PAM_SERVICE_ERR;
+			goto cleanup;
+		}
+		if (seteuid(pwd->pw_uid) != 0) {
+			retval = PAM_SERVICE_ERR;
+			goto cleanup;
+		}
+	}
+
+	(void)gss_acquire_cred_ex_f(NULL,
+				    GSS_C_NO_NAME,
+				    0,
+				    GSS_C_INDEFINITE,
+				    GSS_NTLM_MECHANISM,
+				    GSS_C_INITIATE,
+				    &identity,
+				    NULL,
+				    ac_complete);
+
+	if (euid == 0) {
+		seteuid(euid);
+		setegid(egid);
+	}
+
+	_LOG_DEBUG("pam_sm_setcred: ntlm done, used domain: %s", identity.realm);
+
+cleanup:
+    pam_safe_string_release(password);
+	if (record)
+		CFRelease(record);
+	if (array)
+		CFRelease(array);
+	if (identity.realm)
+		free(identity.realm);
+	pam_unsetenv(pamh, password_key);
+	pam_unsetenv(pamh, password_shm_key);
+	return retval;
+}
+
+/*
+ * account management
+ */
+PAM_EXTERN int
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags __unused,
+    int argc __unused, const char *argv[] __unused)
+{
+	return PAM_SUCCESS;
+}
+
+/*
+ * password management
+ */
+PAM_EXTERN int
+pam_sm_chauthtok(pam_handle_t *pamh, int flags,
+    int argc __unused, const char *argv[] __unused)
+{
+	return PAM_AUTHTOK_ERR;
+}
+
+PAM_MODULE_ENTRY("pam_ntlm");

--- a/src/pam_modules/modules/pam_opendirectory/pam_opendirectory.8
+++ b/src/pam_modules/modules/pam_opendirectory/pam_opendirectory.8
@@ -1,0 +1,75 @@
+.\"
+.\" Copyright (c) 2009 Apple Inc. All rights reserved.
+.\"
+.\" @APPLE_LICENSE_HEADER_START@
+.\" 
+.\" This file contains Original Code and/or Modifications of Original Code
+.\" as defined in and that are subject to the Apple Public Source License
+.\" Version 2.0 (the 'License'). You may not use this file except in
+.\" compliance with the License. Please obtain a copy of the License at
+.\" http://www.opensource.apple.com/apsl/ and read it before using this
+.\" file.
+.\" 
+.\" The Original Code and all software distributed under the License are
+.\" distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+.\" EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+.\" INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+.\" Please see the License for the specific language governing rights and
+.\" limitations under the License.
+.\" 
+.\" @APPLE_LICENSE_HEADER_END@
+.\"
+.Dd February 7, 2009
+.Dt pam_opendirectory 8
+.Os
+.Sh NAME
+.Nm pam_opendirectory
+.Nd OpenDirectory PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_opendirectory
+.Op Ar options
+.Sh DESCRIPTION
+The OpenDirectory PAM module supports the authentication, account management and password management function classes.  In terms of the
+.Ar function-class
+parameter, these are
+.Dq Li auth ,
+.Dq Li account
+and
+.Dq Li password
+respectively.
+.Ss The OpenDirectory Authentication Module
+The OpenDirectory authentication module permits or denies users based on OpenDirectory password authentication.
+.Pp
+The following option may be passed to this authentication module:
+.Bl -tag
+.It Cm nullok
+Allow null passwords.
+.El
+.Ss The OpenDirectory Account Management Module
+The OpenDirectory account management module permits or denies users based whether the account is enabled in OpenDirectory.
+.Pp
+The following option may be passed to this account management module:
+.Bl -tag
+.It Cm no_check_shell
+Skip validating the user's shell.
+.It Cm no_check_home
+Skip validating the user's home directory.
+.It Cm refresh Ns = Ns Ar min
+Sets the mbr_check_membership(3) cache timeout to
+.Ar min
+minutes.  When this option is used, the
+.Ar min
+value must be specified, and it must be an integer.
+.El
+.Ss The OpenDirectory Password Management Module
+The OpenDirectory password management module supports password changing and enforces the OpenDirectory password policy.
+.Sh SEE ALSO
+.Xr mbr_check_membership 3 ,
+.Xr pam.conf 5 ,
+.Xr pam 8 ,
+.Xr pwpolicy 8 ,
+.Xr DirectoryService 8

--- a/src/pam_modules/modules/pam_opendirectory/pam_opendirectory.m
+++ b/src/pam_modules/modules/pam_opendirectory/pam_opendirectory.m
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ * Portions Copyright (c) 2001 PADL Software Pty Ltd. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * Portions Copyright (c) 2000 Apple Computer, Inc.  All Rights
+ * Reserved.  This file contains Original Code and/or Modifications of
+ * Original Code as defined in and that are subject to the Apple Public
+ * Source License Version 1.1 (the "License").  You may not use this file
+ * except in compliance with the License.  Please obtain a copy of the
+ * License at http://www.apple.com/publicsource and read it before using
+ * this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON- INFRINGEMENT.  Please see the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/******************************************************************
+ * The purpose of this module is to provide a basic password
+ * authentication module for Mac OS X.
+ ******************************************************************/
+
+#include <pwd.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#include <membership.h>
+#include <membershipPriv.h>
+#include <ConfigurationProfiles/CPBootstrapToken.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <OpenDirectory/OpenDirectory.h>
+#include <OpenDirectory/OpenDirectoryPriv.h>
+#include <DirectoryService/DirectoryService.h>
+#include "ForkSafeLogging.h"
+
+#define PAM_SM_AUTH
+#define PAM_SM_ACCOUNT
+
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+
+#include "Common.h"
+
+#define PM_DISPLAY_NAME "OpenDirectory"
+#define PAM_OD_PW_EXP "ODPasswordExpire"
+#define PAM_OD_NON_PWD "non_password_auth"
+
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(OpenDirectory)
+#define PAM_LOG PAM_LOG_OpenDirectory()
+#endif
+
+// <rdar://problem/12503092> OD password verification API always leads to user existence timing attacks
+// Define our own implementation of AbsoluteToMicroseconds rather than using CoreService ==> CarbonCore
+// Nanoseconds AbsoluteToNanoseconds(AbsoluteTime inTime);
+//
+// Based on Technical Q&A QA1398 - Mach Absolute Time Units
+// https://developer.apple.com/library/mac/qa/qa1398/_index.html
+
+uint64_t AbsoluteToMicroseconds(uint64_t t) {
+	static double f = 0.0;
+
+	if (f == 0.0) {
+		mach_timebase_info_data_t tbinfo;
+		(void) mach_timebase_info(&tbinfo);
+		f = tbinfo.numer / (1000.0 * tbinfo.denom);
+	}
+
+	return t * f;
+}
+
+int
+_process_prl(ODRecordRef record, pam_handle_t * pamh, const char * user)
+{
+    CFErrorRef error = NULL;
+    int retval = od_record_check_pwpolicy(record, &error);
+    if (retval == PAM_APPLE_ACCT_LOCKED || retval == PAM_APPLE_ACCT_TEMP_LOCK) {
+        /* check user password policy */
+        NSNumber *timeRemaining = ((__bridge NSError *)error).userInfo[kODBackOffSeconds];
+        if (timeRemaining && ([timeRemaining isKindOfClass: [NSNumber class]])) {
+            long backoff = timeRemaining.longValue;
+            pam_set_data(pamh, "prl_backoff", backoff, NULL);
+            _LOG_DEBUG("%s - PRL backoff for user %s reported as %ld", PM_DISPLAY_NAME, user, backoff);
+        } else {
+            _LOG_ERROR("%s - wrong PRL backoff received", PM_DISPLAY_NAME);
+        }
+    }
+    CFReleaseSafe(error);
+    return retval;
+}
+
+PAM_EXTERN int
+pam_sm_acct_mgmt(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+	int retval = PAM_PERM_DENIED;
+	const char *user = NULL;
+	char *homedir = NULL;
+	ODRecordRef cfRecord = NULL;
+	struct passwd *pwd = NULL;
+	struct passwd pwdbuf;
+	char pwbuffer[2 * PATH_MAX];
+	const char *ttl_str = NULL;
+	long ttl = 30 * 60;
+    bool ignorePasswordLockout = openpam_get_option(pamh, PAM_OD_NON_PWD);
+
+	/* get the username */
+	retval = pam_get_user(pamh, &user, NULL);
+	if (PAM_SUCCESS != retval) {
+		goto cleanup;
+	}
+	if (user == NULL || *user == '\0') {
+		retval = PAM_PERM_DENIED;
+		goto cleanup;
+	}
+
+	/* refresh the membership */
+	if (0 != getpwnam_r(user, &pwdbuf, pwbuffer, sizeof(pwbuffer), &pwd) || NULL == pwd) {
+		_LOG_ERROR("%s - Unable to get pwd record.", PM_DISPLAY_NAME);
+		retval = PAM_USER_UNKNOWN;
+		goto cleanup;
+	}
+	if (NULL != (ttl_str = openpam_get_option(pamh, "refresh"))) {
+		ttl = strtol(ttl_str, NULL, 10) * 60;
+	}
+	mbr_set_identifier_ttl(ID_TYPE_UID, &pwd->pw_uid, sizeof(pwd->pw_uid), (unsigned int)ttl);
+    _LOG_DEBUG("%s - Membership cache TTL set to %ld.", PM_DISPLAY_NAME, ttl);
+
+	/* Get user record from OD */
+	retval = od_record_create_cstring(pamh, &cfRecord, (const char*)user);
+	if (PAM_SUCCESS != retval) {
+		_LOG_ERROR("%s - Unable to get user record: %d.", PM_DISPLAY_NAME, retval);
+		goto cleanup;
+	}
+
+	/* check if authentication returned password expired */
+	if (pam_getenv(pamh, PAM_OD_PW_EXP) != NULL) {
+		_LOG_ERROR("%s - Password expired.", PM_DISPLAY_NAME);
+		retval = PAM_NEW_AUTHTOK_REQD;
+		goto cleanup;
+	}
+
+	/* check user password policy */
+    retval = _process_prl(cfRecord, pamh, user);
+    if (retval != PAM_SUCCESS) {
+        if (ignorePasswordLockout && retval == PAM_APPLE_ACCT_TEMP_LOCK) {
+            _LOG_INFO("%s - ignored password lockout because non-password auth was used", PM_DISPLAY_NAME);
+        } else {
+            _LOG_ERROR("%s - check password policy failed %d", PM_DISPLAY_NAME, retval);
+            goto cleanup;
+        }
+    }
+
+	/* check user authentication authority */
+	retval = od_record_check_authauthority(cfRecord);
+	if (PAM_SUCCESS != retval) {
+        _LOG_ERROR("%s - check authority failed %d", PM_DISPLAY_NAME, retval);
+		goto cleanup;
+	}
+
+	/* check user home directory */
+	if (!openpam_get_option(pamh, "no_check_home")) {
+		retval = od_record_check_homedir(cfRecord);
+		if (PAM_SUCCESS != retval) {
+            _LOG_ERROR("%s - check homedir failed %d", PM_DISPLAY_NAME, retval);
+			goto cleanup;
+		}
+	}
+
+	/* check user shell */
+	if (!openpam_get_option(pamh, "no_check_shell")) {
+		retval = od_record_check_shell(cfRecord);
+		if (PAM_SUCCESS != retval) {
+            _LOG_ERROR("%s - shell check failed %d", PM_DISPLAY_NAME, retval);
+			goto cleanup;
+		}
+	}
+
+cleanup:
+	CFReleaseSafe(cfRecord);
+	free(homedir);
+	pam_unsetenv(pamh, PAM_OD_PW_EXP);
+
+	return retval;
+}
+
+PAM_EXTERN int
+pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+	static const char password_prompt[] = "Password:";
+	int retval = PAM_SUCCESS;
+	const char *user = NULL;
+	const char *password = NULL;
+	CFStringRef cfAuthAuthority = NULL;
+	CFStringRef cfPassword = NULL;
+	CFErrorRef odErr = NULL;
+	ODRecordRef cfRecord = NULL;
+	uint64_t mach_start_time = mach_absolute_time();
+	bool should_sleep = 0;
+
+	if (PAM_SUCCESS != (retval = pam_get_user(pamh, &user, NULL))) {
+		_LOG_ERROR("%s - Unable to obtain the username.", PM_DISPLAY_NAME);
+		goto cleanup;
+	}
+	if (PAM_SUCCESS != (retval = pam_get_authtok(pamh, PAM_AUTHTOK, &password, password_prompt))) {
+        _LOG_ERROR("%s - Error obtaining the authtok.", PM_DISPLAY_NAME);
+		retval = PAM_AUTH_ERR;
+		goto cleanup;
+	}
+	if ((password[0] == '\0') && ((NULL == openpam_get_option(pamh, "nullok")) || (flags & PAM_DISALLOW_NULL_AUTHTOK))) {
+        _LOG_ERROR("%s - NULL passwords are not allowed.", PM_DISPLAY_NAME);
+		retval = PAM_AUTH_ERR;
+		goto cleanup;
+	}
+
+	/* From this point, all error paths should be constant time */
+	should_sleep = 1;
+
+	/* Get user record from OD */
+	retval = od_record_create_cstring(pamh, &cfRecord, (const char*)user);
+	if (PAM_SUCCESS != retval) {
+		_LOG_ERROR("%s - Unable to get user record.", PM_DISPLAY_NAME);
+		goto cleanup;
+	}
+
+	if (NULL == cfRecord) {
+		_LOG_ERROR("%s - User record NULL.", PM_DISPLAY_NAME);
+		retval = PAM_USER_UNKNOWN;
+		goto cleanup;
+	}
+
+	/* <rdar://problem/48780154> Adopt new OD SPI and entitlement to use the bootstrap token prior to user authentication */
+	if (&CP_SupportsBootstrapToken != NULL) {
+		retval = od_record_attribute_create_cfstring(cfRecord, (CFStringRef) kODAttributeTypeAuthenticationAuthority, &cfAuthAuthority);
+		NSArray<NSString *> *authAttributes = nil;
+		if (retval == PAM_SUCCESS)
+            authAttributes = [(__bridge NSString *)cfAuthAuthority componentsSeparatedByString:@";"];
+		if ([authAttributes containsObject:@(kDSTagAuthAuthorityLocalCachedUser)] &&
+			CP_SupportsBootstrapToken()) {
+			/* Get token + authenticate. */
+			NSString *token = CP_GetBootstrapTokenWithOptions(@{ @"NetworkTimeout" : @20 }, NULL);
+			if (token != NULL && token.length > 0) {
+                if (ODRecordSetNodeCredentialsWithBootstrapToken(cfRecord, (__bridge CFStringRef) token, &odErr)) {
+                    _LOG_VERBOSE("%s - Authenticated with bootstrap token.", PM_DISPLAY_NAME);
+				} else {
+					_LOG_ERROR("%s - Failed to set bootstrap token: %s.", PM_DISPLAY_NAME, [(__bridge NSError *)odErr description].UTF8String);
+					CFReleaseNull(odErr);
+				}
+			}
+		}
+	}
+
+	/* Verify the user's password */
+	cfPassword = CFStringCreateWithCString(kCFAllocatorDefault, password, kCFStringEncodingUTF8);
+	retval = PAM_USER_UNKNOWN;
+	if (!ODRecordVerifyPassword(cfRecord, cfPassword, &odErr)) {
+		switch (CFErrorGetCode(odErr)) {
+			case kODErrorCredentialsAccountNotFound:
+				retval = PAM_USER_UNKNOWN;
+				_LOG_ERROR("%s - Account not found or invalid.", PM_DISPLAY_NAME);
+				break;
+			case kODErrorCredentialsAccountDisabled:
+			case kODErrorCredentialsAccountInactive:
+                _LOG_ERROR("%s - The account is disabled or inactive.", PM_DISPLAY_NAME);
+				retval = PAM_PERM_DENIED;
+				break;
+			case kODErrorCredentialsPasswordExpired:
+			case kODErrorCredentialsPasswordChangeRequired:
+                _LOG_ERROR("%s - The authtok is expired or requires updating.", PM_DISPLAY_NAME);
+				pam_setenv(pamh, PAM_OD_PW_EXP, "yes", 1);
+				retval = PAM_SUCCESS;
+				break;
+			case kODErrorCredentialsInvalid:
+                _LOG_ERROR("%s - The authtok is incorrect.", PM_DISPLAY_NAME);
+				retval = PAM_AUTH_ERR;
+				break;
+			case kODErrorCredentialsAccountTemporarilyLocked :
+                _LOG_ERROR("%s - Account temporarily locked after incorrect password attempt(s).", PM_DISPLAY_NAME);
+                _process_prl(cfRecord, pamh, user);
+				retval = PAM_APPLE_ACCT_TEMP_LOCK;
+				break;
+			case kODErrorCredentialsAccountLocked :
+                _LOG_ERROR("%s - Account locked after too many incorrect password attempts.", PM_DISPLAY_NAME);
+				retval = PAM_APPLE_ACCT_LOCKED;
+				break;
+			default:
+                _LOG_ERROR("%s  Unexpected error code from ODRecordVerifyPassword(): %ld.",
+					    PM_DISPLAY_NAME, CFErrorGetCode(odErr));
+				retval = PAM_AUTH_ERR;
+				break;
+		}
+	} else {
+		retval = PAM_SUCCESS;
+		should_sleep = 0;
+	}
+
+cleanup:
+	if (should_sleep) {
+		// <rdar://problem/12503092> OD password verification API always leads to user existence timing attacks
+		uint64_t elapsed      = mach_absolute_time() - mach_start_time;
+		uint64_t microseconds = AbsoluteToMicroseconds(elapsed);
+
+		const uint64_t response_delay = 2000000;    // 2000000 us == 2s
+		_LOG_DEBUG("%s - auth %lld µs", PM_DISPLAY_NAME, microseconds);
+		if (microseconds < response_delay)
+			usleep((useconds_t)(response_delay - microseconds));
+
+		elapsed      = mach_absolute_time() - mach_start_time;
+		microseconds = AbsoluteToMicroseconds(elapsed);
+		_LOG_DEBUG("%s - auth %lld µs (blinding)", PM_DISPLAY_NAME, microseconds);
+	}
+
+	CFReleaseSafe(cfAuthAuthority);
+	CFReleaseSafe(cfRecord);
+	CFReleaseSafe(cfPassword);
+	CFReleaseSafe(odErr);
+
+	return retval;
+}
+
+
+PAM_EXTERN int
+pam_sm_setcred(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+	return PAM_SUCCESS;
+}
+
+
+PAM_EXTERN int
+pam_sm_chauthtok(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+	static const char old_password_prompt[] = "Old Password:";
+	static const char new_password_prompt[] = "New Password:";
+	int retval = PAM_SUCCESS;
+	const char *user = NULL;
+	const char *new_password = NULL;
+	const char *old_password = NULL;
+	CFErrorRef odErr = NULL;
+	ODRecordRef cfRecord = NULL;
+	CFStringRef cfOldPassword = NULL;
+	CFStringRef cfNewPassword = NULL;
+
+	if (flags & PAM_PRELIM_CHECK) {
+		retval = PAM_SUCCESS;
+		goto cleanup;
+	}
+
+	if ((retval = pam_get_user(pamh, &user, NULL)) != PAM_SUCCESS) {
+		_LOG_DEBUG("%s - Error obtaining the username.", PM_DISPLAY_NAME);
+		goto cleanup;
+	}
+
+	if (PAM_SUCCESS != (retval = pam_get_authtok(pamh, PAM_OLDAUTHTOK, &old_password, old_password_prompt))) {
+		_LOG_DEBUG("%s - Error obtaining the old password.", PM_DISPLAY_NAME);
+		goto cleanup;
+	}
+	if (PAM_SUCCESS != (retval = pam_get_authtok(pamh, PAM_AUTHTOK, &new_password, new_password_prompt))) {
+		_LOG_DEBUG("%s - Error obtaining the new password.", PM_DISPLAY_NAME);
+		goto cleanup;
+	}
+
+	/* Get user record from OD */
+	retval = od_record_create_cstring(pamh, &cfRecord, (const char*)user);
+	if (PAM_SUCCESS != retval) {
+		_LOG_ERROR("%s - Unable to get user record.", PM_DISPLAY_NAME);
+		goto cleanup;
+	}
+
+	/* reset the user's password */
+	cfOldPassword = CFStringCreateWithCString(kCFAllocatorDefault, old_password, kCFStringEncodingUTF8);
+	cfNewPassword = CFStringCreateWithCString(kCFAllocatorDefault, new_password, kCFStringEncodingUTF8);
+
+	retval = PAM_SYSTEM_ERR;
+	if (!ODRecordChangePassword(cfRecord, cfOldPassword, cfNewPassword, &odErr)) {
+		switch (CFErrorGetCode(odErr)) {
+			case kODErrorCredentialsInvalid:
+			case kODErrorCredentialsPasswordQualityFailed:
+                _LOG_VERBOSE("%s - The authtok is invaild or of low quality.", PM_DISPLAY_NAME);
+				retval = PAM_AUTHTOK_ERR;
+				break;
+			case kODErrorCredentialsNotAuthorized:
+			case kODErrorCredentialsAccountDisabled:
+			case kODErrorCredentialsAccountInactive:
+                _LOG_VERBOSE("%s - The account not authorized, disabled or inactive.", PM_DISPLAY_NAME);
+				retval = PAM_PERM_DENIED;
+				break;
+			case kODErrorCredentialsPasswordUnrecoverable:
+                _LOG_VERBOSE("%s - The authtok us unrecoverable.", PM_DISPLAY_NAME);
+				retval = PAM_AUTHTOK_RECOVERY_ERR;
+				break;
+			case kODErrorCredentialsAccountTemporarilyLocked :
+                _LOG_VERBOSE("%s - Account temporarily locked after incorrect password attempt(s).", PM_DISPLAY_NAME);
+				retval = PAM_APPLE_ACCT_TEMP_LOCK;
+				break;
+			case kODErrorCredentialsAccountLocked :
+                _LOG_VERBOSE("%s - Account locked after too many incorrect password attempts.", PM_DISPLAY_NAME);
+				retval = PAM_APPLE_ACCT_LOCKED;
+				break;
+			default:
+                _LOG_VERBOSE("%s - There was an unexpected error while changing the password.", PM_DISPLAY_NAME);
+				retval = PAM_ABORT;
+				break;
+		}
+	} else {
+		retval = PAM_SUCCESS;
+	}
+
+cleanup:
+	CFReleaseSafe(odErr);
+	CFReleaseSafe(cfRecord);
+	CFReleaseSafe(cfOldPassword);
+	CFReleaseSafe(cfNewPassword);
+
+	return retval;
+}

--- a/src/pam_modules/modules/pam_rootok/README
+++ b/src/pam_modules/modules/pam_rootok/README
@@ -1,0 +1,18 @@
+# $Id: README,v 1.4 2002/03/27 02:36:36 bbraun Exp $
+#
+
+this module is an authentication module that performs one task: if the
+id of the user is '0' then it returns 'PAM_SUCCESS' with the
+'sufficient' /etc/pam.conf control flag it can be used to allow
+password free access to some service for 'root'
+
+Recognized arguments:
+
+	debug		write a message to syslog indicating success or
+			failure.
+
+module services provided:
+
+	auth		_authentication and _setcred (blank)
+
+Andrew Morgan

--- a/src/pam_modules/modules/pam_rootok/pam_rootok.8
+++ b/src/pam_modules/modules/pam_rootok/pam_rootok.8
@@ -1,0 +1,59 @@
+.\" Copyright (c) 2001 Mark R V Murray
+.\" All rights reserved.
+.\"
+.\" Portions Copyright (C) 2005-2009 Apple Inc.  All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
+.\"
+.\" $FreeBSD: src/lib/libpam/modules/pam_rootok/pam_rootok.8,v 1.4 2001/08/15 20:05:31 markm Exp $
+.\"
+.\" Protions copyright (c) 2009 Apple Inc. All rights reserved.
+.\"
+.Dd February 7, 2009
+.Dt pam_rootok 8
+.Os
+.Sh NAME
+.Nm pam_rootok
+.Nd Root OK PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_rootok
+.Op Ar options
+.Sh DESCRIPTION
+The Root OK PAM module supports the authentication function class.  In terms of the
+.Ar function-class
+parameter, this is the
+.Dq Li auth
+class.
+.Pp
+The Root OK authentication module always returns success for the superuser without prompting for a password.
+.Pp
+The following option may be passed to this authentication module:
+.Bl -tag
+.It Cm debug
+Debug information will be printed to the system log.
+.El
+.Sh SEE ALSO
+.Xr pam.conf 5 ,
+.Xr pam 8

--- a/src/pam_modules/modules/pam_rootok/pam_rootok.c
+++ b/src/pam_modules/modules/pam_rootok/pam_rootok.c
@@ -1,0 +1,104 @@
+/* pam_rootok module */
+
+/*
+ * $Id: pam_rootok.c,v 1.5 2002/03/28 08:43:24 bbraun Exp $
+ *
+ * Written by Andrew Morgan <morgan@linux.kernel.org> 1996/3/11
+ *
+ * Portions Copyright (C) 2005-2009 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms of Linux-PAM, with
+ * or without modification, are permitted provided that the following
+ * conditions are met:
+ * 
+ * 1. Redistributions of source code must retain any existing copyright
+ * notice, and this entire permission notice in its entirety,
+ * including the disclaimer of warranties.
+ * 
+ * 2. Redistributions in binary form must reproduce all prior and current
+ * copyright notices, this list of conditions, and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * 
+ * 3. The name of any author may not be used to endorse or promote
+ * products derived from this software without their specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE. 
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <string.h>
+
+/*
+ * here, we make a definition for the externally accessible function
+ * in this file (this definition is required for static a module
+ * but strongly encouraged generally) it is used to instruct the
+ * modules include file to define the function prototypes.
+ */
+
+#define PAM_SM_AUTH
+
+#include <security/pam_modules.h>
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(rootok)
+#define PAM_LOG PAM_LOG_rootok()
+#endif
+
+/* --- authentication management functions (only) --- */
+
+PAM_EXTERN
+int pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc
+			,const char **argv)
+{
+    int retval = PAM_AUTH_ERR;
+
+    if (getuid() == 0)
+	retval = PAM_SUCCESS;
+
+	_LOG_DEBUG("authentication %s", retval==PAM_SUCCESS ? "succeeded":"failed" );
+
+    return retval;
+}
+
+PAM_EXTERN
+int pam_sm_setcred(pam_handle_t *pamh,int flags,int argc
+		   ,const char **argv)
+{
+    return PAM_SUCCESS;
+}
+
+
+#ifdef PAM_STATIC
+
+/* static module data */
+
+struct pam_module _pam_rootok_modstruct = {
+    "pam_rootok",
+    pam_sm_authenticate,
+    pam_sm_setcred,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+#endif
+
+/* end of module definition */

--- a/src/pam_modules/modules/pam_sacl/pam_sacl.8
+++ b/src/pam_modules/modules/pam_sacl/pam_sacl.8
@@ -1,0 +1,62 @@
+.\"
+.\" Copyright (c) 2009 Apple Inc. All rights reserved.
+.\"
+.\" @APPLE_LICENSE_HEADER_START@
+.\" 
+.\" This file contains Original Code and/or Modifications of Original Code
+.\" as defined in and that are subject to the Apple Public Source License
+.\" Version 2.0 (the 'License'). You may not use this file except in
+.\" compliance with the License. Please obtain a copy of the License at
+.\" http://www.opensource.apple.com/apsl/ and read it before using this
+.\" file.
+.\" 
+.\" The Original Code and all software distributed under the License are
+.\" distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+.\" EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+.\" INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+.\" Please see the License for the specific language governing rights and
+.\" limitations under the License.
+.\" 
+.\" @APPLE_LICENSE_HEADER_END@
+.\"
+.Dd February 7, 2009
+.Dt pam_sacl 8
+.Os
+.Sh NAME
+.Nm pam_sacl
+.Nd Service Access Control List PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_sacl
+.Op Ar options
+.Sh DESCRIPTION
+The Service Access Control List PAM module supports the account management function class.  In terms of the
+.Ar function-class
+parameter, this is the
+.Dq Li account
+class.
+.Pp
+The Service Access Control List account management module verifies that the authenticated user is permitted access by checking the username against the the SACL of the service named by the
+.Cm sacl_service
+option.
+.Pp
+The following option must be passed to this account module:
+.Bl -tag
+.It Cm sacl_service=SERVICE
+This option names the SACL that the username should be checked against.  SERVICE should be the literal name of the service
+.Pq e.g. Dq sacl_service=smb .
+.El
+.Pp
+The following options may be passed to the account module:
+.Bl -tag
+.It Cm allow_trustacct
+Always allow access to computer trust accounts.
+.It Cm debug
+Debug information will be printed to the system log.
+.El
+.Sh SEE ALSO
+.Xr pam.conf 5 ,
+.Xr pam 8

--- a/src/pam_modules/modules/pam_sacl/pam_sacl.c
+++ b/src/pam_modules/modules/pam_sacl/pam_sacl.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2007-2009 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include <grp.h>
+#include <pwd.h>
+#include <membership.h>
+#include <membershipPriv.h>
+#include <sys/syslimits.h>
+
+#define _PAM_EXTERN_FUNCTIONS
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+#include <security/openpam.h>
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(sacl)
+#define PAM_LOG PAM_LOG_sacl()
+#endif
+
+#define MODULE_NAME "pam_sacl"
+
+PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t * pamh, int flags,
+			int argc, const char ** argv)
+{
+	const char *	service = NULL;
+	const char *	username = NULL;
+	bool		allow_trustacct = false;
+
+	struct passwd *pwd = NULL;
+	struct passwd pwdbuf;
+	char pwbuffer[2 * PATH_MAX];
+
+	uuid_t	user_uuid;
+	int	err;
+	int	ismember;
+
+	service = openpam_get_option(pamh, "sacl_service");
+	allow_trustacct = openpam_get_option(pamh, "allow_trustacct");
+
+	if (!service) {
+		_LOG_ERROR("%s: missing service option", MODULE_NAME);
+		return PAM_IGNORE;
+	}
+
+	if (pam_get_user(pamh, &username, NULL) != PAM_SUCCESS ||
+	    username == NULL || *username == '\0') {
+        _LOG_ERROR("%s: missing username", MODULE_NAME);
+		return PAM_SYSTEM_ERR;
+	}
+ 
+    _LOG_DEBUG("%s: checking if account '%s' can access service '%s'",
+		    MODULE_NAME, username, service);
+
+	/* Since computer trust accounts in OD are not user accounts, you can't
+	 * add them to a SACL, so we always let them through (if the option is
+	 * set). A computer trust account has a username ending in '$' and no
+	 * corresponding user account (ie. no passwd entry).
+	 */
+	if (allow_trustacct) {
+		const char * c;
+
+		c = strrchr(username, '$');
+		if (c && *(c + 1) == '\0' && getpwnam_r(username, &pwdbuf, pwbuffer, sizeof(pwbuffer), &pwd) == 0) {
+			_LOG_VERBOSE("%s: allowing '%s' because it is a "
+				"computer trust account",
+				MODULE_NAME, username);
+			return PAM_SUCCESS;
+		}
+	}
+
+	/* Get the UUID. This will fail if the user is is logging in over
+	 * SMB, is specifed as DOMAIN\user or user@REALM and the directory
+	 * does not have the aliases we need.
+	 */
+	if (mbr_user_name_to_uuid(username, user_uuid)) {
+		char * sacl_group;
+
+		/* We couldn't map the user to a UID, but we only care about
+		 * this if the relevant SACL groups exist.
+		 */
+
+		if (asprintf(&sacl_group, "com.apple.access_%s\n",
+							service) == -1) {
+			return PAM_SYSTEM_ERR;
+		}
+
+		if (getgrnam(sacl_group) == NULL &&
+		    getgrnam("com.apple.access_all_services") == NULL) {
+
+            _LOG_VERBOSE("%s: allowing '%s' "
+				    "due to absence of service ACL",
+				    MODULE_NAME, username);
+
+			free(sacl_group);
+			return PAM_SUCCESS;
+		}
+
+        _LOG_VERBOSE("%s: denying '%s' due to missing UUID",
+			MODULE_NAME, username);
+
+		free(sacl_group);
+		return PAM_PERM_DENIED;
+	}
+
+	err = mbr_check_service_membership(user_uuid, service, &ismember);
+	if (err) {
+	        if (err == ENOENT) {
+	                /* Service ACLs not configured. */
+                _LOG_VERBOSE("%s: allowing '%s' "
+				"due to unconfigured service ACLs",
+				MODULE_NAME, username);
+	                return PAM_SUCCESS;
+	        }
+	
+        _LOG_VERBOSE("%s: denying '%s' "
+			"due to failed service ACL check (errno=%d)",
+			MODULE_NAME, username, err);
+
+	        return PAM_PERM_DENIED;
+	}
+	
+        if (ismember) {
+            _LOG_VERBOSE("%s: allowing '%s'", MODULE_NAME, username);
+		return PAM_SUCCESS;
+	} else {
+        _LOG_ERROR("%s: denying '%s' "
+			"due to failed service ACL check",
+			MODULE_NAME, username);
+		return PAM_PERM_DENIED;
+	}
+}
+
+#ifdef PAM_STATIC
+PAM_MODULE_ENTRY(MODULE_NAME);
+#endif
+

--- a/src/pam_modules/modules/pam_self/pam_self.8
+++ b/src/pam_modules/modules/pam_self/pam_self.8
@@ -1,0 +1,57 @@
+.\"
+.\" Copyright (C) 2009 Apple Inc.  All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms of pam_self, with
+.\" or without modification, are permitted provided that the following
+.\" conditions are met:
+.\" 
+.\" 1. Redistributions of source code must retain any existing copyright
+.\" notice, and this entire permission notice in its entirety,
+.\" including the disclaimer of warranties.
+.\" 
+.\" 2. Redistributions in binary form must reproduce all prior and current
+.\" copyright notices, this list of conditions, and the following
+.\" disclaimer in the documentation and/or other materials provided
+.\" with the distribution.
+.\" 
+.\" 3. The name of any author may not be used to endorse or promote
+.\" products derived from this software without their specific prior
+.\" written permission.
+.\"
+.\" THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+.\" WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+.\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+.\" IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+.\" INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+.\" BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+.\" OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+.\" ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+.\" TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+.\" USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+.\" DAMAGE. 
+.\"
+.Dd February 7, 2009
+.Dt pam_self 8
+.Os
+.Sh NAME
+.Nm pam_self
+.Nd Self PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_self
+.Op Ar options
+.Sh DESCRIPTION
+The Self PAM module supports the account management function class.  In terms of the
+.Ar function-class
+parameter, this is the
+.Dq Li account
+class.
+.Pp
+The Self account management module verifies that the username for the target account (PAM_USER) and the username of the applicant (PAM_RUSER) are the same.
+.Pp
+.Sh SEE ALSO
+.Xr pam_get_item 3 ,
+.Xr pam.conf 5 ,
+.Xr pam 8

--- a/src/pam_modules/modules/pam_self/pam_self.c
+++ b/src/pam_modules/modules/pam_self/pam_self.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2009 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms of pam_self, with
+ * or without modification, are permitted provided that the following
+ * conditions are met:
+ * 
+ * 1. Redistributions of source code must retain any existing copyright
+ * notice, and this entire permission notice in its entirety,
+ * including the disclaimer of warranties.
+ * 
+ * 2. Redistributions in binary form must reproduce all prior and current
+ * copyright notices, this list of conditions, and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * 
+ * 3. The name of any author may not be used to endorse or promote
+ * products derived from this software without their specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE. 
+ */
+
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+#include <pwd.h>
+#include <sys/syslimits.h>
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(self)
+#define PAM_LOG PAM_LOG_self()
+#endif
+
+PAM_EXTERN int
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	const char *user = NULL, *ruser = NULL;
+	struct passwd *pwd, *rpwd;
+	struct passwd pwdbuf;
+	char pwbuffer[2 * PATH_MAX];
+	uid_t uid, ruid;
+
+	/* get target account */
+	if (pam_get_user(pamh, &user, NULL) != PAM_SUCCESS ||
+	    NULL == user || 0 != getpwnam_r(user, &pwdbuf, pwbuffer, sizeof(pwbuffer), &pwd) || NULL == pwd) {
+		_LOG_ERROR("Invalid user.");
+		return PAM_AUTH_ERR;
+	}
+	uid = pwd->pw_uid;
+
+	/* get applicant */
+	if (pam_get_item(pamh, PAM_RUSER, (const void **)&ruser) != PAM_SUCCESS ||
+	    NULL == ruser || 0 != getpwnam_r(ruser, &pwdbuf, pwbuffer, sizeof(pwbuffer), &rpwd) || NULL == rpwd) {
+        _LOG_ERROR("Invalid remote user.");
+		return PAM_AUTH_ERR;
+	}
+	ruid = rpwd->pw_uid;
+
+	/* compare */
+	if (uid != ruid) {
+        _LOG_ERROR("The provided user and remote user do not match.");
+		return PAM_AUTH_ERR;
+	}
+
+	return PAM_SUCCESS;
+}

--- a/src/pam_modules/modules/pam_smartcard/attribute_matching.c
+++ b/src/pam_modules/modules/pam_smartcard/attribute_matching.c
@@ -1,0 +1,348 @@
+/******************************************************************
+ * The purpose of this module is to implement
+ * attribute based matching for smartcard and user account
+ ******************************************************************/
+
+#include <CoreFoundation/CFURL.h>
+#include <CoreFoundation/CFURLAccess.h>
+#include <CoreFoundation/CFPropertyList.h>
+#include <Security/Security.h>
+#include <Security/SecCertificatePriv.h>
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include "Common.h"
+#include "scmatch_evaluation.h"
+
+// These are keys into the dictionary read from the config file
+#define kCACUserIDKeyFields				CFSTR("fields")
+#define kCACUserIDKeyFormatString		CFSTR("formatString")
+#define kCACUserIDDSAttributeString		CFSTR("dsAttributeString")		// e.g. dsAttrTypeStandard:RealName (kDS1AttrDistinguishedName)
+
+// This is a key into the dictionary returned by examining the certificate, along with kCACUserIDDSAttributeString
+#define kCACUserIDTargetSearchString	CFSTR("targetSearchString")	// i.e. the value in the directory to search for, e.g. "John Smith"
+
+// The names in the brackets match the values in SecurityInterface/lib/CertificateStrings.h, e.g. [GNT_NT_PRINCIPAL_NAME_STR]
+// Fields in the subjectAltName
+#define kCUIKeyRFC822Name				CFSTR("RFC 822 Name")			// e.g. smith@navy.mil			[GNT_RFC_822_NAME_STR]
+#define kCUIKeyNTPrincipalName			CFSTR("NT Principal Name")		// e.g. 0123456789@mil			[GNT_NT_PRINCIPAL_NAME_STR]
+
+// Fields in the Subject Name
+#define kCUIKeyCommonName				CFSTR("Common Name")			// e.g. SMITH.JOHN.Q.0123456789	[COMMON_NAME_STR]
+#define kCUIKeyOrgUnit					CFSTR("OrganizationalUnit:1")	// e.g. USN						[ORG_UNIT_NAME_STR]
+#define kCUIKeyOrgUnit2					CFSTR("OrganizationalUnit:2")	// e.g. PKI
+#define kCUIKeyOrgUnit3					CFSTR("OrganizationalUnit:3")	// e.g. DoD
+#define kCUIKeyOrganization				CFSTR("Organization")			// e.g. U.S. Government			[ORGANIZATION_NAME_STR]
+#define kCUIKeyCountry					CFSTR("Country")				// e.g. US						[COUNTRY_NAME_STR]
+
+#define CAC_CONFIG_FILE CFSTR("/etc/cacloginconfig.plist")
+#define NT_PRICIPAL_OID  CFSTR("1.3.6.1.4.1.311.20.2.3")
+#define GNT_RFC822_LABEL CFSTR("Email Address")
+
+CFPropertyListRef copyConfigFileContent()
+{
+    CFPropertyListRef propertyList = NULL;
+    CFReadStreamRef stream;
+    CFErrorRef error = NULL;
+    
+    CFURLRef fileURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, CAC_CONFIG_FILE, kCFURLPOSIXPathStyle, false);
+    if (!fileURL)
+        return NULL;
+    
+    stream = CFReadStreamCreateWithFile(kCFAllocatorDefault, fileURL);
+    if (!stream)
+        goto cleanup;
+    
+    if (CFReadStreamOpen(stream))
+    {
+        propertyList = CFPropertyListCreateWithStream(kCFAllocatorDefault, stream, 0, kCFPropertyListImmutable, NULL, &error);
+        CFReadStreamClose(stream);
+    }
+    CFRelease(stream);
+    
+    if (error)
+    {
+        CFRelease(error);
+        goto cleanup;
+    }
+
+	if (propertyList == NULL)
+	{
+		goto cleanup;
+	}
+
+    // now check if config file is valid
+    bool configValid;
+    
+    if (CFDictionaryGetCount(propertyList) == 0)
+        configValid = false;
+    else if (CFDictionaryContainsKey(propertyList, kCACUserIDKeyFields) == false)
+        configValid = false;
+    else if (CFDictionaryContainsKey(propertyList, kCACUserIDKeyFormatString) == false)
+        configValid = false;
+    else if (CFDictionaryContainsKey(propertyList, kCACUserIDDSAttributeString) == false)
+        configValid = false;
+    else
+        configValid = true;
+    
+    if (!configValid)
+    {
+        
+        if (propertyList)
+        {
+            CFRelease(propertyList);
+            propertyList = NULL;
+        }
+    }
+    
+cleanup:
+    CFReleaseSafe(fileURL);    
+    return propertyList;
+}
+
+CFTypeRef getSectionData(CFArrayRef values, CFStringRef label)
+{
+    if (!values || CFGetTypeID(values) != CFArrayGetTypeID())
+        return NULL;
+    
+    for (CFIndex i = 0; i < CFArrayGetCount(values); ++i)
+    {
+        CFDictionaryRef item = CFArrayGetValueAtIndex(values, i);
+        if (CFGetTypeID(item) != CFDictionaryGetTypeID())
+            continue;
+        
+        CFStringRef itemLabel = CFDictionaryGetValue(item, kSecPropertyKeyLabel);
+        if (itemLabel && CFStringCompare(itemLabel, label, 0) == kCFCompareEqualTo)
+            return CFDictionaryGetValue(item, kSecPropertyKeyValue);
+    }
+    return NULL;
+}
+
+CFDictionaryRef copyCertificateDetails(SecCertificateRef cert)
+{
+    CFDictionaryRef certDetails = SecCertificateCopyValues(cert, NULL, NULL);
+    if (!certDetails)
+        return NULL;
+    
+    CFTypeRef subjectName = CFDictionaryGetValue(certDetails, kSecOIDX509V1SubjectName);
+    if (subjectName)
+        subjectName = CFDictionaryGetValue(subjectName, kSecPropertyKeyValue);
+    
+    CFTypeRef altName = CFDictionaryGetValue(certDetails, kSecOIDSubjectAltName);
+    if (altName)
+        altName = CFDictionaryGetValue(altName, kSecPropertyKeyValue);
+    
+    CFMutableDictionaryRef result = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (!result)
+        goto cleanup;
+    
+    // process supported subjectName fields
+    if (subjectName)
+    {
+        CFTypeRef value;
+        
+        value = getSectionData(subjectName, kSecOIDCountryName);
+        if (value)
+            CFDictionarySetValue(result, kCUIKeyCountry, value);
+        
+        value = getSectionData(subjectName, kSecOIDOrganizationName);
+        if (value)
+            CFDictionarySetValue(result, kCUIKeyOrganization, value);
+        
+        value = getSectionData(subjectName, kSecOIDCommonName);
+        if (value)
+            CFDictionarySetValue(result, kCUIKeyCommonName, value);
+        
+        value = getSectionData(subjectName, kSecOIDOrganizationalUnitName);
+        if (value)
+        {
+            if (CFGetTypeID(value) == CFStringGetTypeID())
+                CFDictionarySetValue(result, kCUIKeyOrgUnit, value);
+            else if (CFGetTypeID(value) == CFArrayGetTypeID())
+            {
+                CFIndex len = CFArrayGetCount(value);
+                if (len > 0)
+                    CFDictionarySetValue(result, kCUIKeyOrgUnit, CFArrayGetValueAtIndex(value, 0));
+                if (len > 1)
+                    CFDictionarySetValue(result, kCUIKeyOrgUnit2, CFArrayGetValueAtIndex(value, 1));
+                if (len > 2)
+                    CFDictionarySetValue(result, kCUIKeyOrgUnit3, CFArrayGetValueAtIndex(value, 2));
+            }
+        }
+    }
+    
+    // process supported altName fields
+    if (altName)
+    {
+        CFTypeRef value;
+        
+        value = getSectionData(altName, NT_PRICIPAL_OID);
+        if (value)
+            CFDictionarySetValue(result, kCUIKeyNTPrincipalName, value);
+        
+        value = getSectionData(altName, GNT_RFC822_LABEL);
+        if (value)
+            CFDictionarySetValue(result, kCUIKeyRFC822Name, value);
+    }
+    
+cleanup:
+    CFReleaseSafe(certDetails);
+    return result;
+}
+
+
+
+CFDictionaryRef createUserSearchKey(SecCertificateRef certificate)
+{
+    // Returns a dictionary with 2 elements:
+    //		Search string: 0123456789@navy.mil
+    //		user lookup string: dsAttrTypeNative:MyUserIdentifier
+    
+    CFStringRef valueString;
+    CFStringRef tagString;
+    CFMutableDictionaryRef result = NULL;
+    
+    CFDictionaryRef configFile = copyConfigFileContent();
+    if (!configFile)
+        return NULL;
+    
+    CFDictionaryRef values = copyCertificateDetails(certificate);
+    
+    CFArrayRef userSearchValues = CFDictionaryGetValue(configFile, kCACUserIDKeyFields);
+    CFMutableStringRef formatString = CFStringCreateMutableCopy(kCFAllocatorDefault, 0, CFDictionaryGetValue(configFile, kCACUserIDKeyFormatString));
+    if (!formatString)
+        goto cleanup;
+    
+    CFStringRef userLookupString = CFDictionaryGetValue(configFile, kCACUserIDDSAttributeString);
+    
+    for (CFIndex i = 0; i < CFArrayGetCount(userSearchValues); ++i)
+    {
+        tagString = CFArrayGetValueAtIndex(userSearchValues, i);
+        valueString = CFDictionaryGetValue(values, tagString);
+        if (valueString)
+        {
+            CFStringRef replaceString = CFStringCreateWithFormat(kCFAllocatorDefault, NULL, CFSTR("$%d"), (int)(i + 1));
+            CFStringFindAndReplace(formatString, replaceString, valueString, CFRangeMake(0, CFStringGetLength(formatString)), 0);
+            CFRelease(replaceString);
+        }
+    }
+    
+    result = CFDictionaryCreateMutable(kCFAllocatorDefault, 2, &kCFCopyStringDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (result)
+    {
+        CFDictionarySetValue(result, kCACUserIDTargetSearchString, formatString);
+        CFDictionarySetValue(result, kCACUserIDDSAttributeString, userLookupString);
+    }
+cleanup:
+    CFReleaseSafe(values);
+    CFReleaseSafe(formatString);
+    CFRelease(configFile);
+    return result;
+}
+
+bool isNonRepudiated(SecCertificateRef cert)
+{
+    bool result = false;
+    
+    CFDictionaryRef certDetails = SecCertificateCopyValues(cert, NULL, NULL);
+    if (!certDetails)
+        return result;
+
+    // the most correct way to do this is to get key ACL and look if it needs PIN, but since getACL for smartcards record is hardcoded,
+    // we are unable to distinguish between records on ACL basis. Using key name is also not a proper way because it is based on tokend
+    // implementation
+    // please note that the fact certificate itself has no kSecKeyUsageNonRepudiation bit set does not imply anything because "PIN every time" policy
+    // is enforced by smartcard and not by the certificate. So let's hope the cards are made the correct way and certificates have
+    // kSecKeyUsageNonRepudiation set, like DHS cards do.
+
+    CFDictionaryRef usageDict = CFDictionaryGetValue(certDetails, kSecOIDKeyUsage);
+    if (usageDict)
+    {
+        CFNumberRef usage = CFDictionaryGetValue(usageDict, kSecPropertyKeyValue);
+        if (usage)
+        {
+            uint32_t usageBits;
+            CFNumberGetValue(usage, kCFNumberSInt32Type, &usageBits);
+            if (usageBits & kSecKeyUsageNonRepudiation)
+            {
+                result = true;
+            }
+        }
+    }
+    CFRelease(certDetails);
+    return result;
+}
+
+SecKeychainRef copyAttributeMatchedKeychain(ODRecordRef odRecord, CFArrayRef identities, SecIdentityRef* returnedIdentity)
+{
+    CFDictionaryRef dict;
+    
+    if (identities == NULL)
+        return NULL;
+
+    SecKeychainRef keychainCandidate = NULL;
+    SecIdentityRef identityCandidate = NULL;
+    bool isNonRepu;
+    SecKeychainRef keychain = NULL;
+    for (CFIndex i = 0; i < CFArrayGetCount(identities); ++i)
+    {
+        SecIdentityRef identity = (SecIdentityRef)CFArrayGetValueAtIndex(identities, i);
+        SecCertificateRef candidate;
+        OSStatus status = SecIdentityCopyCertificate(identity, &candidate);
+        if (status != errSecSuccess)
+            continue;
+
+        dict = createUserSearchKey(candidate);
+        isNonRepu = isNonRepudiated(candidate);
+		status = SecKeychainItemCopyKeychain((SecKeychainItemRef)candidate, &keychain);
+		CFReleaseNull(candidate);
+
+        if (status == errSecSuccess && dict)
+        {
+            // find user for this pair
+            CFStringRef expectedValue = (CFStringRef) CFDictionaryGetValue(dict, kCACUserIDTargetSearchString);
+            CFStringRef attributeName = (CFStringRef) CFDictionaryGetValue(dict, kCACUserIDDSAttributeString);
+            CFStringRef value = NULL;
+            int res = od_record_attribute_create_cfstring(odRecord, attributeName, &value);
+            bool match = (res == 0) && (value) && (CFStringCompare(expectedValue, value, 0) == kCFCompareEqualTo);
+            CFRelease(dict);
+
+            if (match == true)
+            {
+                // check if this certificate is non-repudiated
+                // if so, keep it as a candidate for the case we won't find better one
+                if (!isNonRepu)
+                {
+                    CFReleaseSafe(keychainCandidate); // no need to retain candidate
+                    if (returnedIdentity)
+                        *returnedIdentity = identity;
+                    return keychain;
+                }
+                else
+                {
+                    if (keychainCandidate == NULL)
+                    {
+                        CFRetain(keychain);
+                        keychainCandidate = keychain;
+                        identityCandidate = identity;
+                    }
+                    else
+                    {
+                        // not interested in additional candidates
+                        CFReleaseSafe(keychainCandidate);
+                    }
+                }
+            }
+        }
+		CFReleaseNull(keychain);
+    }
+
+    // if we got here, all available certificates were either non-repu or non-matching
+    if (keychainCandidate)
+    {
+        if (returnedIdentity)
+            *returnedIdentity = identityCandidate;
+        return keychainCandidate;
+    }
+
+    return NULL;
+}

--- a/src/pam_modules/modules/pam_smartcard/authorization_ctk
+++ b/src/pam_modules/modules/pam_smartcard/authorization_ctk
@@ -1,0 +1,3 @@
+# ctk: auth 
+auth       required       pam_smartcard.so 		use_first_pass pkinit
+account    required       pam_opendirectory.so  non_password_auth

--- a/src/pam_modules/modules/pam_smartcard/ds_ops.c
+++ b/src/pam_modules/modules/pam_smartcard/ds_ops.c
@@ -1,0 +1,523 @@
+// Copyright (c) 2007-2008 Apple Inc. All Rights Reserved.
+#import <stdint.h>
+#import <pthread.h>
+
+#import "ds_ops.h"
+#import "Common.h"
+
+#pragma mark constants in their DirectoryServices getup
+
+static tDataListPtr _empty_data_list = NULL;
+static tDataListPtr _default_attributes = NULL;
+static tDataListPtr _user_record_type_list = NULL;
+static tDataNodePtr _user_record_type = NULL;
+
+static pthread_once_t ds_const_init = PTHREAD_ONCE_INIT; 
+#define DS_CONST_INIT	pthread_once(&ds_const_init, initialize_directoryservice_statics);
+void initialize_directoryservice_statics()
+{
+	_empty_data_list = dsDataListAllocate(0/*unused*/);
+
+	// separate list for extractable attributes?  So far, that's only "_guest"
+	_default_attributes = dsDataListAllocate(0/*unused*/);
+	dsBuildListFromStringsAlloc(0/*unused*/, _default_attributes, 
+		kDSNativeAttrTypePrefix "original_authentication_authority",
+		kDSNativeAttrTypePrefix "home_info",
+		kDSNativeAttrTypePrefix "_guest",
+		kDSNAttrMetaNodeLocation, kDSNAttrRecordName, kDS1AttrGeneratedUID, 
+		kDS1AttrUniqueID, kDS1AttrPrimaryGroupID,
+		kDS1AttrDistinguishedName, kDS1AttrNFSHomeDirectory, kDSNAttrHomeDirectory,
+		kDSNAttrAuthenticationAuthority, kDS1AttrAuthenticationHint, NULL);
+
+	_user_record_type_list = dsDataListAllocate(0/*unused*/);
+	dsAppendStringToListAlloc(0/*unused*/, _user_record_type_list, kDSStdRecordTypeUsers);
+
+	_user_record_type = dsDataNodeAllocateString(/*unused*/0, kDSStdRecordTypeUsers);
+}
+
+tDataListPtr default_attributes() { DS_CONST_INIT; return _default_attributes; }
+tDataListPtr user_record_type_list() { DS_CONST_INIT; return _user_record_type_list; }
+tDataNodePtr user_record_type() { DS_CONST_INIT; return _user_record_type; }
+tDataListPtr empty_data_list() { DS_CONST_INIT; return _empty_data_list; }
+
+static inline tDataBufferPtr _get_data_buffer(tDirReference dir_ref, tDataBufferPtr in_buffer)
+{
+	int bufferSize = 1024;
+	if (in_buffer) {
+		bufferSize = 2 * in_buffer->fBufferSize;
+		dsDataBufferDeAllocate(dir_ref, in_buffer);
+		if (bufferSize > 1024*1024)
+			return NULL;
+	}
+	return dsDataBufferAllocate(dir_ref, bufferSize);
+}
+
+tDataListPtr *
+ds_find_dir_nodes(tDirReference dir_ref, tDirPatternMatch pattern, tDataListPtr _dataListPtr)
+{
+    tDirStatus status = eDSNoErr;
+    UInt32 node_count;
+    tContextData continuation_data_ptr = 0;
+	tDataListPtr node_name_pattern_data_list_ptr = NULL;
+	tDataBufferPtr buffer = NULL;
+	tDataListPtr *results = NULL, *result = NULL;
+	UInt32 result_count = 0;
+	
+	if (!_dataListPtr)
+		node_name_pattern_data_list_ptr = empty_data_list();
+	else
+		node_name_pattern_data_list_ptr = _dataListPtr;
+
+	buffer = _get_data_buffer(dir_ref, NULL);
+	for (;;) {
+		if (!buffer) break;
+		status = dsFindDirNodes(dir_ref, buffer, 
+							 node_name_pattern_data_list_ptr, pattern,
+							 &node_count, &continuation_data_ptr);
+		if (status == eDSBufferTooSmall) {
+			buffer = _get_data_buffer(dir_ref, buffer);
+			continue;
+		}
+
+		if (status != eDSNoErr)
+			break;
+
+		do {
+			if (!node_count)
+				break;
+
+			results = reallocf(results, (result_count+node_count+1)*sizeof(tDataListPtr));
+			result  = NULL;
+			if (!results)
+				break;
+			
+			result = &results[result_count];
+			uint32_t node = node_count;
+			while (node > 0) {
+				status = dsGetDirNodeName(dir_ref, buffer, node, result);
+				if (status == eDSNoErr)
+					result++;
+				node--;
+			}
+		} while (0);
+		
+		if (!continuation_data_ptr)
+			break;
+	}
+	
+	if (result)
+		*result = NULL;
+	
+	if (continuation_data_ptr)
+		dsReleaseContinueData(dir_ref, continuation_data_ptr);
+	
+	if (buffer)
+		dsDataBufferDeAllocate(dir_ref, buffer);
+
+	return results;
+}
+
+tDataListPtr
+ds_get_node_for_user_record(tDirReference dir_ref, tDirNodeReference nodeRef, const char *name)
+{
+    tDirStatus status = eDSNoErr;
+    UInt32 record_count = 1;
+    tContextData continuation_data_ptr = 0;
+	tDataListPtr node_location = NULL;
+    tDataListPtr record_name_ptr = dsBuildListFromStrings(dir_ref, name, NULL);
+    tDataListPtr attributes_ptr = dsBuildListFromStrings(dir_ref, kDSNAttrMetaNodeLocation, NULL);
+	tDataBufferPtr buffer = _get_data_buffer(dir_ref, NULL);
+	
+	for (;;) {
+		if (!buffer) break;
+			
+		status = dsGetRecordList(nodeRef, buffer,
+			record_name_ptr, eDSExact,
+			user_record_type_list(),
+			attributes_ptr,
+			false,
+			&record_count,
+			&continuation_data_ptr);
+			
+		if (status == eDSBufferTooSmall) {
+			buffer = _get_data_buffer(dir_ref, buffer);
+			continue;
+		}
+
+		if (status != eDSNoErr)
+			break;
+			
+		do {
+			if (!record_count)
+				break;
+
+			tAttributeListRef attr_list_ref = 0;
+			tRecordEntryPtr record_entry_ptr = NULL; 
+			
+			status = dsGetRecordEntry(nodeRef, buffer,
+				1, &attr_list_ref, &record_entry_ptr);
+			if (status)
+				break;
+
+			unsigned int rec_attr_count = record_entry_ptr->fRecordAttributeCount;
+			if (rec_attr_count != 1)
+				break;
+				
+			tAttributeValueListRef attr_value_list_ref;
+			tAttributeEntryPtr attr_info_ptr;
+			if (dsGetAttributeEntry(nodeRef, buffer, attr_list_ref, 1,
+									&attr_value_list_ref, &attr_info_ptr))
+					break;
+			unsigned long attr_value_count = attr_info_ptr->fAttributeValueCount;
+			if (attr_value_count < 1)
+				break;
+
+			tAttributeValueEntryPtr value_entry_ptr;
+			if (!dsGetAttributeValue( nodeRef, buffer, 1, attr_value_list_ref, &value_entry_ptr)) {
+			    node_location = dsDataListAllocate(dir_ref);
+				dsBuildListFromPathAlloc(dir_ref, node_location, value_entry_ptr->fAttributeValueData.fBufferData, "/");
+			}
+			dsDeallocAttributeEntry(dir_ref, attr_info_ptr);
+			dsCloseAttributeValueList(attr_value_list_ref);
+						
+			dsCloseAttributeList(attr_list_ref);
+			dsDeallocRecordEntry(dir_ref, record_entry_ptr);
+		} while(0);
+		
+		if (!continuation_data_ptr)
+			break;
+	}
+	dsDataListDeallocate(dir_ref, record_name_ptr);
+	dsDataListDeallocate(dir_ref, attributes_ptr);
+
+	if (continuation_data_ptr)
+		dsReleaseContinueData(nodeRef, continuation_data_ptr);
+		
+	return node_location;
+}
+
+
+static CF_RETURNS_RETAINED
+CFMutableDictionaryRef
+ds_get_attributes(tDirReference dir_ref, tDirNodeReference nodeRef, tDataBufferPtr buffer, tRecordEntryPtr record_entry_ptr, tAttributeListRef attr_list_ref)
+{
+	unsigned int rec_attr_count = record_entry_ptr->fRecordAttributeCount;
+	
+	CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(kCFAllocatorDefault, rec_attr_count, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	if (!attributes)
+		return NULL;
+	unsigned int i;
+    for ( i=1; i<= rec_attr_count; i++)
+    {
+        tAttributeValueListRef attr_value_list_ref;
+        tAttributeEntryPtr attr_info_ptr;
+        if (dsGetAttributeEntry( nodeRef, buffer, attr_list_ref, i,
+                             &attr_value_list_ref, &attr_info_ptr ))
+			return NULL;
+        unsigned long attr_value_count = attr_info_ptr->fAttributeValueCount;
+        if (attr_value_count > 0) {
+			CFStringRef key = CFStringCreateWithCString(kCFAllocatorDefault, attr_info_ptr->fAttributeSignature.fBufferData, kCFStringEncodingUTF8);
+			CFTypeRef values = NULL;
+			tAttributeValueEntryPtr value_entry_ptr;
+			if (attr_value_count > 1)
+				values = CFArrayCreateMutable(kCFAllocatorDefault, attr_value_count, &kCFTypeArrayCallBacks);
+			unsigned int j;
+			for (j=1; j <= attr_value_count; j++) {
+				if (!dsGetAttributeValue( nodeRef, buffer, j, attr_value_list_ref, &value_entry_ptr)) {
+					CFStringRef value = CFStringCreateWithCString(kCFAllocatorDefault, value_entry_ptr->fAttributeValueData.fBufferData, kCFStringEncodingUTF8);
+					if (value) {
+						if (attr_value_count > 1) {
+							CFArrayAppendValue((CFMutableArrayRef)values, value);
+							CFRelease(value);
+						} else
+							values = value;
+					}
+				}
+			}
+			if (key && values)
+				CFDictionarySetValue(attributes, key, values);
+            CFReleaseSafe(key);
+            CFReleaseSafe(values);
+        }
+        dsDeallocAttributeEntry(dir_ref, attr_info_ptr);
+        dsCloseAttributeValueList(attr_value_list_ref);
+    }
+	return attributes;
+}
+
+CF_RETURNS_RETAINED
+CFMutableArrayRef
+ds_get_user_records_for_name(tDirReference dir_ref, tDirNodeReference node_ref, const char *name, uint32_t max_records)
+{
+    tDirStatus status = eDSNoErr;
+    uint32_t record_count = max_records; // This is an input variable too: stop after 1, which is much cheaper when using NetInfo
+    tContextData continuation_data_ptr = 0;
+
+    tDataListPtr record_name_ptr = dsBuildListFromStrings(dir_ref, name , NULL);
+	tDataBufferPtr buffer = NULL;	
+	CFMutableArrayRef results = NULL;
+	
+	buffer = _get_data_buffer(dir_ref, NULL);
+	for (;;) {
+		if (!buffer) break;
+			
+		status = dsGetRecordList(node_ref, buffer,
+			record_name_ptr, eDSExact,
+			user_record_type_list(),
+			default_attributes(),
+			false,
+			&record_count,
+			&continuation_data_ptr);
+			
+		if (status == eDSBufferTooSmall) {
+			buffer = _get_data_buffer(dir_ref, buffer);
+			continue;
+		}
+		else
+			printf("buffer size: %u length: %u\n", 
+				(uint32_t)buffer->fBufferSize, (uint32_t)buffer->fBufferLength);
+
+		if (status != eDSNoErr)
+			break;
+			
+		do {
+			if (!record_count)
+				break;
+
+			if (!results)
+				results = CFArrayCreateMutable(kCFAllocatorDefault, record_count, &kCFTypeArrayCallBacks);
+			
+			unsigned int i;
+			for (i=1; i <= record_count; i++) {
+				tAttributeListRef attr_list_ref = 0;
+				tRecordEntryPtr record_entry_ptr = NULL; 
+				
+				status = dsGetRecordEntry(node_ref, buffer,
+					i, &attr_list_ref, &record_entry_ptr);
+				if (status)
+					continue;
+									
+				CFMutableDictionaryRef attrs = ds_get_attributes(dir_ref, node_ref, buffer, record_entry_ptr, attr_list_ref);
+				if (attrs) {
+					CFArrayAppendValue(results, attrs);
+					CFRelease(attrs);
+				}
+
+				dsCloseAttributeList(attr_list_ref);
+				dsDeallocRecordEntry(dir_ref, record_entry_ptr);
+			}
+		} while(0);
+		
+		if (!continuation_data_ptr)
+			break;
+	}
+	dsDataListDeallocate(dir_ref, record_name_ptr);
+
+	if (continuation_data_ptr)
+		dsReleaseContinueData(node_ref, continuation_data_ptr);
+		
+	return results;
+}
+
+tDirStatus 
+ds_dir_node_auth_operation(tDirReference _directoryRef, tDirNodeReference _nodeRef, const char *operation, const char *username, const char *password, bool authentication_only)
+{
+	tDirStatus authStatus = eDSNotAuthorized;
+
+    if (!username)
+		return eDSUserUnknown;
+
+    size_t ulNameLen = strlen(username);
+    size_t ulPassLen = password ? strlen(password) : 0;
+    tDataNodePtr _authType = dsDataNodeAllocateString (_directoryRef, operation); // dnAuthType
+    tDataBufferPtr _authdataBufferPtr = dsDataBufferAllocate(_directoryRef,(uint32_t)(2 * sizeof (ulNameLen) + ulNameLen + ulPassLen)); // dbAuth
+    tDataBufferPtr _stepBufferPtr = dsDataBufferAllocate(_directoryRef, 2048); // dbStep
+	if (eDSNoErr != (authStatus = dsFillAuthBuffer(_authdataBufferPtr, 2, (uint32_t)ulNameLen, username, ulPassLen, password)))
+		return authStatus;
+
+    // Authenticate the user.
+    authStatus = dsDoDirNodeAuth (_nodeRef, _authType, authentication_only, _authdataBufferPtr, _stepBufferPtr, 0);
+    
+	bzero(_authdataBufferPtr->fBufferData, _authdataBufferPtr->fBufferLength);
+    dsDataNodeDeAllocate(_directoryRef, _authType);
+    dsDataBufferDeAllocate(_directoryRef, _authdataBufferPtr);
+    dsDataBufferDeAllocate(_directoryRef, _stepBufferPtr);
+
+	return authStatus;
+}
+
+
+//[authNode setAttributeForUserRecord:[[userRecord name] UTF8String] length:[passwordHintData length] data:[passwordHintData bytes] type:kDS1AttrAuthenticationHint atIndex:1];
+
+tDirStatus 
+ds_set_attribute_in_user_record(tDirReference _directoryRef, tDirNodeReference _nodeRef, const char *recordname, size_t length, const void *data, const char *attr_type, uint32_t value_index)
+{
+	tDirStatus status = noErr;
+    tDataNodePtr attributeType = dsDataNodeAllocateString(_directoryRef, attr_type);
+	tDataNodePtr userRecordName = dsDataNodeAllocateString(_directoryRef, recordname);
+	tRecordReference recordRef = 0;
+
+	if (attributeType && userRecordName) do {
+		status = dsOpenRecord(_nodeRef, user_record_type(), userRecordName, &recordRef);
+
+		if (status)
+			break;
+			
+		tAttributeValueEntryPtr valueEntryPtr = NULL;
+		status = dsGetRecordAttributeValueByIndex(recordRef, attributeType, value_index, &valueEntryPtr);
+
+		if (status) {
+			// if getting the nth value failed, just add it
+			tDataNodePtr attributeValue = dsDataNodeAllocateBlock(_directoryRef, (uint32_t)length, (uint32_t)length, (void*)data);
+			if (attributeValue) {
+				status = dsAddAttributeValue(recordRef, attributeType, attributeValue);
+				dsDataNodeDeAllocate(_directoryRef, attributeValue);
+			}
+		} else {
+			tAttributeValueEntryPtr attributeValue = dsAllocAttributeValueEntry(_directoryRef, valueEntryPtr->fAttributeValueID, (void*)data, (uint32_t)length);
+			if (attributeValue) {
+				status = dsSetAttributeValue(recordRef, attributeType, attributeValue);
+				dsDeallocAttributeValueEntry(_directoryRef, attributeValue);
+			}
+			dsDeallocAttributeValueEntry(_directoryRef, valueEntryPtr);
+		}
+		dsCloseRecord(recordRef);
+	} while (0);
+	if (attributeType) dsDataNodeDeAllocate(_directoryRef, attributeType);
+	if (userRecordName) dsDataNodeDeAllocate(_directoryRef, userRecordName);
+	return status;
+}
+
+
+CF_RETURNS_RETAINED CFMutableArrayRef
+ds_find_user_records_by_dsattr(tDirReference _directoryRef, tDirNodeReference _nodeRef, const char *attr, const char *value)
+{ 
+	// attr is e.g. kDSNAttrAuthenticationAuthority
+	tDirStatus status = 0;
+    UInt32 record_count = 0; // This is an input variable too
+    tContextData continuation_data_ptr = 0;
+    CFMutableArrayRef results = NULL;
+
+	tDataNodePtr attributeType = dsDataNodeAllocateString(_directoryRef, attr);
+	tDataNodePtr attributeValue = dsDataNodeAllocateString(_directoryRef, value);
+
+	tDataBufferPtr buffer = NULL;	
+	buffer = _get_data_buffer(_directoryRef, NULL);
+	for (;;) {
+		if (!buffer) break;			
+			// should be eDSStartsWith such that we can 
+			// find all entries and not key off opt parameters
+			status = dsDoAttributeValueSearchWithData(
+				_nodeRef, buffer,
+				user_record_type_list(),
+				attributeType, 
+				eDSiExact,
+				attributeValue,
+				default_attributes(),	/* all attributes (NULL is documented to be legal but that's a documentation bug */
+				false,			/* attr info and data */
+				&record_count,
+				&continuation_data_ptr);
+			
+		if (status == eDSBufferTooSmall) {
+			buffer = _get_data_buffer(_directoryRef, buffer);
+			continue;
+		}
+
+		if (status != eDSNoErr)
+			break;
+			
+		do {
+			if (!record_count)
+				break;
+
+			if (!results)
+				results = CFArrayCreateMutable(kCFAllocatorDefault, record_count, &kCFTypeArrayCallBacks);
+			
+			unsigned int i;
+			for (i=1; i <= record_count; i++) {
+				tAttributeListRef attr_list_ref = 0;
+				tRecordEntryPtr record_entry_ptr = NULL; 
+				
+				status = dsGetRecordEntry(_nodeRef, buffer,
+					i, &attr_list_ref, &record_entry_ptr);
+				if (status)
+					continue;
+
+				CFMutableDictionaryRef attrs = ds_get_attributes(_directoryRef, _nodeRef, buffer, record_entry_ptr, attr_list_ref);
+				if (attrs) {
+					CFArrayAppendValue(results, attrs);
+					CFRelease(attrs);
+				}
+
+				dsCloseAttributeList(attr_list_ref);
+				dsDeallocRecordEntry(_directoryRef, record_entry_ptr);
+			}
+		} while(0);
+		
+		if (!continuation_data_ptr)
+			break;
+	}
+
+	if (continuation_data_ptr) dsReleaseContinueData(_nodeRef, continuation_data_ptr);
+	if (attributeType) dsDataNodeDeAllocate(_directoryRef, attributeType);
+	if (attributeValue) dsDataNodeDeAllocate(_directoryRef, attributeValue);
+
+	return results;
+}
+
+bool 
+ds_open_search_node(tDirReference _directoryRef, tDirNodeReference *_nodeRef)
+{
+	bool result = false;
+	tDataListPtr *nodes = ds_find_dir_nodes(_directoryRef, eDSSearchNodeName, NULL);
+	tDataListPtr node = NULL;
+	if (nodes) {
+		node = *nodes;
+		free(nodes);
+	}
+	if (node) {
+		result = !dsOpenDirNode(_directoryRef, node, _nodeRef);
+		dsDataListDeallocate(_directoryRef, node);
+	}
+	return result;
+}
+
+bool
+ds_open_node_for_user_record(tDirReference _directoryRef, const char *name, tDirNodeReference *_nodeRef)
+{
+	bool result = false;
+	tDirNodeReference _searchnodeRef;
+	if (ds_open_search_node(_directoryRef, &_searchnodeRef)) {
+		tDataListPtr node_name_ptr = ds_get_node_for_user_record(_directoryRef, _searchnodeRef, name);
+		dsCloseDirNode(_searchnodeRef);
+		if (node_name_ptr) {
+			result = !dsOpenDirNode(_directoryRef, node_name_ptr, _nodeRef);
+			dsDataListDeallocate(_directoryRef, node_name_ptr);
+		}
+	}
+	return result;
+}
+
+CF_RETURNS_RETAINED
+CFMutableArrayRef find_user_record_by_attr_value(const char *attr, const char *value)
+{
+    tDirReference directory_ref = 0;
+    tDirNodeReference node_ref = 0;
+    CFMutableArrayRef results = NULL;
+        
+    do {
+        if (dsOpenDirService(&directory_ref) != eDSNoErr)
+            break;
+
+        if (!ds_open_search_node(directory_ref, &node_ref))
+            break;
+                
+        results = ds_find_user_records_by_dsattr(directory_ref, node_ref, attr, value);
+        
+        dsCloseDirNode(node_ref);
+    } while (0);
+
+    if (directory_ref)
+        dsCloseDirService(directory_ref);
+    return results;
+}

--- a/src/pam_modules/modules/pam_smartcard/ds_ops.h
+++ b/src/pam_modules/modules/pam_smartcard/ds_ops.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2007 Apple Inc. All Rights Reserved.
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <DirectoryService/DirectoryService.h>
+
+// find user records by attribute
+
+bool ds_open_search_node(tDirReference _directoryRef, tDirNodeReference *_nodeRef);
+
+CF_RETURNS_RETAINED
+CFMutableArrayRef ds_find_user_records_by_dsattr(tDirReference _directoryRef, tDirNodeReference _nodeRef, const char *attr, const char *value);
+
+// authenticate user and get info
+
+bool ds_open_node_for_user_record(tDirReference _directoryRef, const char *name, tDirNodeReference *_nodeRef);
+
+tDirStatus ds_dir_node_auth_operation(tDirReference _directoryRef, tDirNodeReference _nodeRef, const char *operation, const char *username, const char *password, bool authentication_only);
+
+CF_RETURNS_RETAINED
+CFMutableArrayRef ds_get_user_records_for_name(tDirReference dir_ref, tDirNodeReference node_ref, const char *name, uint32_t max_records);
+
+tDirStatus ds_set_attribute_in_user_record(tDirReference _directoryRef, tDirNodeReference _nodeRef, const char *recordname, size_t length, const void *data, const char *attr_type, uint32_t value_index);
+
+CFMutableArrayRef find_user_record_by_attr_value(const char *attr, const char *value);

--- a/src/pam_modules/modules/pam_smartcard/hash_matching.c
+++ b/src/pam_modules/modules/pam_smartcard/hash_matching.c
@@ -1,0 +1,92 @@
+/******************************************************************
+ * The purpose of this module is to implement
+ * hash matching for smartcard and user account
+ ******************************************************************/
+
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <Security/SecCertificatePriv.h>
+#include "Common.h"
+#include "scmatch_evaluation.h"
+
+#if !defined(kODAuthAuthorityPubkey)
+#define kODAuthAuthorityPubkey                      CFSTR("pubkeyhash")
+#endif
+
+CFDataRef createDataFromHexString(CFStringRef str)
+{
+    CFIndex length = CFStringGetLength(str);
+    CFMutableDataRef data = CFDataCreateMutable(kCFAllocatorDefault, (length + 1)/ 2); // for odd length
+    if (!data)
+        return NULL;
+    char byteChars[3] = {0, 0, 0};
+    uint8_t wholeByte;
+    for (CFIndex i = 0; i < length; i += 2) {
+        byteChars[0] = (char)CFStringGetCharacterAtIndex(str, i);
+        byteChars[1] = (char)CFStringGetCharacterAtIndex(str, i + 1);
+        wholeByte = (uint8_t)strtoul(byteChars, NULL, 16);
+        CFDataAppendBytes(data, (UInt8*)&wholeByte, 1);
+    }
+    return data;
+}
+
+SecKeychainRef copyHashMatchedKeychain(ODRecordRef odRecord, CFArrayRef identities, SecIdentityRef* returnedIdentity)
+{
+    CFArrayRef authStrings;
+    CFDataRef hash = NULL;
+    
+    int odRes = od_record_attribute_create_cfarray(odRecord, kODAttributeTypeAuthenticationAuthority,  &authStrings);
+    if (odRes != PAM_SUCCESS)
+        return NULL;
+    
+    
+    for (CFIndex i = 0; i < CFArrayGetCount(authStrings); ++i)
+    {
+        CFArrayRef parts = CFStringCreateArrayBySeparatingStrings(kCFAllocatorDefault, CFArrayGetValueAtIndex(authStrings, i), CFSTR(";"));
+        if (parts)
+        {
+            if (CFArrayGetCount(parts) == 3 && CFStringCompare(CFArrayGetValueAtIndex(parts, 1), kODAuthAuthorityPubkey, kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+            {
+                hash = createDataFromHexString(CFArrayGetValueAtIndex(parts, 2));
+            }
+            CFRelease(parts);
+        }
+        if (hash)
+            break;
+    }
+    CFRelease(authStrings);
+    
+    if (!hash)
+        return NULL;
+
+    CFIndex count = CFArrayGetCount(identities);
+    uint32_t index;
+    bool matches;
+    SecKeychainRef keychain = NULL;
+
+    for (index = 0; index < count; ++index)
+    {
+        SecIdentityRef identity = (SecIdentityRef)CFArrayGetValueAtIndex(identities, index);
+        SecCertificateRef candidate;
+        OSStatus status = SecIdentityCopyCertificate(identity, &candidate);
+        if (status != errSecSuccess)
+            continue;
+
+        CFDataRef certificateHash = SecCertificateCopyPublicKeySHA1Digest(candidate);
+        status = SecKeychainItemCopyKeychain((SecKeychainItemRef)candidate, &keychain);
+        CFRelease(candidate);
+        matches = certificateHash && CFEqual(certificateHash, hash);
+        CFReleaseSafe(certificateHash);
+        if (status == errSecSuccess && matches == true)
+        {
+            if (returnedIdentity)
+                *returnedIdentity = identity;
+            break;
+
+        }
+        CFReleaseNull(keychain);
+    }
+
+    CFRelease(hash);
+    return keychain;
+}

--- a/src/pam_modules/modules/pam_smartcard/krb5principal.m
+++ b/src/pam_modules/modules/pam_smartcard/krb5principal.m
@@ -1,0 +1,188 @@
+//
+//  krb5principal.m
+//  SecurityAgent
+//
+//  Created by Conrad Sauerwald on Mon Mar 24 2003.
+//  Copyright (c) 2003,2005 Apple Computer, Inc. All Rights Reserved.
+//
+
+/*
+Some documentation on the Kerberos Auth authority:
+
+Kerberos Authentication Authority
+	Version = 1.0.0
+	AuthorityTag = 'Kerberosv5' (kDSTagAuthAuthorityKerberosv5)
+	AuthorityData = [128-bit uid]; [user principal (with realm)]; realm; [realm public key]
+
+
+The optional 128-bit UID is encoded in the same fashion as the ID in the Password Server Auth Authority.
+The optional user principal is the user principal for this user within the Kerberos system.
+The required realm name is the name of the Kerberos realm to which the user belongs
+The optional realm public key may be used to authenticate the KDC in a future release.
+
+if user principal is not present, the short name of the user record is taken to be the username for the principal. This allows a fixed auth authority to be set up and applied to all user records in a database. If the UID is present, it will be used before the short name is used.
+
+The authentication authority is parsed to find the user principal during login, which is handed to the Kerberos framework for the actual authentication.
+
+For example:
+1.0;Kerberosv5;35382900696e4469725265663a702831;kerbdude@APPLE.COM;APPLE.COM;4346537472696e673a28312c33332900
+Would yield a user principal of kerbdude@APPLE.COM
+
+1.0;Kerberosv5;35382900696e4469725265663a702831;;APPLE.COM;4346537472696e673a28312c33332900
+Would yield a user principal of 35382900696e4469725265663a702831@APPLE.COM
+
+if the user record is named "kirby"
+;Kerberosv5;;;APPLE.COM;4346537472696e673a28312c33332900
+Would yield a user principal of kirby@APPLE.COM
+
+Here's an example of the local kdc authentication authority.
+;Kerberosv5;;local@LKDC:SHA1.3D1A965A4624679D7E25C300A2ABAF13C1E80447;LKDC:SHA1.3D1A965A4624679D7E25C300A2ABAF13C1E80447;
+*/
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <DirectoryService/DirServicesConst.h>
+
+
+CF_RETURNS_RETAINED
+CFStringRef	GetPrincipalFromUser(CFDictionaryRef inUserRecord);
+OSStatus	ParseKerbAuthAuthority(CFStringRef inAuthority, CFArrayRef *outTokens);
+
+/*
+    The Kerberos auth authority is a CFString of the form:
+    1.0;Kerbv5;[128-bit uid]; [user principal (with realm)]; realm; [realm public key];
+
+*/
+OSStatus ParseKerbAuthAuthority(CFStringRef inAuthority, CFArrayRef *outTokens)
+{
+    OSStatus			theError = -1;
+    CFComparisonResult	result;
+    CFIndex				max;
+    CFStringRef			tmpString = NULL;
+
+	// No separators in the string returns array with that string; string == sep returns two empty strings
+    *outTokens = CFStringCreateArrayBySeparatingStrings(NULL, inAuthority, CFSTR(";"));
+    if(*outTokens == NULL) {
+        theError = -1;
+    } else {
+        while (true) {
+            theError = 0;
+			// check that the second token "Kerbv5" and that we have enough elements
+			max = CFArrayGetCount(*outTokens);
+			if (max < 6) { // The 1.0 version of the auth authority has 6 elements
+				theError = -1;
+				break;
+			}
+
+			result = CFStringCompare(CFSTR(kDSTagAuthAuthorityKerberosv5), (CFStringRef) CFArrayGetValueAtIndex(*outTokens, 1), kCFCompareCaseInsensitive);
+			if (result != kCFCompareEqualTo)
+            {
+				theError = -1;
+            }
+
+			tmpString = (CFStringRef) CFArrayGetValueAtIndex(*outTokens, 4); // should be the realm
+			if (CFStringGetLength(tmpString) == 0)	// realm is required
+            {
+				theError = -1;
+            }
+
+			break;
+        }
+
+		if (theError != noErr) {
+			// Clean up
+            CFRelease(*outTokens);
+            *outTokens = NULL;
+        }
+    }
+
+    return theError;
+}
+
+
+
+// Get the first auth-authority value that mentions Kerberos and use that to build the user principal.
+
+CF_RETURNS_RETAINED
+CFStringRef	GetPrincipalFromUser(CFDictionaryRef inUserRecord)
+{
+	CFArrayRef	tokens = NULL;
+	CFArrayRef	tmpArray = NULL;
+	CFTypeRef	tmpTypeRef = NULL;
+	CFStringRef	authAuthority = NULL;
+	CFStringRef	tmpString = NULL;
+	CFStringRef	realmString = NULL;
+	CFStringRef	principal = NULL;
+	CFIndex		index;
+
+	// extract the auth-authority from the original attribute first, in case it is cached user
+	// @notes:  We could check the current auth authority to see if it is a cached user, but that would be
+	//          lots of extra code.  We could check the node to ensure it is local node only, but since
+	//          this isn't used for authentications, it is only for getting the TGT, we really don't care
+	CFStringRef originalAuth = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@original_authentication_authority"), CFSTR(kDSNativeAttrTypePrefix));
+	tmpTypeRef = CFDictionaryGetValue(inUserRecord, originalAuth);
+	CFRelease( originalAuth );
+	if (tmpTypeRef == NULL)	{
+		// if not a cached user with original auth authority, then let's check the real thing
+		tmpTypeRef = CFDictionaryGetValue(inUserRecord, CFSTR(kDSNAttrAuthenticationAuthority));
+        if(tmpTypeRef == NULL) {
+			return NULL;
+        }
+	}
+		
+	if (CFArrayGetTypeID() == CFGetTypeID(tmpTypeRef)) {
+		// tmpTypeRef is an array of auth-authority strings
+		CFArrayRef authArray = (CFArrayRef)tmpTypeRef;
+		CFIndex authArrayCount = CFArrayGetCount(authArray);
+		for (index = 0; index < authArrayCount; index++) {
+			authAuthority = CFArrayGetValueAtIndex(authArray, index);
+			if ((authAuthority != NULL) && (CFStringGetTypeID() == CFGetTypeID(authAuthority)))	{
+				if (ParseKerbAuthAuthority(authAuthority, &tokens) == noErr) {
+					break;
+				}
+			}
+		}
+	} else if (CFStringGetTypeID() == CFGetTypeID(tmpTypeRef)) {
+		ParseKerbAuthAuthority((CFStringRef)tmpTypeRef, &tokens);
+	}
+
+    if (tokens == NULL)	// we didn't find a Kerberos auth authority
+        return NULL;
+
+    // stupid hack for <rdar://problem/5236943> Security::SecurityServer::ClientSession::authCopyRights blocks for ~20 seconds
+	// we're going to put a kdc in the auth authority and then not run it because we're idiots
+    // when the local kdc starts running per default this hack must be removed.
+	realmString = (CFStringRef) CFArrayGetValueAtIndex(tokens, 4);
+	if (realmString && CFStringHasPrefix(realmString, CFSTR("LKDC:"))) {
+		CFRelease(tokens);
+		return NULL;
+	}
+	// end of stupid hack
+
+    // do we have a principal name?
+	tmpString = (CFStringRef) CFArrayGetValueAtIndex(tokens, 3);
+	if (CFStringGetLength(tmpString) > 3) {	// smallest principal name is a@a
+		CFRetain(tmpString);
+		CFRelease(tokens);
+		return tmpString;
+	} else {
+		// No principal name in auth-authority, is there an id?
+		tmpString = (CFStringRef) CFArrayGetValueAtIndex(tokens, 2);
+		if (CFStringGetLength(tmpString) > 0) {
+			// Non-empty is good enough for an id
+			realmString = (CFStringRef) CFArrayGetValueAtIndex(tokens, 4);
+			principal = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@@%@"), tmpString, realmString);
+			CFRelease(tokens);
+			return principal;
+		}
+	 }
+    // no id, get the user's short name
+    tmpArray = (CFArrayRef) CFDictionaryGetValue(inUserRecord, CFSTR(kDSNAttrRecordName));
+    tmpString = CFArrayGetValueAtIndex(tmpArray, 0);
+
+    realmString = (CFStringRef) CFArrayGetValueAtIndex(tokens, 4);
+    principal = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@@%@"), tmpString, realmString);
+    CFRelease(tokens);
+    return principal;
+}
+
+

--- a/src/pam_modules/modules/pam_smartcard/pam_smartcard.8
+++ b/src/pam_modules/modules/pam_smartcard/pam_smartcard.8
@@ -1,0 +1,59 @@
+.\"
+.\" Copyright (c) 2009 Apple Inc. All rights reserved.
+.\"
+.\" @APPLE_LICENSE_HEADER_START@
+.\" 
+.\" This file contains Original Code and/or Modifications of Original Code
+.\" as defined in and that are subject to the Apple Public Source License
+.\" Version 2.0 (the 'License'). You may not use this file except in
+.\" compliance with the License. Please obtain a copy of the License at
+.\" http://www.opensource.apple.com/apsl/ and read it before using this
+.\" file.
+.\" 
+.\" The Original Code and all software distributed under the License are
+.\" distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+.\" EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+.\" INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+.\" Please see the License for the specific language governing rights and
+.\" limitations under the License.
+.\" 
+.\" @APPLE_LICENSE_HEADER_END@
+.\"
+.Dd August 27, 2015
+.Dt pam_smartcard 8
+.Os
+.Sh NAME
+.Nm pam_smartcard
+.Nd Smartcard PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_smartcard
+.Op Ar options
+.Sh DESCRIPTION
+The Smartcard PAM module supports authentication function class.  In terms of the
+.Ar function-class
+parameter, this is
+.Dq Li auth.
+.Ss The Smartcard Authentication Module
+This module permits or denies users based on smartcard authentication support in the Open Directory database, and the presence of an appropriate smartcard in the reader attached to the local machine. When a card is locked, the user is asked to unlock it with his PIN.
+.Ss The following options may be passed to this account management module:
+.Bl -tag -width Ds
+.It Cm no_check_shell
+Continues evaluation even if user's shell is not valid. Normally, users with a shell like /usr/bin/false are considered as disabled.
+.It Cm no_ignore
+Return failure when an appropriate smartcard is not present.
+.El
+.Sh EXAMPLE
+.Bl -tag -width Ds
+.Bd -unfilled
+.It Ev Adding the following line on the top of the /etc/pam.d/sudo enables smartcard support for sudo:
+auth   sufficient     pam_smartcard.so
+.Ed
+.El
+.Sh SEE ALSO
+.Xr pam.conf 5 ,
+.Xr pam 8
+.Xr SmartCardServices 7

--- a/src/pam_modules/modules/pam_smartcard/pam_smartcard.m
+++ b/src/pam_modules/modules/pam_smartcard/pam_smartcard.m
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * Portions Copyright (c) 2000 Apple Computer, Inc.  All Rights
+ * Reserved.  This file contains Original Code and/or Modifications of
+ * Original Code as defined in and that are subject to the Apple Public
+ * Source License Version 1.1 (the "License").  You may not use this file
+ * except in compliance with the License.  Please obtain a copy of the
+ * License at http://www.apple.com/publicsource and read it before using
+ * this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON- INFRINGEMENT.  Please see the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/******************************************************************
+ * The purpose of this module is to provide a local smartcard
+ * authentication module for Mac OS X.
+ ******************************************************************/
+
+/* Define which PAM interfaces we provide */
+
+#define PAM_SM_AUTH
+#define PAM_SM_ACCOUNT
+
+#define PM_DISPLAY_NAME "SmartCard"
+#define MAX_PIN_RETRY (3)
+
+/* Include PAM headers */
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <Security/SecBase.h>
+#include <OpenDirectory/OpenDirectory.h>
+#include <Security/SecItem.h>
+#include <Security/Security.h>
+#include <Security/SecKeychainPriv.h>
+#include <ctkloginhelper.h>
+#include <ctkclient/ctkclient.h>
+#include <pwd.h>
+#include <sys/param.h>
+#include "Common.h"
+#include "scmatch_evaluation.h"
+#include "ds_ops.h"
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(SmartCard)
+#define PAM_LOG PAM_LOG_SmartCard()
+#endif
+
+#if __has_feature(objc_arc)
+#   error "this file must be compiled without ARC"
+#endif
+
+#define CFReleaseSafe(CF) { CFTypeRef _cf = (CF); if (_cf) CFRelease(_cf); }
+#define PAM_OPT_PKINIT	"pkinit"
+
+typedef NS_ENUM(NSInteger, enKeychainUnlock) {
+    enNoUnlock                         = 0,
+    enUnlockDirectly                   = 1,
+    enUnlockUsingAhp                   = 2
+};
+
+void cleanup_func(__unused pam_handle_t *pamh, void *data, __unused int error_status)
+{
+	CFReleaseSafe(data);
+}
+
+CFStringRef copy_pin(pam_handle_t *pamh, const char *prompt, const char **outPin)
+{
+	const char *pass;
+	int ret = pam_get_authtok(pamh, PAM_AUTHTOK, &pass, prompt);
+	if (ret != PAM_SUCCESS) {
+		_LOG_ERROR("Unable to get PIN: %d", ret);
+		return NULL;
+	}
+	if (outPin)
+		*outPin = pass;
+	return CFStringCreateWithCString(kCFAllocatorDefault, pass, kCFStringEncodingUTF8);
+}
+
+Boolean copy_smartcard_unlock_context(char *buffer, size_t buffsize, CFStringRef token_id, CFStringRef pin, CFDataRef pub_key_hash, CFDataRef pub_key_hash_wrap)
+{
+	CFMutableDictionaryRef dict = NULL;
+	CFDataRef serializedData = NULL;
+	Boolean retval = FALSE;
+
+    if (token_id == NULL || pin == NULL || pub_key_hash == NULL || pub_key_hash_wrap == NULL) {
+        _LOG_ERROR("SC context - wrong params");
+        return retval;
+    }
+
+	dict = CFDictionaryCreateMutable(kCFAllocatorDefault, 4, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (dict == NULL) {
+        _LOG_ERROR("SC context - invalid dict");
+        return retval;
+    }
+
+	CFDictionarySetValue(dict, kSecAttrTokenID, token_id);
+	CFDictionarySetValue(dict, kSecAttrService, pin);
+	CFDictionarySetValue(dict, kSecAttrPublicKeyHash, pub_key_hash);
+	CFDictionarySetValue(dict, kSecAttrAccount, pub_key_hash_wrap);
+	serializedData = CFPropertyListCreateData(kCFAllocatorDefault, dict, kCFPropertyListBinaryFormat_v1_0, 0, NULL);
+    if (serializedData == NULL) {
+        _LOG_ERROR("SC context - invalid serialized data");
+        goto cleanup;
+    }
+
+    @autoreleasepool {
+        CFDataRef encodedData = (CFDataRef)[(NSData *)serializedData base64EncodedDataWithOptions:0];
+        if (encodedData) {
+            CFStringRef stringFromData = CFStringCreateWithBytes (kCFAllocatorDefault, CFDataGetBytePtr(encodedData), CFDataGetLength(encodedData), kCFStringEncodingUTF8, TRUE);
+            if (stringFromData) {
+                retval = CFStringGetCString(stringFromData, buffer, buffsize, kCFStringEncodingUTF8);
+                _LOG_DEBUG("Keychain unlock data size %zu", buffsize);
+                CFRelease(stringFromData);
+            } else {
+                _LOG_ERROR("SC context - not valid string");
+            }
+        } else {
+            _LOG_ERROR("SC context - invalid encoded data");
+        }
+    }
+
+cleanup:
+	CFReleaseSafe(dict);
+	CFReleaseSafe(serializedData);
+
+	return retval;
+}
+
+CFDataRef get_key_hash_wrap(CFDictionaryRef context, CFStringRef keys, CFStringRef values, CFStringRef token_id)
+{
+	CFArrayRef wrap_hashes = CFDictionaryGetValue(context, keys);
+	CFArrayRef token_ids = CFDictionaryGetValue(context, values);
+	if (wrap_hashes && token_ids) {
+		CFIndex count = CFArrayGetCount(token_ids);
+		for (CFIndex i = 0; i < count; ++i) {
+			CFStringRef wrap_token_id = CFArrayGetValueAtIndex(token_ids, i);
+			if (CFEqual(token_id, wrap_token_id)) {
+				return CFArrayGetValueAtIndex(wrap_hashes, i);
+			}
+		}
+	}
+	return NULL;
+}
+
+PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+    char prompt[PATH_MAX * 2];
+    char certificate_name[PATH_MAX];
+    int retval = PAM_AUTH_ERR;
+    const char *user = NULL;
+    const char *pin = NULL;
+    CFStringRef cf_pin = NULL;
+    OSStatus status;
+    ODRecordRef od_record = NULL;
+    CFDataRef *token_context = NULL;
+    CFDataRef pub_key_hash = NULL;
+    CFDataRef pub_key_hash_wrap = NULL;
+    CFStringRef token_id = NULL;
+    CFStringRef kerberos_principal = NULL;
+    CFPropertyListRef context = NULL;
+    CFStringRef cf_user = NULL;
+    CFErrorRef error = NULL;
+    Boolean interactive;
+    uid_t agent_uid = 0;
+    Boolean no_ignore = FALSE;
+    CFDictionaryRef all_tokens_data = NULL;
+    Boolean valid_user = FALSE;
+    CFStringRef authorization_right = NULL;
+    
+    _LOG_DEBUG("pam_sm_authenticate");
+    
+    if (NULL != openpam_get_option(pamh, "no_ignore")) {
+        no_ignore = TRUE;
+    }
+    
+    retval = pam_get_user(pamh, &user, "Username: ");
+    if (retval != PAM_SUCCESS) {
+        _LOG_ERROR("%s - Unable to get the username: %s", PM_DISPLAY_NAME, pam_strerror(pamh, retval));
+        return retval;
+    }
+    
+    if (user == NULL || *user == '\0') {
+        _LOG_ERROR("%s - Username is invalid.", PM_DISPLAY_NAME);
+        return retval;
+    }
+    
+    struct passwd *pwd = getpwnam(user);
+    if (pwd == NULL) {
+        _LOG_ERROR("%s - Unable to get user details.", PM_DISPLAY_NAME);
+        return retval;
+    }
+    
+    retval = od_record_create_cstring(pamh, &od_record, (const char*)user);
+    if (retval != PAM_SUCCESS) {
+        _LOG_ERROR("%s - Unable to get user record %d.", PM_DISPLAY_NAME, retval);
+        goto cleanup;
+    }
+    cf_user = CFStringCreateWithCString(kCFAllocatorDefault, user, kCFStringEncodingUTF8);
+    if (openpam_get_option(pamh, PAM_OPT_PKINIT)) {
+        pam_get_data(pamh, "kerberos", (void *)&kerberos_principal);
+        if (kerberos_principal) {
+            CFRetain(kerberos_principal);
+            _LOG_DEBUG("%s - Kerberos Principal passed in variable", PM_DISPLAY_NAME);
+        }
+    } else {
+        _LOG_DEBUG("%s - Trying to get kerbPrincipal from OD", PM_DISPLAY_NAME);
+        CFArrayRef records = find_user_record_by_attr_value(kDSNAttrRecordName, user);
+        if (records) {
+            for (CFIndex i = 0; i < CFArrayGetCount(records); ++i) {
+                CFTypeRef userRecord = CFArrayGetValueAtIndex(records, i);
+                kerberos_principal = GetPrincipalFromUser(userRecord);
+                if (kerberos_principal) {
+                    break;
+                }
+            }
+        }
+    }
+    if (kerberos_principal) {
+        _LOG_DEBUG("%s - Will ask for kerberos ticket", PM_DISPLAY_NAME);
+    }
+
+    pam_get_data(pamh, "authorization_right", (void *)&authorization_right);
+    if (authorization_right) {
+        CFRetain(authorization_right);
+        _LOG_DEBUG("%s - evaluating authorization right %@", PM_DISPLAY_NAME, authorization_right);
+    }
+    
+    uid_t *tmpUid;
+    if (PAM_SUCCESS == pam_get_data(pamh, "agent_uid", (void *)&tmpUid)) {
+        agent_uid = *tmpUid;
+    } else {
+        agent_uid = 0; // 0 means autodetect for TKFunctions
+    }
+    _LOG_DEBUG("%s - using %d as agent uid", PM_DISPLAY_NAME, agent_uid);
+    
+    // get the token context
+    pam_get_data(pamh, "token_ctk", (void *)&token_context); // we do not need to check status as token_id presence reveals success
+    interactive = token_context == NULL;
+
+    CFMutableDictionaryRef hints = CFDictionaryCreateMutable(kCFAllocatorDefault, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+     if (hints && cf_user) {
+         CFDictionaryAddValue(hints, CFSTR(kTKXpcKeyUserName), cf_user);
+         all_tokens_data = TKCopyAvailableTokensInfo(agent_uid, hints);
+    }
+    
+    if (all_tokens_data) {
+        CFArrayRef mappedUsers = CFDictionaryGetValue(all_tokens_data, CFSTR("0")); // 0 is APEventHintUsers from AuthenticationHintsProvider
+        if (mappedUsers && CFArrayContainsValue(mappedUsers, CFRangeMake(0, CFArrayGetCount(mappedUsers)), cf_user)) {
+            valid_user = TRUE;
+        }
+    }
+    
+    if (!valid_user) {
+        _LOG_ERROR("%s - User %s is not paired with any smartcard.", PM_DISPLAY_NAME, user);
+        retval = PAM_AUTH_ERR;
+        goto cleanup;
+    }
+    
+    if (interactive) {
+        CFDataRef contextData = CFDictionaryGetValue(all_tokens_data, CFSTR(kTkHintContextData));
+        if (contextData) {
+            context = CFPropertyListCreateWithData(kCFAllocatorDefault, contextData, 0, NULL, NULL);
+        }
+    } else {
+        context = CFPropertyListCreateWithData(kCFAllocatorDefault, *token_context, 0, NULL, NULL);
+    }
+    
+    if (context == NULL) {
+        _LOG_ERROR("%s - Cannot find context", PM_DISPLAY_NAME);
+        goto cleanup;
+    }
+    
+    CFDictionaryRef pub_key_hashes = CFDictionaryGetValue(context, CFSTR(kTkHintAllPubkeyHashes));
+    if (pub_key_hashes) {
+        CFStringRef user_string = CFStringCreateWithCString(kCFAllocatorDefault, user, kCFStringEncodingUTF8);
+        if (user_string) {
+            pub_key_hash = (CFDataRef)CFDictionaryGetValue(pub_key_hashes, user_string);
+            if (pub_key_hash) {
+                CFRetain(pub_key_hash);
+            }
+            CFRelease(user_string);
+        }
+    }
+    
+    if (pub_key_hash) {
+        // these arrays are keys and values, the same length
+        CFArrayRef hashes = CFDictionaryGetValue(context, CFSTR(kTkHintTokenNameHashes));
+        CFArrayRef token_ids = CFDictionaryGetValue(context, CFSTR(kTkHintTokenNameIds));
+        CFIndex count = CFArrayGetCount(hashes);
+        for (CFIndex i = 0; i < count; ++i) {
+            CFDataRef hash = CFArrayGetValueAtIndex(hashes, i);
+            if (CFEqual(hash, pub_key_hash)) {
+                token_id = CFArrayGetValueAtIndex(token_ids, i);
+                CFRetain(token_id);
+                break;
+            }
+        }
+        if (interactive) { // prepare prompt for interactive password request
+            CFArrayRef hashes = CFDictionaryGetValue(context, CFSTR(kTkHintFriendlyNameHashes));
+            CFArrayRef friendlyNames = CFDictionaryGetValue(context, CFSTR(kTkHintFriendlyNames));
+            CFIndex count = CFArrayGetCount(hashes);
+            CFStringRef certificateName = NULL;
+            for (CFIndex i = 0; i < count; ++i) {
+                CFDataRef hash = CFArrayGetValueAtIndex(hashes, i);
+                if (CFEqual(hash, pub_key_hash)) {
+                    certificateName = CFArrayGetValueAtIndex(friendlyNames, i);
+                    break;
+                }
+            }
+            
+            if (!certificateName || !CFStringGetCString(certificateName, (char *)&certificate_name, PATH_MAX - 1, kCFStringEncodingUTF8))
+                strncpy(certificate_name, "Unnamed certificate", PATH_MAX - 1);
+            
+            snprintf(prompt, sizeof(prompt), "Enter PIN for '%s': ", certificate_name);
+        } else if (token_id) { // first try RSA keys
+            pub_key_hash_wrap = get_key_hash_wrap(context, CFSTR(kTkHintUnlockTokenHashes), CFSTR(kTkHintUnlockTokenIds), token_id);
+            if (pub_key_hash_wrap) {
+                CFRetain(pub_key_hash_wrap);
+                _LOG_DEBUG("Wrap key found.");
+            }
+        }
+    }
+    CFRelease(context);
+
+	retval = (interactive && !no_ignore) ? PAM_IGNORE : PAM_AUTH_ERR;
+    
+    for (int i = 0; i < (interactive ? MAX_PIN_RETRY : 1); ++i) {
+        CFReleaseNull(cf_pin);
+        cf_pin = copy_pin(pamh, prompt, &pin); // gets pre-stored password for Authorization / asks user during interactive session
+        if (cf_pin) {
+            status = TKPerformLogin(agent_uid, token_id, pub_key_hash, cf_pin, kerberos_principal, &error);
+            _LOG_DEBUG("%s - Smartcard verification result %d", PM_DISPLAY_NAME, (int)status);
+            if (status == errSecSuccess) {
+                CFReleaseSafe(error);
+                // after successfull auth, cache pubkeyhash in OD for FVUnlock mode
+                // TKBindUserAm checks if caching is necessary
+                TKBindUserAm(cf_user, pub_key_hash, NULL);
+                retval = PAM_SUCCESS;
+                break;
+            } else if (status == kTKErrorCodeAuthenticationFailed) {
+                // existing ahp_error is automatically released by pam_set_data when setting a new one
+                pam_set_data(pamh, "ahp_error", (void *)error, cleanup_func); // automatically releases previous object
+                error = nil; // already transferred to ahp_error
+            } else {
+                CFReleaseNull(error);
+                break; // do not retry on other errors than PIN failed
+            }
+        } else {
+            _LOG_ERROR("%s - Unable to get %s PIN", PM_DISPLAY_NAME, interactive ? "interactive":"stored");
+        }
+    }
+
+	if (interactive == FALSE && retval == PAM_SUCCESS && token_id) {
+		// for authorization set token ID
+		CFRetain(token_id);
+		pam_set_data(pamh, "token_id", (void *)token_id, cleanup_func);
+        NSString *auth_right = (NSString *)authorization_right;
+        NSString *exeName = NSBundle.mainBundle.executablePath;
+        enKeychainUnlock keychainUnlockWay = enNoUnlock;
+        if ([exeName isEqualToString:@"/System/Library/CoreServices/loginwindow.app/Contents/MacOS/loginwindow"]) {
+            // loginwindow uses this module just to unlock the screen when switched to PAM mode
+            keychainUnlockWay = enUnlockDirectly;
+        } else if ([auth_right isEqualToString:@"system.login.screensaver"]) {
+            // auth_right is set only by authorizationhost so its implied that we are invoked from authorizationhost
+            keychainUnlockWay = enUnlockUsingAhp;
+        }
+        if (keychainUnlockWay != enNoUnlock) {
+            char pin_context_buff[PATH_MAX];
+            if (copy_smartcard_unlock_context(pin_context_buff, PATH_MAX, token_id, cf_pin, pub_key_hash, pub_key_hash_wrap)) {
+                // check if we are running in the user session as this means we are called inside screensaver unlock
+                _LOG_DEBUG("%s - Going to unlock keychain", PM_DISPLAY_NAME);
+                if (keychainUnlockWay == enUnlockDirectly) {
+                    // unlock user keychain
+                    status = SecKeychainLogin((UInt32)strlen(user), user, (UInt32)strlen(pin_context_buff), pin_context_buff);
+                    _LOG_DEBUG("%s - Keychain unlock result %d", PM_DISPLAY_NAME, (int)status);
+                } else if (keychainUnlockWay == enUnlockUsingAhp){
+                    NSString *pinData = [NSString stringWithUTF8String:pin_context_buff];
+                    if (pinData) {
+                        status = TKUnlockKeybag(pwd->pw_uid, (__bridge CFStringRef)pinData);
+                        _LOG_DEBUG("%s - TKUnlockKeybag unlock result %d", PM_DISPLAY_NAME, (int)status);
+                    } else {
+                        _LOG_ERROR("%s - Unable to construct pindata for keychain unlock", PM_DISPLAY_NAME);
+                    }
+                }
+            } else {
+                _LOG_ERROR("%s - Unable to get data for keychain unlock", PM_DISPLAY_NAME);
+            }
+        } else {
+            _LOG_DEBUG("%s - keychain unlock not needed", PM_DISPLAY_NAME);
+        }
+	}
+
+cleanup:
+	CFReleaseSafe(od_record);
+	CFReleaseSafe(token_id);
+	CFReleaseSafe(pub_key_hash);
+	CFReleaseSafe(pub_key_hash_wrap);
+	CFReleaseSafe(cf_user);
+    CFReleaseSafe(cf_pin);
+    CFReleaseSafe(kerberos_principal);
+    CFReleaseSafe(all_tokens_data);
+    CFReleaseSafe(authorization_right);
+	return retval;
+}
+
+PAM_EXTERN int pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	return PAM_SUCCESS;
+}
+
+PAM_EXTERN int pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	return PAM_SUCCESS;
+}
+
+PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+	return PAM_SUCCESS;
+}

--- a/src/pam_modules/modules/pam_smartcard/scmatch_evaluation.c
+++ b/src/pam_modules/modules/pam_smartcard/scmatch_evaluation.c
@@ -1,0 +1,179 @@
+#include <OpenDirectory/OpenDirectory.h>
+#include <Security/Security.h>
+#include <Security/SecCertificatePriv.h>
+#include <Security/SecKeyPriv.h>
+#include <Security/SecTrustPriv.h>
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <CommonCrypto/CommonDigest.h>
+
+#include "scmatch_evaluation.h"
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(SCMatch)
+#define PAM_LOG PAM_LOG_SCMatch()
+#endif
+
+CFDataRef copyRandomData(size_t size)
+{
+    if (!size)
+        return NULL;
+    
+    unsigned char buffer[size];
+    int fd = open("/dev/random", O_RDONLY, 0);
+    if (fd < 0)
+        return NULL;
+    
+    size_t readlength = read(fd, buffer, size);
+    close (fd);
+    if (readlength == size)
+        return CFDataCreate(kCFAllocatorDefault, buffer, size);
+    
+    return NULL;
+}
+
+OSStatus validateCertificate(SecCertificateRef certificate, SecKeychainRef keychain)
+{
+    OSStatus result = errSecInternalError;
+    SecPolicyRef policy = SecPolicyCreateBasicX509();
+    CFArrayRef certificates = NULL;
+    CFDataRef hash = NULL;
+    CFStringRef commonName = NULL;
+    
+    
+    OSStatus status = SecCertificateCopyCommonName(certificate, &commonName);
+    if (status != errSecSuccess)
+        goto cleanup;
+    
+    // make the query as detailed as possible to avoid trust and revocation checking of multiple certificates
+    const void *keys[] = { kSecClass, kSecReturnRef, kSecMatchLimit, kSecMatchValidOnDate, kSecMatchPolicy, kSecMatchTrustedOnly, kSecMatchValidOnDate, kSecMatchSubjectWholeString};
+    const void *vals[] = { kSecClassCertificate, kCFBooleanTrue, kSecMatchLimitAll, kCFNull, policy, kCFBooleanTrue, kCFNull, commonName };
+    
+    CFDictionaryRef query = CFDictionaryCreate(kCFAllocatorDefault, keys, vals, sizeof(keys) / sizeof(keys[0]), NULL, NULL);
+    if (!query)
+        goto cleanup;
+    
+    // policy is used so additional trust test is performed in Security
+    status = SecItemCopyMatching(query, (CFTypeRef*)&certificates);
+    CFRelease(query);
+    
+    if (status != errSecSuccess)
+    {
+        result = status;
+        goto cleanup;
+    }
+    
+    if (CFGetTypeID(certificates) != CFArrayGetTypeID())
+        goto cleanup;
+
+    // now check if our wanted certificate is returned in the array of valid ones
+    hash = SecCertificateCopyPublicKeySHA1Digest(certificate);
+    for (CFIndex i = 0; i < CFArrayGetCount(certificates); ++i)
+    {
+        SecCertificateRef cert = (SecCertificateRef)CFArrayGetValueAtIndex(certificates, i);
+        if (CFGetTypeID(cert) != SecCertificateGetTypeID())
+            continue;
+        CFDataRef checkedHash = SecCertificateCopyPublicKeySHA1Digest(cert);
+        bool found = CFEqual(hash, checkedHash);
+        CFReleaseSafe(checkedHash);
+        if (found)
+        {
+            result = errSecSuccess;
+            break;
+        }
+    }
+    
+cleanup:
+    
+    _LOG_DEBUG("validateCertificate completed with: %d", (int)result);
+    CFReleaseSafe(commonName);
+    CFReleaseSafe(policy);
+    CFReleaseSafe(certificates);
+    CFReleaseSafe(hash);
+    
+    return result;
+}
+
+OSStatus verifySmartCardSigning(SecKeyRef publicKey, SecKeyRef privateKey)
+{
+    if (!publicKey || !privateKey)
+        return false;
+    
+    OSStatus result = errSecAuthFailed;
+    CFDataRef randomData = NULL;
+    size_t blockSize = SecKeyGetBlockSize(privateKey);
+    unsigned char signature[blockSize];
+    
+    randomData = copyRandomData(CC_SHA1_DIGEST_LENGTH);
+    size_t signature_len = blockSize;
+
+    if (randomData != NULL)
+    {
+        result = SecKeyRawSign(privateKey, kSecPaddingPKCS1, CFDataGetBytePtr(randomData), CC_SHA1_DIGEST_LENGTH, signature, &signature_len);
+        if (result == errSecSuccess && signature_len == blockSize)
+        {
+            result = SecKeyRawVerify(publicKey, kSecPaddingPKCS1, CFDataGetBytePtr(randomData), CC_SHA1_DIGEST_LENGTH, signature, blockSize);
+        }
+        CFRelease(randomData);
+    }
+    return result;
+}
+
+CFArrayRef copyCardIdentities()
+{
+    CFArrayRef smartCardKeychains  = NULL;
+    CFTypeRef certificates = NULL;
+    
+    OSStatus status = SecKeychainCopyDomainSearchList(kSecPreferencesDomainDynamic, &smartCardKeychains);
+    if (status != errSecSuccess)
+        goto cleanup;
+    
+    const void *keys[] = { kSecClass, kSecReturnRef, kSecMatchLimit, kSecMatchSearchList };
+    const void *vals[] = { kSecClassIdentity, kCFBooleanTrue, kSecMatchLimitAll, smartCardKeychains };
+    CFDictionaryRef query = CFDictionaryCreate(kCFAllocatorDefault, keys, vals, sizeof(keys) / sizeof(keys[0]), NULL, NULL);
+    if (!query)
+        goto cleanup;
+    
+    status = SecItemCopyMatching(query, &certificates);
+    CFRelease(query);
+    
+    if (status != errSecSuccess)
+        goto cleanup;
+    
+cleanup:
+    if (smartCardKeychains)
+        CFRelease(smartCardKeychains);
+    
+    if(certificates == NULL)
+        return NULL;
+    
+    if (CFGetTypeID(certificates) == CFArrayGetTypeID())
+        return certificates;
+    
+    CFRelease(certificates);
+    return NULL;
+}
+
+SecKeychainRef copySmartCardKeychainForUser(ODRecordRef odRecord, const char* username, SecIdentityRef* copiedIdentity)
+{
+    if (odRecord == NULL || username == NULL)
+        return NULL;
+    
+    CFArrayRef identities = copyCardIdentities();
+    if (identities)
+    {
+        SecKeychainRef result = copyHashMatchedKeychain(odRecord, identities, copiedIdentity);
+        if (result == NULL)
+            result = copyAttributeMatchedKeychain(odRecord, identities, copiedIdentity);
+
+        if (copiedIdentity && *copiedIdentity)
+            CFRetain(*copiedIdentity);
+        
+        CFRelease(identities);
+        return result;
+    }
+    
+    return NULL;
+}

--- a/src/pam_modules/modules/pam_smartcard/scmatch_evaluation.h
+++ b/src/pam_modules/modules/pam_smartcard/scmatch_evaluation.h
@@ -1,0 +1,20 @@
+#ifndef scmatch_evaluation_h
+#define scmatch_evaluation_h
+#include <Security/Security.h>
+#include <CoreFoundation/CFArray.h>
+#include <OpenDirectory/OpenDirectory.h>
+
+SecKeychainRef copyAttributeMatchedKeychain(ODRecordRef odRecord, CFArrayRef identities, SecIdentityRef* returnedIdentity);
+SecKeychainRef copyHashMatchedKeychain(ODRecordRef odRecord, CFArrayRef identities, SecIdentityRef* returnedIdentity);
+
+// caller is responsible for releasing copiedIdentity
+SecKeychainRef copySmartCardKeychainForUser(ODRecordRef odRecord, const char* username, SecIdentityRef* copiedIdentity);
+
+OSStatus verifySmartCardSigning(SecKeyRef publicKey, SecKeyRef privateKey);
+OSStatus validateCertificate(SecCertificateRef certificate, SecKeychainRef keychain);
+
+#define CFReleaseSafe(CF) { CFTypeRef _cf = (CF); if (_cf) CFRelease(_cf); }
+#define CFReleaseNull(CF) { CFTypeRef _cf = (CF); \
+    if (_cf) { (CF) = NULL; CFRelease(_cf); } }
+
+#endif /* scmatch_evaluation_h */

--- a/src/pam_modules/modules/pam_smartcard/screensaver_ctk
+++ b/src/pam_modules/modules/pam_smartcard/screensaver_ctk
@@ -1,0 +1,6 @@
+# ctk: auth 
+auth       required       pam_smartcard.so			use_first_pass
+account    required       pam_opendirectory.so      non_password_auth
+account    sufficient     pam_self.so
+account    required       pam_group.so no_warn group=admin,wheel fail_safe
+account    required       pam_group.so no_warn deny group=admin,wheel ruser fail_safe

--- a/src/pam_modules/modules/pam_smartcard/screensaver_new_ctk
+++ b/src/pam_modules/modules/pam_smartcard/screensaver_new_ctk
@@ -1,0 +1,3 @@
+# ctk: auth 
+auth       required       pam_smartcard.so 		use_first_pass pkinit
+account    required       pam_opendirectory.so  non_password_auth

--- a/src/pam_modules/modules/pam_tid/pam_tid.c
+++ b/src/pam_modules/modules/pam_tid/pam_tid.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ * Portions Copyright (c) 2001 PADL Software Pty Ltd. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * Portions Copyright (c) 2000 Apple Computer, Inc.  All Rights
+ * Reserved.  This file contains Original Code and/or Modifications of
+ * Original Code as defined in and that are subject to the Apple Public
+ * Source License Version 1.1 (the "License").  You may not use this file
+ * except in compliance with the License.  Please obtain a copy of the
+ * License at http://www.apple.com/publicsource and read it before using
+ * this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON- INFRINGEMENT.  Please see the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/******************************************************************
+ * The purpose of this module is to provide a Touch ID
+ * based authentication module for Mac OS X.
+ ******************************************************************/
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <coreauthd_spi.h>
+#include <pwd.h>
+#include <LocalAuthentication/LAPrivateDefines.h>
+
+#define PAM_SM_AUTH
+#define PAM_SM_ACCOUNT
+
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+#include <Security/Authorization.h>
+#include <vproc_priv.h>
+#include "Logging.h"
+#include "Common.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(touchid)
+#define PAM_LOG PAM_LOG_touchid()
+#endif
+
+PAM_EXTERN int
+pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    _LOG_DEBUG("pam_tid: pam_sm_authenticate");
+
+    int retval = PAM_AUTH_ERR;
+    CFTypeRef context = NULL;
+    CFErrorRef error = NULL;
+    CFMutableDictionaryRef options = NULL;
+    CFNumberRef key = NULL;
+    CFNumberRef value = NULL;
+	CFNumberRef key2 = NULL;
+	CFNumberRef value2 = NULL;
+	AuthorizationRef authorizationRef = NULL;
+
+    int tmp;
+
+    const char *user = NULL;
+    struct passwd *pwd = NULL;
+    struct passwd pwdbuf;
+
+    /* determine the required bufsize for getpwnam_r */
+    long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (bufsize == -1) {
+        bufsize = 2 * PATH_MAX;
+    }
+    
+    /* get information about user to authenticate for */
+    char *buffer = malloc(bufsize);
+    if (pam_get_user(pamh, &user, NULL) != PAM_SUCCESS || !user ||
+        getpwnam_r(user, &pwdbuf, buffer, bufsize, &pwd) != 0 || !pwd) {
+        _LOG_ERROR("unable to obtain the username.");
+        retval = PAM_AUTHINFO_UNAVAIL;
+        goto cleanup;
+    }
+
+	// check if we are running under Aqua session
+	char *manager;
+	if (vproc_swap_string(NULL, VPROC_GSK_MGR_NAME, NULL, &manager) != NULL) {
+		_LOG_ERROR("unable to determine session.");
+		retval = PAM_AUTH_ERR;
+		goto cleanup;
+	}
+	bool runningInAquaSession = manager ? !strcmp(manager, VPROCMGR_SESSION_AQUA) : FALSE;
+	free(manager);
+	if (!runningInAquaSession) {
+		_LOG_ERROR("UI not available.");
+		retval = PAM_AUTH_ERR;
+		goto cleanup;
+	}
+
+    const void *askpass;
+    retval = pam_get_data(pamh, "askpass-enabled", &askpass);
+    if (retval == PAM_SUCCESS) {
+        _LOG_DEBUG("sudo askpass mode, not showing UI");
+        retval = PAM_AUTHINFO_UNAVAIL;
+        goto cleanup;
+    }
+	// check if user is eligible to use Touch ID. If not, fail.
+    /* prepare the options dictionary, aka rewrite @{ @(LAOptionNotInteractive) : @YES } without Foundation */
+    tmp = kLAOptionNotInteractive;
+    key = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &tmp);
+
+    tmp = 1;
+    value = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &tmp);
+
+	tmp = kLAOptionUserId;
+	key2 = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &tmp);
+
+	tmp = pwd->pw_uid;
+	value2 = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &tmp);
+
+	if (! (key && value && key2 && value2)) {
+		_LOG_ERROR("unable to create data structures.");
+		retval = PAM_AUTH_ERR;
+		goto cleanup;
+	}
+
+    options = CFDictionaryCreateMutable(kCFAllocatorDefault, 2, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFDictionarySetValue(options, key, value);
+	CFDictionarySetValue(options, key2, value2);
+
+	context = LACreateNewContextWithACMContext(NULL, &error);
+	if (!context) {
+		_LOG_ERROR("unable to create context.");
+		retval = PAM_AUTH_ERR;
+		goto cleanup;
+	}
+
+    /* evaluate policy */
+    if (!LAEvaluatePolicy(context, kLAPolicyDeviceOwnerAuthenticationWithBiometrics, options, &error)) {
+		// error is intended as failure means Touch ID is not usable which is in fact not an error but the state we need to handle
+		if (CFErrorGetCode(error) != kLAErrorNotInteractive) {
+			_LOG_DEBUG("policy evaluation failed: %ld", CFErrorGetCode(error));
+			retval = PAM_AUTH_ERR;
+			goto cleanup;
+		}
+    }
+
+	OSStatus status = AuthorizationCreate(NULL, NULL, kAuthorizationFlagDefaults, &authorizationRef);
+	if (status == errAuthorizationSuccess) {
+		AuthorizationItem myItems = {"com.apple.security.sudo", 0, NULL, 0};
+		AuthorizationRights myRights = {1, &myItems};
+		AuthorizationRights *authorizedRights = NULL;
+		AuthorizationFlags flags = kAuthorizationFlagDefaults | kAuthorizationFlagInteractionAllowed | kAuthorizationFlagExtendRights;
+		status = AuthorizationCopyRights(authorizationRef, &myRights, kAuthorizationEmptyEnvironment, flags, &authorizedRights);
+		_LOG_DEBUG("Authorization result: %d", (int)status);
+		if (authorizedRights)
+			AuthorizationFreeItemSet(authorizedRights);
+		AuthorizationFree(authorizationRef, kAuthorizationFlagDefaults);
+	}
+
+    /* we passed the Touch ID authentication successfully */
+	if (status == errAuthorizationSuccess) {
+		retval = PAM_SUCCESS;
+	}
+
+cleanup:
+	CFReleaseSafe(context);
+	CFReleaseSafe(key);
+	CFReleaseSafe(value);
+	CFReleaseSafe(key2);
+	CFReleaseSafe(value2);
+	CFReleaseSafe(options);
+	CFReleaseSafe(error);
+    free(buffer);
+	_LOG_DEBUG("pam_tid: pam_sm_authenticate returned %d", retval);
+    return retval;
+}
+
+
+PAM_EXTERN int
+pam_sm_setcred(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    return PAM_SUCCESS;
+}
+
+
+PAM_EXTERN int
+pam_sm_acct_mgmt(pam_handle_t * pamh, int flags, int argc, const char **argv)
+{
+    return PAM_SUCCESS;
+}

--- a/src/pam_modules/modules/pam_uwtmp/pam_uwtmp.8
+++ b/src/pam_modules/modules/pam_uwtmp/pam_uwtmp.8
@@ -1,0 +1,57 @@
+.\"
+.\" Copyright (C) 2002-2009 Apple Inc.  All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms of pam_uwtmp, with
+.\" or without modification, are permitted provided that the following
+.\" conditions are met:
+.\" 
+.\" 1. Redistributions of source code must retain any existing copyright
+.\" notice, and this entire permission notice in its entirety,
+.\" including the disclaimer of warranties.
+.\" 
+.\" 2. Redistributions in binary form must reproduce all prior and current
+.\" copyright notices, this list of conditions, and the following
+.\" disclaimer in the documentation and/or other materials provided
+.\" with the distribution.
+.\" 
+.\" 3. The name of any author may not be used to endorse or promote
+.\" products derived from this software without their specific prior
+.\" written permission.
+.\"
+.\" THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+.\" WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+.\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+.\" IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+.\" INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+.\" BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+.\" OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+.\" ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+.\" TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+.\" USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+.\" DAMAGE. 
+.\"
+.Dd February 7, 2009
+.Dt pam_uwtmp 8
+.Os
+.Sh NAME
+.Nm pam_uwtmp
+.Nd User Accounting PAM module
+.Sh SYNOPSIS
+.Op Ar service-name
+.Ar function-class
+.Ar control-flag
+pam_uwtmp
+.Op Ar options
+.Sh DESCRIPTION
+The User Accounting PAM module supports the session management function class.  In terms of the
+.Ar function-class
+parameter, this is the
+.Dq Li session
+class.
+.Pp
+The User Accounting session management module updates the system's user accounting database when a users logs in or out of the system.
+.Pp
+.Sh SEE ALSO
+.Xr pam.conf 5 ,
+.Xr pam 8
+.Xr utmpx 5

--- a/src/pam_modules/modules/pam_uwtmp/pam_uwtmp.c
+++ b/src/pam_modules/modules/pam_uwtmp/pam_uwtmp.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2002-2009 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms of pam_uwtmp, with
+ * or without modification, are permitted provided that the following
+ * conditions are met:
+ * 
+ * 1. Redistributions of source code must retain any existing copyright
+ * notice, and this entire permission notice in its entirety,
+ * including the disclaimer of warranties.
+ * 
+ * 2. Redistributions in binary form must reproduce all prior and current
+ * copyright notices, this list of conditions, and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * 
+ * 3. The name of any author may not be used to endorse or promote
+ * products derived from this software without their specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE. 
+ */
+
+#include <sys/types.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <utmpx.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define PAM_SM_SESSION
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+#include <security/openpam.h>
+#include "Logging.h"
+
+#ifdef PAM_USE_OS_LOG
+PAM_DEFINE_LOG(uwtmp)
+#define PAM_LOG PAM_LOG_uwtmp()
+#endif
+
+#define DATA_NAME "pam_uwtmp.utmpx"
+
+struct pam_uwtmp_data {
+	struct utmpx	utmpx;
+	struct utmpx	backup;
+	int				restore;
+};
+
+PAM_EXTERN int
+populate_struct(pam_handle_t *pamh, struct utmpx *u, int populate)
+{
+	int status;
+	char *tty;
+	char *user;
+	char *remhost;
+
+	if (NULL == u)
+		return PAM_SYSTEM_ERR;
+
+	if (PAM_SUCCESS != (status = pam_get_item(pamh, PAM_USER, (const void **)&user))) {
+		_LOG_ERROR("Unable to obtain the username.");
+		return status;
+	}
+	if (NULL != user)
+		strlcpy(u->ut_user, user, sizeof(u->ut_user));
+
+	if (populate) {
+		if (PAM_SUCCESS != (status = pam_get_item(pamh, PAM_TTY, (const void **)&tty))) {
+            _LOG_ERROR("Unable to obtain the tty.");
+			return status;
+		}
+		if (NULL == tty) {
+            _LOG_ERROR("The tty is NULL.");
+			return PAM_IGNORE;
+		} else
+			strlcpy(u->ut_line, tty, sizeof(u->ut_line));
+
+		if (PAM_SUCCESS != (status = pam_get_item(pamh, PAM_RHOST, (const void **)&remhost))) {
+            _LOG_ERROR("Unable to obtain the rhost.");
+			return status;
+		}
+		if (NULL != remhost)
+			strlcpy(u->ut_host, remhost, sizeof(u->ut_host));
+	}
+
+	u->ut_pid = getpid();
+	gettimeofday(&u->ut_tv, NULL);
+
+	return status;
+}
+
+PAM_EXTERN int
+pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	int status;
+	struct pam_uwtmp_data *pam_data = NULL;
+	struct utmpx *u = NULL;
+	struct utmpx *t = NULL;
+	char *tty;
+
+	if( (pam_data = calloc(1, sizeof(*pam_data))) == NULL ) {
+		_LOG_ERROR("Memory allocation error.");
+		return PAM_BUF_ERR;
+	}
+
+	u = &pam_data->utmpx;
+	
+	// Existing utmpx entry for current terminal?
+	status = pam_get_item(pamh, PAM_TTY, (const void **) &tty);
+	if (status == PAM_SUCCESS && tty != NULL) {
+		strlcpy(u->ut_line, tty, sizeof(u->ut_line));
+		t = getutxline(u);
+	}
+
+	if (t) {
+		// YES: backup existing utmpx entry + update
+		_LOG_DEBUG("Updating existing entry for %s", u->ut_line);
+		memcpy(&pam_data->utmpx,  t, sizeof(*t));
+		memcpy(&pam_data->backup, t, sizeof(*t));
+		pam_data->restore = 1;
+
+		if (PAM_SUCCESS != (status = populate_struct(pamh, &pam_data->utmpx, 0)))
+			goto err;
+	} else {
+		// NO: create new utmpx entry
+		_LOG_DEBUG("New entry for %s", tty ?: "-");
+		if (PAM_SUCCESS != (status = populate_struct(pamh, u, 1)))
+			goto err;
+
+		u->ut_type = UTMPX_AUTOFILL_MASK | USER_PROCESS;
+	}
+
+	if (PAM_SUCCESS != (status = pam_set_data(pamh, DATA_NAME, pam_data, openpam_free_data))) {
+		_LOG_ERROR("There was an error setting data in the context.");
+		goto err;
+	}
+	pam_data = NULL;
+
+	if( pututxline(u) == NULL ) {
+		_LOG_ERROR("Unable to write the utmp record.");
+		status = PAM_SYSTEM_ERR;
+		goto err;
+	}
+
+	return PAM_SUCCESS;
+
+err:
+	pam_set_data(pamh, DATA_NAME, NULL, NULL);
+	free(pam_data);
+	return status;
+}
+
+PAM_EXTERN int
+pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	int status;
+	struct pam_uwtmp_data *pam_data = NULL;
+	struct utmpx *u = NULL;
+	int free_u = 0;
+
+	status = pam_get_data(pamh, DATA_NAME, (const void **)&pam_data);
+	if( status != PAM_SUCCESS ) {
+		_LOG_DEBUG("Unable to obtain the tmp record from the context.");
+	}
+
+	if (NULL == pam_data) {
+		if( (u = calloc(1, sizeof(*u))) == NULL ) {
+			_LOG_ERROR("Memory allocation error.");
+			return PAM_BUF_ERR;
+		}
+		free_u = 1;
+
+		if (PAM_SUCCESS != (status = populate_struct(pamh, u, 1)))
+			goto fin;
+	} else {
+		u = &pam_data->utmpx;
+	}
+
+	if (pam_data != NULL && pam_data->restore) {
+		u = &pam_data->backup;
+		_LOG_DEBUG("Restoring previous entry for %s", u->ut_line);
+	} else {
+		_LOG_VERBOSE("Dead process");
+		u->ut_type = UTMPX_AUTOFILL_MASK | DEAD_PROCESS;
+	}
+
+	if( pututxline(u) == NULL ) {
+		_LOG_ERROR("Unable to write the utmp record.");
+		status = PAM_SYSTEM_ERR;
+		goto fin;
+	}
+
+	status = PAM_SUCCESS;
+
+fin:
+	if (1 == free_u)
+		free(u);
+	return status;
+}

--- a/src/pam_modules/pam_modules.xcodeproj/project.pbxproj
+++ b/src/pam_modules/pam_modules.xcodeproj/project.pbxproj
@@ -1,0 +1,2165 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 45;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		1CFF7DB51021164C0097ADA4 /* pam_modules */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 1CFF7DD4102116A60097ADA4 /* Build configuration list for PBXAggregateTarget "pam_modules" */;
+			buildPhases = (
+			);
+			dependencies = (
+				4770A3342D669E6C000535FB /* PBXTargetDependency */,
+				5FE441C91C5619790010C4FD /* PBXTargetDependency */,
+				1CFF7DCF1021165B0097ADA4 /* PBXTargetDependency */,
+				1CFF7DCD1021165B0097ADA4 /* PBXTargetDependency */,
+				1CFF7DCB1021165B0097ADA4 /* PBXTargetDependency */,
+				1CFF7DC91021165B0097ADA4 /* PBXTargetDependency */,
+				5FFEF0151C04A6620083839D /* PBXTargetDependency */,
+				1CFF7DC71021165B0097ADA4 /* PBXTargetDependency */,
+				1CFF7DC51021165B0097ADA4 /* PBXTargetDependency */,
+				1CFF7DC31021165B0097ADA4 /* PBXTargetDependency */,
+				1CFF7DC11021165B0097ADA4 /* PBXTargetDependency */,
+				1CFF7DBF1021165B0097ADA4 /* PBXTargetDependency */,
+				1CFF7DBD1021165B0097ADA4 /* PBXTargetDependency */,
+				F6F8C6821B8F6F00002596AE /* PBXTargetDependency */,
+				F6AAC60A1DF07A5F008A6811 /* PBXTargetDependency */,
+				1CFF7DB91021165B0097ADA4 /* PBXTargetDependency */,
+				7434C89F125544F9001D7F9E /* PBXTargetDependency */,
+				1CFF8088102119940097ADA4 /* PBXTargetDependency */,
+				1CFF80D910211B040097ADA4 /* PBXTargetDependency */,
+			);
+			name = pam_modules;
+			productName = pam_modules;
+		};
+		1CFF806D102119880097ADA4 /* Install Manpages */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 1CFF809F102119E70097ADA4 /* Build configuration list for PBXAggregateTarget "Install Manpages" */;
+			buildPhases = (
+				1CFF806C102119880097ADA4 /* man8 */,
+			);
+			dependencies = (
+			);
+			name = "Install Manpages";
+			productName = "Install Manpages";
+		};
+		1CFF80BC10211AF10097ADA4 /* Cleanup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 1CFF80DC10211B140097ADA4 /* Build configuration list for PBXAggregateTarget "Cleanup" */;
+			buildPhases = (
+				1CFF80BB10211AF10097ADA4 /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = Cleanup;
+			productName = Cleanup;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		1C23731C10290C600055216A /* pam_env.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731010290C600055216A /* pam_env.8 */; };
+		1C23731D10290C600055216A /* pam_group.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731110290C600055216A /* pam_group.8 */; };
+		1C23731E10290C600055216A /* pam_krb5.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731210290C600055216A /* pam_krb5.8 */; };
+		1C23731F10290C600055216A /* pam_launchd.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731310290C600055216A /* pam_launchd.8 */; };
+		1C23732010290C600055216A /* pam_mount.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731410290C600055216A /* pam_mount.8 */; };
+		1C23732110290C600055216A /* pam_nologin.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731510290C600055216A /* pam_nologin.8 */; };
+		1C23732210290C600055216A /* pam_opendirectory.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731610290C600055216A /* pam_opendirectory.8 */; };
+		1C23732310290C600055216A /* pam_rootok.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731710290C600055216A /* pam_rootok.8 */; };
+		1C23732410290C600055216A /* pam_sacl.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731810290C600055216A /* pam_sacl.8 */; };
+		1C23732510290C600055216A /* pam_self.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731910290C600055216A /* pam_self.8 */; };
+		1C23732710290C600055216A /* pam_uwtmp.8 in man8 */ = {isa = PBXBuildFile; fileRef = 1C23731B10290C600055216A /* pam_uwtmp.8 */; };
+		1C23758610290D290055216A /* pam_env.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C23732810290CBB0055216A /* pam_env.c */; };
+		1C23758710290D2B0055216A /* pam_group.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C23732910290CBB0055216A /* pam_group.c */; };
+		1C23758810290D8E0055216A /* pam_krb5.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C23732A10290CBB0055216A /* pam_krb5.c */; };
+		1C2375A810290D9D0055216A /* pam_launchd.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C23732B10290CBB0055216A /* pam_launchd.c */; };
+		1C2375A910290D9F0055216A /* pam_mount.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C23732C10290CBB0055216A /* pam_mount.c */; };
+		1C2375AA10290DA50055216A /* pam_nologin.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C23732D10290CBB0055216A /* pam_nologin.c */; };
+		1C2375AB10290DAD0055216A /* pam_opendirectory.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C23732E10290CBB0055216A /* pam_opendirectory.m */; };
+		1C2375AC10290DB20055216A /* pam_rootok.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C23732F10290CBB0055216A /* pam_rootok.c */; };
+		1C2375AD10290DB50055216A /* pam_sacl.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C23733010290CBB0055216A /* pam_sacl.c */; };
+		1C2375AE10290DB90055216A /* pam_self.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C23733110290CBB0055216A /* pam_self.c */; };
+		1C2375B010290DC10055216A /* pam_uwtmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C23733310290CBB0055216A /* pam_uwtmp.c */; };
+		1CFF7DD6102116B70097ADA4 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		1CFF7DDE102116F40097ADA4 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		1CFF7DDF102116FA0097ADA4 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		1CFF7DE0102116FF0097ADA4 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		1CFF7DE1102117040097ADA4 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		1CFF7DE2102117080097ADA4 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		1CFF7DE31021170D0097ADA4 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		1CFF7DE5102117170097ADA4 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		1CFF7DE61021171D0097ADA4 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		1CFF7DE8102117270097ADA4 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		1CFF7DFF102117810097ADA4 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF2102117580097ADA4 /* CoreFoundation.framework */; };
+		1CFF7E21102117890097ADA4 /* OpenDirectory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF5102117720097ADA4 /* OpenDirectory.framework */; };
+		1CFF7F06102118410097ADA4 /* NetFS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7F05102118410097ADA4 /* NetFS.framework */; };
+		1CFF7F15102118530097ADA4 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF2102117580097ADA4 /* CoreFoundation.framework */; };
+		1CFF7F16102118620097ADA4 /* OpenDirectory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF5102117720097ADA4 /* OpenDirectory.framework */; };
+		1CFF7F50102118980097ADA4 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF2102117580097ADA4 /* CoreFoundation.framework */; };
+		1CFF7F51102118980097ADA4 /* OpenDirectory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF5102117720097ADA4 /* OpenDirectory.framework */; };
+		430DE2BD22F4F39A00547FA4 /* ConfigurationProfiles.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 430DE2BC22F4F39A00547FA4 /* ConfigurationProfiles.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		4394E9851C90CEFE00FD055E /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FD7DF871C05FF43005DC226 /* Security.framework */; };
+		4791978E2D7B670E006E3989 /* pam_basesystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 4791978D2D7B670E006E3989 /* pam_basesystem.m */; };
+		479197902D7B6A36006E3989 /* pam_basesystem.8 in man8 */ = {isa = PBXBuildFile; fileRef = 4791978F2D7B6A36006E3989 /* pam_basesystem.8 */; };
+		47C0C08E2D5FEBED00811117 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		5E033EA72248CE4C00D486A0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E033EA62248CE4C00D486A0 /* Foundation.framework */; };
+		5E033EA82248CE8900D486A0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E033EA62248CE4C00D486A0 /* Foundation.framework */; };
+		5F91456B1C56179800E307FC /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		5FD7DF861C05FF14005DC226 /* libcoreauthd_client.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FD7DF851C05FF14005DC226 /* libcoreauthd_client.a */; };
+		5FD7DF881C05FF43005DC226 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FD7DF871C05FF43005DC226 /* Security.framework */; };
+		5FD7DF901C060053005DC226 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FD7DF8F1C060053005DC226 /* main.m */; };
+		5FD7DF951C06047D005DC226 /* libpam.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FD7DF941C06047D005DC226 /* libpam.tbd */; };
+		5FE441CA1C5619900010C4FD /* pam_aks.8 in man8 */ = {isa = PBXBuildFile; fileRef = 5FE441C71C56191F0010C4FD /* pam_aks.8 */; };
+		5FE441CB1C561B270010C4FD /* pam_aks.c in Sources */ = {isa = PBXBuildFile; fileRef = 5FE441C61C56190B0010C4FD /* pam_aks.c */; };
+		5FE441E11C5656AF0010C4FD /* authorization_la in Copy PAM profiles */ = {isa = PBXBuildFile; fileRef = 5FE441DF1C5656880010C4FD /* authorization_la */; };
+		5FE441E21C5656AF0010C4FD /* screensaver_la in Copy PAM profiles */ = {isa = PBXBuildFile; fileRef = 5FE441E01C5656880010C4FD /* screensaver_la */; };
+		5FE441E31C5656C20010C4FD /* authorization_aks in Copy PAM profiles */ = {isa = PBXBuildFile; fileRef = 5FE441DD1C5656880010C4FD /* authorization_aks */; };
+		5FE441E41C5656C20010C4FD /* screensaver_aks in Copy PAM profiles */ = {isa = PBXBuildFile; fileRef = 5FE441DE1C5656880010C4FD /* screensaver_aks */; };
+		5FFEF00C1C04A3950083839D /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF2102117580097ADA4 /* CoreFoundation.framework */; };
+		5FFEF00E1C04A3950083839D /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		5FFEF0161C04A6850083839D /* pam_localauthentication.8 in man8 */ = {isa = PBXBuildFile; fileRef = 5FFEF0121C04A3F70083839D /* pam_localauthentication.8 */; };
+		5FFEF0171C04A94C0083839D /* pam_localauthentication.c in Sources */ = {isa = PBXBuildFile; fileRef = 5FFEF0131C04A40E0083839D /* pam_localauthentication.c */; };
+		7244A33921C2C7810049D0A8 /* libsandbox.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7244A33821C2C7810049D0A8 /* libsandbox.tbd */; };
+		7434C8991255449C001D7F9E /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		7434C89D125544C7001D7F9E /* GSS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7434C88E12554434001D7F9E /* GSS.framework */; };
+		7434C8A11255452A001D7F9E /* pam_ntlm.c in Sources */ = {isa = PBXBuildFile; fileRef = 7434C8A01255452A001D7F9E /* pam_ntlm.c */; };
+		7434C8A912554588001D7F9E /* Heimdal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7434C88F12554434001D7F9E /* Heimdal.framework */; };
+		7434C8AC125545E7001D7F9E /* pam_ntlm.8 in man8 */ = {isa = PBXBuildFile; fileRef = 7434C8AB125545DA001D7F9E /* pam_ntlm.8 */; };
+		7434C98812554EC1001D7F9E /* Common.c in Sources */ = {isa = PBXBuildFile; fileRef = 7434C97812554E6F001D7F9E /* Common.c */; };
+		7434C9A912554FBF001D7F9E /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF2102117580097ADA4 /* CoreFoundation.framework */; };
+		7434CA1A12554FE5001D7F9E /* OpenDirectory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF5102117720097ADA4 /* OpenDirectory.framework */; };
+		7434CA761255560B001D7F9E /* Common.c in Sources */ = {isa = PBXBuildFile; fileRef = 7434C97812554E6F001D7F9E /* Common.c */; };
+		7434CA791255562B001D7F9E /* Common.c in Sources */ = {isa = PBXBuildFile; fileRef = 7434C97812554E6F001D7F9E /* Common.c */; };
+		764807DA1E60799B00EB2DEF /* authorization_lacont in Copy PAM profiles */ = {isa = PBXBuildFile; fileRef = 764807D91E6068B000EB2DEF /* authorization_lacont */; };
+		EB27C0B5143CA4AA003F6770 /* Common.c in Sources */ = {isa = PBXBuildFile; fileRef = 7434C97812554E6F001D7F9E /* Common.c */; };
+		F60ABCB41BB40E4E006F85AD /* DirectoryService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F60ABCB31BB40E4E006F85AD /* DirectoryService.framework */; };
+		F63F81BE2E51F9BA0061C0C1 /* SharedMem.h in Headers */ = {isa = PBXBuildFile; fileRef = F63F81BC2E51F9BA0061C0C1 /* SharedMem.h */; };
+		F63F81BF2E51F9BA0061C0C1 /* SharedMem.h in Headers */ = {isa = PBXBuildFile; fileRef = F63F81BC2E51F9BA0061C0C1 /* SharedMem.h */; };
+		F63F81C02E51F9BA0061C0C1 /* SharedMem.m in Sources */ = {isa = PBXBuildFile; fileRef = F63F81BB2E51F9BA0061C0C1 /* SharedMem.m */; };
+		F63F81C12E51F9BA0061C0C1 /* SharedMem.h in Headers */ = {isa = PBXBuildFile; fileRef = F63F81BC2E51F9BA0061C0C1 /* SharedMem.h */; };
+		F63F81C22E51F9BA0061C0C1 /* SharedMem.m in Sources */ = {isa = PBXBuildFile; fileRef = F63F81BB2E51F9BA0061C0C1 /* SharedMem.m */; };
+		F63F81F62E54B5230061C0C1 /* ForkSafeLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = F63F81F52E54B5230061C0C1 /* ForkSafeLogging.h */; };
+		F6529BBA1C84BE1D005245B2 /* libctkclient.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F6529BB91C84BE1D005245B2 /* libctkclient.a */; };
+		F67CB7E21C899F3600DABE90 /* authorization_ctk in Copy PAM profiles */ = {isa = PBXBuildFile; fileRef = F67CB7DF1C899EB800DABE90 /* authorization_ctk */; };
+		F67CB7E31C899F3600DABE90 /* screensaver_ctk in Copy PAM profiles */ = {isa = PBXBuildFile; fileRef = F67CB7E01C899EB800DABE90 /* screensaver_ctk */; };
+		F6AAC5F91DF07A05008A6811 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FD7DF871C05FF43005DC226 /* Security.framework */; };
+		F6AAC5FA1DF07A05008A6811 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF2102117580097ADA4 /* CoreFoundation.framework */; };
+		F6AAC5FC1DF07A05008A6811 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		F6AAC6081DF07A59008A6811 /* pam_tid.c in Sources */ = {isa = PBXBuildFile; fileRef = F6AAC5EE1DF079F0008A6811 /* pam_tid.c */; };
+		F6AAC60C1DF18289008A6811 /* libcoreauthd_client.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FD7DF851C05FF14005DC226 /* libcoreauthd_client.a */; };
+		F6B5E6982A4D709C009EE29E /* screensaver_new_ctk in Copy PAM profiles */ = {isa = PBXBuildFile; fileRef = F6B5E6962A4D7036009EE29E /* screensaver_new_ctk */; };
+		F6B5E6992A4D70B5009EE29E /* screensaver_new_aks in Copy PAM profiles */ = {isa = PBXBuildFile; fileRef = F6B5E6972A4D7066009EE29E /* screensaver_new_aks */; };
+		F6B5E69A2A4D70C3009EE29E /* screensaver_new_la in Copy PAM profiles */ = {isa = PBXBuildFile; fileRef = F6B5E6942A4D702B009EE29E /* screensaver_new_la */; };
+		F6C0B8E81B8DE6BC00892765 /* Common.c in Sources */ = {isa = PBXBuildFile; fileRef = 7434C97812554E6F001D7F9E /* Common.c */; };
+		F6C0B8EB1B8DE6BC00892765 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF2102117580097ADA4 /* CoreFoundation.framework */; };
+		F6C0B8EC1B8DE6BC00892765 /* OpenDirectory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DF5102117720097ADA4 /* OpenDirectory.framework */; };
+		F6C0B8ED1B8DE6BC00892765 /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		F6D2E89126737A41005D165D /* ds_ops.c in Sources */ = {isa = PBXBuildFile; fileRef = F6D2E89026737A41005D165D /* ds_ops.c */; };
+		F6D2E89326737AB2005D165D /* krb5principal.m in Sources */ = {isa = PBXBuildFile; fileRef = F6D2E89226737AB2005D165D /* krb5principal.m */; };
+		F6D2E89526737C8C005D165D /* ds_ops.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D2E89426737C8C005D165D /* ds_ops.h */; };
+		F6DD1CAD1B8DFE0B00BA6BE0 /* pam_smartcard.m in Sources */ = {isa = PBXBuildFile; fileRef = F6DD1CAC1B8DFDAE00BA6BE0 /* pam_smartcard.m */; };
+		F6DF97902AB1B20300577C2B /* libpam.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */; };
+		F6EF67F01D1C308000342741 /* attribute_matching.c in Sources */ = {isa = PBXBuildFile; fileRef = F6EF67ED1D1C306100342741 /* attribute_matching.c */; };
+		F6EF67F11D1C308000342741 /* hash_matching.c in Sources */ = {isa = PBXBuildFile; fileRef = F6EF67EE1D1C306100342741 /* hash_matching.c */; };
+		F6EF67F21D1C308000342741 /* scmatch_evaluation.c in Sources */ = {isa = PBXBuildFile; fileRef = F6EF67EF1D1C306100342741 /* scmatch_evaluation.c */; };
+		F6F434831C8D912A000BB264 /* libctkloginhelper.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F6F434821C8D912A000BB264 /* libctkloginhelper.a */; };
+		F6F8C6841B8F709E002596AE /* pam_smartcard.8 in man8 */ = {isa = PBXBuildFile; fileRef = F6F8C6831B8F708F002596AE /* pam_smartcard.8 */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1CFF7DB81021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D861021150B0097ADA4;
+			remoteInfo = wtmp;
+		};
+		1CFF7DBC1021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D76102114E10097ADA4;
+			remoteInfo = self;
+		};
+		1CFF7DBE1021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D6E102114C60097ADA4;
+			remoteInfo = sacl;
+		};
+		1CFF7DC01021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D66102114B50097ADA4;
+			remoteInfo = rootok;
+		};
+		1CFF7DC21021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D5E1021149E0097ADA4;
+			remoteInfo = opendirectory;
+		};
+		1CFF7DC41021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D56102114890097ADA4;
+			remoteInfo = nologin;
+		};
+		1CFF7DC61021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D4E1021147B0097ADA4;
+			remoteInfo = mount;
+		};
+		1CFF7DC81021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D461021146B0097ADA4;
+			remoteInfo = launchd;
+		};
+		1CFF7DCA1021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D3E102114560097ADA4;
+			remoteInfo = krb5;
+		};
+		1CFF7DCC1021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D361021142C0097ADA4;
+			remoteInfo = group;
+		};
+		1CFF7DCE1021165B0097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF7D2110210FC20097ADA4;
+			remoteInfo = env;
+		};
+		1CFF8087102119940097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF806D102119880097ADA4;
+			remoteInfo = "Install Manpages";
+		};
+		1CFF80D810211B040097ADA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CFF80BC10211AF10097ADA4;
+			remoteInfo = Cleanup;
+		};
+		4770A3332D669E6C000535FB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 47C0C0892D5FEBED00811117;
+			remoteInfo = basesystem;
+		};
+		5FD7DF961C0607C9005DC226 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5FFEF0061C04A3950083839D;
+			remoteInfo = localauthentication;
+		};
+		5FE441C81C5619790010C4FD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5F9145641C56179800E307FC;
+			remoteInfo = aks;
+		};
+		5FE441CC1C563EE30010C4FD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5F9145641C56179800E307FC;
+			remoteInfo = aks;
+		};
+		5FFEF0141C04A6620083839D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5FFEF0061C04A3950083839D;
+			remoteInfo = localauthentication;
+		};
+		7434C89E125544F9001D7F9E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7434C8911255449C001D7F9E;
+			remoteInfo = ntlm;
+		};
+		F6AAC6091DF07A5F008A6811 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F6AAC5EF1DF07A05008A6811;
+			remoteInfo = tid;
+		};
+		F6F8C6811B8F6F00002596AE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F6C0B8E51B8DE6BC00892765;
+			remoteInfo = smartcard;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		1CFF806C102119880097ADA4 /* man8 */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstPath = /usr/share/man/man8;
+			dstSubfolderSpec = 0;
+			files = (
+				5FE441CA1C5619900010C4FD /* pam_aks.8 in man8 */,
+				5FFEF0161C04A6850083839D /* pam_localauthentication.8 in man8 */,
+				F6F8C6841B8F709E002596AE /* pam_smartcard.8 in man8 */,
+				479197902D7B6A36006E3989 /* pam_basesystem.8 in man8 */,
+				1C23731C10290C600055216A /* pam_env.8 in man8 */,
+				1C23731D10290C600055216A /* pam_group.8 in man8 */,
+				1C23731E10290C600055216A /* pam_krb5.8 in man8 */,
+				1C23731F10290C600055216A /* pam_launchd.8 in man8 */,
+				1C23732010290C600055216A /* pam_mount.8 in man8 */,
+				1C23732110290C600055216A /* pam_nologin.8 in man8 */,
+				7434C8AC125545E7001D7F9E /* pam_ntlm.8 in man8 */,
+				1C23732210290C600055216A /* pam_opendirectory.8 in man8 */,
+				1C23732310290C600055216A /* pam_rootok.8 in man8 */,
+				1C23732410290C600055216A /* pam_sacl.8 in man8 */,
+				1C23732510290C600055216A /* pam_self.8 in man8 */,
+				1C23732710290C600055216A /* pam_uwtmp.8 in man8 */,
+			);
+			name = man8;
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		47C0C08F2D5FEBED00811117 /* Copy PAM profiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstPath = /private/etc/pam.d;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			name = "Copy PAM profiles";
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		5FD7DF8B1C060053005DC226 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		5FE441D91C5641EA0010C4FD /* Copy PAM profiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstPath = /private/etc/pam.d;
+			dstSubfolderSpec = 0;
+			files = (
+				764807DA1E60799B00EB2DEF /* authorization_lacont in Copy PAM profiles */,
+				5FE441E11C5656AF0010C4FD /* authorization_la in Copy PAM profiles */,
+				5FE441E21C5656AF0010C4FD /* screensaver_la in Copy PAM profiles */,
+				F6B5E69A2A4D70C3009EE29E /* screensaver_new_la in Copy PAM profiles */,
+			);
+			name = "Copy PAM profiles";
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		5FE441DB1C5642210010C4FD /* Copy PAM profiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstPath = /private/etc/pam.d;
+			dstSubfolderSpec = 0;
+			files = (
+				5FE441E31C5656C20010C4FD /* authorization_aks in Copy PAM profiles */,
+				5FE441E41C5656C20010C4FD /* screensaver_aks in Copy PAM profiles */,
+				F6B5E6992A4D70B5009EE29E /* screensaver_new_aks in Copy PAM profiles */,
+			);
+			name = "Copy PAM profiles";
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		F67CB7E11C899F2B00DABE90 /* Copy PAM profiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstPath = /private/etc/pam.d;
+			dstSubfolderSpec = 0;
+			files = (
+				F67CB7E21C899F3600DABE90 /* authorization_ctk in Copy PAM profiles */,
+				F67CB7E31C899F3600DABE90 /* screensaver_ctk in Copy PAM profiles */,
+				F6B5E6982A4D709C009EE29E /* screensaver_new_ctk in Copy PAM profiles */,
+			);
+			name = "Copy PAM profiles";
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		1C23731010290C600055216A /* pam_env.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_env.8; path = modules/pam_env/pam_env.8; sourceTree = "<group>"; };
+		1C23731110290C600055216A /* pam_group.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_group.8; path = modules/pam_group/pam_group.8; sourceTree = "<group>"; };
+		1C23731210290C600055216A /* pam_krb5.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_krb5.8; path = modules/pam_krb5/pam_krb5.8; sourceTree = "<group>"; };
+		1C23731310290C600055216A /* pam_launchd.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_launchd.8; path = modules/pam_launchd/pam_launchd.8; sourceTree = "<group>"; };
+		1C23731410290C600055216A /* pam_mount.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_mount.8; path = modules/pam_mount/pam_mount.8; sourceTree = "<group>"; };
+		1C23731510290C600055216A /* pam_nologin.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_nologin.8; path = modules/pam_nologin/pam_nologin.8; sourceTree = "<group>"; };
+		1C23731610290C600055216A /* pam_opendirectory.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_opendirectory.8; path = modules/pam_opendirectory/pam_opendirectory.8; sourceTree = "<group>"; };
+		1C23731710290C600055216A /* pam_rootok.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_rootok.8; path = modules/pam_rootok/pam_rootok.8; sourceTree = "<group>"; };
+		1C23731810290C600055216A /* pam_sacl.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_sacl.8; path = modules/pam_sacl/pam_sacl.8; sourceTree = "<group>"; };
+		1C23731910290C600055216A /* pam_self.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_self.8; path = modules/pam_self/pam_self.8; sourceTree = "<group>"; };
+		1C23731B10290C600055216A /* pam_uwtmp.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_uwtmp.8; path = modules/pam_uwtmp/pam_uwtmp.8; sourceTree = "<group>"; };
+		1C23732810290CBB0055216A /* pam_env.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_env.c; path = modules/pam_env/pam_env.c; sourceTree = "<group>"; };
+		1C23732910290CBB0055216A /* pam_group.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_group.c; path = modules/pam_group/pam_group.c; sourceTree = "<group>"; };
+		1C23732A10290CBB0055216A /* pam_krb5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_krb5.c; path = modules/pam_krb5/pam_krb5.c; sourceTree = "<group>"; };
+		1C23732B10290CBB0055216A /* pam_launchd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_launchd.c; path = modules/pam_launchd/pam_launchd.c; sourceTree = "<group>"; };
+		1C23732C10290CBB0055216A /* pam_mount.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_mount.c; path = modules/pam_mount/pam_mount.c; sourceTree = "<group>"; };
+		1C23732D10290CBB0055216A /* pam_nologin.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_nologin.c; path = modules/pam_nologin/pam_nologin.c; sourceTree = "<group>"; };
+		1C23732E10290CBB0055216A /* pam_opendirectory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = pam_opendirectory.m; path = modules/pam_opendirectory/pam_opendirectory.m; sourceTree = "<group>"; };
+		1C23732F10290CBB0055216A /* pam_rootok.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_rootok.c; path = modules/pam_rootok/pam_rootok.c; sourceTree = "<group>"; };
+		1C23733010290CBB0055216A /* pam_sacl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_sacl.c; path = modules/pam_sacl/pam_sacl.c; sourceTree = "<group>"; };
+		1C23733110290CBB0055216A /* pam_self.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_self.c; path = modules/pam_self/pam_self.c; sourceTree = "<group>"; };
+		1C23733310290CBB0055216A /* pam_uwtmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_uwtmp.c; path = modules/pam_uwtmp/pam_uwtmp.c; sourceTree = "<group>"; };
+		1CFF7D2210210FC20097ADA4 /* pam_env.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_env.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7D3D1021142C0097ADA4 /* pam_group.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_group.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7D45102114560097ADA4 /* pam_krb5.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_krb5.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7D4D1021146B0097ADA4 /* pam_launchd.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_launchd.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7D551021147B0097ADA4 /* pam_mount.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_mount.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7D5D102114890097ADA4 /* pam_nologin.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_nologin.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7D651021149E0097ADA4 /* pam_opendirectory.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_opendirectory.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7D6D102114B50097ADA4 /* pam_rootok.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_rootok.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7D75102114C60097ADA4 /* pam_sacl.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_sacl.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7D7D102114E10097ADA4 /* pam_self.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_self.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7D8D1021150B0097ADA4 /* pam_uwtmp.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_uwtmp.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libpam.2.tbd; path = usr/lib/libpam.2.tbd; sourceTree = SDKROOT; };
+		1CFF7DF2102117580097ADA4 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
+		1CFF7DF5102117720097ADA4 /* OpenDirectory.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenDirectory.framework; path = System/Library/Frameworks/OpenDirectory.framework; sourceTree = SDKROOT; };
+		1CFF7F05102118410097ADA4 /* NetFS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetFS.framework; path = System/Library/Frameworks/NetFS.framework; sourceTree = SDKROOT; };
+		430DE2BC22F4F39A00547FA4 /* ConfigurationProfiles.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ConfigurationProfiles.framework; path = System/Library/PrivateFrameworks/ConfigurationProfiles.framework; sourceTree = SDKROOT; };
+		4791978D2D7B670E006E3989 /* pam_basesystem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = pam_basesystem.m; path = modules/pam_basesystem/pam_basesystem.m; sourceTree = "<group>"; };
+		4791978F2D7B6A36006E3989 /* pam_basesystem.8 */ = {isa = PBXFileReference; lastKnownFileType = text; name = pam_basesystem.8; path = modules/pam_basesystem/pam_basesystem.8; sourceTree = "<group>"; };
+		47C0C0952D5FEBED00811117 /* pam_basesystem.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_basesystem.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E033EA62248CE4C00D486A0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		5F91456F1C56179800E307FC /* pam_aks.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_aks.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FD7DF851C05FF14005DC226 /* libcoreauthd_client.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcoreauthd_client.a; path = usr/local/lib/libcoreauthd_client.a; sourceTree = SDKROOT; };
+		5FD7DF871C05FF43005DC226 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		5FD7DF8D1C060053005DC226 /* test_pam_localauthentication */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = test_pam_localauthentication; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FD7DF8F1C060053005DC226 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		5FD7DF941C06047D005DC226 /* libpam.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libpam.tbd; path = usr/lib/libpam.tbd; sourceTree = SDKROOT; };
+		5FE441C61C56190B0010C4FD /* pam_aks.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_aks.c; path = modules/pam_aks/pam_aks.c; sourceTree = "<group>"; };
+		5FE441C71C56191F0010C4FD /* pam_aks.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_aks.8; path = modules/pam_aks/pam_aks.8; sourceTree = "<group>"; };
+		5FE441DD1C5656880010C4FD /* authorization_aks */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = authorization_aks; path = modules/pam_aks/authorization_aks; sourceTree = "<group>"; };
+		5FE441DE1C5656880010C4FD /* screensaver_aks */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = screensaver_aks; path = modules/pam_aks/screensaver_aks; sourceTree = "<group>"; };
+		5FE441DF1C5656880010C4FD /* authorization_la */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = authorization_la; path = modules/pam_localauthentication/authorization_la; sourceTree = "<group>"; };
+		5FE441E01C5656880010C4FD /* screensaver_la */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = screensaver_la; path = modules/pam_localauthentication/screensaver_la; sourceTree = "<group>"; };
+		5FFEF0111C04A3950083839D /* pam_localauthentication.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_localauthentication.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FFEF0121C04A3F70083839D /* pam_localauthentication.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_localauthentication.8; path = modules/pam_localauthentication/pam_localauthentication.8; sourceTree = "<group>"; };
+		5FFEF0131C04A40E0083839D /* pam_localauthentication.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_localauthentication.c; path = modules/pam_localauthentication/pam_localauthentication.c; sourceTree = "<group>"; };
+		7244A33821C2C7810049D0A8 /* libsandbox.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsandbox.tbd; path = usr/lib/libsandbox.tbd; sourceTree = SDKROOT; };
+		7434C88E12554434001D7F9E /* GSS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GSS.framework; path = System/Library/Frameworks/GSS.framework; sourceTree = SDKROOT; };
+		7434C88F12554434001D7F9E /* Heimdal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Heimdal.framework; path = System/Library/PrivateFrameworks/Heimdal.framework; sourceTree = SDKROOT; };
+		7434C89C1255449C001D7F9E /* pam_ntlm.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_ntlm.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		7434C8A01255452A001D7F9E /* pam_ntlm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_ntlm.c; path = modules/pam_ntlm/pam_ntlm.c; sourceTree = "<group>"; };
+		7434C8AB125545DA001D7F9E /* pam_ntlm.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_ntlm.8; path = modules/pam_ntlm/pam_ntlm.8; sourceTree = "<group>"; };
+		7434C97812554E6F001D7F9E /* Common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = Common.c; path = common/Common.c; sourceTree = "<group>"; };
+		7434C97912554E6F001D7F9E /* Common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Common.h; path = common/Common.h; sourceTree = "<group>"; };
+		764807D91E6068B000EB2DEF /* authorization_lacont */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = authorization_lacont; path = modules/pam_localauthentication/authorization_lacont; sourceTree = "<group>"; };
+		F60ABCB31BB40E4E006F85AD /* DirectoryService.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DirectoryService.framework; path = System/Library/Frameworks/DirectoryService.framework; sourceTree = SDKROOT; };
+		F63F81BB2E51F9BA0061C0C1 /* SharedMem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SharedMem.m; path = common/SharedMem.m; sourceTree = "<group>"; };
+		F63F81BC2E51F9BA0061C0C1 /* SharedMem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SharedMem.h; path = common/SharedMem.h; sourceTree = "<group>"; };
+		F63F81F52E54B5230061C0C1 /* ForkSafeLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ForkSafeLogging.h; path = common/ForkSafeLogging.h; sourceTree = "<group>"; };
+		F6529BB91C84BE1D005245B2 /* libctkclient.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libctkclient.a; path = usr/local/lib/libctkclient.a; sourceTree = SDKROOT; };
+		F67CB7DF1C899EB800DABE90 /* authorization_ctk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = authorization_ctk; path = modules/pam_smartcard/authorization_ctk; sourceTree = "<group>"; };
+		F67CB7E01C899EB800DABE90 /* screensaver_ctk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = screensaver_ctk; path = modules/pam_smartcard/screensaver_ctk; sourceTree = "<group>"; };
+		F6AAC5EE1DF079F0008A6811 /* pam_tid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pam_tid.c; path = modules/pam_tid/pam_tid.c; sourceTree = "<group>"; };
+		F6AAC6041DF07A05008A6811 /* pam_tid.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_tid.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		F6AAC6061DF07A3C008A6811 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
+		F6AAC60B1DF07D6A008A6811 /* Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Logging.h; path = common/Logging.h; sourceTree = "<group>"; };
+		F6ABB8B11D22CDCC00AECC36 /* scmatch_evaluation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scmatch_evaluation.h; path = modules/pam_smartcard/scmatch_evaluation.h; sourceTree = "<group>"; };
+		F6B5E6942A4D702B009EE29E /* screensaver_new_la */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = screensaver_new_la; path = modules/pam_localauthentication/screensaver_new_la; sourceTree = "<group>"; };
+		F6B5E6962A4D7036009EE29E /* screensaver_new_ctk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = screensaver_new_ctk; path = modules/pam_smartcard/screensaver_new_ctk; sourceTree = "<group>"; };
+		F6B5E6972A4D7066009EE29E /* screensaver_new_aks */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = screensaver_new_aks; path = modules/pam_aks/screensaver_new_aks; sourceTree = "<group>"; };
+		F6C0B8F01B8DE6BC00892765 /* pam_smartcard.so.2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = pam_smartcard.so.2; sourceTree = BUILT_PRODUCTS_DIR; };
+		F6D2E89026737A41005D165D /* ds_ops.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ds_ops.c; path = modules/pam_smartcard/ds_ops.c; sourceTree = "<group>"; };
+		F6D2E89226737AB2005D165D /* krb5principal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = krb5principal.m; path = modules/pam_smartcard/krb5principal.m; sourceTree = "<group>"; };
+		F6D2E89426737C8C005D165D /* ds_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ds_ops.h; path = modules/pam_smartcard/ds_ops.h; sourceTree = "<group>"; };
+		F6DD1CAC1B8DFDAE00BA6BE0 /* pam_smartcard.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = pam_smartcard.m; path = modules/pam_smartcard/pam_smartcard.m; sourceTree = "<group>"; };
+		F6EF67ED1D1C306100342741 /* attribute_matching.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = attribute_matching.c; path = modules/pam_smartcard/attribute_matching.c; sourceTree = "<group>"; };
+		F6EF67EE1D1C306100342741 /* hash_matching.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = hash_matching.c; path = modules/pam_smartcard/hash_matching.c; sourceTree = "<group>"; };
+		F6EF67EF1D1C306100342741 /* scmatch_evaluation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = scmatch_evaluation.c; path = modules/pam_smartcard/scmatch_evaluation.c; sourceTree = "<group>"; };
+		F6F434821C8D912A000BB264 /* libctkloginhelper.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libctkloginhelper.a; path = usr/local/lib/libctkloginhelper.a; sourceTree = SDKROOT; };
+		F6F8C6831B8F708F002596AE /* pam_smartcard.8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = pam_smartcard.8; path = modules/pam_smartcard/pam_smartcard.8; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1CFF7D2010210FC20097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CFF7DD6102116B70097ADA4 /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D391021142C0097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CFF7DDE102116F40097ADA4 /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D41102114560097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CFF7E21102117890097ADA4 /* OpenDirectory.framework in Frameworks */,
+				1CFF7DFF102117810097ADA4 /* CoreFoundation.framework in Frameworks */,
+				1CFF7DDF102116FA0097ADA4 /* libpam.2.tbd in Frameworks */,
+				7434C8A912554588001D7F9E /* Heimdal.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D491021146B0097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CFF7DE0102116FF0097ADA4 /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D511021147B0097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7244A33921C2C7810049D0A8 /* libsandbox.tbd in Frameworks */,
+				1CFF7F16102118620097ADA4 /* OpenDirectory.framework in Frameworks */,
+				1CFF7F06102118410097ADA4 /* NetFS.framework in Frameworks */,
+				1CFF7F15102118530097ADA4 /* CoreFoundation.framework in Frameworks */,
+				1CFF7DE1102117040097ADA4 /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D59102114890097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CFF7DE2102117080097ADA4 /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D611021149E0097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CFF7F50102118980097ADA4 /* CoreFoundation.framework in Frameworks */,
+				1CFF7F51102118980097ADA4 /* OpenDirectory.framework in Frameworks */,
+				1CFF7DE31021170D0097ADA4 /* libpam.2.tbd in Frameworks */,
+				430DE2BD22F4F39A00547FA4 /* ConfigurationProfiles.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D69102114B50097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F6DF97902AB1B20300577C2B /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D71102114C60097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CFF7DE5102117170097ADA4 /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D79102114E10097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CFF7DE61021171D0097ADA4 /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D891021150B0097ADA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CFF7DE8102117270097ADA4 /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		47C0C08D2D5FEBED00811117 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				47C0C08E2D5FEBED00811117 /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5F9145681C56179800E307FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5F91456B1C56179800E307FC /* libpam.2.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5FD7DF8A1C060053005DC226 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5FD7DF951C06047D005DC226 /* libpam.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5FFEF00B1C04A3950083839D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5E033EA72248CE4C00D486A0 /* Foundation.framework in Frameworks */,
+				5FFEF00C1C04A3950083839D /* CoreFoundation.framework in Frameworks */,
+				5FD7DF881C05FF43005DC226 /* Security.framework in Frameworks */,
+				5FFEF00E1C04A3950083839D /* libpam.2.tbd in Frameworks */,
+				5FD7DF861C05FF14005DC226 /* libcoreauthd_client.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7434C8961255449C001D7F9E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7434CA1A12554FE5001D7F9E /* OpenDirectory.framework in Frameworks */,
+				7434C9A912554FBF001D7F9E /* CoreFoundation.framework in Frameworks */,
+				7434C8991255449C001D7F9E /* libpam.2.tbd in Frameworks */,
+				7434C89D125544C7001D7F9E /* GSS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F6AAC5F71DF07A05008A6811 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5E033EA82248CE8900D486A0 /* Foundation.framework in Frameworks */,
+				F6AAC5F91DF07A05008A6811 /* Security.framework in Frameworks */,
+				F6AAC5FA1DF07A05008A6811 /* CoreFoundation.framework in Frameworks */,
+				F6AAC5FC1DF07A05008A6811 /* libpam.2.tbd in Frameworks */,
+				F6AAC60C1DF18289008A6811 /* libcoreauthd_client.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F6C0B8EA1B8DE6BC00892765 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F60ABCB41BB40E4E006F85AD /* DirectoryService.framework in Frameworks */,
+				4394E9851C90CEFE00FD055E /* Security.framework in Frameworks */,
+				F6C0B8EB1B8DE6BC00892765 /* CoreFoundation.framework in Frameworks */,
+				F6C0B8EC1B8DE6BC00892765 /* OpenDirectory.framework in Frameworks */,
+				F6C0B8ED1B8DE6BC00892765 /* libpam.2.tbd in Frameworks */,
+				F6529BBA1C84BE1D005245B2 /* libctkclient.a in Frameworks */,
+				F6F434831C8D912A000BB264 /* libctkloginhelper.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		08FB7794FE84155DC02AAC07 /* pam_modules */ = {
+			isa = PBXGroup;
+			children = (
+				1C47A8A9112CB89F00013ABE /* Common */,
+				08FB7795FE84155DC02AAC07 /* Modules */,
+				C6A0FF2B0290797F04C91782 /* Documentation */,
+				5FE441D41C56413D0010C4FD /* Configurations */,
+				5FD7DF8E1C060053005DC226 /* test_pam_localauthentication */,
+				1CFF7DDD102116DB0097ADA4 /* Linked */,
+				1AB674ADFE9D54B511CA2CBB /* Products */,
+				F6DF978F2AB1B20300577C2B /* Frameworks */,
+			);
+			name = pam_modules;
+			sourceTree = "<group>";
+		};
+		08FB7795FE84155DC02AAC07 /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				5FE441C61C56190B0010C4FD /* pam_aks.c */,
+				4791978D2D7B670E006E3989 /* pam_basesystem.m */,
+				1C23732810290CBB0055216A /* pam_env.c */,
+				1C23732910290CBB0055216A /* pam_group.c */,
+				1C23732A10290CBB0055216A /* pam_krb5.c */,
+				1C23732B10290CBB0055216A /* pam_launchd.c */,
+				5FFEF0131C04A40E0083839D /* pam_localauthentication.c */,
+				1C23732C10290CBB0055216A /* pam_mount.c */,
+				1C23732D10290CBB0055216A /* pam_nologin.c */,
+				7434C8A01255452A001D7F9E /* pam_ntlm.c */,
+				1C23732E10290CBB0055216A /* pam_opendirectory.m */,
+				1C23732F10290CBB0055216A /* pam_rootok.c */,
+				1C23733010290CBB0055216A /* pam_sacl.c */,
+				1C23733110290CBB0055216A /* pam_self.c */,
+				F6DD1CAC1B8DFDAE00BA6BE0 /* pam_smartcard.m */,
+				F6AAC5EE1DF079F0008A6811 /* pam_tid.c */,
+				1C23733310290CBB0055216A /* pam_uwtmp.c */,
+			);
+			name = Modules;
+			sourceTree = "<group>";
+		};
+		1AB674ADFE9D54B511CA2CBB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1CFF7D2210210FC20097ADA4 /* pam_env.so.2 */,
+				1CFF7D3D1021142C0097ADA4 /* pam_group.so.2 */,
+				1CFF7D45102114560097ADA4 /* pam_krb5.so.2 */,
+				1CFF7D4D1021146B0097ADA4 /* pam_launchd.so.2 */,
+				1CFF7D551021147B0097ADA4 /* pam_mount.so.2 */,
+				1CFF7D5D102114890097ADA4 /* pam_nologin.so.2 */,
+				1CFF7D651021149E0097ADA4 /* pam_opendirectory.so.2 */,
+				1CFF7D6D102114B50097ADA4 /* pam_rootok.so.2 */,
+				1CFF7D75102114C60097ADA4 /* pam_sacl.so.2 */,
+				1CFF7D7D102114E10097ADA4 /* pam_self.so.2 */,
+				1CFF7D8D1021150B0097ADA4 /* pam_uwtmp.so.2 */,
+				7434C89C1255449C001D7F9E /* pam_ntlm.so.2 */,
+				F6C0B8F01B8DE6BC00892765 /* pam_smartcard.so.2 */,
+				5FFEF0111C04A3950083839D /* pam_localauthentication.so.2 */,
+				5FD7DF8D1C060053005DC226 /* test_pam_localauthentication */,
+				5F91456F1C56179800E307FC /* pam_aks.so.2 */,
+				F6AAC6041DF07A05008A6811 /* pam_tid.so.2 */,
+				47C0C0952D5FEBED00811117 /* pam_basesystem.so.2 */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1C47A8A9112CB89F00013ABE /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				F63F81BC2E51F9BA0061C0C1 /* SharedMem.h */,
+				F63F81BB2E51F9BA0061C0C1 /* SharedMem.m */,
+				F63F81F52E54B5230061C0C1 /* ForkSafeLogging.h */,
+				F6EF67ED1D1C306100342741 /* attribute_matching.c */,
+				F6D2E89426737C8C005D165D /* ds_ops.h */,
+				F6D2E89026737A41005D165D /* ds_ops.c */,
+				F6EF67EE1D1C306100342741 /* hash_matching.c */,
+				F6D2E89226737AB2005D165D /* krb5principal.m */,
+				F6ABB8B11D22CDCC00AECC36 /* scmatch_evaluation.h */,
+				F6EF67EF1D1C306100342741 /* scmatch_evaluation.c */,
+				7434C97812554E6F001D7F9E /* Common.c */,
+				7434C97912554E6F001D7F9E /* Common.h */,
+				F6AAC60B1DF07D6A008A6811 /* Logging.h */,
+			);
+			name = Common;
+			sourceTree = "<group>";
+		};
+		1CFF7DDD102116DB0097ADA4 /* Linked */ = {
+			isa = PBXGroup;
+			children = (
+				430DE2BC22F4F39A00547FA4 /* ConfigurationProfiles.framework */,
+				1CFF7DF2102117580097ADA4 /* CoreFoundation.framework */,
+				F60ABCB31BB40E4E006F85AD /* DirectoryService.framework */,
+				5E033EA62248CE4C00D486A0 /* Foundation.framework */,
+				7434C88E12554434001D7F9E /* GSS.framework */,
+				7434C88F12554434001D7F9E /* Heimdal.framework */,
+				F6AAC6061DF07A3C008A6811 /* LocalAuthentication.framework */,
+				1CFF7F05102118410097ADA4 /* NetFS.framework */,
+				1CFF7DF5102117720097ADA4 /* OpenDirectory.framework */,
+				5FD7DF871C05FF43005DC226 /* Security.framework */,
+				5FD7DF851C05FF14005DC226 /* libcoreauthd_client.a */,
+				F6529BB91C84BE1D005245B2 /* libctkclient.a */,
+				F6F434821C8D912A000BB264 /* libctkloginhelper.a */,
+				1CFF7DD5102116B70097ADA4 /* libpam.2.tbd */,
+				5FD7DF941C06047D005DC226 /* libpam.tbd */,
+				7244A33821C2C7810049D0A8 /* libsandbox.tbd */,
+			);
+			name = Linked;
+			sourceTree = "<group>";
+		};
+		5FD7DF8E1C060053005DC226 /* test_pam_localauthentication */ = {
+			isa = PBXGroup;
+			children = (
+				5FD7DF8F1C060053005DC226 /* main.m */,
+			);
+			path = test_pam_localauthentication;
+			sourceTree = "<group>";
+		};
+		5FE441D41C56413D0010C4FD /* Configurations */ = {
+			isa = PBXGroup;
+			children = (
+				5FE441DD1C5656880010C4FD /* authorization_aks */,
+				F67CB7DF1C899EB800DABE90 /* authorization_ctk */,
+				5FE441DF1C5656880010C4FD /* authorization_la */,
+				764807D91E6068B000EB2DEF /* authorization_lacont */,
+				5FE441DE1C5656880010C4FD /* screensaver_aks */,
+				F67CB7E01C899EB800DABE90 /* screensaver_ctk */,
+				5FE441E01C5656880010C4FD /* screensaver_la */,
+				F6B5E6972A4D7066009EE29E /* screensaver_new_aks */,
+				F6B5E6962A4D7036009EE29E /* screensaver_new_ctk */,
+				F6B5E6942A4D702B009EE29E /* screensaver_new_la */,
+			);
+			name = Configurations;
+			sourceTree = "<group>";
+		};
+		C6A0FF2B0290797F04C91782 /* Documentation */ = {
+			isa = PBXGroup;
+			children = (
+				5FE441C71C56191F0010C4FD /* pam_aks.8 */,
+				4791978F2D7B6A36006E3989 /* pam_basesystem.8 */,
+				7434C8AB125545DA001D7F9E /* pam_ntlm.8 */,
+				1C23731010290C600055216A /* pam_env.8 */,
+				1C23731110290C600055216A /* pam_group.8 */,
+				1C23731210290C600055216A /* pam_krb5.8 */,
+				1C23731310290C600055216A /* pam_launchd.8 */,
+				5FFEF0121C04A3F70083839D /* pam_localauthentication.8 */,
+				1C23731410290C600055216A /* pam_mount.8 */,
+				1C23731510290C600055216A /* pam_nologin.8 */,
+				1C23731610290C600055216A /* pam_opendirectory.8 */,
+				1C23731710290C600055216A /* pam_rootok.8 */,
+				1C23731810290C600055216A /* pam_sacl.8 */,
+				1C23731910290C600055216A /* pam_self.8 */,
+				F6F8C6831B8F708F002596AE /* pam_smartcard.8 */,
+				1C23731B10290C600055216A /* pam_uwtmp.8 */,
+			);
+			name = Documentation;
+			sourceTree = "<group>";
+		};
+		F6DF978F2AB1B20300577C2B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		1CFF7D1E10210FC20097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D371021142C0097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D3F102114560097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D471021146B0097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D4F1021147B0097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F63F81BF2E51F9BA0061C0C1 /* SharedMem.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D57102114890097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D5F1021149E0097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D67102114B50097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D6F102114C60097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D77102114E10097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D871021150B0097ADA4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		47C0C08A2D5FEBED00811117 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5F9145651C56179800E307FC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5FFEF0071C04A3950083839D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7434C8921255449C001D7F9E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F63F81C12E51F9BA0061C0C1 /* SharedMem.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F6AAC5F01DF07A05008A6811 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F6C0B8E61B8DE6BC00892765 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F63F81F62E54B5230061C0C1 /* ForkSafeLogging.h in Headers */,
+				F6D2E89526737C8C005D165D /* ds_ops.h in Headers */,
+				F63F81BE2E51F9BA0061C0C1 /* SharedMem.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		1CFF7D2110210FC20097ADA4 /* env */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D2A10210FE80097ADA4 /* Build configuration list for PBXNativeTarget "env" */;
+			buildPhases = (
+				1CFF7D1E10210FC20097ADA4 /* Headers */,
+				1CFF7D1F10210FC20097ADA4 /* Sources */,
+				1CFF7D2010210FC20097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = env;
+			productName = pam_env;
+			productReference = 1CFF7D2210210FC20097ADA4 /* pam_env.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		1CFF7D361021142C0097ADA4 /* group */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D3A1021142C0097ADA4 /* Build configuration list for PBXNativeTarget "group" */;
+			buildPhases = (
+				1CFF7D371021142C0097ADA4 /* Headers */,
+				1CFF7D381021142C0097ADA4 /* Sources */,
+				1CFF7D391021142C0097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = group;
+			productName = pam_env;
+			productReference = 1CFF7D3D1021142C0097ADA4 /* pam_group.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		1CFF7D3E102114560097ADA4 /* krb5 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D42102114560097ADA4 /* Build configuration list for PBXNativeTarget "krb5" */;
+			buildPhases = (
+				1CFF7D3F102114560097ADA4 /* Headers */,
+				1CFF7D40102114560097ADA4 /* Sources */,
+				1CFF7D41102114560097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = krb5;
+			productName = pam_env;
+			productReference = 1CFF7D45102114560097ADA4 /* pam_krb5.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		1CFF7D461021146B0097ADA4 /* launchd */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D4A1021146B0097ADA4 /* Build configuration list for PBXNativeTarget "launchd" */;
+			buildPhases = (
+				1CFF7D471021146B0097ADA4 /* Headers */,
+				1CFF7D481021146B0097ADA4 /* Sources */,
+				1CFF7D491021146B0097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = launchd;
+			productName = pam_env;
+			productReference = 1CFF7D4D1021146B0097ADA4 /* pam_launchd.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		1CFF7D4E1021147B0097ADA4 /* mount */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D521021147B0097ADA4 /* Build configuration list for PBXNativeTarget "mount" */;
+			buildPhases = (
+				1CFF7D4F1021147B0097ADA4 /* Headers */,
+				1CFF7D501021147B0097ADA4 /* Sources */,
+				1CFF7D511021147B0097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = mount;
+			productName = pam_env;
+			productReference = 1CFF7D551021147B0097ADA4 /* pam_mount.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		1CFF7D56102114890097ADA4 /* nologin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D5A102114890097ADA4 /* Build configuration list for PBXNativeTarget "nologin" */;
+			buildPhases = (
+				1CFF7D57102114890097ADA4 /* Headers */,
+				1CFF7D58102114890097ADA4 /* Sources */,
+				1CFF7D59102114890097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = nologin;
+			productName = pam_env;
+			productReference = 1CFF7D5D102114890097ADA4 /* pam_nologin.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		1CFF7D5E1021149E0097ADA4 /* opendirectory */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D621021149E0097ADA4 /* Build configuration list for PBXNativeTarget "opendirectory" */;
+			buildPhases = (
+				1CFF7D5F1021149E0097ADA4 /* Headers */,
+				1CFF7D601021149E0097ADA4 /* Sources */,
+				1CFF7D611021149E0097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = opendirectory;
+			productName = pam_env;
+			productReference = 1CFF7D651021149E0097ADA4 /* pam_opendirectory.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		1CFF7D66102114B50097ADA4 /* rootok */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D6A102114B50097ADA4 /* Build configuration list for PBXNativeTarget "rootok" */;
+			buildPhases = (
+				1CFF7D67102114B50097ADA4 /* Headers */,
+				1CFF7D68102114B50097ADA4 /* Sources */,
+				1CFF7D69102114B50097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = rootok;
+			productName = pam_env;
+			productReference = 1CFF7D6D102114B50097ADA4 /* pam_rootok.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		1CFF7D6E102114C60097ADA4 /* sacl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D72102114C60097ADA4 /* Build configuration list for PBXNativeTarget "sacl" */;
+			buildPhases = (
+				1CFF7D6F102114C60097ADA4 /* Headers */,
+				1CFF7D70102114C60097ADA4 /* Sources */,
+				1CFF7D71102114C60097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = sacl;
+			productName = pam_env;
+			productReference = 1CFF7D75102114C60097ADA4 /* pam_sacl.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		1CFF7D76102114E10097ADA4 /* self */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D7A102114E10097ADA4 /* Build configuration list for PBXNativeTarget "self" */;
+			buildPhases = (
+				1CFF7D77102114E10097ADA4 /* Headers */,
+				1CFF7D78102114E10097ADA4 /* Sources */,
+				1CFF7D79102114E10097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = self;
+			productName = pam_env;
+			productReference = 1CFF7D7D102114E10097ADA4 /* pam_self.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		1CFF7D861021150B0097ADA4 /* uwtmp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CFF7D8A1021150B0097ADA4 /* Build configuration list for PBXNativeTarget "uwtmp" */;
+			buildPhases = (
+				1CFF7D871021150B0097ADA4 /* Headers */,
+				1CFF7D881021150B0097ADA4 /* Sources */,
+				1CFF7D891021150B0097ADA4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = uwtmp;
+			productName = pam_env;
+			productReference = 1CFF7D8D1021150B0097ADA4 /* pam_uwtmp.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		47C0C0892D5FEBED00811117 /* basesystem */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 47C0C0932D5FEBED00811117 /* Build configuration list for PBXNativeTarget "basesystem" */;
+			buildPhases = (
+				47C0C08A2D5FEBED00811117 /* Headers */,
+				47C0C08B2D5FEBED00811117 /* Sources */,
+				47C0C08D2D5FEBED00811117 /* Frameworks */,
+				47C0C08F2D5FEBED00811117 /* Copy PAM profiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = basesystem;
+			productName = pam_env;
+			productReference = 47C0C0952D5FEBED00811117 /* pam_basesystem.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		5F9145641C56179800E307FC /* aks */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5F91456D1C56179800E307FC /* Build configuration list for PBXNativeTarget "aks" */;
+			buildPhases = (
+				5F9145651C56179800E307FC /* Headers */,
+				5F9145661C56179800E307FC /* Sources */,
+				5F9145681C56179800E307FC /* Frameworks */,
+				5FE441DB1C5642210010C4FD /* Copy PAM profiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = aks;
+			productName = pam_env;
+			productReference = 5F91456F1C56179800E307FC /* pam_aks.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		5FD7DF8C1C060053005DC226 /* test_pam_localauthentication */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5FD7DF911C060053005DC226 /* Build configuration list for PBXNativeTarget "test_pam_localauthentication" */;
+			buildPhases = (
+				5FD7DF891C060053005DC226 /* Sources */,
+				5FD7DF8A1C060053005DC226 /* Frameworks */,
+				5FD7DF8B1C060053005DC226 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5FE441CD1C563EE30010C4FD /* PBXTargetDependency */,
+				5FD7DF971C0607C9005DC226 /* PBXTargetDependency */,
+			);
+			name = test_pam_localauthentication;
+			productName = test_pam_localauthentication;
+			productReference = 5FD7DF8D1C060053005DC226 /* test_pam_localauthentication */;
+			productType = "com.apple.product-type.tool";
+		};
+		5FFEF0061C04A3950083839D /* localauthentication */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5FFEF00F1C04A3950083839D /* Build configuration list for PBXNativeTarget "localauthentication" */;
+			buildPhases = (
+				5FFEF0071C04A3950083839D /* Headers */,
+				5FFEF0081C04A3950083839D /* Sources */,
+				5FFEF00B1C04A3950083839D /* Frameworks */,
+				5FE441D91C5641EA0010C4FD /* Copy PAM profiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = localauthentication;
+			productName = pam_env;
+			productReference = 5FFEF0111C04A3950083839D /* pam_localauthentication.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		7434C8911255449C001D7F9E /* ntlm */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7434C89A1255449C001D7F9E /* Build configuration list for PBXNativeTarget "ntlm" */;
+			buildPhases = (
+				7434C8921255449C001D7F9E /* Headers */,
+				7434C8931255449C001D7F9E /* Sources */,
+				7434C8961255449C001D7F9E /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ntlm;
+			productName = pam_env;
+			productReference = 7434C89C1255449C001D7F9E /* pam_ntlm.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		F6AAC5EF1DF07A05008A6811 /* tid */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F6AAC6021DF07A05008A6811 /* Build configuration list for PBXNativeTarget "tid" */;
+			buildPhases = (
+				F6AAC5F01DF07A05008A6811 /* Headers */,
+				F6AAC5F11DF07A05008A6811 /* Sources */,
+				F6AAC5F71DF07A05008A6811 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = tid;
+			productName = pam_env;
+			productReference = F6AAC6041DF07A05008A6811 /* pam_tid.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		F6C0B8E51B8DE6BC00892765 /* smartcard */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F6C0B8EE1B8DE6BC00892765 /* Build configuration list for PBXNativeTarget "smartcard" */;
+			buildPhases = (
+				F6C0B8E61B8DE6BC00892765 /* Headers */,
+				F6C0B8E71B8DE6BC00892765 /* Sources */,
+				F6C0B8EA1B8DE6BC00892765 /* Frameworks */,
+				F67CB7E11C899F2B00DABE90 /* Copy PAM profiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = smartcard;
+			productName = pam_env;
+			productReference = F6C0B8F01B8DE6BC00892765 /* pam_smartcard.so.2 */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		08FB7793FE84155DC02AAC07 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				TargetAttributes = {
+					5F9145641C56179800E307FC = {
+						LastSwiftMigration = 1630;
+					};
+					5FD7DF8C1C060053005DC226 = {
+						CreatedOnToolsVersion = 7.2;
+					};
+				};
+			};
+			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "pam_modules" */;
+			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
+			mainGroup = 08FB7794FE84155DC02AAC07 /* pam_modules */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1CFF7DB51021164C0097ADA4 /* pam_modules */,
+				5F9145641C56179800E307FC /* aks */,
+				47C0C0892D5FEBED00811117 /* basesystem */,
+				1CFF7D2110210FC20097ADA4 /* env */,
+				1CFF7D361021142C0097ADA4 /* group */,
+				1CFF7D3E102114560097ADA4 /* krb5 */,
+				7434C8911255449C001D7F9E /* ntlm */,
+				1CFF7D461021146B0097ADA4 /* launchd */,
+				5FFEF0061C04A3950083839D /* localauthentication */,
+				1CFF7D4E1021147B0097ADA4 /* mount */,
+				1CFF7D56102114890097ADA4 /* nologin */,
+				1CFF7D5E1021149E0097ADA4 /* opendirectory */,
+				1CFF7D66102114B50097ADA4 /* rootok */,
+				1CFF7D6E102114C60097ADA4 /* sacl */,
+				1CFF7D76102114E10097ADA4 /* self */,
+				F6C0B8E51B8DE6BC00892765 /* smartcard */,
+				F6AAC5EF1DF07A05008A6811 /* tid */,
+				1CFF7D861021150B0097ADA4 /* uwtmp */,
+				1CFF806D102119880097ADA4 /* Install Manpages */,
+				1CFF80BC10211AF10097ADA4 /* Cleanup */,
+				5FD7DF8C1C060053005DC226 /* test_pam_localauthentication */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		1CFF80BB10211AF10097ADA4 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "\ncd \"${DSTROOT}\"\n\n# Well, not pretty. \nfind . -exec chown root:wheel \"{}\" \\;";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1CFF7D1F10210FC20097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C23758610290D290055216A /* pam_env.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D381021142C0097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C23758710290D2B0055216A /* pam_group.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D40102114560097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C23758810290D8E0055216A /* pam_krb5.c in Sources */,
+				7434CA761255560B001D7F9E /* Common.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D481021146B0097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C2375A810290D9D0055216A /* pam_launchd.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D501021147B0097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F63F81C02E51F9BA0061C0C1 /* SharedMem.m in Sources */,
+				7434CA791255562B001D7F9E /* Common.c in Sources */,
+				1C2375A910290D9F0055216A /* pam_mount.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D58102114890097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C2375AA10290DA50055216A /* pam_nologin.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D601021149E0097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7434C98812554EC1001D7F9E /* Common.c in Sources */,
+				1C2375AB10290DAD0055216A /* pam_opendirectory.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D68102114B50097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C2375AC10290DB20055216A /* pam_rootok.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D70102114C60097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C2375AD10290DB50055216A /* pam_sacl.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D78102114E10097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C2375AE10290DB90055216A /* pam_self.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CFF7D881021150B0097ADA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C2375B010290DC10055216A /* pam_uwtmp.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		47C0C08B2D5FEBED00811117 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4791978E2D7B670E006E3989 /* pam_basesystem.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5F9145661C56179800E307FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5FE441CB1C561B270010C4FD /* pam_aks.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5FD7DF891C060053005DC226 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5FD7DF901C060053005DC226 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5FFEF0081C04A3950083839D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5FFEF0171C04A94C0083839D /* pam_localauthentication.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7434C8931255449C001D7F9E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F63F81C22E51F9BA0061C0C1 /* SharedMem.m in Sources */,
+				EB27C0B5143CA4AA003F6770 /* Common.c in Sources */,
+				7434C8A11255452A001D7F9E /* pam_ntlm.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F6AAC5F11DF07A05008A6811 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F6AAC6081DF07A59008A6811 /* pam_tid.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F6C0B8E71B8DE6BC00892765 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F6EF67F01D1C308000342741 /* attribute_matching.c in Sources */,
+				F6EF67F11D1C308000342741 /* hash_matching.c in Sources */,
+				F6EF67F21D1C308000342741 /* scmatch_evaluation.c in Sources */,
+				F6DD1CAD1B8DFE0B00BA6BE0 /* pam_smartcard.m in Sources */,
+				F6C0B8E81B8DE6BC00892765 /* Common.c in Sources */,
+				F6D2E89326737AB2005D165D /* krb5principal.m in Sources */,
+				F6D2E89126737A41005D165D /* ds_ops.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1CFF7DB91021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D861021150B0097ADA4 /* uwtmp */;
+			targetProxy = 1CFF7DB81021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF7DBD1021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D76102114E10097ADA4 /* self */;
+			targetProxy = 1CFF7DBC1021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF7DBF1021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D6E102114C60097ADA4 /* sacl */;
+			targetProxy = 1CFF7DBE1021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF7DC11021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D66102114B50097ADA4 /* rootok */;
+			targetProxy = 1CFF7DC01021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF7DC31021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D5E1021149E0097ADA4 /* opendirectory */;
+			targetProxy = 1CFF7DC21021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF7DC51021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D56102114890097ADA4 /* nologin */;
+			targetProxy = 1CFF7DC41021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF7DC71021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D4E1021147B0097ADA4 /* mount */;
+			targetProxy = 1CFF7DC61021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF7DC91021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D461021146B0097ADA4 /* launchd */;
+			targetProxy = 1CFF7DC81021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF7DCB1021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D3E102114560097ADA4 /* krb5 */;
+			targetProxy = 1CFF7DCA1021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF7DCD1021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D361021142C0097ADA4 /* group */;
+			targetProxy = 1CFF7DCC1021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF7DCF1021165B0097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF7D2110210FC20097ADA4 /* env */;
+			targetProxy = 1CFF7DCE1021165B0097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF8088102119940097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF806D102119880097ADA4 /* Install Manpages */;
+			targetProxy = 1CFF8087102119940097ADA4 /* PBXContainerItemProxy */;
+		};
+		1CFF80D910211B040097ADA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CFF80BC10211AF10097ADA4 /* Cleanup */;
+			targetProxy = 1CFF80D810211B040097ADA4 /* PBXContainerItemProxy */;
+		};
+		4770A3342D669E6C000535FB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 47C0C0892D5FEBED00811117 /* basesystem */;
+			targetProxy = 4770A3332D669E6C000535FB /* PBXContainerItemProxy */;
+		};
+		5FD7DF971C0607C9005DC226 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5FFEF0061C04A3950083839D /* localauthentication */;
+			targetProxy = 5FD7DF961C0607C9005DC226 /* PBXContainerItemProxy */;
+		};
+		5FE441C91C5619790010C4FD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5F9145641C56179800E307FC /* aks */;
+			targetProxy = 5FE441C81C5619790010C4FD /* PBXContainerItemProxy */;
+		};
+		5FE441CD1C563EE30010C4FD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5F9145641C56179800E307FC /* aks */;
+			targetProxy = 5FE441CC1C563EE30010C4FD /* PBXContainerItemProxy */;
+		};
+		5FFEF0151C04A6620083839D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5FFEF0061C04A3950083839D /* localauthentication */;
+			targetProxy = 5FFEF0141C04A6620083839D /* PBXContainerItemProxy */;
+		};
+		7434C89F125544F9001D7F9E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7434C8911255449C001D7F9E /* ntlm */;
+			targetProxy = 7434C89E125544F9001D7F9E /* PBXContainerItemProxy */;
+		};
+		F6AAC60A1DF07A5F008A6811 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F6AAC5EF1DF07A05008A6811 /* tid */;
+			targetProxy = F6AAC6091DF07A5F008A6811 /* PBXContainerItemProxy */;
+		};
+		F6F8C6821B8F6F00002596AE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F6C0B8E51B8DE6BC00892765 /* smartcard */;
+			targetProxy = F6F8C6811B8F6F00002596AE /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1CFF7D2410210FC30097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = env;
+			};
+			name = Release;
+		};
+		1CFF7D3C1021142C0097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = group;
+			};
+			name = Release;
+		};
+		1CFF7D44102114560097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks\"",
+				);
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = krb5;
+			};
+			name = Release;
+		};
+		1CFF7D4C1021146B0097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = launchd;
+			};
+			name = Release;
+		};
+		1CFF7D541021147B0097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks\"",
+				);
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = mount;
+			};
+			name = Release;
+		};
+		1CFF7D5C102114890097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = nologin;
+			};
+			name = Release;
+		};
+		1CFF7D641021149E0097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks\"",
+				);
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = opendirectory;
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(inherited) $(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks";
+			};
+			name = Release;
+		};
+		1CFF7D6C102114B50097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = rootok;
+			};
+			name = Release;
+		};
+		1CFF7D74102114C60097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = sacl;
+			};
+			name = Release;
+		};
+		1CFF7D7C102114E10097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = self;
+			};
+			name = Release;
+		};
+		1CFF7D8C1021150B0097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = uwtmp;
+			};
+			name = Release;
+		};
+		1CFF7DB71021164C0097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = "-Ddarwin";
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				OTHER_CFLAGS = "-no-cpp-precomp";
+				PRODUCT_NAME = pam_modules;
+				WARNING_CFLAGS = "-Wall";
+			};
+			name = Release;
+		};
+		1CFF806E102119880097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INSTALL_MODE_FLAG = 0644;
+				PRODUCT_NAME = "Install Manpages";
+			};
+			name = Release;
+		};
+		1CFF80BD10211AF10097ADA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = Cleanup;
+			};
+			name = Release;
+		};
+		1DEB928B08733DD80010E9CD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = darwin;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				INSTALL_MODE_FLAG = 0444;
+				SDKROOT = macosx.internal;
+				WARNING_CFLAGS = "-Wall";
+			};
+			name = Release;
+		};
+		47C0C0942D5FEBED00811117 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		5F91456E1C56179800E307FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 6.0;
+				VALID_ARCHS = "x86_64 x86_64h";
+			};
+			name = Release;
+		};
+		5FD7DF921C060053005DC226 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx.internal;
+			};
+			name = Release;
+		};
+		5FFEF0101C04A3950083839D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks\"",
+				);
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		7434C89B1255449C001D7F9E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks\"",
+				);
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = ntlm;
+			};
+			name = Release;
+		};
+		F6AAC6031DF07A05008A6811 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks\"",
+				);
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		F6C0B8EF1B8DE6BC00892765 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = so.2;
+				EXECUTABLE_PREFIX = pam_;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks\"",
+				);
+				INSTALL_PATH = /usr/lib/pam;
+				PREBINDING = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1CFF7D2A10210FE80097ADA4 /* Build configuration list for PBXNativeTarget "env" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D2410210FC30097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7D3A1021142C0097ADA4 /* Build configuration list for PBXNativeTarget "group" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D3C1021142C0097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7D42102114560097ADA4 /* Build configuration list for PBXNativeTarget "krb5" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D44102114560097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7D4A1021146B0097ADA4 /* Build configuration list for PBXNativeTarget "launchd" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D4C1021146B0097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7D521021147B0097ADA4 /* Build configuration list for PBXNativeTarget "mount" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D541021147B0097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7D5A102114890097ADA4 /* Build configuration list for PBXNativeTarget "nologin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D5C102114890097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7D621021149E0097ADA4 /* Build configuration list for PBXNativeTarget "opendirectory" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D641021149E0097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7D6A102114B50097ADA4 /* Build configuration list for PBXNativeTarget "rootok" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D6C102114B50097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7D72102114C60097ADA4 /* Build configuration list for PBXNativeTarget "sacl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D74102114C60097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7D7A102114E10097ADA4 /* Build configuration list for PBXNativeTarget "self" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D7C102114E10097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7D8A1021150B0097ADA4 /* Build configuration list for PBXNativeTarget "uwtmp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7D8C1021150B0097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF7DD4102116A60097ADA4 /* Build configuration list for PBXAggregateTarget "pam_modules" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF7DB71021164C0097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF809F102119E70097ADA4 /* Build configuration list for PBXAggregateTarget "Install Manpages" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF806E102119880097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1CFF80DC10211B140097ADA4 /* Build configuration list for PBXAggregateTarget "Cleanup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFF80BD10211AF10097ADA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "pam_modules" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1DEB928B08733DD80010E9CD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		47C0C0932D5FEBED00811117 /* Build configuration list for PBXNativeTarget "basesystem" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				47C0C0942D5FEBED00811117 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5F91456D1C56179800E307FC /* Build configuration list for PBXNativeTarget "aks" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5F91456E1C56179800E307FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5FD7DF911C060053005DC226 /* Build configuration list for PBXNativeTarget "test_pam_localauthentication" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5FD7DF921C060053005DC226 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5FFEF00F1C04A3950083839D /* Build configuration list for PBXNativeTarget "localauthentication" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5FFEF0101C04A3950083839D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7434C89A1255449C001D7F9E /* Build configuration list for PBXNativeTarget "ntlm" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7434C89B1255449C001D7F9E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F6AAC6021DF07A05008A6811 /* Build configuration list for PBXNativeTarget "tid" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F6AAC6031DF07A05008A6811 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F6C0B8EE1B8DE6BC00892765 /* Build configuration list for PBXNativeTarget "smartcard" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F6C0B8EF1B8DE6BC00892765 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 08FB7793FE84155DC02AAC07 /* Project object */;
+}

--- a/src/pam_modules/pam_modules.xcodeproj/xcshareddata/xcschemes/basesystem.xcscheme
+++ b/src/pam_modules/pam_modules.xcodeproj/xcshareddata/xcschemes/basesystem.xcscheme
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "47C0C0892D5FEBED00811117"
+               BuildableName = "pam_basesystem.so.2"
+               BlueprintName = "basesystem"
+               ReferencedContainer = "container:pam_modules.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      internalIOSLaunchStyle = "3">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "47C0C0892D5FEBED00811117"
+            BuildableName = "pam_basesystem.so.2"
+            BlueprintName = "basesystem"
+            ReferencedContainer = "container:pam_modules.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/src/pam_modules/pammodulestest.c
+++ b/src/pam_modules/pammodulestest.c
@@ -1,0 +1,80 @@
+/*
+ * pammodulestest — PAM port iter 2 (issue #95) CI gate.
+ *
+ * Dlopens each of the 5 vendored Apple standalone modules
+ * (pam_self, pam_rootok, pam_uwtmp, pam_nologin, pam_env) from
+ * /usr/lib/pam_NAME.so.6 and verifies the standard pam_sm_*
+ * entry points exist. Emits PAM-MODULES-OK when all 5 pass;
+ * PAM-MODULES-FAIL on the first failure.
+ *
+ * Why this and not pam_start(): iter 2 doesn't yet ship overlay
+ * pam.d service files referencing these modules — that's iter 3.
+ * Until then the modules sit in /usr/lib/ unreferenced by any PAM
+ * service. The most surgical check is direct dlopen + dlsym to
+ * prove the .so files are well-formed and ABI-compatible with our
+ * libpam.so.6 (which iter 1 already verified holistically).
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct module_check {
+	const char *path;
+	const char *required_sym;	/* one canonical pam_sm_* entry */
+};
+
+/* Each module exposes at least one pam_sm_* entry that matches the
+ * facility it implements. Checking one is enough to prove the .so
+ * is a real PAM module and not a corrupted file. */
+static const struct module_check checks[] = {
+	{ "/usr/lib/pam_self.so.6",     "pam_sm_authenticate" },
+	{ "/usr/lib/pam_rootok.so.6",   "pam_sm_authenticate" },
+	{ "/usr/lib/pam_uwtmp.so.6",    "pam_sm_open_session" },
+	{ "/usr/lib/pam_nologin.so.6",  "pam_sm_authenticate" },
+	{ "/usr/lib/pam_env.so.6",      "pam_sm_open_session" },
+};
+
+int
+main(void)
+{
+	size_t i;
+	int failures = 0;
+
+	for (i = 0; i < sizeof(checks) / sizeof(checks[0]); i++) {
+		void *h;
+		void *sym;
+
+		h = dlopen(checks[i].path, RTLD_NOW | RTLD_LOCAL);
+		if (h == NULL) {
+			(void)printf("PAM-MODULES-FAIL: dlopen %s: %s\n",
+			    checks[i].path, dlerror());
+			failures++;
+			continue;
+		}
+		sym = dlsym(h, checks[i].required_sym);
+		if (sym == NULL) {
+			(void)printf("PAM-MODULES-FAIL: dlsym %s in %s: %s\n",
+			    checks[i].required_sym, checks[i].path,
+			    dlerror());
+			(void)dlclose(h);
+			failures++;
+			continue;
+		}
+		(void)printf("  %s: dlopen ok, %s present\n",
+		    checks[i].path, checks[i].required_sym);
+		(void)dlclose(h);
+	}
+
+	if (failures > 0) {
+		(void)printf("PAM-MODULES-FAIL: %d module(s) failed checks\n",
+		    failures);
+		return (1);
+	}
+
+	(void)printf("PAM-MODULES-OK: all 5 Apple modules loadable + ABI "
+	    "valid (pam_self, pam_rootok, pam_uwtmp, pam_nologin, "
+	    "pam_env via /usr/lib/pam_*.so.6)\n");
+	return (0);
+}

--- a/src/pam_modules/test_pam_localauthentication/main.m
+++ b/src/pam_modules/test_pam_localauthentication/main.m
@@ -1,0 +1,61 @@
+//
+//  main.m
+//  test_pam_localauthentication
+//
+//  Created by Jiri Margaritov on 25/11/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+#include <security/pam_appl.h>
+#include <security/openpam.h>
+#import <LocalAuthentication/LAContext+Private.h>
+
+int main(int argc, const char * argv[]) {
+    int pam_res = PAM_SYSTEM_ERR;
+
+    @autoreleasepool {
+        pam_handle_t *pamh = NULL;
+        struct pam_conv pamc = { openpam_nullconv, NULL };
+        LAContext *context = nil;
+        CFDataRef econtext = NULL;
+        const char *username = NULL;
+
+        if (argc > 1) {
+            username = argv[1];
+        }
+
+        if (!username)
+            goto cleanup;
+
+        if (PAM_SUCCESS != (pam_res = pam_start("localauthentication", username, &pamc, &pamh)))
+            goto cleanup;
+
+        context = [LAContext new];
+        econtext = CFDataCreate(kCFAllocatorDefault, context.externalizedContext.bytes, context.externalizedContext.length);
+
+        if (!econtext)
+            goto cleanup;
+
+        if (PAM_SUCCESS != (pam_res = pam_set_data(pamh, "token_la", (void *)&econtext, NULL)))
+            goto cleanup;
+
+        if (PAM_SUCCESS != (pam_res = pam_authenticate(pamh, 0)))
+            goto cleanup;
+        
+        if (PAM_SUCCESS != (pam_res = pam_acct_mgmt(pamh, 0)))
+            goto cleanup;
+
+cleanup:
+        if (pamh) {
+            pam_end(pamh, pam_res);
+        }
+        
+        if (econtext) {
+            CFRelease(econtext);
+        }
+    }
+
+    return pam_res;
+}

--- a/src/pam_modules/tests/test_login_concurrent
+++ b/src/pam_modules/tests/test_login_concurrent
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+serial_cmd="./test_login_serial"
+
+declare -a users_name users_pass
+declare -i start_time stop_time
+
+total_count=$1
+recursion_count=$2
+
+if [[ $# -ne 2 ]]
+then
+	echo "Usage: <# logins> <# recursion>"
+	exit 1
+fi
+
+
+users_total=3
+users_name[0]="local"
+users_pass[0]="local"
+users_name[1]="local"
+users_pass[1]="local"
+users_name[2]="local"
+users_pass[2]="local"
+users_name[3]="local"
+users_pass[3]="local"
+users_name[4]="local"
+users_pass[4]="local"
+users_name[5]="local"
+users_pass[5]="local"
+
+printf "\n"
+printf "Starting test..."
+
+start_time=$(date +%s)
+
+for ((count=0; count<users_total; ++count))
+do
+	${serial_cmd} ${users_name[${count}]} ${users_pass[${count}]} \
+		${total_count} ${recursion_count} > /dev/null &
+done
+
+wait
+
+stop_time=$(date +%s)
+printf "\n"
+printf " done.\n"
+
+elap_time=$((${stop_time}-${start_time}))
+iter_total=$((${users_total}*${total_count}*${recursion_count}))
+
+printf "\n"
+printf "Total iterations: %d = %d * %d * %d\n" ${iter_total} ${total_count} ${recursion_count} ${users_total}
+printf "Elapsed time    : %d seconds\n" ${elap_time}
+printf "Login/second    : %d\n" $((iter_total/${elap_time}))

--- a/src/pam_modules/tests/test_login_serial
+++ b/src/pam_modules/tests/test_login_serial
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+declare -i iter_count total_count
+declare -i start_time stop_time
+
+user_name=$1
+user_pass=$2
+total_count=$3
+recursion_count=$4
+
+if [[ $# -ne 4 ]]
+then
+	echo "Usage: <user name> <password> <# logins> <# recursion>"
+	exit 1
+fi
+
+exec_prog="./test-auth"
+iter_count=0
+
+printf "\n"
+printf "Login count    : %d\n" ${total_count}
+printf "Recursion count: %d\n" ${recursion_count}
+printf "\n"
+printf "Starting test..."
+
+start_time=$(date +%s)
+
+while ((${iter_count} < ${total_count}))
+do
+	${exec_prog} ${user_name} ${user_pass} ${recursion_count} > /dev/null
+	iter_count=$((1+${iter_count}))
+done
+
+stop_time=$(date +%s)
+printf " done.\n"
+
+elap_time=$((${stop_time}-${start_time}))
+iter_total=$((${iter_count}*${recursion_count}))
+
+printf "\n"
+printf "Total iterations: %d = %d * %d \n" ${iter_total} ${iter_count} ${recursion_count}
+printf "Elapsed time    : %d seconds\n" ${elap_time}
+printf "Logins/second   : %d\n" $((iter_total/${elap_time}))

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -1082,6 +1082,25 @@ expect {
     }
 }
 
+# PAM-MODULES — issue #95 iter 2 gate. pammodulestest dlopens each
+# of the 5 vendored Apple standalone modules at /usr/lib/pam_NAME.so.6
+# and verifies the canonical pam_sm_* entry point is present.
+# Indirectly verifies the existing post-login marker chain stays
+# green with OUR pam_self.so.6 + pam_uwtmp.so.6 (used by getty/login).
+expect {
+    timeout {
+        puts "\nFAIL: PAM-MODULES marker not seen"
+        exit 1
+    }
+    "PAM-MODULES-FAIL" {
+        puts "\nFAIL: one or more Apple PAM standalone modules failed to load or expose required entry points"
+        exit 1
+    }
+    "PAM-MODULES-OK" {
+        puts "\nOK: 5 Apple PAM standalone modules (pam_self, pam_rootok, pam_uwtmp, pam_nologin, pam_env) loadable + ABI-valid"
+    }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
## Summary

Iter 2 of the [PAM port plan](https://pkgdemon.github.io/freebsd-pam-port-plan.html). Vendors `apple-oss-distributions/pam_modules @ pam_modules-217.100.6` into `src/pam_modules/`. Builds the 5 standalone modules with no OD/SecurityServer/SmartCard dependencies.

Closes #95.

### What ships

| Path | Source | Role |
|---|---|---|
| `/usr/lib/pam_self.so.6` | `modules/pam_self/pam_self.c` | allow root to su to anyone |
| `/usr/lib/pam_rootok.so.6` | `modules/pam_rootok/pam_rootok.c` | allow root without password |
| `/usr/lib/pam_uwtmp.so.6` | `modules/pam_uwtmp/pam_uwtmp.c` | utmp/wtmp accounting |
| `/usr/lib/pam_nologin.so.6` | `modules/pam_nologin/pam_nologin.c` | respect `/etc/nologin` |
| `/usr/lib/pam_env.so.6` | `modules/pam_env/pam_env.c` | set environment variables |

Same `/usr/lib/pam_NAME.so.6` install pattern iter 1 established — overwrites FreeBSD-pam's same-named files in-place. After this iter, login's PAM stack (using the unchanged FreeBSD `/etc/pam.d/login`) loads OUR `pam_self.so.6` + `pam_uwtmp.so.6` + the existing iter-1 `pam_unix.so.6` + the still-FreeBSD `pam_xdg.so.6` etc.

### Skipped (need Apple-private subsystems)

`pam_aks`, `pam_basesystem`, `pam_group`, `pam_krb5`, `pam_launchd`, `pam_localauthentication`, `pam_mount`, `pam_ntlm`, `pam_opendirectory`, `pam_sacl`, `pam_smartcard`, `pam_tid` — left in `src/pam_modules/modules/` for future iters but not compiled.

### CI gate

New `PAM-MODULES-OK` via `pammodulestest`: dlopens each of the 5 modules from `/usr/lib/pam_NAME.so.6` + dlsyms a canonical `pam_sm_*` entry point. Indirectly verified by the existing post-login marker chain (login still works = our modules actually do their job when loaded via libpam).

### Out of scope (iter 3/4)

- Overlay `/etc/pam.d/*` files — iter 3.
- Dropping `FreeBSD-pam` + `FreeBSD-pam-lib` packages — iter 3.
- Restoring `RunAtLoad=true` on hostnamed + syslogd — iter 4.

## Test plan

- [ ] Build green.
- [ ] `PAM-MODULES-OK: all 5 Apple modules loadable + ABI valid` fires.
- [ ] `PAM-FRAMEWORK-OK` from iter 1 still fires (no regression).
- [ ] All existing post-login markers stay green (login → MACH-SMOKE-OK → … → HOSTNAMED-DHCP-OK) — proves login still authenticates with our newly-vendored modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)