### PR TITLE
feat(adv_cmds): iter 4 — stty (#113)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -439,13 +439,14 @@ ls -lh "$WORK/rootfs/bin/cat" "$WORK/rootfs/usr/bin/cut" \
 #
 #      Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#adv_cmds
 #
-echo "==> building Apple adv_cmds (iter 1+2+3: 7 tools)"
+echo "==> building Apple adv_cmds (iter 1+2+3+4: 8 tools)"
 make -C "$ROOT/src/adv_cmds" install DESTDIR="$WORK/rootfs"
 
 for ADVCMD_BIN in /usr/bin/tabs /usr/bin/tty /usr/bin/whois \
                   /usr/sbin/lsvfs \
                   /usr/bin/cap_mkdb /usr/bin/finger \
-                  /usr/bin/locale; do
+                  /usr/bin/locale \
+                  /bin/stty; do
     if [ ! -x "$WORK/rootfs$ADVCMD_BIN" ]; then
         echo "ERROR: adv_cmds install didn't land $ADVCMD_BIN" >&2
         exit 1

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -485,16 +485,17 @@ if [ $TEXTCMD_FAIL -ne 0 ]; then
     exit 1
 fi
 
-# 6.9. adv_cmds iter 1+2+3 (#113 / #105d). Fourth Apple-userland-cmds
+# 6.9. adv_cmds iter 1+2+3+4 (#113 / #105d). Fourth Apple-userland-cmds
 # repo port. iter 1: tabs/tty/whois/lsvfs; iter 2: cap_mkdb/finger;
-# iter 3: locale (C++).
+# iter 3: locale (C++); iter 4: stty (terminal mode setter).
 #
 # Plan: https://pkgdemon.github.io/freebsd-apple-userland-cmds-plan.html#adv_cmds
 ADVCMD_FAIL=0
 for fbin in /usr/bin/tabs /usr/bin/tty /usr/bin/whois \
             /usr/sbin/lsvfs \
             /usr/bin/cap_mkdb /usr/bin/finger \
-            /usr/bin/locale; do
+            /usr/bin/locale \
+            /bin/stty; do
     if [ ! -x "$fbin" ]; then
         echo "ADVCMD-LEAF-FAIL: $fbin missing or not executable"
         ls -la "$fbin" 2>&1 || true
@@ -534,7 +535,15 @@ if [ $ADVCMD_FAIL -eq 0 ]; then
     fi
 fi
 if [ $ADVCMD_FAIL -eq 0 ]; then
-    echo "ADVCMD-LEAF-OK: 7/7 adv_cmds binaries overlaid (lsvfs/cap_mkdb/finger/locale probes pass)"
+    # stty -a reads current termios; on a serial console (CI) the tty
+    # is valid so this must succeed and print at least "speed".
+    if ! /bin/stty -a 2>/dev/null | /usr/bin/grep -q 'speed'; then
+        echo "ADVCMD-LEAF-FAIL: stty -a didn't print termios state"
+        ADVCMD_FAIL=1
+    fi
+fi
+if [ $ADVCMD_FAIL -eq 0 ]; then
+    echo "ADVCMD-LEAF-OK: 8/8 adv_cmds binaries overlaid (lsvfs/cap_mkdb/finger/locale/stty probes pass)"
 else
     exit 1
 fi

--- a/src/adv_cmds/Makefile
+++ b/src/adv_cmds/Makefile
@@ -17,9 +17,15 @@
 # client, multi-source POSIX). last DEFERRED — Apple uses non-standard
 # getutxent_wtmp() which isn't in FreeBSD's libc.
 #
-# Iter 3+: locale (locale.cc — C++), localedef (10 .c), genwrap (yacc/lex),
-# plus the load-bearing tools (ps + pkill — need Apple kinfo_proc shim,
-# stty — POSIX but minor Apple flag additions).
+# Iter 3 (merged): locale (locale.cc — C++).
+#
+# Iter 4 (this): stty — terminal mode setter. 7 sources, mostly POSIX
+# termios; Apple-specific flag/disc references (NTTYDISC, TABLDISC,
+# VERASE2, cfmakesane override) are #ifdef'd. Apple's <get_compat.h>
+# (modes.c) is shadowed by a local COMPAT_MODE(a,b)=1 fallback.
+#
+# Iter 5+: localedef (10 .c), genwrap (yacc/lex), ps + pkill (need
+# Apple kinfo_proc shim).
 #
 # Usage: make -C src/adv_cmds install DESTDIR=$WORK/rootfs
 
@@ -36,8 +42,10 @@ ITER2_BINS = cap_mkdb/cap_mkdb finger/finger
 # localedef DEFERRED — 10 .c with Apple-internal msgcat machinery.
 # genwrap DEFERRED — yacc/lex driver.
 ITER3_BINS = locale/locale
+# Iter 4: stty (7 .c — cchar, gfmt, key, modes, print, stty, util).
+ITER4_BINS = stty/stty
 
-all: $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
+all: $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS) $(ITER4_BINS)
 
 # --- iter 1 (4 single-source-or-near-leaf tools) ---
 tabs/tabs: tabs/tabs.c
