### PR TITLE
feat(rescue): drop FreeBSD-rescue pkg; build /rescue/ from /usr/src (#104)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -220,6 +220,57 @@ mkdir -p "$WORK/freebsd-src"
 tar -xJf "$DIST/src.txz" -C "$WORK/freebsd-src"
 
 #
+# 3a2. build /rescue/ from /usr/src per srclist-rescue.txt (issue #104).
+#      Drops the FreeBSD-rescue pkgbase package in favor of a per-line
+#      manifest of /usr/src directories that build.sh iterates. Proof
+#      of concept for the manifest-driven build pattern issue #105
+#      extends to FreeBSD-runtime + FreeBSD-utilities, and issue #106
+#      uses for the first per-tool Apple-source swap (getty).
+#
+#      /rescue/ is by design ONE statically-linked multi-call binary
+#      (crunchgen) with symlinks for each command name; srclist
+#      has a single entry (rescue/rescue). MAKEOBJDIRPREFIX is
+#      isolated under $WORK so we don't pollute /usr/obj on the
+#      builder. SRCCONF / __MAKE_CONF /dev/null isolates from any
+#      host /etc/src.conf that might disable rescue or set unwanted
+#      WITH_/WITHOUT_ flags.
+#
+echo "==> building /rescue/ from /usr/src per srclist-rescue.txt"
+RESCUE_LIST=$(grep -v '^[[:space:]]*#' "$ROOT/srclist-rescue.txt" 2>/dev/null \
+              | grep -v '^[[:space:]]*$' || true)
+if [ -z "$RESCUE_LIST" ]; then
+    echo "ERROR: srclist-rescue.txt is empty; refusing to skip /rescue/" >&2
+    exit 1
+fi
+
+SRCBUILD_OBJ="$WORK/srcbuild-obj"
+mkdir -p "$SRCBUILD_OBJ"
+SRCBUILD_MAKE_FLAGS="__MAKE_CONF=/dev/null SRCCONF=/dev/null \
+                     MK_MAN=no MK_TESTS=no"
+
+for DIR in $RESCUE_LIST; do
+    SRC="$WORK/freebsd-src/usr/src/$DIR"
+    if [ ! -d "$SRC" ]; then
+        echo "ERROR: srclist-rescue entry '$DIR' not under usr/src ($SRC)" >&2
+        exit 1
+    fi
+    echo "    src-build: $DIR"
+    # shellcheck disable=SC2086
+    env MAKEOBJDIRPREFIX="$SRCBUILD_OBJ" \
+        make -C "$SRC" $SRCBUILD_MAKE_FLAGS obj
+    # shellcheck disable=SC2086
+    env MAKEOBJDIRPREFIX="$SRCBUILD_OBJ" \
+        make -C "$SRC" $SRCBUILD_MAKE_FLAGS
+    # shellcheck disable=SC2086
+    env MAKEOBJDIRPREFIX="$SRCBUILD_OBJ" \
+        make -C "$SRC" $SRCBUILD_MAKE_FLAGS \
+        install DESTDIR="$WORK/rootfs"
+done
+
+ls -lh "$WORK/rootfs/rescue/rescue"
+echo "    /rescue/ entry count: $(ls "$WORK/rootfs/rescue/" | wc -l | tr -d ' ')"
+
+#
 # 3b. build mach.ko against the freshly-extracted kernel sources and
 #     install it into $WORK/rootfs/boot/kernel/mach.ko so it ships
 #     inside rootfs.uzip. Step 8 below also copies it onto the cd9660

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -244,6 +244,28 @@ else
     exit 1
 fi
 
+# 6.5. rescue from src (issue #104): /rescue/ should exist with the
+# expected multi-call statically-linked binary plus per-command
+# symlinks. build.sh step 3a2 replaced the FreeBSD-rescue pkgbase
+# package with an in-build rebuild from /usr/src/rescue/rescue/.
+# Proves the manifest-driven /usr/src build mechanism that issue
+# #105 extends to FreeBSD-runtime + FreeBSD-utilities.
+if [ -x /rescue/rescue ] && [ -L /rescue/sh ]; then
+    if hello_out=$(/rescue/sh -c 'echo hello' 2>&1) && \
+       [ "$hello_out" = "hello" ]; then
+        rescue_count=$(ls /rescue/ 2>/dev/null | wc -l | tr -d ' ')
+        echo "RESCUE-SRC-OK: /rescue/ built from /usr/src (${rescue_count} entries)"
+    else
+        echo "RESCUE-SRC-FAIL: /rescue/sh -c 'echo hello' got: $hello_out"
+        ls -la /rescue/ 2>&1 | head -20 || true
+        exit 1
+    fi
+else
+    echo "RESCUE-SRC-FAIL: /rescue/rescue binary or /rescue/sh symlink missing"
+    ls -la /rescue/ 2>&1 | head -20 || true
+    exit 1
+fi
+
 # 7. launchd-842 daemon: must exec + reject non-PID-1 invocation.
 # launchd-842's main() (launchd.c:163) checks
 #   getpid() != 1 && getppid() != 1

--- a/pkglist-base.txt
+++ b/pkglist-base.txt
@@ -30,13 +30,16 @@ FreeBSD-bootloader
 FreeBSD-kernel-generic
 
 # ---- /sbin/init + boot ----
-# rescue: /init.sh shebangs /rescue/sh and uses /rescue/{mount,mdconfig,
-#   chroot,kldload,init} pre-pivot.
+# rescue: DROPPED 2026-05-26 (issue #104). Replaced by an in-build
+#   rebuild of /rescue/ from /usr/src/rescue/rescue/ via build.sh
+#   step 3a2 + srclist-rescue.txt. Proof-of-concept for the
+#   manifest-driven /usr/src build pattern that issue #105 extends
+#   to FreeBSD-runtime + FreeBSD-utilities.
 # runtime: /sbin/halt, /sbin/reboot, basic boot binaries, plus the
 #   /sbin/init we *don't* use (init.sh exec's /sbin/launchd directly,
 #   bypassing init entirely -- see ramdisk/init.sh comment block).
 #   Also ships /usr/libexec/getty, /usr/bin/login, /bin/sh.
-FreeBSD-rescue
+#FreeBSD-rescue
 FreeBSD-runtime
 
 # ---- core libc + base userland ----

--- a/srclist-rescue.txt
+++ b/srclist-rescue.txt
@@ -1,0 +1,16 @@
+# srclist-rescue.txt — /usr/src directories to build into the rootfs
+# in lieu of the FreeBSD-rescue pkgbase package.
+#
+# Iterated by build.sh step 3a2. Per-line format: <relative path
+# under /usr/src>; lines starting with # or empty lines are ignored.
+#
+# Issue #104 — proof-of-concept for the manifest-driven /usr/src
+# build pattern that issue #105 extends to FreeBSD-runtime +
+# FreeBSD-utilities, and issue #106 uses for the first per-tool
+# Apple-source swap (getty from system_cmds).
+#
+# /rescue/ is by design ONE statically-linked multi-call binary built
+# via crunchgen, with symlinks for each command name (sh, ls, cp, mv,
+# mount, fsck, kldload, etc.). Single entry below.
+
+rescue/rescue

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -344,6 +344,17 @@ expect {
 }
 expect {
     timeout {
+        puts "\nFAIL: RESCUE-SRC marker not seen"
+        exit 1
+    }
+    "RESCUE-SRC-FAIL" {
+        puts "\nFAIL: /rescue/ from src missing or non-functional"
+        exit 1
+    }
+    "RESCUE-SRC-OK" { puts "\nOK: /rescue/ built from /usr/src (issue #104)" }
+}
+expect {
+    timeout {
         puts "\nFAIL: LAUNCHD-BUILD marker not seen"
         exit 1
     }


### PR DESCRIPTION
## Summary

Closes #104 (proof-of-concept). Drops the `FreeBSD-rescue` pkgbase package and rebuilds `/rescue/` from `/usr/src/rescue/rescue/` via a new `srclist-rescue.txt` manifest iterated by `build.sh`. Proves the manifest-driven `/usr/src` build mechanism that #105 will extend to FreeBSD-runtime + FreeBSD-utilities, and #106 will use for the first per-tool Apple-source swap (getty).

## Changes

- **New file: `srclist-rescue.txt`** — single entry `rescue/rescue`; documented format for #105 + #106 to follow
- **`pkglist-base.txt`** — `FreeBSD-rescue` commented out; comment block updated to reference #104 + #105
- **`build.sh`** — new step 3a2 (right after src.txz extraction) iterates `srclist-rescue.txt`, runs `make obj && make && make install DESTDIR=$WORK/rootfs` per entry. Isolated `MAKEOBJDIRPREFIX` under `$WORK/srcbuild-obj`; isolated `SRCCONF=/dev/null` + `__MAKE_CONF=/dev/null` from host `/etc/src.conf`.
- **`overlays/usr/tests/freebsd-launchd-mach/run.sh`** — new section 6.5 emits `RESCUE-SRC-OK` after verifying `/rescue/rescue` is executable, `/rescue/sh` is a symlink, and `/rescue/sh -c 'echo hello'` round-trips
- **`tests/boot-test.sh`** — new expect block gates `RESCUE-SRC-OK` between MIG-BUILD and LAUNCHD-BUILD

## Why this PR

Per the [userland-cmds v3 plan](https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html), every FreeBSD pkgbase pkg whose content we want to control per-tool needs to be dropped + rebuilt from /usr/src via a manifest. FreeBSD-rescue is the lowest-stakes pkg to pilot the mechanism on (`/rescue/` is only used in single-user / emergency mode). Once this lands and CI is green, #105 expands the same pattern to the much larger FreeBSD-runtime + FreeBSD-utilities pkgs, unlocking per-tool replacement (e.g. swapping in Apple's getty in #106).

## Test plan

- [ ] CI boot-test green on the new branch
- [ ] `RESCUE-SRC-OK` marker emitted by run.sh
- [ ] No regression in any downstream marker (MACH-SMOKE-OK through HOSTNAMED-DHCP-OK)
- [ ] Manual verification on bsd01 (or any boot of the resulting ISO):
  - [ ] \`ls /rescue/\` shows the expected static rescue binary + symlinks (sh, ls, cp, mv, mount, fsck, kldload, init, ...)
  - [ ] \`/rescue/sh -c 'echo ok'\` prints "ok"
  - [ ] \`pkg info FreeBSD-rescue\` returns not-installed

## Sister tickets

- #105 — Drop FreeBSD-runtime + FreeBSD-utilities + FreeBSD-pam-lib via `srclist-runtime.txt` (extends this mechanism)
- #106 — Swap getty Apple-source via manifest swap (first per-tool replacement)
- #103 — Closed transitively by #105 once it merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)