### PR TITLE
chore: vendor remaining 6 FreeBSD-runtime shlibs via fbsdglue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -279,12 +279,16 @@ SRCBUILD_MAKE_FLAGS="__MAKE_CONF=/dev/null SRCCONF=/dev/null \
 
 # Pre-create /usr/include/ subdirs that FreeBSD-lib installs assume
 # exist (FreeBSD normally pre-populates these via `mtree -d` from
-# /etc/mtree/BSD.include.dist before make install). lib/libcasper
-# installs cap_*.h into /usr/include/casper/; lib/libbsm installs
-# headers into /usr/include/bsm/. Without these dirs the `install`
-# command exits 71 (EX_OSERR / no such directory).
+# /etc/mtree/BSD.include.dist before make install). Without these
+# the `install` command exits 71 (EX_OSERR / no such directory).
+#
+#   casper/   ← lib/libcasper installs cap_*.h here
+#   bsm/      ← lib/libbsm installs <bsm/*.h> here
+#   editline/ ← lib/libedit installs <editline/readline/readline.h> here
 mkdir -p "$WORK/rootfs/usr/include/casper" \
-         "$WORK/rootfs/usr/include/bsm"
+         "$WORK/rootfs/usr/include/bsm" \
+         "$WORK/rootfs/usr/include/editline" \
+         "$WORK/rootfs/usr/include/editline/readline"
 
 for DIR in $FBSDGLUE_LIST; do
     SRC="$WORK/freebsd-src/usr/src/$DIR"

--- a/srclist-fbsdglue.txt
+++ b/srclist-fbsdglue.txt
@@ -107,3 +107,12 @@ lib/libbsm
 lib/libmd
 lib/libutil
 lib/libnv
+# Remaining FreeBSD-runtime shlibs — finishing the foundational-shlib
+# set so on-disk content at /lib/lib*.so.* is all from our build, even
+# though FreeBSD-runtime stays in the pkg DB (shlib-manifest reasons).
+lib/libcrypt
+lib/libedit
+lib/libelf
+lib/libjail
+lib/libgeom
+lib/libexpat


### PR DESCRIPTION
## Summary

Finishes the foundational-shlib set in `srclist-fbsdglue.txt`. After this, all 9 shlibs originally owned by FreeBSD-runtime have on-disk content from our `/usr/src` build:

| Source | Provides |
|---|---|
| `lib/libcrypt` | libcrypt.so.5 |
| `lib/libedit` | libedit.so.8 (installs to `/usr/include/editline/[readline/]` — pre-mkdir'd in build.sh) |
| `lib/libelf` | libelf.so.2 |
| `lib/libjail` | libjail.so.1 |
| `lib/libgeom` | libgeom.so.5 |
| `lib/libexpat` | libbsdxml.so.4 |

Combined with the earlier additions (libmd, libutil, libnv) this completes **Goal A** for shlibs — the booted image's `/lib/lib*.so.*` content is all built from sources we control. FreeBSD-runtime stays in the pkg DB (manifest-resolver reasons) but its on-disk content is ours where it matters.

## Test plan

- [ ] Build green — 6 more `/usr/src` lib builds run cleanly (no codegen-prereq or include-subdir issues besides the pre-mkdir'd `editline/`).
- [ ] Boot + login + all markers pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)