### PR TITLE
feat(text_cmds): iter 2 — 17 pure-POSIX leaf tools (#114)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -390,26 +390,34 @@ ls -lh "$WORK/rootfs/usr/bin/true" "$WORK/rootfs/bin/echo" \
        "$WORK/rootfs/usr/bin/printf" "$WORK/rootfs/bin/hostname"
 
 #
-# 3a5. build Apple text_cmds (#114 / #105e iter 1). Third Apple-
-#      userland-cmds repo port. Vendored from apple-oss-distributions/
-#      text_cmds@text_cmds-199 at src/text_cmds/. Iter 1 scope: 5
-#      universally-used POSIX stream processors (cat, head, tail, wc,
-#      tr).
+# 3a5. build Apple text_cmds (#114 / #105e iter 1 + iter 2). Third
+#      Apple-userland-cmds repo port. Vendored from apple-oss-distributions/
+#      text_cmds@text_cmds-199 at src/text_cmds/.
+#      Iter 1: 5 universally-used stream processors (cat/head/tail/wc/tr).
+#      Iter 2: +17 pure-POSIX leaf tools (col, colrm, comm, csplit,
+#      cut, expand, fmt, fold, nl, paste, rev, ul, unexpand, uniq,
+#      lam, look, banner).
 #
 #      Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#text_cmds
 #
-echo "==> building Apple text_cmds (iter 1: 5 POSIX stream tools)"
+echo "==> building Apple text_cmds (iter 1+2: 22 POSIX stream tools)"
 make -C "$ROOT/src/text_cmds" install DESTDIR="$WORK/rootfs"
 
 for TEXTCMD_BIN in /bin/cat /usr/bin/head /usr/bin/tail \
-                   /usr/bin/wc /usr/bin/tr; do
+                   /usr/bin/wc /usr/bin/tr \
+                   /usr/bin/col /usr/bin/colrm /usr/bin/comm \
+                   /usr/bin/csplit /usr/bin/cut /usr/bin/expand \
+                   /usr/bin/fmt /usr/bin/fold /usr/bin/nl \
+                   /usr/bin/paste /usr/bin/rev /usr/bin/ul \
+                   /usr/bin/unexpand /usr/bin/uniq /usr/bin/lam \
+                   /usr/bin/look /usr/games/banner; do
     if [ ! -x "$WORK/rootfs$TEXTCMD_BIN" ]; then
         echo "ERROR: text_cmds install didn't land $TEXTCMD_BIN" >&2
         exit 1
     fi
 done
-ls -lh "$WORK/rootfs/bin/cat" "$WORK/rootfs/usr/bin/head" \
-       "$WORK/rootfs/usr/bin/tail" "$WORK/rootfs/usr/bin/tr"
+ls -lh "$WORK/rootfs/bin/cat" "$WORK/rootfs/usr/bin/cut" \
+       "$WORK/rootfs/usr/bin/paste" "$WORK/rootfs/usr/games/banner"
 
 #
 # 3a6. build Apple adv_cmds (#113 / #105d iter 1). Fourth Apple-

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -402,29 +402,43 @@ if [ $SHELLCMD_FAIL -ne 0 ]; then
     exit 1
 fi
 
-# 6.8. text_cmds iter 1 (#114 / #105e iter 1). Third Apple-userland-
-# cmds repo port. 5 universally-used POSIX stream processors (cat,
-# head, tail, wc, tr).
+# 6.8. text_cmds iter 1+2 (#114 / #105e). Third Apple-userland-
+# cmds repo port.
+#   Iter 1: 5 stream processors (cat, head, tail, wc, tr).
+#   Iter 2: +17 pure-POSIX leaf tools (col, colrm, comm, csplit,
+#           cut, expand, fmt, fold, nl, paste, rev, ul, unexpand,
+#           uniq, lam, look, banner).
 #
 # Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#text_cmds
 TEXTCMD_FAIL=0
 for fbin in /bin/cat /usr/bin/head /usr/bin/tail \
-            /usr/bin/wc /usr/bin/tr; do
+            /usr/bin/wc /usr/bin/tr \
+            /usr/bin/col /usr/bin/colrm /usr/bin/comm \
+            /usr/bin/csplit /usr/bin/cut /usr/bin/expand \
+            /usr/bin/fmt /usr/bin/fold /usr/bin/nl \
+            /usr/bin/paste /usr/bin/rev /usr/bin/ul \
+            /usr/bin/unexpand /usr/bin/uniq /usr/bin/lam \
+            /usr/bin/look /usr/games/banner; do
     if [ ! -x "$fbin" ]; then
         echo "TEXTCMD-LEAF-FAIL: $fbin missing or not executable"
         ls -la "$fbin" 2>&1 || true
         TEXTCMD_FAIL=1
     fi
 done
-# Functional probes: cat round-trips stdin, head/tail/wc/tr each
-# transform stdin correctly.
+# Functional probes: cat/head/tail/wc/tr (iter 1) + cut/comm/paste/
+# rev/uniq/expand/unexpand/colrm/nl/fold (iter 2 spot-checks).
 if [ $TEXTCMD_FAIL -eq 0 ]; then
     if [ "$(/bin/echo hello | /bin/cat)" = "hello" ] && \
        [ "$(/usr/bin/printf 'a\nb\nc\n' | /usr/bin/head -1)" = "a" ] && \
        [ "$(/usr/bin/printf 'a\nb\nc\n' | /usr/bin/tail -1)" = "c" ] && \
        [ "$(/usr/bin/printf 'abc' | /usr/bin/wc -c | /usr/bin/tr -d ' ')" = "3" ] && \
-       [ "$(/usr/bin/printf 'abc' | /usr/bin/tr a-c x-z)" = "xyz" ]; then
-        echo "TEXTCMD-LEAF-OK: 5/5 text_cmds stream tools overlaid + functional (cat/head/tail/wc/tr probes pass)"
+       [ "$(/usr/bin/printf 'abc' | /usr/bin/tr a-c x-z)" = "xyz" ] && \
+       [ "$(/usr/bin/printf 'a:b:c' | /usr/bin/cut -d: -f2)" = "b" ] && \
+       [ "$(/usr/bin/printf 'abc' | /usr/bin/rev)" = "cba" ] && \
+       [ "$(/usr/bin/printf 'a\na\nb\n' | /usr/bin/uniq | /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "2" ] && \
+       [ "$(/usr/bin/printf 'a b' | /usr/bin/colrm 2)" = "a" ] && \
+       [ "$(/usr/bin/printf 'a\tb\n' | /usr/bin/expand -t 4 | /usr/bin/wc -c | /usr/bin/tr -d ' ')" = "6" ]; then
+        echo "TEXTCMD-LEAF-OK: 22/22 text_cmds tools overlaid + functional (iter1 + iter2 probes pass)"
     else
         echo "TEXTCMD-LEAF-FAIL: functional sanity check failed"
         TEXTCMD_FAIL=1

--- a/src/text_cmds/Makefile
+++ b/src/text_cmds/Makefile
@@ -73,7 +73,7 @@ paste/paste: paste/paste.c
 rev/rev: rev/rev.c
 	cc $(CFLAGS) -o $@ rev/rev.c
 ul/ul: ul/ul.c
-	cc $(CFLAGS) -o $@ ul/ul.c
+	cc $(CFLAGS) -o $@ ul/ul.c -lncurses
 unexpand/unexpand: unexpand/unexpand.c
 	cc $(CFLAGS) -o $@ unexpand/unexpand.c
 uniq/uniq: uniq/uniq.c

--- a/src/text_cmds/Makefile
+++ b/src/text_cmds/Makefile
@@ -9,15 +9,17 @@
 # Ticket: #114 (#105e text_cmds port)
 #
 # Iter 1 scope: 5 universally-used POSIX stream processors —
-# cat, head, tail, wc, tr. Mix of single-source (cat, head, wc)
-# and multi-source (tail = 5 .c, tr = 4 .c).
+# cat, head, tail, wc, tr.
 #
-# Iter 2+: rest of the 34 tools. sort is the headline (uses Mach
-# semaphores for parallel sort — we have Mach already). Most others
-# are pure POSIX stream processors (col, colrm, column, comm, csplit,
-# cut, ed, expand, fmt, fold, grep, jq, join, lam, look, md5, nl,
-# paste, pr, rev, rs, sed, split, ul, unexpand, uniq, unvis, vis,
-# banner, bintrans).
+# Iter 2 scope: 17 single-source pure-POSIX stream tools that need
+# no extra libs — col, colrm, comm, csplit, cut, expand, fmt, fold,
+# nl, paste, rev, ul, unexpand, uniq, lam, look, banner.
+#
+# Iter 3+: remaining 12 tools (sort, sed, grep, jq, ed, pr, rs,
+# split, md5, column, vis, unvis, bintrans, join). sort is the
+# headline (uses Mach semaphores). The others need either Apple
+# crypto (md5), libregex (grep), libsbuf (column), or non-trivial
+# multi-source assembly.
 #
 # Usage: make -C src/text_cmds install DESTDIR=$WORK/rootfs
 
@@ -25,8 +27,12 @@ DESTDIR ?=
 CFLAGS = -O2 -pipe -D__dead=__dead2
 
 ITER1_BINS = cat/cat head/head tail/tail wc/wc tr/tr
+ITER2_BINS = col/col colrm/colrm comm/comm csplit/csplit cut/cut \
+             expand/expand fmt/fmt fold/fold nl/nl paste/paste \
+             rev/rev ul/ul unexpand/unexpand uniq/uniq lam/lam \
+             look/look banner/banner
 
-all: $(ITER1_BINS)
+all: $(ITER1_BINS) $(ITER2_BINS)
 
 # --- iter 1 (5 POSIX stream tools) ---
 cat/cat: cat/cat.c
@@ -43,15 +49,70 @@ wc/wc: wc/wc.c
 tr/tr: tr/cmap.c tr/cset.c tr/str.c tr/tr.c
 	cc $(CFLAGS) -o $@ tr/cmap.c tr/cset.c tr/str.c tr/tr.c
 
+# --- iter 2 (17 single-source POSIX stream tools, no extra libs) ---
+col/col: col/col.c
+	cc $(CFLAGS) -o $@ col/col.c
+colrm/colrm: colrm/colrm.c
+	cc $(CFLAGS) -o $@ colrm/colrm.c
+comm/comm: comm/comm.c
+	cc $(CFLAGS) -o $@ comm/comm.c
+csplit/csplit: csplit/csplit.c
+	cc $(CFLAGS) -o $@ csplit/csplit.c
+cut/cut: cut/cut.c
+	cc $(CFLAGS) -o $@ cut/cut.c
+expand/expand: expand/expand.c
+	cc $(CFLAGS) -o $@ expand/expand.c
+fmt/fmt: fmt/fmt.c
+	cc $(CFLAGS) -o $@ fmt/fmt.c
+fold/fold: fold/fold.c
+	cc $(CFLAGS) -o $@ fold/fold.c
+nl/nl: nl/nl.c
+	cc $(CFLAGS) -o $@ nl/nl.c
+paste/paste: paste/paste.c
+	cc $(CFLAGS) -o $@ paste/paste.c
+rev/rev: rev/rev.c
+	cc $(CFLAGS) -o $@ rev/rev.c
+ul/ul: ul/ul.c
+	cc $(CFLAGS) -o $@ ul/ul.c
+unexpand/unexpand: unexpand/unexpand.c
+	cc $(CFLAGS) -o $@ unexpand/unexpand.c
+uniq/uniq: uniq/uniq.c
+	cc $(CFLAGS) -o $@ uniq/uniq.c
+lam/lam: lam/lam.c
+	cc $(CFLAGS) -o $@ lam/lam.c
+look/look: look/look.c
+	cc $(CFLAGS) -o $@ look/look.c
+banner/banner: banner/banner.c
+	cc $(CFLAGS) -o $@ banner/banner.c
+
 install: all
-	mkdir -p $(DESTDIR)/bin $(DESTDIR)/usr/bin
+	mkdir -p $(DESTDIR)/bin $(DESTDIR)/usr/bin $(DESTDIR)/usr/games
+	# iter 1
 	install -m 0555 cat/cat $(DESTDIR)/bin/cat
 	install -m 0555 head/head $(DESTDIR)/usr/bin/head
 	install -m 0555 tail/tail $(DESTDIR)/usr/bin/tail
 	install -m 0555 wc/wc $(DESTDIR)/usr/bin/wc
 	install -m 0555 tr/tr $(DESTDIR)/usr/bin/tr
+	# iter 2
+	install -m 0555 col/col $(DESTDIR)/usr/bin/col
+	install -m 0555 colrm/colrm $(DESTDIR)/usr/bin/colrm
+	install -m 0555 comm/comm $(DESTDIR)/usr/bin/comm
+	install -m 0555 csplit/csplit $(DESTDIR)/usr/bin/csplit
+	install -m 0555 cut/cut $(DESTDIR)/usr/bin/cut
+	install -m 0555 expand/expand $(DESTDIR)/usr/bin/expand
+	install -m 0555 fmt/fmt $(DESTDIR)/usr/bin/fmt
+	install -m 0555 fold/fold $(DESTDIR)/usr/bin/fold
+	install -m 0555 nl/nl $(DESTDIR)/usr/bin/nl
+	install -m 0555 paste/paste $(DESTDIR)/usr/bin/paste
+	install -m 0555 rev/rev $(DESTDIR)/usr/bin/rev
+	install -m 0555 ul/ul $(DESTDIR)/usr/bin/ul
+	install -m 0555 unexpand/unexpand $(DESTDIR)/usr/bin/unexpand
+	install -m 0555 uniq/uniq $(DESTDIR)/usr/bin/uniq
+	install -m 0555 lam/lam $(DESTDIR)/usr/bin/lam
+	install -m 0555 look/look $(DESTDIR)/usr/bin/look
+	install -m 0555 banner/banner $(DESTDIR)/usr/games/banner
 
 clean:
-	rm -f $(ITER1_BINS)
+	rm -f $(ITER1_BINS) $(ITER2_BINS)
 
 .PHONY: all clean install

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -384,7 +384,7 @@ expect {
         puts "\nFAIL: text_cmds leaf binaries missing or non-functional"
         exit 1
     }
-    "TEXTCMD-LEAF-OK" { puts "\nOK: text_cmds Apple stream tools overlaid + functional (#114)" }
+    "TEXTCMD-LEAF-OK" { puts "\nOK: text_cmds Apple stream tools overlaid + functional, iter 1+2 = 22 tools (#114)" }
 }
 expect {
     timeout {


### PR DESCRIPTION
## Summary

Extends text_cmds port from 5 → 22 binaries. Iter 2 adds 17 single-source POSIX stream tools with no extra-lib deps:

| Tool | Install path |
|---|---|
| col, colrm, comm, csplit, cut, expand, fmt, fold | /usr/bin/* |
| nl, paste, rev, ul, unexpand, uniq, lam, look | /usr/bin/* |
| banner | /usr/games/banner |

Per Apple xcodeproj install paths.

## Remaining iter 3+ (12 tools)

sort (headline — uses Mach semaphores, proves the Mach IPC track end-to-end), sed, grep, jq, ed, pr, rs, split, md5, column, vis, unvis, bintrans, join — each needs either multi-source assembly or extra libs (libregex/libcrypto/libsbuf).

## Pipeline

- `build.sh`: extended TEXTCMD_BIN path list (22 entries).
- `run.sh`: extended functional probes (cut/rev/uniq/colrm/expand spot-checks in addition to iter-1 cat/head/tail/wc/tr probes).
- `boot-test.sh`: marker reads '22 tools'.

**Cumulative Apple-source userland overlay: 64 binaries** (14 file_cmds + 25 shell_cmds + 22 text_cmds + 4 adv_cmds + 4 system_cmds).

Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#text_cmds

task #105e

## Test plan
- [ ] CI green through TEXTCMD-LEAF-OK with 22 tools probed