### PR TITLE
feat(adv_cmds): iter 3 — locale (C++) (#113)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -439,12 +439,13 @@ ls -lh "$WORK/rootfs/bin/cat" "$WORK/rootfs/usr/bin/cut" \
 #
 #      Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#adv_cmds
 #
-echo "==> building Apple adv_cmds (iter 1+2: 6 tools)"
+echo "==> building Apple adv_cmds (iter 1+2+3: 7 tools)"
 make -C "$ROOT/src/adv_cmds" install DESTDIR="$WORK/rootfs"
 
 for ADVCMD_BIN in /usr/bin/tabs /usr/bin/tty /usr/bin/whois \
                   /usr/sbin/lsvfs \
-                  /usr/bin/cap_mkdb /usr/bin/finger; do
+                  /usr/bin/cap_mkdb /usr/bin/finger \
+                  /usr/bin/locale; do
     if [ ! -x "$WORK/rootfs$ADVCMD_BIN" ]; then
         echo "ERROR: adv_cmds install didn't land $ADVCMD_BIN" >&2
         exit 1

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -485,14 +485,16 @@ if [ $TEXTCMD_FAIL -ne 0 ]; then
     exit 1
 fi
 
-# 6.9. adv_cmds iter 1+2 (#113 / #105d). Fourth Apple-userland-cmds
-# repo port. iter 1: tabs/tty/whois/lsvfs; iter 2: cap_mkdb/finger.
+# 6.9. adv_cmds iter 1+2+3 (#113 / #105d). Fourth Apple-userland-cmds
+# repo port. iter 1: tabs/tty/whois/lsvfs; iter 2: cap_mkdb/finger;
+# iter 3: locale (C++).
 #
 # Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#adv_cmds
 ADVCMD_FAIL=0
 for fbin in /usr/bin/tabs /usr/bin/tty /usr/bin/whois \
             /usr/sbin/lsvfs \
-            /usr/bin/cap_mkdb /usr/bin/finger; do
+            /usr/bin/cap_mkdb /usr/bin/finger \
+            /usr/bin/locale; do
     if [ ! -x "$fbin" ]; then
         echo "ADVCMD-LEAF-FAIL: $fbin missing or not executable"
         ls -la "$fbin" 2>&1 || true
@@ -525,7 +527,14 @@ if [ $ADVCMD_FAIL -eq 0 ]; then
     fi
 fi
 if [ $ADVCMD_FAIL -eq 0 ]; then
-    echo "ADVCMD-LEAF-OK: 6/6 adv_cmds binaries overlaid (lsvfs/cap_mkdb/finger probes pass)"
+    # locale -a lists all installed locales; should at least print "C".
+    if ! /usr/bin/locale -a 2>/dev/null | /usr/bin/grep -q '^C$'; then
+        echo "ADVCMD-LEAF-FAIL: locale -a didn't list C locale"
+        ADVCMD_FAIL=1
+    fi
+fi
+if [ $ADVCMD_FAIL -eq 0 ]; then
+    echo "ADVCMD-LEAF-OK: 7/7 adv_cmds binaries overlaid (lsvfs/cap_mkdb/finger/locale probes pass)"
 else
     exit 1
 fi

--- a/src/adv_cmds/Makefile
+++ b/src/adv_cmds/Makefile
@@ -31,8 +31,13 @@ CFLAGS = -O2 -pipe -D__dead=__dead2
 # matching Apple's libc/nlsmsg internals. Not load-bearing — defer.
 ITER1_BINS = tabs/tabs tty/tty whois/whois lsvfs/lsvfs
 ITER2_BINS = cap_mkdb/cap_mkdb finger/finger
+# Iter 3: locale (C++, 446 LOC). xlocale.h + langinfo.h are present on
+# FreeBSD, and the source uses only C++ STL otherwise.
+# localedef DEFERRED — 10 .c with Apple-internal msgcat machinery.
+# genwrap DEFERRED — yacc/lex driver.
+ITER3_BINS = locale/locale
 
-all: $(ITER1_BINS) $(ITER2_BINS)
+all: $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
 
 # --- iter 1 (4 single-source-or-near-leaf tools) ---
 tabs/tabs: tabs/tabs.c
@@ -53,6 +58,11 @@ finger/finger: finger/finger.c finger/lprint.c finger/net.c finger/sprint.c fing
 	cc $(CFLAGS) -o $@ finger/finger.c finger/lprint.c finger/net.c \
 	    finger/sprint.c finger/util.c
 
+# --- iter 3 ---
+# locale: C++ STL, uses xlocale + langinfo. -O2 -pipe with c++.
+locale/locale: locale/locale.cc
+	c++ -O2 -pipe -o $@ locale/locale.cc
+
 install: all
 	mkdir -p $(DESTDIR)/usr/bin $(DESTDIR)/usr/sbin
 	install -m 0555 tabs/tabs $(DESTDIR)/usr/bin/tabs
@@ -63,8 +73,10 @@ install: all
 	# iter 2
 	install -m 0555 cap_mkdb/cap_mkdb $(DESTDIR)/usr/bin/cap_mkdb
 	install -m 0555 finger/finger $(DESTDIR)/usr/bin/finger
+	# iter 3
+	install -m 0555 locale/locale $(DESTDIR)/usr/bin/locale
 
 clean:
-	rm -f $(ITER1_BINS) $(ITER2_BINS)
+	rm -f $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
 
 .PHONY: all clean install

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -395,7 +395,7 @@ expect {
         puts "\nFAIL: adv_cmds leaf binaries missing or non-functional"
         exit 1
     }
-    "ADVCMD-LEAF-OK" { puts "\nOK: adv_cmds iter 1+2 (6 Apple tools overlaid) (#113)" }
+    "ADVCMD-LEAF-OK" { puts "\nOK: adv_cmds iter 1+2+3 (7 Apple tools overlaid) (#113)" }
 }
 expect {
     timeout {


### PR DESCRIPTION
## Summary

Extends adv_cmds port from 6 → 7 binaries.

| Tool | Source | Notes |
|---|---|---|
| `/usr/bin/locale` | `locale/locale.cc` (446 LOC) | POSIX locale tool, C++ STL. Uses xlocale.h + langinfo.h. |

First C++ binary in the userland-cmds port — uses FreeBSD's c++ (clang++).

## Deferred

- **localedef** — 10 .c with Apple-internal NLS msgcat machinery.
- **genwrap** — yacc/lex driver for wrapper-script generation.
- **ps/pkill/stty** — need Apple kinfo_proc shim + Apple flag work.

## Pipeline

- `build.sh`: 7-entry ADVCMD_BIN list.
- `run.sh`: `locale -a` probe (must list at least 'C').
- `boot-test.sh`: marker reads '7 tools'.

**Cumulative Apple-source userland overlay: 104 binaries** (17 file_cmds + 38 shell_cmds + 34 text_cmds + 7 adv_cmds + 8 system_cmds).

Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#adv_cmds

task #105d

## Test plan
- [ ] CI green through ADVCMD-LEAF-OK with 7 tools probed