### PR TITLE
feat(file_cmds): iter 4 — du (#111)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -333,10 +333,10 @@ ls -lh "$WORK/rootfs/sbin/kldload" "$WORK/rootfs/sbin/mount" \
 #
 #      Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#file_cmds
 #
-echo "==> building Apple file_cmds (iter 1+2+3: 17 tools)"
+echo "==> building Apple file_cmds (iter 1+2+3+4: 18 tools)"
 make -C "$ROOT/src/file_cmds" install DESTDIR="$WORK/rootfs"
 
-# Confirm Apple binaries are present (iter 1 + iter 2 + iter 3).
+# Confirm Apple binaries are present (iter 1 + iter 2 + iter 3 + iter 4).
 # Apple's file_cmds strings contain "Apple Computer" or apple-source
 # __APPLE__ guards; FreeBSD's same tools have "FreeBSD" + __FBSDID
 # variants. Boot-test marker probes binary identity for one
@@ -348,7 +348,8 @@ for FILECMD_BIN in /bin/chflags /bin/mkdir /bin/mkfifo /bin/rmdir \
                    /usr/bin/cksum /usr/bin/compress \
                    /sbin/mknod /usr/bin/shar \
                    /usr/bin/touch /usr/bin/truncate \
-                   /usr/bin/stat /usr/sbin/chown /bin/df; do
+                   /usr/bin/stat /usr/sbin/chown /bin/df \
+                   /usr/bin/du; do
     if [ ! -x "$WORK/rootfs$FILECMD_BIN" ]; then
         echo "ERROR: file_cmds install didn't land $FILECMD_BIN" >&2
         exit 1

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -318,10 +318,10 @@ else
     exit 1
 fi
 
-# 6.6. file_cmds iter 2 (#111 / #105b iter 2). Extends iter 1's
-# 5-binary leaf set to 16 pure-POSIX file_cmds tools (+ shar shell
+# 6.6. file_cmds iter 1+2+3+4 (#111 / #105b). Extends iter 1's
+# 5-binary leaf set to 18 pure-POSIX file_cmds tools (+ shar shell
 # script). Apple binaries overlay-overwrite FreeBSD-runtime's same
-# paths per the OpenPAM iter-3 pattern. Iter 3+ adds the tools with
+# paths per the OpenPAM iter-3 pattern. Iter 5+ adds the tools with
 # Apple-specific deps (cp/mv/ls/chmod/install/gzip/pax/mtree).
 #
 # Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#file_cmds
@@ -331,7 +331,8 @@ for fbin in /bin/chflags /bin/mkdir /bin/mkfifo /bin/rmdir \
             /bin/dd /bin/ln /bin/rm \
             /usr/bin/cksum /usr/bin/compress \
             /sbin/mknod /usr/bin/touch /usr/bin/truncate \
-            /usr/bin/stat /usr/sbin/chown /bin/df; do
+            /usr/bin/stat /usr/sbin/chown /bin/df \
+            /usr/bin/du; do
     if [ ! -x "$fbin" ]; then
         echo "FILECMD-LEAF-FAIL: $fbin missing or not executable"
         ls -la "$fbin" 2>&1 || true
@@ -350,11 +351,11 @@ fi
 # from "FreeBSD-runtime's chflags is still in place."
 if [ $FILECMD_FAIL -eq 0 ]; then
     if strings /bin/chflags 2>/dev/null | grep -qi 'apple computer\|copyright.*apple\|opensource'; then
-        echo "FILECMD-LEAF-OK: 17/17 file_cmds binaries overlaid; /bin/chflags identifies as Apple's"
+        echo "FILECMD-LEAF-OK: 18/18 file_cmds binaries overlaid; /bin/chflags identifies as Apple's"
     else
         # Fall back: at minimum check that chflags works.
         if /bin/chflags 2>&1 | grep -q 'usage'; then
-            echo "FILECMD-LEAF-OK: 17/17 file_cmds binaries present; chflags responds to invocation (Apple identity not verifiable in strings — informational)"
+            echo "FILECMD-LEAF-OK: 18/18 file_cmds binaries present; chflags responds to invocation (Apple identity not verifiable in strings — informational)"
         else
             echo "FILECMD-LEAF-FAIL: chflags doesn't respond to invocation"
             FILECMD_FAIL=1

--- a/src/file_cmds/Makefile
+++ b/src/file_cmds/Makefile
@@ -18,7 +18,13 @@
 # multi-source rules below spell out their .c file lists. shar is
 # a shell script that just gets copied.
 #
-# Iter 3+ (future): cp/mv/ls/chmod/install/gzip/pax/mtree — the
+# Iter 3 (merged): stat, chown, df.
+#
+# Iter 4 (this): du. Single-source; libutil for humanize_number /
+# expand_number / getbsize. Apple getattrlist() hardlinked-directory
+# dedupe is #ifdef __APPLE__-guarded (UFS/ZFS lack the feature).
+#
+# Iter 5+ (future): cp/mv/ls/chmod/install/gzip/pax/mtree — the
 # tools with Apple-specific deps (clonefile, libacl, libdispatch,
 # fcopyfile, xattr). Each needs its own shim work.
 #
@@ -44,14 +50,18 @@ ITER2_BINS = cksum/cksum compress/compress dd/dd \
 #   chown (single-source, POSIX)
 #   df (single-source; uses libutil + libxo; #ifdef __APPLE__ guards
 #      the getattrlist code path)
-# du DEFERRED — uses Apple getattrlist() unconditionally for hardlink
-#   counting (du.c:595 isn't __APPLE__-guarded). Would need a small
-#   patch or shim.
 # cp/mv/ls/chmod/gzip/install/mtree/xattr DEFERRED — these need
 #   libacl/copyfile/commoncrypto/xattr shims, scoped per plan §6.
 ITER3_BINS = stat/stat chown/chown df/df
+# Iter 4 scope:
+#   du — single-source; uses libutil (humanize_number, expand_number,
+#        getbsize). Apple uses getattrlist(ATTR_DIR_LINKCOUNT) for
+#        hardlinked-directory dedupe (HFS+ Time Machine); UFS/ZFS don't
+#        support hardlinked directories, so dirlinkchk() is #ifdef'd
+#        out on non-Apple and returns 0.
+ITER4_BINS = du/du
 
-all: $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
+all: $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS) $(ITER4_BINS)
 
 # --- iter 1 (single-source leaf tools) ---
 chflags/chflags: chflags/chflags.c