@@ -63,6 +71,15 @@ finger/finger: finger/finger.c finger/lprint.c finger/net.c finger/sprint.c fing
 locale/locale: locale/locale.cc
 	c++ -O2 -pipe -o $@ locale/locale.cc
 
+# --- iter 4 ---
+# stty: 7 .c. Apple-only blocks (NTTYDISC, TABLDISC, cfmakesane,
+# get_compat) are #ifdef __APPLE__-guarded; FreeBSD-only VERASE2
+# is added via the !__APPLE__ branch in cchar.c.
+stty/stty: stty/cchar.c stty/gfmt.c stty/key.c stty/modes.c \
+           stty/print.c stty/stty.c stty/util.c
+	cc $(CFLAGS) -o $@ stty/cchar.c stty/gfmt.c stty/key.c \
+	    stty/modes.c stty/print.c stty/stty.c stty/util.c
+
 install: all
 	mkdir -p $(DESTDIR)/usr/bin $(DESTDIR)/usr/sbin
 	install -m 0555 tabs/tabs $(DESTDIR)/usr/bin/tabs
@@ -75,8 +92,11 @@ install: all
 	install -m 0555 finger/finger $(DESTDIR)/usr/bin/finger
 	# iter 3
 	install -m 0555 locale/locale $(DESTDIR)/usr/bin/locale
+	# iter 4
+	mkdir -p $(DESTDIR)/bin
+	install -m 0555 stty/stty $(DESTDIR)/bin/stty
 
 clean:
-	rm -f $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS)
+	rm -f $(ITER1_BINS) $(ITER2_BINS) $(ITER3_BINS) $(ITER4_BINS)
 
 .PHONY: all clean install

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -395,7 +395,7 @@ expect {
         puts "\nFAIL: adv_cmds leaf binaries missing or non-functional"
         exit 1
     }
-    "ADVCMD-LEAF-OK" { puts "\nOK: adv_cmds iter 1+2+3 (7 Apple tools overlaid) (#113)" }
+    "ADVCMD-LEAF-OK" { puts "\nOK: adv_cmds iter 1+2+3+4 (8 Apple tools overlaid) (#113)" }
 }
 expect {
     timeout {


### PR DESCRIPTION
## Summary

- Adds `/bin/stty` to the Apple adv_cmds overlay (7 → 8 binaries).
- 7-source POSIX termios tool; Apple-only references (NTTYDISC, TABLDISC, cfmakesane override, `<get_compat.h>`) are all already `#ifdef __APPLE__`-guarded upstream. FreeBSD-only `VERASE2` is added via the `!__APPLE__` branch in cchar.c.
- No extra link libs beyond libc.

## Test plan

- [ ] CI build green (FreeBSD QEMU boot-test pipeline).
- [ ] `ADVCMD-LEAF-OK` marker reports `8/8 adv_cmds binaries overlaid`.
- [ ] `/bin/stty -a` prints termios state (probe greps for `speed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)