### PR TITLE
feat(#105h): drop FreeBSD-runtime + FreeBSD-utilities (closes #117, #103)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -191,18 +191,14 @@ if [ -n "$RUNTIME_PKGS" ] || [ -n "$DRIVER_PKGS" ] || [ -n "$BUILD_PKGS" ]; then
             pkg set -y -A 0 -n FreeBSD-pam FreeBSD-pam-lib \
                                 FreeBSD-pam-dev 2>/dev/null || true
 
-        # Same pattern for FreeBSD-runtime + FreeBSD-utilities (#111 /
-        # #105b file_cmds port iter 1, and all subsequent Apple-userland-
-        # cmds repo ports through #105h). Our /usr/src builds via
-        # srclist-fbsdglue.txt + Apple-source builds via src/file_cmds/
-        # etc. overlay-overwrite their pkgbase paths. Mark non-automatic
-        # so a stray pkg autoremove doesn't cull them as orphans (which
-        # would also remove THEIR file ownership entries from the pkg
-        # DB; our overlayed files survive but pkg's manifest goes
-        # incoherent).
-        chroot "$WORK/rootfs" env ASSUME_ALWAYS_YES=yes \
-            pkg set -y -A 0 -n FreeBSD-runtime FreeBSD-utilities \
-                                2>/dev/null || true
+        # FreeBSD-runtime + FreeBSD-utilities pins REMOVED 2026-05-27
+        # (#105h drop probe). Both pkgs are now commented out in
+        # pkglist-base.txt — if they get pulled in as transitive deps
+        # they'll be subject to autoremove at end-of-build, which is
+        # fine because every path they used to own is now either an
+        # Apple-source overlay or a srclist-fbsdglue /usr/src build.
+        # CI will surface any path that's NOT covered as a concrete
+        # boot failure or missing-binary error.
     fi
 
     if [ -n "$BUILD_PKGS" ]; then

--- a/pkglist-base.txt
+++ b/pkglist-base.txt
@@ -39,22 +39,21 @@ FreeBSD-kernel-generic
 #   Historical: #104 (closed not-planned), PR #107 (closed unmerged).
 #   The earlier /init.sh comment about /rescue/sh etc. was stale —
 #   current boot path is direct kernel → /sbin/launchd as PID 1.
-# runtime: STAYS INSTALLED. Source-of-truth pivots over the
-#   #105a iter 1 → #105g iter sequence (per srclist build plan §9.2):
-#   - The ~11 irreducibly-FreeBSD-only paths (kld*, mount/umount/fsck,
-#     devfs, ldconfig, kenv, freebsd-version) get rebuilt from /usr/src
-#     via srclist-fbsdglue.txt + build.sh step 3a2, overlay-overwriting
-#     pkgbase's same paths.
-#   - The remaining ~155 Apple-replaceable paths get overlaid by Apple
-#     binaries from the seven sequential Apple-repo PRs (#105b-#105g).
-#   - #105h commits to the final drop of FreeBSD-runtime from this list
-#     once every path it provides is either Apple-source or fbsdglue.
+# runtime: DROPPED 2026-05-27 (#105h probe).
+# utilities: DROPPED 2026-05-27 (#105h probe). With ~109 Apple-source
+# overlay paths from src/*/Makefile (file_cmds + shell_cmds + adv_cmds
+# + text_cmds + system_cmds) plus the srclist-fbsdglue.txt /usr/src
+# builds (kld*, mount/fsck/newfs, devfs, ldconfig, kenv, freebsd-
+# version, pw, nologin, …), the paths these pkgs uniquely provide are
+# now (in theory) all covered. This probe verifies that experimentally
+# — CI failures will surface concrete gaps that need either a new
+# Apple-overlay iter or a new srclist-fbsdglue entry.
 #FreeBSD-rescue
-FreeBSD-runtime
+#FreeBSD-runtime
 
 # ---- core libc + base userland ----
 FreeBSD-clibs
-FreeBSD-utilities
+#FreeBSD-utilities
 FreeBSD-csh
 FreeBSD-vi
 

--- a/srclist-fbsdglue.txt
+++ b/srclist-fbsdglue.txt
@@ -46,6 +46,12 @@ sbin/umount
 
 # --- usr.bin/ — minimal set; debug toolkit deferred (see comment) ---
 usr.bin/ldd
+# su: Apple's su needs a BSM audit stub (deferred). FreeBSD's su(1)
+# from /usr/src links libpam + libutil — both work against our Apple
+# OpenPAM + FreeBSD libutil. Surfaced when #105h drop probe (#140)
+# revealed PAM-LOGIN-FAIL: /usr/bin/su missing after FreeBSD-utilities
+# was dropped.
+usr.bin/su
 
 # --- usr.sbin/ FreeBSD HW/FS introspection + user mgmt ---
 usr.sbin/crashinfo


### PR DESCRIPTION
## Summary

**The drop.** Closes #117 (#105h final drop) and #103 (FreeBSD-pam-lib phantom). Comments out `FreeBSD-runtime` + `FreeBSD-utilities` in `pkglist-base.txt` and removes the `pkg set -A 0 -n FreeBSD-runtime FreeBSD-utilities` workaround in `build.sh`. `FreeBSD-pam-lib` was already commented out — it now de-installs naturally since nothing else depends on it.

CI surfaced one concrete gap during the probe: `/usr/bin/su` (owned by FreeBSD-utilities; Apple's `su(1)` needs a deferred BSM stub). Filled by adding `usr.bin/su` to `srclist-fbsdglue.txt` — FreeBSD's `su` builds against our Apple OpenPAM (libpam.so.6) and FreeBSD libutil.

Coverage at this point:
- **109 Apple-source overlay paths** from `src/*/Makefile` (file_cmds + shell_cmds + adv_cmds + text_cmds + system_cmds).
- **~30 fbsdglue /usr/src builds** (kld* family, mount/fsck/newfs, devfs, ldconfig, kenv, pw, nologin, crashinfo, devctl, diskinfo, ldd, pciconf, **su**, …).
- Other FreeBSD pkgs still installed at their canonical paths: `FreeBSD-clibs` (libc + libutil + sh), `FreeBSD-csh`, `FreeBSD-vi`, `FreeBSD-ufs`, `FreeBSD-geom`, `FreeBSD-mtree`, openssl/zlib/xz/bzip2, etc.

## Test plan

- [x] Build green (no pkg dependency-resolution errors).
- [x] Boot reaches login prompt.
- [x] All markers OK through `MACH-SMOKE-OK`, `FILECMD-LEAF-OK`, `SHELLCMD-LEAF-OK`, `TEXTCMD-LEAF-OK`, `ADVCMD-LEAF-OK`, `SYSCMD-LEAF-OK`, `PAM-LOGIN-OK` (su round-trip via Apple OpenPAM works after fbsdglue su addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)