@@ -125,6 +135,13 @@ chown/chown: chown/chown.c
 df/df: df/df.c
 	cc $(CFLAGS) -o $@ df/df.c -lutil -lxo -lm
 
+# --- iter 4 ---
+# du: -lutil for humanize_number / expand_number / getbsize. Apple-only
+# dirlinkchk() (getattrlist) is #ifdef __APPLE__-guarded; FreeBSD path
+# returns 0 (no hardlinked directories on UFS/ZFS).
+du/du: du/du.c
+	cc $(CFLAGS) -o $@ du/du.c -lutil
+
 # shar is a shell script (no compile); install handled below.
 
 install: all
@@ -151,8 +168,10 @@ install: all
 	install -m 0555 stat/stat $(DESTDIR)/usr/bin/stat
 	install -m 0555 chown/chown $(DESTDIR)/usr/sbin/chown
 	install -m 0555 df/df $(DESTDIR)/bin/df
+	# iter 4
+	install -m 0555 du/du $(DESTDIR)/usr/bin/du
 
 clean:
-	rm -f $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
+	rm -f $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS) $(ITER4_BINS)
 
 .PHONY: all clean install

--- a/src/file_cmds/du/du.c
+++ b/src/file_cmds/du/du.c
@@ -49,7 +49,9 @@ static const char sccsid[] = "@(#)du.c	8.5 (Berkeley) 5/4/95";
 #include <sys/param.h>
 #include <sys/queue.h>
 #include <sys/stat.h>
+#ifdef __APPLE__
 #include <sys/attr.h>
+#endif
 
 #include <err.h>
 #include <errno.h>
@@ -566,6 +568,15 @@ linkchk(FTSENT *p)
 static int
 dirlinkchk(FTSENT *p)
 {
+#ifndef __APPLE__
+	/*
+	 * Apple uses getattrlist(ATTR_DIR_LINKCOUNT) to detect hardlinked
+	 * directories (an HFS+ Time Machine feature).  UFS/ZFS don't
+	 * support hardlinked directories, so there is nothing to dedupe.
+	 */
+	(void)p;
+	return 0;
+#else
 	struct links_entry {
 		struct links_entry *next;
 		struct links_entry *previous;
@@ -704,6 +715,7 @@ dirlinkchk(FTSENT *p)
 		buckets[hash]->previous = le;
 	buckets[hash] = le;
 	return (0);
+#endif /* __APPLE__ */
 }
 
 static void

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -362,7 +362,7 @@ expect {
         puts "\nFAIL: file_cmds leaf binaries missing or non-functional"
         exit 1
     }
-    "FILECMD-LEAF-OK" { puts "\nOK: file_cmds Apple binaries overlaid pkgbase paths, iter 1+2+3 = 17 tools (#111)" }
+    "FILECMD-LEAF-OK" { puts "\nOK: file_cmds Apple binaries overlaid pkgbase paths, iter 1+2+3+4 = 18 tools (#111)" }
 }
 expect {
     timeout {


### PR DESCRIPTION
## Summary

- Adds `/usr/bin/du` to the Apple file_cmds overlay (17 → 18 binaries).
- Deferred at iter 3 because `dirlinkchk()` used `getattrlist(ATTR_DIR_LINKCOUNT)` unconditionally to detect hardlinked directories — an HFS+ Time Machine feature absent on UFS/ZFS.
- Fix is a one-line guard: `#include <sys/attr.h>` moves under `__APPLE__`, and `dirlinkchk()` short-circuits to `return 0` on non-Apple. Link line uses `-lutil` (humanize_number / expand_number / getbsize) — same as `df` and `truncate`.
- Cumulative Apple-source userland overlay: **90 binaries**.

## Test plan

- [ ] CI build green (FreeBSD QEMU boot-test pipeline).
- [ ] `FILECMD-LEAF-OK` marker reports `18/18 file_cmds binaries overlaid`.
- [ ] `/usr/bin/du` present and executable on the booted rootfs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)