### PR TITLE
feat(shell_cmds): iter 4 — find + who (#112)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -370,7 +370,7 @@ ls -lh "$WORK/rootfs/bin/chflags" "$WORK/rootfs/bin/rm" \
 #
 #      Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#shell_cmds
 #
-echo "==> building Apple shell_cmds (iter 1+2+3: 36 POSIX tools)"
+echo "==> building Apple shell_cmds (iter 1+2+3+4: 38 POSIX tools)"
 make -C "$ROOT/src/shell_cmds" install DESTDIR="$WORK/rootfs"
 
 for SHELLCMD_BIN in /usr/bin/true /usr/bin/false \
@@ -385,7 +385,8 @@ for SHELLCMD_BIN in /usr/bin/true /usr/bin/false \
                     /usr/sbin/chroot /bin/date /usr/bin/hexdump \
                     /usr/bin/od /usr/bin/lockf /usr/bin/script \
                     /usr/bin/shlock /usr/bin/stdbuf /bin/test "/bin/[" \
-                    /usr/bin/whereis /usr/bin/which /usr/bin/xargs; do
+                    /usr/bin/whereis /usr/bin/which /usr/bin/xargs \
+                    /usr/bin/find /usr/bin/who; do
     if [ ! -x "$WORK/rootfs$SHELLCMD_BIN" ]; then
         echo "ERROR: shell_cmds install didn't land $SHELLCMD_BIN" >&2
         exit 1

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -365,11 +365,12 @@ if [ $FILECMD_FAIL -ne 0 ]; then
     exit 1
 fi
 
-# 6.7. shell_cmds iter 1+2+3 (#112 / #105c). Extends to 36 tools.
+# 6.7. shell_cmds iter 1+2+3+4 (#112 / #105c). Extends to 38 tools.
 #   Iter 1: true/false/echo/sleep/basename.
 #   Iter 2: 20 more POSIX tools.
 #   Iter 3: +11 more (chroot, date, hexdump, lockf, script, shlock,
 #           stdbuf, test, whereis, which, xargs) + 'od' link + '[' link.
+#   Iter 4: +2 (find, who).
 #
 # Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#shell_cmds
 SHELLCMD_FAIL=0
@@ -385,7 +386,8 @@ for fbin in /usr/bin/true /usr/bin/false /bin/echo /bin/sleep \
             /usr/sbin/chroot /bin/date /usr/bin/hexdump \
             /usr/bin/od /usr/bin/lockf /usr/bin/script \
             /usr/bin/shlock /usr/bin/stdbuf /bin/test /bin/[ \
-            /usr/bin/whereis /usr/bin/which /usr/bin/xargs; do
+            /usr/bin/whereis /usr/bin/which /usr/bin/xargs \
+            /usr/bin/find /usr/bin/who; do
     if [ ! -x "$fbin" ]; then
         echo "SHELLCMD-LEAF-FAIL: $fbin missing or not executable"
         ls -la "$fbin" 2>&1 || true
@@ -407,8 +409,10 @@ if [ $SHELLCMD_FAIL -eq 0 ]; then
        [ "$(/bin/echo -n A | /usr/bin/hexdump -e '"%02x"')" = "41" ] && \
        /bin/[ 1 -lt 2 ] && \
        [ "$(/bin/echo hello | /usr/bin/xargs /bin/echo)" = "hello" ] && \
-       [ -n "$(/usr/bin/which sh)" ]; then
-        echo "SHELLCMD-LEAF-OK: 36/36 shell_cmds binaries overlaid + functional (iter1+2+3 probes pass)"
+       [ -n "$(/usr/bin/which sh)" ] && \
+       /usr/bin/find /etc/hosts -maxdepth 0 -type f >/dev/null && \
+       /usr/bin/who >/dev/null 2>&1; then
+        echo "SHELLCMD-LEAF-OK: 38/38 shell_cmds binaries overlaid + functional (iter1+2+3+4 probes pass)"
     else
         echo "SHELLCMD-LEAF-FAIL: functional sanity check failed"
         SHELLCMD_FAIL=1

--- a/src/shell_cmds/Makefile
+++ b/src/shell_cmds/Makefile
@@ -140,17 +140,20 @@ xargs/xargs: xargs/xargs.c xargs/strnsubst.c
 	cc $(CFLAGS) -o $@ xargs/xargs.c xargs/strnsubst.c
 
 # --- iter 4 ---
-# find: 7 .c (find/function/ls/main/misc/operator/option).
-# getdate.y is orphaned (no .c calls get_date in current Apple sources).
+# find: 7 .c (find/function/ls/main/misc/operator/option) + getdate.y
+# (yacc-generated date parser used by -newerXY / get_date()).
 # Apple guards <unistd.h> behind #ifdef __APPLE__ in find.c (line 53-55)
 # but uses X_OK at line 242 — force-include unistd.h to declare it.
 # join-style fix: define unix2003_compat=0 so the BSD path is taken.
+find/getdate.c: find/getdate.y
+	yacc -o $@ find/getdate.y
 find/find: find/find.c find/function.c find/ls.c find/main.c \
-           find/misc.c find/operator.c find/option.c
+           find/misc.c find/operator.c find/option.c find/getdate.c
 	cc $(CFLAGS) -include unistd.h -include libgen.h \
 	    -Dunix2003_compat=0 \
 	    -o $@ find/find.c find/function.c find/ls.c \
-	    find/main.c find/misc.c find/operator.c find/option.c
+	    find/main.c find/misc.c find/operator.c find/option.c \
+	    find/getdate.c
 who/who: who/who.c
 	cc $(CFLAGS) -o $@ who/who.c
 

--- a/src/shell_cmds/Makefile
+++ b/src/shell_cmds/Makefile
@@ -142,9 +142,14 @@ xargs/xargs: xargs/xargs.c xargs/strnsubst.c
 # --- iter 4 ---
 # find: 7 .c (find/function/ls/main/misc/operator/option).
 # getdate.y is orphaned (no .c calls get_date in current Apple sources).
+# Apple guards <unistd.h> behind #ifdef __APPLE__ in find.c (line 53-55)
+# but uses X_OK at line 242 — force-include unistd.h to declare it.
+# join-style fix: define unix2003_compat=0 so the BSD path is taken.
 find/find: find/find.c find/function.c find/ls.c find/main.c \
            find/misc.c find/operator.c find/option.c
-	cc $(CFLAGS) -o $@ find/find.c find/function.c find/ls.c \
+	cc $(CFLAGS) -include unistd.h -include libgen.h \
+	    -Dunix2003_compat=0 \
+	    -o $@ find/find.c find/function.c find/ls.c \
 	    find/main.c find/misc.c find/operator.c find/option.c
 who/who: who/who.c
 	cc $(CFLAGS) -o $@ who/who.c

--- a/src/shell_cmds/Makefile
+++ b/src/shell_cmds/Makefile
@@ -38,8 +38,15 @@ ITER2_BINS = apply/apply dirname/dirname env/env getopt/getopt \
 ITER3_BINS = chroot/chroot date/date hexdump/hexdump lockf/lockf \
              script/script shlock/shlock stdbuf/stdbuf test/test \
              whereis/whereis which/which xargs/xargs
+# Iter 4 scope:
+#   find — load-bearing POSIX file-finder (7 .c; getdate.y is orphaned).
+#   who  — utmpx-based logged-in users listing.
+# w DEFERRED — uses KERN_PROCARGS2 (Apple-specific sysctl) + -lkvm
+#   (would need a kvm-style proc shim).
+# Remaining deferred buckets — see iter 3 commit message.
+ITER4_BINS = find/find who/who
 
-all: $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
+all: $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS) $(ITER4_BINS)
 
 # --- iter 1 (single-source pure-POSIX leaf tools) ---
 true/true: true/true.c
@@ -132,6 +139,16 @@ which/which: which/which.c
 xargs/xargs: xargs/xargs.c xargs/strnsubst.c
 	cc $(CFLAGS) -o $@ xargs/xargs.c xargs/strnsubst.c
 
+# --- iter 4 ---
+# find: 7 .c (find/function/ls/main/misc/operator/option).
+# getdate.y is orphaned (no .c calls get_date in current Apple sources).
+find/find: find/find.c find/function.c find/ls.c find/main.c \
+           find/misc.c find/operator.c find/option.c
+	cc $(CFLAGS) -o $@ find/find.c find/function.c find/ls.c \
+	    find/main.c find/misc.c find/operator.c find/option.c
+who/who: who/who.c
+	cc $(CFLAGS) -o $@ who/who.c
+
 install: all
 	mkdir -p $(DESTDIR)/bin $(DESTDIR)/usr/bin
 	# iter 1
@@ -176,8 +193,11 @@ install: all
 	install -m 0555 whereis/whereis $(DESTDIR)/usr/bin/whereis
 	install -m 0555 which/which $(DESTDIR)/usr/bin/which
 	install -m 0555 xargs/xargs $(DESTDIR)/usr/bin/xargs
+	# iter 4
+	install -m 0555 find/find $(DESTDIR)/usr/bin/find
+	install -m 0555 who/who $(DESTDIR)/usr/bin/who
 
 clean:
-	rm -f $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
+	rm -f $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS) $(ITER4_BINS)
 
 .PHONY: all clean install

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -373,7 +373,7 @@ expect {
         puts "\nFAIL: shell_cmds leaf binaries missing or non-functional"
         exit 1
     }
