### PR TITLE
chore: drop FreeBSD-csh + FreeBSD-vi

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -481,6 +481,18 @@ ls -lh "$WORK/rootfs/bin/sync" "$WORK/rootfs/bin/wait4path" \
        "$WORK/rootfs/usr/sbin/mkfile" "$WORK/rootfs/usr/bin/newgrp" \
        "$WORK/rootfs/usr/sbin/vipw"
 
+# 3a8. Flip root's default shell from /bin/csh to /bin/sh.
+#      FreeBSD-csh was dropped from pkglist-base.txt 2026-05-27, but
+#      FreeBSD-runtime's stock /etc/master.passwd still names /bin/csh
+#      as root's shell. Without this fix login(1) sets SHELL=/bin/csh
+#      which doesn't exist on the booted system, dropping the user
+#      into a non-functional shell. /usr/sbin/pw comes from srclist-
+#      fbsdglue.txt (always built earlier).
+echo "==> flipping root shell to /bin/sh (FreeBSD-csh dropped)"
+chroot "$WORK/rootfs" /usr/sbin/pw usermod root -s /bin/sh
+chroot "$WORK/rootfs" /usr/bin/grep '^root:' /etc/master.passwd | \
+    /usr/bin/awk -F: '{print "    root shell now: " $10}'
+
 #
 # 3b. build mach.ko against the freshly-extracted kernel sources and
 #     install it into $WORK/rootfs/boot/kernel/mach.ko so it ships

--- a/pkglist-base.txt
+++ b/pkglist-base.txt
@@ -54,8 +54,13 @@ FreeBSD-kernel-generic
 # ---- core libc + base userland ----
 FreeBSD-clibs
 #FreeBSD-utilities
-FreeBSD-csh
-FreeBSD-vi
+# csh: DROPPED 2026-05-27 — root shell flipped to /bin/sh in build.sh
+#   post-install (pw usermod). Users can `pkg install zsh` later for
+#   an interactive shell; /bin/sh stays available via FreeBSD-runtime.
+#FreeBSD-csh
+# vi: DROPPED 2026-05-27 — Apple text_cmds ships /usr/bin/ed; vi
+#   itself is `pkg install vim` if a user wants it.
+#FreeBSD-vi
 
 # Console keymap data (loaded by vt(4)).
 FreeBSD-vt-data


### PR DESCRIPTION
## Summary

Drops two FreeBSD pkgs that aren't needed on the shipping image. **FreeBSD-libexecinfo NOT dropped** — verified that syslogd, libdispatch, and libmach all use `backtrace_symbols()`.

| Pkg | Replacement |
|---|---|
| `FreeBSD-csh` | `/bin/sh` (root shell flipped via `pw usermod` post-install). Users can `pkg install zsh` later. |
| `FreeBSD-vi` | `/usr/bin/ed` (Apple text_cmds), or `pkg install vim`. |

The `pw usermod root -s /bin/sh` step uses `/usr/sbin/pw` from srclist-fbsdglue.txt (always built earlier in build.sh).

## Test plan

- [ ] Build green.
- [ ] Boot: `login: root` succeeds and lands on `/bin/sh` (not "no shell" message).
- [ ] All existing markers still pass through `PAM-LOGIN-OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)