### PR TITLE
chore: vendor bin/sh + lib/libmd/libutil/libnv via fbsdglue

### DIFF
--- a/srclist-fbsdglue.txt
+++ b/srclist-fbsdglue.txt
@@ -27,6 +27,13 @@
 # --- bin/ ---
 bin/freebsd-version
 bin/kenv
+# sh: /bin/sh from FreeBSD's POSIX sh. FreeBSD-runtime currently owns
+#   this path; vendoring via fbsdglue moves it under our build.
+#   (Apple sh source is vendored at src/shell_cmds/sh/ but not built
+#    — would only matter for "Apple-shape" consistency, not for
+#    Linux portability since neither Apple sh nor FreeBSD sh map to
+#    Linux's bash/dash anyway.)
+bin/sh
 
 # --- sbin/ kernel-bound (kld(4), VFS, devfs, rtld hint) + UFS family ---
 # (sbin/camcontrol DEFERRED — needs lib/libnvmf privatelib prereq;
@@ -84,3 +91,19 @@ libexec/save-entropy
 lib/ncurses
 lib/libcasper
 lib/libbsm
+# libmd / libutil / libnv: foundational shlibs owned by FreeBSD-runtime
+#   today. Many other pkgs shlib-depend on them (geom, mtree, pkg-
+#   bootstrap, xz-lib use libmd; geom, mtree use libutil; libcasper
+#   uses libnv). Adding to fbsdglue puts the .so files on disk under
+#   our build, but FreeBSD-runtime stays in the pkg DB because pkg's
+#   resolver works on pkg-manifest shlib metadata not filesystem
+#   content. The reason to do this anyway: when we eventually run
+#   the "local pkg repo with shadow manifests" workstream, the .so
+#   files already exist from /usr/src here. Plus Linux-portability
+#   prep: these libs are FreeBSD-specific (no straight Linux peer);
+#   when the Linux port comes, this list converts to libmd/libutil/
+#   libnv from libxcrypt + elfutils + custom code, but the build
+#   shape stays the same.
+lib/libmd
+lib/libutil
+lib/libnv


### PR DESCRIPTION
## Summary

Adds 4 more entries to `srclist-fbsdglue.txt`, all paths currently owned by FreeBSD-runtime:

| Source | Provides | Used by |
|---|---|---|
| `bin/sh` | `/bin/sh` | Every script's interpreter |
| `lib/libmd` | `libmd.so.7` | geom, mtree, pkg-bootstrap, xz-lib |
| `lib/libutil` | `libutil.so.10` | geom, mtree (and our own builds) |
| `lib/libnv` | `libnv.so.1` | libcasper |

Moves these files under our build. **FreeBSD-runtime stays in the pkg DB** (pkg's resolver looks at pkg-manifest shlib metadata, not filesystem content) — the content at these paths just gets overlayed by our fbsdglue builds. Preparation for an eventual full-eject of FreeBSD-runtime via either local-pkg-repo shadow manifests or `pkg delete --force` after overlays.

Apple sh source vendored at `src/shell_cmds/sh/` but not built — would only matter for "Apple-shape" consistency, not for Linux-portability (neither Apple sh nor FreeBSD sh map to Linux's bash/dash anyway).

## Test plan

- [ ] Build green (CI builds each fbsdglue lib + bin/sh from `/usr/src` cleanly).
- [ ] Boot reaches login; PAM-LOGIN-OK round-trip passes (proves `/bin/sh` runs).
- [ ] All SHELLCMD/FILECMD/etc markers OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)