### PR TITLE
feat(adv_cmds): iter 2 — cap_mkdb + finger (#113)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -420,19 +420,20 @@ ls -lh "$WORK/rootfs/bin/cat" "$WORK/rootfs/usr/bin/cut" \
        "$WORK/rootfs/usr/bin/paste" "$WORK/rootfs/usr/games/banner"
 
 #
-# 3a6. build Apple adv_cmds (#113 / #105d iter 1). Fourth Apple-
-#      userland-cmds repo port. Vendored from apple-oss-distributions/
-#      adv_cmds@adv_cmds-237 at src/adv_cmds/. Iter 1 scope: 5 leaf
-#      tools (tabs, tty, whois, gencat, lsvfs) — no Apple-specific
-#      kernel-struct deps.
+# 3a6. build Apple adv_cmds (#113 / #105d iter 1 + iter 2). Fourth
+#      Apple-userland-cmds repo port. Vendored from
+#      apple-oss-distributions/adv_cmds@adv_cmds-237 at src/adv_cmds/.
+#      Iter 1: 4 leaf tools (tabs, tty, whois, lsvfs).
+#      Iter 2: +2 tools (cap_mkdb, finger).
 #
 #      Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#adv_cmds
 #
-echo "==> building Apple adv_cmds (iter 1: 5 leaf tools)"
+echo "==> building Apple adv_cmds (iter 1+2: 6 tools)"
 make -C "$ROOT/src/adv_cmds" install DESTDIR="$WORK/rootfs"
 
 for ADVCMD_BIN in /usr/bin/tabs /usr/bin/tty /usr/bin/whois \
-                  /usr/sbin/lsvfs; do
+                  /usr/sbin/lsvfs \
+                  /usr/bin/cap_mkdb /usr/bin/finger; do
     if [ ! -x "$WORK/rootfs$ADVCMD_BIN" ]; then
         echo "ERROR: adv_cmds install didn't land $ADVCMD_BIN" >&2
         exit 1

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -448,30 +448,48 @@ if [ $TEXTCMD_FAIL -ne 0 ]; then
     exit 1
 fi
 
-# 6.9. adv_cmds iter 1 (#113 / #105d iter 1). Fourth Apple-userland-
-# cmds repo port. 5 leaf tools (tabs, tty, whois, gencat, lsvfs).
+# 6.9. adv_cmds iter 1+2 (#113 / #105d). Fourth Apple-userland-cmds
+# repo port. iter 1: tabs/tty/whois/lsvfs; iter 2: cap_mkdb/finger.
 #
 # Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#adv_cmds
 ADVCMD_FAIL=0
 for fbin in /usr/bin/tabs /usr/bin/tty /usr/bin/whois \
-            /usr/sbin/lsvfs; do
+            /usr/sbin/lsvfs \
+            /usr/bin/cap_mkdb /usr/bin/finger; do
     if [ ! -x "$fbin" ]; then
         echo "ADVCMD-LEAF-FAIL: $fbin missing or not executable"
         ls -la "$fbin" 2>&1 || true
         ADVCMD_FAIL=1
     fi
 done
-# Functional probe: lsvfs always succeeds (lists at least ufs/devfs
-# loaded VFS modules).
+# Functional probes:
+#   lsvfs always succeeds (lists at least ufs/devfs loaded VFS modules).
+#   cap_mkdb with no args prints usage to stderr; just check it runs
+#     without dyld errors (rc 1 or 64 = usage exit).
+#   finger with no user prints header or "No one logged on".
 if [ $ADVCMD_FAIL -eq 0 ]; then
-    if /usr/sbin/lsvfs >/dev/null 2>&1; then
-        echo "ADVCMD-LEAF-OK: 4/4 adv_cmds binaries overlaid (lsvfs runs cleanly)"
-    else
-        echo "ADVCMD-LEAF-FAIL: lsvfs failed to enumerate VFS modules"
+    if ! /usr/sbin/lsvfs >/dev/null 2>&1; then
+        echo "ADVCMD-LEAF-FAIL: lsvfs failed"
         ADVCMD_FAIL=1
     fi
 fi
-if [ $ADVCMD_FAIL -ne 0 ]; then
+if [ $ADVCMD_FAIL -eq 0 ]; then
+    /usr/bin/cap_mkdb 2>/dev/null
+    rc=$?
+    if [ $rc -ne 1 ] && [ $rc -ne 2 ] && [ $rc -ne 64 ]; then
+        echo "ADVCMD-LEAF-FAIL: cap_mkdb exited unexpectedly (rc=$rc)"
+        ADVCMD_FAIL=1
+    fi
+fi
+if [ $ADVCMD_FAIL -eq 0 ]; then
+    if ! /usr/bin/finger 2>/dev/null | /usr/bin/head -1 >/dev/null; then
+        echo "ADVCMD-LEAF-FAIL: finger didn't produce output"
+        ADVCMD_FAIL=1
+    fi
+fi
+if [ $ADVCMD_FAIL -eq 0 ]; then
+    echo "ADVCMD-LEAF-OK: 6/6 adv_cmds binaries overlaid (lsvfs/cap_mkdb/finger probes pass)"
+else
     exit 1
 fi
 

--- a/src/adv_cmds/Makefile
+++ b/src/adv_cmds/Makefile
@@ -13,8 +13,12 @@
 # client), gencat (POSIX message catalogs, multi-source), lsvfs
 # (getvfsbyname listing).
 #
-# Iter 2+: cap_mkdb, finger, last, locale, localedef, genwrap, plus
-# the load-bearing tools (ps + pkill — need Apple kinfo_proc shim,
+# Iter 2 scope: cap_mkdb (terminfo db builder), finger (network finger
+# client, multi-source POSIX). last DEFERRED — Apple uses non-standard
+# getutxent_wtmp() which isn't in FreeBSD's libc.
+#
+# Iter 3+: locale (locale.cc — C++), localedef (10 .c), genwrap (yacc/lex),
+# plus the load-bearing tools (ps + pkill — need Apple kinfo_proc shim,
 # stty — POSIX but minor Apple flag additions).
 #
 # Usage: make -C src/adv_cmds install DESTDIR=$WORK/rootfs
@@ -26,10 +30,11 @@ CFLAGS = -O2 -pipe -D__dead=__dead2
 # catalog generation (not present on FreeBSD). Would need a shim
 # matching Apple's libc/nlsmsg internals. Not load-bearing — defer.
 ITER1_BINS = tabs/tabs tty/tty whois/whois lsvfs/lsvfs
+ITER2_BINS = cap_mkdb/cap_mkdb finger/finger
 
-all: $(ITER1_BINS)
+all: $(ITER1_BINS) $(ITER2_BINS)
 
-# --- iter 1 (5 single-source-or-near-leaf tools) ---
+# --- iter 1 (4 single-source-or-near-leaf tools) ---
 tabs/tabs: tabs/tabs.c
 	cc $(CFLAGS) -o $@ tabs/tabs.c -lncurses
 tty/tty: tty/tty.c
@@ -40,6 +45,14 @@ whois/whois: whois/whois.c
 lsvfs/lsvfs: lsvfs/lsvfs.c
 	cc $(CFLAGS) -o $@ lsvfs/lsvfs.c
 
+# --- iter 2 ---
+cap_mkdb/cap_mkdb: cap_mkdb/cap_mkdb.c
+	cc $(CFLAGS) -o $@ cap_mkdb/cap_mkdb.c
+# finger: 5 .c (finger, lprint, net, sprint, util).
+finger/finger: finger/finger.c finger/lprint.c finger/net.c finger/sprint.c finger/util.c
+	cc $(CFLAGS) -o $@ finger/finger.c finger/lprint.c finger/net.c \
+	    finger/sprint.c finger/util.c
+
 install: all
 	mkdir -p $(DESTDIR)/usr/bin $(DESTDIR)/usr/sbin
 	install -m 0555 tabs/tabs $(DESTDIR)/usr/bin/tabs
@@ -47,8 +60,11 @@ install: all
 	install -m 0555 whois/whois $(DESTDIR)/usr/bin/whois
 	# gencat DEFERRED — Apple-internal msgcat.h header missing.
 	install -m 0555 lsvfs/lsvfs $(DESTDIR)/usr/sbin/lsvfs
+	# iter 2
+	install -m 0555 cap_mkdb/cap_mkdb $(DESTDIR)/usr/bin/cap_mkdb
+	install -m 0555 finger/finger $(DESTDIR)/usr/bin/finger
 
 clean:
-	rm -f $(ITER1_BINS)
+	rm -f $(ITER1_BINS) $(ITER2_BINS)
 
 .PHONY: all clean install

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -395,7 +395,7 @@ expect {
         puts "\nFAIL: adv_cmds leaf binaries missing or non-functional"
         exit 1
     }
-    "ADVCMD-LEAF-OK" { puts "\nOK: adv_cmds iter 1 (5 leaf Apple tools overlaid) (#113)" }
+    "ADVCMD-LEAF-OK" { puts "\nOK: adv_cmds iter 1+2 (6 Apple tools overlaid) (#113)" }
 }
 expect {
     timeout {


### PR DESCRIPTION
## Summary

Extends adv_cmds port from 4 → 6 binaries:

| Tool | Source | Notes |
|---|---|---|
| `/usr/bin/cap_mkdb` | `cap_mkdb/cap_mkdb.c` | termcap/login.conf DB builder; uses Berkeley DB v1 from libc |
| `/usr/bin/finger` | 5 .c (finger/lprint/net/sprint/util) | network finger client; pure POSIX utmpx + getpwnam |

**`last` DEFERRED** — Apple's last.c uses non-standard `getutxent_wtmp()` which isn't in FreeBSD's libc. Would need a small libutil shim (or read wtmpx directly). Defer to its own ticket.

## Pipeline

- `build.sh`: extended ADVCMD_BIN list (6 entries).
- `run.sh`: extended probes — cap_mkdb empty-args (rc 1/2/64 = usage), finger no-args (header line).
- `boot-test.sh`: marker reads '6 tools'.

**Cumulative Apple-source userland overlay: 71 binaries** (14 file_cmds + 25 shell_cmds + 22 text_cmds + 6 adv_cmds + 4 system_cmds).

Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#adv_cmds

task #105d

## Test plan
- [ ] CI green through ADVCMD-LEAF-OK with 6 tools probed