### PR TITLE
feat(shell_cmds): iter 2 — 20 more single-source POSIX tools (#112 iter 2)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -369,18 +369,25 @@ ls -lh "$WORK/rootfs/bin/chflags" "$WORK/rootfs/bin/rm" \
 #
 #      Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#shell_cmds
 #
-echo "==> building Apple shell_cmds (iter 1: 5 trivial leaf tools)"
+echo "==> building Apple shell_cmds (iter 2: 25 single-source POSIX tools)"
 make -C "$ROOT/src/shell_cmds" install DESTDIR="$WORK/rootfs"
 
 for SHELLCMD_BIN in /usr/bin/true /usr/bin/false \
-                    /bin/echo /bin/sleep /usr/bin/basename; do
+                    /bin/echo /bin/sleep /usr/bin/basename \
+                    /usr/bin/apply /usr/bin/dirname /usr/bin/env \
+                    /usr/bin/getopt /bin/hostname /usr/bin/jot \
+                    /bin/kill /usr/bin/logname /usr/bin/mktemp \
+                    /usr/bin/nice /usr/bin/nohup /usr/bin/printenv \
+                    /usr/bin/printf /bin/pwd /bin/realpath \
+                    /usr/bin/renice /usr/bin/tee /usr/bin/uname \
+                    /usr/bin/what /usr/bin/yes; do
     if [ ! -x "$WORK/rootfs$SHELLCMD_BIN" ]; then
         echo "ERROR: shell_cmds install didn't land $SHELLCMD_BIN" >&2
         exit 1
     fi
 done
 ls -lh "$WORK/rootfs/usr/bin/true" "$WORK/rootfs/bin/echo" \
-       "$WORK/rootfs/usr/bin/basename"
+       "$WORK/rootfs/usr/bin/printf" "$WORK/rootfs/bin/hostname"
 
 #
 # 3b. build mach.ko against the freshly-extracted kernel sources and

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -364,14 +364,20 @@ if [ $FILECMD_FAIL -ne 0 ]; then
     exit 1
 fi
 
-# 6.7. shell_cmds iter 1 (#112 / #105c iter 1). Second Apple-userland-
-# cmds repo port. Verifies the 5 trivial leaf Apple binaries (true,
-# false, echo, sleep, basename) are present at canonical paths.
+# 6.7. shell_cmds iter 2 (#112 / #105c iter 2). Extends iter 1's
+# 5-binary leaf set to 25 single-source POSIX tools.
 #
 # Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#shell_cmds
 SHELLCMD_FAIL=0
 for fbin in /usr/bin/true /usr/bin/false /bin/echo /bin/sleep \
-            /usr/bin/basename; do
+            /usr/bin/basename \
+            /usr/bin/apply /usr/bin/dirname /usr/bin/env \
+            /usr/bin/getopt /bin/hostname /usr/bin/jot \
+            /bin/kill /usr/bin/logname /usr/bin/mktemp \
+            /usr/bin/nice /usr/bin/nohup /usr/bin/printenv \
+            /usr/bin/printf /bin/pwd /bin/realpath \
+            /usr/bin/renice /usr/bin/tee /usr/bin/uname \
+            /usr/bin/what /usr/bin/yes; do
     if [ ! -x "$fbin" ]; then
         echo "SHELLCMD-LEAF-FAIL: $fbin missing or not executable"
         ls -la "$fbin" 2>&1 || true
@@ -379,12 +385,14 @@ for fbin in /usr/bin/true /usr/bin/false /bin/echo /bin/sleep \
     fi
 done
 # Functional sanity: true returns 0, false returns non-zero, echo
-# round-trips a string. These three together prove the binaries
-# actually run (not just exist as zero-byte files or rtld stubs).
+# round-trips a string. Plus iter-2 spot checks for tools with more
+# complex code paths.
 if [ $SHELLCMD_FAIL -eq 0 ]; then
     if /usr/bin/true && ! /usr/bin/false && \
-       [ "$(/bin/echo hello)" = "hello" ]; then
-        echo "SHELLCMD-LEAF-OK: 5/5 shell_cmds leaf binaries overlaid + functional (true=0, false=non-zero, echo round-trips)"
+       [ "$(/bin/echo hello)" = "hello" ] && \
+       [ "$(/usr/bin/printf 'x%s' yz)" = "xyz" ] && \
+       [ "$(/usr/bin/jot 1 5)" = "5" ]; then
+        echo "SHELLCMD-LEAF-OK: 25/25 shell_cmds binaries overlaid + functional (true/false/echo/printf/jot probes pass)"
     else
         echo "SHELLCMD-LEAF-FAIL: functional sanity check failed"
         SHELLCMD_FAIL=1

--- a/src/shell_cmds/Makefile
+++ b/src/shell_cmds/Makefile
@@ -8,28 +8,35 @@
 # Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#shell_cmds
 # Ticket: #112 (#105c shell_cmds port)
 #
-# Iter 1 scope: 5 trivial leaf tools (true, false, echo, sleep,
-# basename) — all single-source pure POSIX. Same validation shape
-# as file_cmds iter 1: prove the per-Apple-repo vendor + Makefile
-# pattern scales beyond file_cmds before tackling the load-bearing
-# tools (/bin/sh swap, id with libopendirectory shim, killall with
-# KERN_PROCARGS2, su with BSM stub, the ~40 other tools).
+# Iter 1 (merged commit eeb58dd): 5 trivial leaf tools (true, false,
+# echo, sleep, basename) — proves the vendor pattern.
 #
-# Iter 2+ (future): basename, chroot, date, dirname, env, expr,
-# find, getopt, hexdump, hostname, jot, kill, lockf, logname,
-# mktemp, nice, nohup, printenv, printf, pwd, realpath, renice,
-# script, seq, sh, shlock, stdbuf, tee, test, time, tty, uname, w,
-# who, xargs, yes, plus id/su/path_helper/killall with their shims.
+# Iter 2 (this): expand to 20 more single-source pure-POSIX tools
+# (apply, dirname, env, getopt, hostname, jot, kill, logname, mktemp,
+# nice, nohup, printenv, printf, pwd, realpath, renice, tee, uname,
+# what, yes). -D__dead=__dead2 added to global CFLAGS preemptively
+# (file_cmds iter 2 mknod fix; safer to apply repo-wide).
+#
+# Iter 3+: load-bearing tools (/bin/sh swap, /usr/bin/id with
+# libopendirectory shim, /usr/bin/su with BSM stub, /usr/bin/killall
+# with KERN_PROCARGS2). And remaining multi-source tools (date, expr,
+# find, hexdump, lastcomm, locate, script, sh, su, w, who, xargs)
+# with their own builds.
 #
 # Usage: make -C src/shell_cmds install DESTDIR=$WORK/rootfs
 
 DESTDIR ?=
-CFLAGS = -O2 -pipe
+CFLAGS = -O2 -pipe -D__dead=__dead2
 
 ITER1_BINS = true/true false/false echo/echo sleep/sleep \
              basename/basename
+ITER2_BINS = apply/apply dirname/dirname env/env getopt/getopt \
+             hostname/hostname jot/jot kill/kill logname/logname \
+             mktemp/mktemp nice/nice nohup/nohup printenv/printenv \
+             printf/printf pwd/pwd realpath/realpath renice/renice \
+             tee/tee uname/uname what/what yes/yes
 
-all: $(ITER1_BINS)
+all: $(ITER1_BINS) $(ITER2_BINS)
 
 # --- iter 1 (single-source pure-POSIX leaf tools) ---
 true/true: true/true.c
@@ -43,15 +50,83 @@ sleep/sleep: sleep/sleep.c
 basename/basename: basename/basename.c
 	cc $(CFLAGS) -o $@ basename/basename.c
 
+# --- iter 2 (single-source POSIX tools) ---
+# Most are pure libc; jot/seq use libm; printf may use libxo (Apple
+# extension — skip if causes issues).
+apply/apply: apply/apply.c
+	cc $(CFLAGS) -o $@ apply/apply.c
+dirname/dirname: dirname/dirname.c
+	cc $(CFLAGS) -o $@ dirname/dirname.c
+# env: env.c + envopts.c (multi-source).
+env/env: env/env.c env/envopts.c
+	cc $(CFLAGS) -o $@ env/env.c env/envopts.c
+getopt/getopt: getopt/getopt.c
+	cc $(CFLAGS) -o $@ getopt/getopt.c
+hostname/hostname: hostname/hostname.c
+	cc $(CFLAGS) -o $@ hostname/hostname.c
+# jot uses libm (math functions).
+jot/jot: jot/jot.c
+	cc $(CFLAGS) -o $@ jot/jot.c -lm
+kill/kill: kill/kill.c
+	cc $(CFLAGS) -o $@ kill/kill.c
+logname/logname: logname/logname.c
+	cc $(CFLAGS) -o $@ logname/logname.c
+mktemp/mktemp: mktemp/mktemp.c
+	cc $(CFLAGS) -o $@ mktemp/mktemp.c
+nice/nice: nice/nice.c
+	cc $(CFLAGS) -o $@ nice/nice.c
+nohup/nohup: nohup/nohup.c
+	cc $(CFLAGS) -o $@ nohup/nohup.c
+printenv/printenv: printenv/printenv.c
+	cc $(CFLAGS) -o $@ printenv/printenv.c
+printf/printf: printf/printf.c
+	cc $(CFLAGS) -o $@ printf/printf.c
+pwd/pwd: pwd/pwd.c
+	cc $(CFLAGS) -o $@ pwd/pwd.c
+realpath/realpath: realpath/realpath.c
+	cc $(CFLAGS) -o $@ realpath/realpath.c
+renice/renice: renice/renice.c
+	cc $(CFLAGS) -o $@ renice/renice.c
+tee/tee: tee/tee.c
+	cc $(CFLAGS) -o $@ tee/tee.c
+uname/uname: uname/uname.c
+	cc $(CFLAGS) -o $@ uname/uname.c
+what/what: what/what.c
+	cc $(CFLAGS) -o $@ what/what.c
+yes/yes: yes/yes.c
+	cc $(CFLAGS) -o $@ yes/yes.c
+
 install: all
 	mkdir -p $(DESTDIR)/bin $(DESTDIR)/usr/bin
+	# iter 1
 	install -m 0555 true/true $(DESTDIR)/usr/bin/true
 	install -m 0555 false/false $(DESTDIR)/usr/bin/false
 	install -m 0555 echo/echo $(DESTDIR)/bin/echo
 	install -m 0555 sleep/sleep $(DESTDIR)/bin/sleep
 	install -m 0555 basename/basename $(DESTDIR)/usr/bin/basename
+	# iter 2 — install at Apple-canonical paths (matches macOS):
+	install -m 0555 apply/apply $(DESTDIR)/usr/bin/apply
+	install -m 0555 dirname/dirname $(DESTDIR)/usr/bin/dirname
+	install -m 0555 env/env $(DESTDIR)/usr/bin/env
+	install -m 0555 getopt/getopt $(DESTDIR)/usr/bin/getopt
+	install -m 0555 hostname/hostname $(DESTDIR)/bin/hostname
+	install -m 0555 jot/jot $(DESTDIR)/usr/bin/jot
+	install -m 0555 kill/kill $(DESTDIR)/bin/kill
+	install -m 0555 logname/logname $(DESTDIR)/usr/bin/logname
+	install -m 0555 mktemp/mktemp $(DESTDIR)/usr/bin/mktemp
+	install -m 0555 nice/nice $(DESTDIR)/usr/bin/nice
+	install -m 0555 nohup/nohup $(DESTDIR)/usr/bin/nohup
+	install -m 0555 printenv/printenv $(DESTDIR)/usr/bin/printenv
+	install -m 0555 printf/printf $(DESTDIR)/usr/bin/printf
+	install -m 0555 pwd/pwd $(DESTDIR)/bin/pwd
+	install -m 0555 realpath/realpath $(DESTDIR)/bin/realpath
+	install -m 0555 renice/renice $(DESTDIR)/usr/bin/renice
+	install -m 0555 tee/tee $(DESTDIR)/usr/bin/tee
+	install -m 0555 uname/uname $(DESTDIR)/usr/bin/uname
+	install -m 0555 what/what $(DESTDIR)/usr/bin/what
+	install -m 0555 yes/yes $(DESTDIR)/usr/bin/yes
 
 clean:
-	rm -f $(ITER1_BINS)
+	rm -f $(ITER1_BINS) $(ITER2_BINS)
 
 .PHONY: all clean install

--- a/src/shell_cmds/Makefile
+++ b/src/shell_cmds/Makefile
@@ -59,7 +59,7 @@ dirname/dirname: dirname/dirname.c
 	cc $(CFLAGS) -o $@ dirname/dirname.c
 # env: env.c + envopts.c (multi-source).
 env/env: env/env.c env/envopts.c
-	cc $(CFLAGS) -o $@ env/env.c env/envopts.c
+	cc $(CFLAGS) -o $@ env/env.c env/envopts.c -lutil
 getopt/getopt: getopt/getopt.c
 	cc $(CFLAGS) -o $@ getopt/getopt.c
 hostname/hostname: hostname/hostname.c

--- a/src/shell_cmds/Makefile
+++ b/src/shell_cmds/Makefile
@@ -54,7 +54,7 @@ basename/basename: basename/basename.c
 # Most are pure libc; jot/seq use libm; printf may use libxo (Apple
 # extension — skip if causes issues).
 apply/apply: apply/apply.c
-	cc $(CFLAGS) -o $@ apply/apply.c
+	cc $(CFLAGS) -o $@ apply/apply.c -lsbuf
 dirname/dirname: dirname/dirname.c
 	cc $(CFLAGS) -o $@ dirname/dirname.c
 # env: env.c + envopts.c (multi-source).


### PR DESCRIPTION
## Summary

Closes #112 iter 2. Extends iter 1's 5-tool leaf set (PR #123) with 20 more shell_cmds binaries:

| Install path | Tools |
|---|---|
| /bin | echo, sleep (iter 1) + **hostname**, **kill**, **pwd**, **realpath** |
| /usr/bin | true, false, basename (iter 1) + **apply**, **dirname**, **env**, **getopt**, **jot**, **logname**, **mktemp**, **nice**, **nohup**, **printenv**, **printf**, **renice**, **tee**, **uname**, **what**, **yes** |

**Total: 25 binaries overlaid** (up from 5).

## Preemptive shim

Added `-D__dead=__dead2` to global CFLAGS (Apple uses NetBSD-ism `__dead` for non-returning functions; FreeBSD has `__dead2`). Same fix as file_cmds iter 2 mknod — applied repo-wide here so it doesn't surface per-tool during iteration.

## Iter 3+ remaining

The shell_cmds work that still needs doing:

- **/bin/sh** — load-bearing shell swap; multi-source; high risk
- **/usr/bin/id** — needs `libopendirectory` no-op shim
- **/usr/bin/su** — needs BSM audit stub
- **/usr/bin/killall** — needs `KERN_PROCARGS2` for full-argv match
- **/usr/bin/path_helper** — reads /etc/paths + /etc/paths.d/ to build PATH
- **Multi-source** remaining: date (date.c + vary.c), expr, find, hexdump, lastcomm, locate, script, w, who, xargs
- **Other** remaining: alias (shell), shlock, stdbuf, test, time, tty, users, whereis, which, systime

## Test plan

- [ ] CI boot-test green
- [ ] SHELLCMD-LEAF-OK marker reports 25/25 + functional probes (true=0, false=non-zero, echo round-trips, printf format string works, jot single-value works)
- [ ] All 25 Apple binaries land at canonical paths
- [ ] No regression in any prior marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)