### PR TITLE
feat(shell_cmds): iter 3 — 11 more leaf tools + od/[ links (#112)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -369,7 +369,7 @@ ls -lh "$WORK/rootfs/bin/chflags" "$WORK/rootfs/bin/rm" \
 #
 #      Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#shell_cmds
 #
-echo "==> building Apple shell_cmds (iter 2: 25 single-source POSIX tools)"
+echo "==> building Apple shell_cmds (iter 1+2+3: 36 POSIX tools)"
 make -C "$ROOT/src/shell_cmds" install DESTDIR="$WORK/rootfs"
 
 for SHELLCMD_BIN in /usr/bin/true /usr/bin/false \
@@ -380,7 +380,11 @@ for SHELLCMD_BIN in /usr/bin/true /usr/bin/false \
                     /usr/bin/nice /usr/bin/nohup /usr/bin/printenv \
                     /usr/bin/printf /bin/pwd /bin/realpath \
                     /usr/bin/renice /usr/bin/tee /usr/bin/uname \
-                    /usr/bin/what /usr/bin/yes; do
+                    /usr/bin/what /usr/bin/yes \
+                    /usr/sbin/chroot /bin/date /usr/bin/hexdump \
+                    /usr/bin/od /usr/bin/lockf /usr/bin/script \
+                    /usr/bin/shlock /usr/bin/stdbuf /bin/test "/bin/[" \
+                    /usr/bin/whereis /usr/bin/which /usr/bin/xargs; do
     if [ ! -x "$WORK/rootfs$SHELLCMD_BIN" ]; then
         echo "ERROR: shell_cmds install didn't land $SHELLCMD_BIN" >&2
         exit 1

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -364,8 +364,11 @@ if [ $FILECMD_FAIL -ne 0 ]; then
     exit 1
 fi
 
-# 6.7. shell_cmds iter 2 (#112 / #105c iter 2). Extends iter 1's
-# 5-binary leaf set to 25 single-source POSIX tools.
+# 6.7. shell_cmds iter 1+2+3 (#112 / #105c). Extends to 36 tools.
+#   Iter 1: true/false/echo/sleep/basename.
+#   Iter 2: 20 more POSIX tools.
+#   Iter 3: +11 more (chroot, date, hexdump, lockf, script, shlock,
+#           stdbuf, test, whereis, which, xargs) + 'od' link + '[' link.
 #
 # Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#shell_cmds
 SHELLCMD_FAIL=0
@@ -377,22 +380,34 @@ for fbin in /usr/bin/true /usr/bin/false /bin/echo /bin/sleep \
             /usr/bin/nice /usr/bin/nohup /usr/bin/printenv \
             /usr/bin/printf /bin/pwd /bin/realpath \
             /usr/bin/renice /usr/bin/tee /usr/bin/uname \
-            /usr/bin/what /usr/bin/yes; do
+            /usr/bin/what /usr/bin/yes \
+            /usr/sbin/chroot /bin/date /usr/bin/hexdump \
+            /usr/bin/od /usr/bin/lockf /usr/bin/script \
+            /usr/bin/shlock /usr/bin/stdbuf /bin/test /bin/[ \
+            /usr/bin/whereis /usr/bin/which /usr/bin/xargs; do
     if [ ! -x "$fbin" ]; then
         echo "SHELLCMD-LEAF-FAIL: $fbin missing or not executable"
         ls -la "$fbin" 2>&1 || true
         SHELLCMD_FAIL=1
     fi
 done
-# Functional sanity: true returns 0, false returns non-zero, echo
-# round-trips a string. Plus iter-2 spot checks for tools with more
-# complex code paths.
+# Functional sanity: iter-1/2 probes plus iter-3 spot checks.
+#   date — prints a year that looks like 20xx.
+#   hexdump — hex-dumps a 1-char input cleanly.
+#   test — [ 1 -lt 2 ] returns 0.
+#   xargs — echo via xargs round-trips.
+#   which — finds /bin/sh.
 if [ $SHELLCMD_FAIL -eq 0 ]; then
     if /usr/bin/true && ! /usr/bin/false && \
        [ "$(/bin/echo hello)" = "hello" ] && \
        [ "$(/usr/bin/printf 'x%s' yz)" = "xyz" ] && \
-       [ "$(/usr/bin/jot 1 5)" = "5" ]; then
-        echo "SHELLCMD-LEAF-OK: 25/25 shell_cmds binaries overlaid + functional (true/false/echo/printf/jot probes pass)"
+       [ "$(/usr/bin/jot 1 5)" = "5" ] && \
+       /bin/date +%Y | /usr/bin/grep -qE '^20[0-9][0-9]$' && \
+       [ "$(/bin/echo -n A | /usr/bin/hexdump -e '"%02x"')" = "41" ] && \
+       /bin/[ 1 -lt 2 ] && \
+       [ "$(/bin/echo hello | /usr/bin/xargs /bin/echo)" = "hello" ] && \
+       [ -n "$(/usr/bin/which sh)" ]; then
+        echo "SHELLCMD-LEAF-OK: 36/36 shell_cmds binaries overlaid + functional (iter1+2+3 probes pass)"
     else
         echo "SHELLCMD-LEAF-FAIL: functional sanity check failed"
         SHELLCMD_FAIL=1

--- a/src/shell_cmds/Makefile
+++ b/src/shell_cmds/Makefile
@@ -35,8 +35,11 @@ ITER2_BINS = apply/apply dirname/dirname env/env getopt/getopt \
              mktemp/mktemp nice/nice nohup/nohup printenv/printenv \
              printf/printf pwd/pwd realpath/realpath renice/renice \
              tee/tee uname/uname what/what yes/yes
+ITER3_BINS = chroot/chroot date/date hexdump/hexdump lockf/lockf \
+             script/script shlock/shlock stdbuf/stdbuf test/test \
+             whereis/whereis which/which xargs/xargs
 
-all: $(ITER1_BINS) $(ITER2_BINS)
+all: $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
 
 # --- iter 1 (single-source pure-POSIX leaf tools) ---
 true/true: true/true.c
@@ -96,6 +99,39 @@ what/what: what/what.c
 yes/yes: yes/yes.c
 	cc $(CFLAGS) -o $@ yes/yes.c
 
+# --- iter 3 ---
+chroot/chroot: chroot/chroot.c
+	cc $(CFLAGS) -o $@ chroot/chroot.c
+# date: date.c + vary.c
+date/date: date/date.c date/vary.c
+	cc $(CFLAGS) -o $@ date/date.c date/vary.c
+# hexdump: 6 .c (conv, display, hexdump, hexsyntax, odsyntax, parse).
+# Also produces /usr/bin/od as a hardlink.
+hexdump/hexdump: hexdump/conv.c hexdump/display.c hexdump/hexdump.c \
+                 hexdump/hexsyntax.c hexdump/odsyntax.c hexdump/parse.c
+	cc $(CFLAGS) -o $@ hexdump/conv.c hexdump/display.c \
+	    hexdump/hexdump.c hexdump/hexsyntax.c hexdump/odsyntax.c \
+	    hexdump/parse.c
+lockf/lockf: lockf/lockf.c
+	cc $(CFLAGS) -o $@ lockf/lockf.c
+# script: needs libutil (openpty/login_tty).
+script/script: script/script.c
+	cc $(CFLAGS) -o $@ script/script.c -lutil
+shlock/shlock: shlock/shlock.c
+	cc $(CFLAGS) -o $@ shlock/shlock.c
+stdbuf/stdbuf: stdbuf/stdbuf.c
+	cc $(CFLAGS) -o $@ stdbuf/stdbuf.c
+# test: single-source; also produces `[` as a hardlink.
+test/test: test/test.c
+	cc $(CFLAGS) -o $@ test/test.c
+whereis/whereis: whereis/whereis.c
+	cc $(CFLAGS) -o $@ whereis/whereis.c
+which/which: which/which.c
+	cc $(CFLAGS) -o $@ which/which.c
+# xargs: xargs.c + strnsubst.c
+xargs/xargs: xargs/xargs.c xargs/strnsubst.c
+	cc $(CFLAGS) -o $@ xargs/xargs.c xargs/strnsubst.c
+
 install: all
 	mkdir -p $(DESTDIR)/bin $(DESTDIR)/usr/bin
 	# iter 1
@@ -125,8 +161,23 @@ install: all
 	install -m 0555 uname/uname $(DESTDIR)/usr/bin/uname
 	install -m 0555 what/what $(DESTDIR)/usr/bin/what
 	install -m 0555 yes/yes $(DESTDIR)/usr/bin/yes
+	# iter 3
+	mkdir -p $(DESTDIR)/usr/sbin
+	install -m 0555 chroot/chroot $(DESTDIR)/usr/sbin/chroot
+	install -m 0555 date/date $(DESTDIR)/bin/date
+	install -m 0555 hexdump/hexdump $(DESTDIR)/usr/bin/hexdump
+	ln -f $(DESTDIR)/usr/bin/hexdump $(DESTDIR)/usr/bin/od
+	install -m 0555 lockf/lockf $(DESTDIR)/usr/bin/lockf
+	install -m 0555 script/script $(DESTDIR)/usr/bin/script
+	install -m 0555 shlock/shlock $(DESTDIR)/usr/bin/shlock
+	install -m 0555 stdbuf/stdbuf $(DESTDIR)/usr/bin/stdbuf
+	install -m 0555 test/test $(DESTDIR)/bin/test
+	ln -f $(DESTDIR)/bin/test $(DESTDIR)/bin/[
+	install -m 0555 whereis/whereis $(DESTDIR)/usr/bin/whereis
+	install -m 0555 which/which $(DESTDIR)/usr/bin/which
+	install -m 0555 xargs/xargs $(DESTDIR)/usr/bin/xargs
 
 clean:
-	rm -f $(ITER1_BINS) $(ITER2_BINS)
+	rm -f $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
 
 .PHONY: all clean install

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -373,7 +373,7 @@ expect {
         puts "\nFAIL: shell_cmds leaf binaries missing or non-functional"
         exit 1
     }
-    "SHELLCMD-LEAF-OK" { puts "\nOK: shell_cmds Apple binaries overlaid + functional (#112)" }
+    "SHELLCMD-LEAF-OK" { puts "\nOK: shell_cmds Apple binaries overlaid + functional, iter 1+2+3 = 36 tools (#112)" }
 }
 expect {
     timeout {


### PR DESCRIPTION
## Summary

Extends shell_cmds port from 25 → 36 binaries.

| Tool | Path | Source |
|---|---|---|
| chroot | /usr/sbin/chroot | chroot.c |
| date | /bin/date | date.c + vary.c |
| hexdump + od | /usr/bin/hexdump, /usr/bin/od (link) | 6 .c |
| lockf | /usr/bin/lockf | lockf.c |
| script | /usr/bin/script | script.c (-lutil for openpty/login_tty) |
| shlock | /usr/bin/shlock | shlock.c |
| stdbuf | /usr/bin/stdbuf | stdbuf.c |
| test + [ | /bin/test, /bin/[ (link) | test.c |
| whereis | /usr/bin/whereis | whereis.c |
| which | /usr/bin/which | which.c |
| xargs | /usr/bin/xargs | xargs.c + strnsubst.c |

## Remaining iter 4+ (deferred)

- **Open Directory**: id (libopendirectory shim).
- **BSM-audit**: su.
- **Apple kernel-struct**: killall (KERN_PROCARGS2).
- **Apple-specific**: path_helper, systime, time (Apple sysctls), lastcomm (accton format).
- **Larger ports**: find (7 .c), sh (full Bourne shell), expr/locate (script wrappers), w/who/users (utmpx + KERN_PROC).
- **Trivial-but-conflicts**: alias (sh builtin only).

## Pipeline

- `build.sh`: 36-entry SHELLCMD_BIN list (incl. od + \`[\`).
- `run.sh`: extended probes — date prints 20xx year, hexdump -e of 'A' → '41', \`[ 1 -lt 2 ]\`, xargs round-trip, which sh.
- `boot-test.sh`: marker reads '36 tools'.

**Cumulative Apple-source userland overlay: 86 binaries** (14 file_cmds + 36 shell_cmds + 22 text_cmds + 6 adv_cmds + 8 system_cmds).

Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#shell_cmds

task #105c

## Test plan
- [ ] CI green through SHELLCMD-LEAF-OK with 36 tools probed