### PR TITLE
chore: drop 4 FreeBSD base pkgs via fbsdglue (ncurses, libcasper, libbsm, certctl)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -277,6 +277,15 @@ mkdir -p "$SRCBUILD_OBJ"
 SRCBUILD_MAKE_FLAGS="__MAKE_CONF=/dev/null SRCCONF=/dev/null \
                      MK_MAN=no MK_TESTS=no"
 
+# Pre-create /usr/include/ subdirs that FreeBSD-lib installs assume
+# exist (FreeBSD normally pre-populates these via `mtree -d` from
+# /etc/mtree/BSD.include.dist before make install). lib/libcasper
+# installs cap_*.h into /usr/include/casper/; lib/libbsm installs
+# headers into /usr/include/bsm/. Without these dirs the `install`
+# command exits 71 (EX_OSERR / no such directory).
+mkdir -p "$WORK/rootfs/usr/include/casper" \
+         "$WORK/rootfs/usr/include/bsm"
+
 for DIR in $FBSDGLUE_LIST; do
     SRC="$WORK/freebsd-src/usr/src/$DIR"
     if [ ! -d "$SRC" ]; then

--- a/pkglist-base.txt
+++ b/pkglist-base.txt
@@ -90,7 +90,10 @@ FreeBSD-libarchive
 FreeBSD-openssl
 FreeBSD-openssl-lib
 FreeBSD-caroot
-FreeBSD-certctl
+# certctl: DROPPED 2026-05-27 — we don't run it post-install; the actual
+#   CA bundle ships via FreeBSD-caroot (still kept). Just the management
+#   tool is gone.
+#FreeBSD-certctl
 
 # ---- compression ----
 FreeBSD-zlib
@@ -120,7 +123,11 @@ FreeBSD-bzip2
 # build under src/libdispatch (its bundled BlocksRuntime is upstream
 # Apple compiler-rt, same source FreeBSD-libblocksruntime is built
 # from). See libdispatch+mach spike §6.2 + install layout spike §15.
-FreeBSD-libcasper
+# libcasper: DROPPED 2026-05-27 — libcasper.so now built from /usr/src/
+#   lib/libcasper via srclist-fbsdglue.txt; our overlay file owns the
+#   path. Cat/wc/md5's #ifndef __APPLE__ libcasper paths now link our
+#   build, not pkgbase's.
+#FreeBSD-libcasper
 # Note: there is no FreeBSD-libcompiler_rt runtime pkg — only the -dev
 # variant. The runtime libcompiler_rt.so is bundled in FreeBSD-clibs.
 FreeBSD-libexecinfo

--- a/srclist-fbsdglue.txt
+++ b/srclist-fbsdglue.txt
@@ -66,3 +66,21 @@ usr.sbin/pw
 
 # --- libexec/ ---
 libexec/save-entropy
+
+# --- lib/ — shared libraries we own (replacing FreeBSD pkgbase pkgs) ---
+# Added 2026-05-27 to drop 4 FreeBSD-base pkgs in one go:
+#   - lib/ncurses    replaces FreeBSD-ncurses-lib (libncurses.so + terminfo
+#                    data; consumers: tabs(1), ul(1))
+#   - lib/libcasper  replaces FreeBSD-libcasper (libcasper.so; consumers:
+#                    cat/wc/md5 use the headers inside #ifndef __APPLE__
+#                    blocks, runtime calls bind through libcasper.so)
+#   - lib/libbsm     replaces FreeBSD-audit-lib (libbsm.so + <bsm/*.h>;
+#                    consumers: syslogd, aslmanager, asl util, notifyd,
+#                    Libnotify, libmach all link -lbsm). FreeBSD-pam-lib
+#                    will still pull in FreeBSD-audit-lib via its manifest
+#                    shlib dep, so audit-lib survives in pkg DB — but our
+#                    consumers now resolve libbsm.so from our fbsdglue
+#                    build, not from FreeBSD-audit-lib.
+lib/ncurses
+lib/libcasper
+lib/libbsm


### PR DESCRIPTION
## Summary

Adds 3 lib dirs to `srclist-fbsdglue.txt` so the build produces our own `libncurses.so` / `libcasper.so` / `libbsm.so` from `/usr/src`, then drops the matching pkgbase pkgs from `pkglist-base.txt` where they were explicit.

| Pkg | Disposition |
|---|---|
| `FreeBSD-certctl` | dropped (explicit, no reverse-deps) |
| `FreeBSD-libcasper` | dropped (explicit); .so now from fbsdglue |
| `FreeBSD-ncurses-lib` | autoremoved (was transitive, csh+vi were the only consumers — both gone); fbsdglue now provides libncurses.so + terminfo for tabs/ul |
| `FreeBSD-audit-lib` | **likely stays** — `FreeBSD-pam-lib`'s manifest declares a shlib dep on `libbsm.so` (and pam-lib is transitively pulled by `FreeBSD-runtime`, deferred). Our consumers (syslogd/aslmanager/notifyd/Libnotify/libmach) now link `libbsm.so` from our fbsdglue build, not from `FreeBSD-audit-lib`. Same incoherent-pkg-DB shape as the existing #103 pam-lib phantom we accepted. |

`FreeBSD-audit-dev` kept in `buildpkgs-base.txt` — `/usr/include/sys/ucred.h` transitively includes `<bsm/audit.h>`, build-chroot needs it; pkg is autoremoved before shipping.

## Test plan

- [ ] Build green (fbsdglue builds lib/ncurses, lib/libcasper, lib/libbsm cleanly from /usr/src).
- [ ] Boot reaches login.
- [ ] All existing markers pass (PAM-LOGIN-OK round-trips, FILECMD/SHELLCMD/ADVCMD/TEXTCMD/SYSCMD all green — confirms ul, tabs, cat, wc, md5 all run with their libs resolved from our overlay).
- [ ] Probe afterward to confirm which of the 4 pkgs actually left the pkg DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)