### PR TITLE
feat(file_cmds): iter 3 — stat + chown + df (#111)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -333,11 +333,11 @@ ls -lh "$WORK/rootfs/sbin/kldload" "$WORK/rootfs/sbin/mount" \
 #
 #      Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#file_cmds
 #
-echo "==> building Apple file_cmds (iter 2: 16 pure-POSIX tools)"
+echo "==> building Apple file_cmds (iter 1+2+3: 17 tools)"
 make -C "$ROOT/src/file_cmds" install DESTDIR="$WORK/rootfs"
 
-# Confirm Apple binaries are present (iter 1 + iter 2). Apple's
-# file_cmds strings contain "Apple Computer" or apple-source
+# Confirm Apple binaries are present (iter 1 + iter 2 + iter 3).
+# Apple's file_cmds strings contain "Apple Computer" or apple-source
 # __APPLE__ guards; FreeBSD's same tools have "FreeBSD" + __FBSDID
 # variants. Boot-test marker probes binary identity for one
 # representative (chflags); per-path existence check here covers
@@ -347,7 +347,8 @@ for FILECMD_BIN in /bin/chflags /bin/mkdir /bin/mkfifo /bin/rmdir \
                    /bin/dd /bin/ln /bin/rm \
                    /usr/bin/cksum /usr/bin/compress \
                    /sbin/mknod /usr/bin/shar \
-                   /usr/bin/touch /usr/bin/truncate; do
+                   /usr/bin/touch /usr/bin/truncate \
+                   /usr/bin/stat /usr/sbin/chown /bin/df; do
     if [ ! -x "$WORK/rootfs$FILECMD_BIN" ]; then
         echo "ERROR: file_cmds install didn't land $FILECMD_BIN" >&2
         exit 1

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -330,7 +330,8 @@ for fbin in /bin/chflags /bin/mkdir /bin/mkfifo /bin/rmdir \
             /usr/bin/pathchk \
             /bin/dd /bin/ln /bin/rm \
             /usr/bin/cksum /usr/bin/compress \
-            /sbin/mknod /usr/bin/touch /usr/bin/truncate; do
+            /sbin/mknod /usr/bin/touch /usr/bin/truncate \
+            /usr/bin/stat /usr/sbin/chown /bin/df; do
     if [ ! -x "$fbin" ]; then
         echo "FILECMD-LEAF-FAIL: $fbin missing or not executable"
         ls -la "$fbin" 2>&1 || true
@@ -349,11 +350,11 @@ fi
 # from "FreeBSD-runtime's chflags is still in place."
 if [ $FILECMD_FAIL -eq 0 ]; then
     if strings /bin/chflags 2>/dev/null | grep -qi 'apple computer\|copyright.*apple\|opensource'; then
-        echo "FILECMD-LEAF-OK: 14/14 file_cmds binaries overlaid; /bin/chflags identifies as Apple's"
+        echo "FILECMD-LEAF-OK: 17/17 file_cmds binaries overlaid; /bin/chflags identifies as Apple's"
     else
         # Fall back: at minimum check that chflags works.
         if /bin/chflags 2>&1 | grep -q 'usage'; then
-            echo "FILECMD-LEAF-OK: 14/14 file_cmds binaries present; chflags responds to invocation (Apple identity not verifiable in strings — informational)"
+            echo "FILECMD-LEAF-OK: 17/17 file_cmds binaries present; chflags responds to invocation (Apple identity not verifiable in strings — informational)"
         else
             echo "FILECMD-LEAF-FAIL: chflags doesn't respond to invocation"
             FILECMD_FAIL=1

--- a/src/file_cmds/Makefile
+++ b/src/file_cmds/Makefile
@@ -123,7 +123,7 @@ chown/chown: chown/chown.c
 # df: -lutil for humanize_number, -lxo for libxo. Apple-only paths
 # (getattrlist) are #ifdef __APPLE__-guarded.
 df/df: df/df.c
-	cc $(CFLAGS) -o $@ df/df.c -lutil -lxo
+	cc $(CFLAGS) -o $@ df/df.c -lutil -lxo -lm
 
 # shar is a shell script (no compile); install handled below.
 

--- a/src/file_cmds/Makefile
+++ b/src/file_cmds/Makefile
@@ -38,8 +38,20 @@ ITER1_BINS = chflags/chflags mkdir/mkdir mkfifo/mkfifo rmdir/rmdir \
 ITER2_BINS = cksum/cksum compress/compress dd/dd \
              ln/ln mknod/mknod rm/rm \
              touch/touch truncate/truncate
+# Iter 3 scope: 3 leaf tools that compile cleanly without Apple-only
+# APIs:
+#   stat (single-source, POSIX)
+#   chown (single-source, POSIX)
+#   df (single-source; uses libutil + libxo; #ifdef __APPLE__ guards
+#      the getattrlist code path)
+# du DEFERRED — uses Apple getattrlist() unconditionally for hardlink
+#   counting (du.c:595 isn't __APPLE__-guarded). Would need a small
+#   patch or shim.
+# cp/mv/ls/chmod/gzip/install/mtree/xattr DEFERRED — these need
+#   libacl/copyfile/commoncrypto/xattr shims, scoped per plan §6.
+ITER3_BINS = stat/stat chown/chown df/df
 
-all: $(ITER1_BINS) $(ITER2_BINS)
+all: $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
 
 # --- iter 1 (single-source leaf tools) ---
 chflags/chflags: chflags/chflags.c
@@ -101,6 +113,18 @@ touch/touch: touch/touch.c
 truncate/truncate: truncate/truncate.c
 	cc $(CFLAGS) -o $@ truncate/truncate.c -lutil
 
+# --- iter 3 ---
+# stat: pure POSIX, no extra libs.
+stat/stat: stat/stat.c
+	cc $(CFLAGS) -o $@ stat/stat.c
+# chown: pure POSIX, no extra libs.
+chown/chown: chown/chown.c
+	cc $(CFLAGS) -o $@ chown/chown.c
+# df: -lutil for humanize_number, -lxo for libxo. Apple-only paths
+# (getattrlist) are #ifdef __APPLE__-guarded.
+df/df: df/df.c
+	cc $(CFLAGS) -o $@ df/df.c -lutil -lxo
+
 # shar is a shell script (no compile); install handled below.
 
 install: all
@@ -123,8 +147,12 @@ install: all
 	install -m 0555 truncate/truncate $(DESTDIR)/usr/bin/truncate
 	# shar: shell script
 	install -m 0555 shar/shar.sh $(DESTDIR)/usr/bin/shar
+	# iter 3
+	install -m 0555 stat/stat $(DESTDIR)/usr/bin/stat
+	install -m 0555 chown/chown $(DESTDIR)/usr/sbin/chown
+	install -m 0555 df/df $(DESTDIR)/bin/df
 
 clean:
-	rm -f $(ITER1_BINS) $(ITER2_BINS)
+	rm -f $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
 
 .PHONY: all clean install

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -362,7 +362,7 @@ expect {
         puts "\nFAIL: file_cmds leaf binaries missing or non-functional"
         exit 1
     }
-    "FILECMD-LEAF-OK" { puts "\nOK: file_cmds Apple binaries overlaid pkgbase paths (#111)" }
+    "FILECMD-LEAF-OK" { puts "\nOK: file_cmds Apple binaries overlaid pkgbase paths, iter 1+2+3 = 17 tools (#111)" }
 }
 expect {
     timeout {


### PR DESCRIPTION
## Summary

Extends file_cmds port from 14 → 17 binaries.

| Tool | Path | Notes |
|---|---|---|
| stat | /usr/bin/stat | single-source POSIX |
| chown | /usr/sbin/chown | single-source POSIX |
| df | /bin/df | -lutil + -lxo; Apple getattrlist path is __APPLE__-guarded |

**Deferred:**
- `du` — uses Apple `getattrlist()` unconditionally at du.c:595 (not __APPLE__-guarded). Needs a small patch or shim.
- `cp/mv/ls/chmod/gzip/install/mtree/xattr` — remain deferred behind libacl/copyfile/commoncrypto/xattr shims per plan §6.

## Pipeline

- `build.sh`: extended FILECMD_BIN list (17 entries).
- `run.sh`: extended path check (17 entries); functional probe unchanged (chflags identity).
- `boot-test.sh`: marker reads '17 tools'.

**Cumulative Apple-source userland overlay: 89 binaries** (17 file_cmds + 36 shell_cmds + 22 text_cmds + 6 adv_cmds + 8 system_cmds).

Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#file_cmds

task #105b

## Test plan
- [ ] CI green through FILECMD-LEAF-OK with 17 tools probed