-    "SHELLCMD-LEAF-OK" { puts "\nOK: shell_cmds Apple binaries overlaid + functional, iter 1+2+3 = 36 tools (#112)" }
+    "SHELLCMD-LEAF-OK" { puts "\nOK: shell_cmds Apple binaries overlaid + functional, iter 1+2+3+4 = 38 tools (#112)" }
 }
 expect {
     timeout {


### PR DESCRIPTION
## Summary

Extends shell_cmds port from 36 → 38 binaries.

| Tool | Path | Notes |
|---|---|---|
| find | /usr/bin/find | 7 .c (find/function/ls/main/misc/operator/option); getdate.y orphaned |
| who | /usr/bin/who | utmpx-based logged-in users listing |

## Deferred (still)

- **w** — KERN_PROCARGS2 (Apple sysctl) + -lkvm; needs kvm-style proc shim.
- id/su/killall/locate/expr/users/path_helper/sh/systime/time/lastcomm/alias — each needs Apple kernel-struct shims, Open Directory, BSM audit, full-shell port, yacc, or C++ build setup. Defer per their own iters.

## Pipeline

- `build.sh`: 38-entry SHELLCMD_BIN list.
- `run.sh`: extended probes — find on /etc/hosts, who exec smoke.
- `boot-test.sh`: marker reads '38 tools'.

**Cumulative Apple-source userland overlay: 103 binaries** (17 file_cmds + 38 shell_cmds + 34 text_cmds + 6 adv_cmds + 8 system_cmds).

Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#shell_cmds

task #105c

## Test plan
- [ ] CI green through SHELLCMD-LEAF-OK with 38 tools probed