### PR TITLE
chore: add sbin/reboot + sbin/shutdown to fbsdglue

### DIFF
--- a/srclist-fbsdglue.txt
+++ b/srclist-fbsdglue.txt
@@ -50,6 +50,17 @@ sbin/mount
 sbin/newfs
 sbin/tunefs
 sbin/umount
+# reboot: provides /sbin/reboot + /sbin/halt + /sbin/fastboot +
+#   /sbin/fasthalt + /sbin/nextboot (all hardlinks to one binary).
+#   Apple's vendored system_cmds reboot is mostly the same FreeBSD
+#   source in its !__APPLE__ branches; the Apple-specific kextmanager
+#   RPC is #ifdef'd out on our build anyway, so going through fbsdglue
+#   is the same code with less debug overhead.
+sbin/reboot
+# shutdown: provides /sbin/shutdown + /sbin/poweroff. Same reasoning
+#   as reboot — Apple's vendored shutdown is mostly the FreeBSD
+#   source on the non-Apple branch.
+sbin/shutdown
 
 # --- usr.bin/ — minimal set; debug toolkit deferred (see comment) ---
 usr.bin/ldd


### PR DESCRIPTION
## Summary

Routes `/sbin/reboot` + `/sbin/halt` + `/sbin/fastboot` + `/sbin/fasthalt` + `/sbin/nextboot` (all hardlinks to `sbin/reboot`) and `/sbin/shutdown` + `/sbin/poweroff` (from `sbin/shutdown`) through srclist-fbsdglue.txt instead of FreeBSD-runtime.

Apple's vendored `system_cmds/reboot` and `system_cmds/shutdown` non-Apple branches are essentially upstream FreeBSD source — the Apple-specific kextmanager RPC glue is `#ifdef __APPLE__`-guarded out on our build anyway. Going via fbsdglue gives us the same code with less debug overhead than going through Apple's vendored copies.

Tracked separately:
- #148 — `ipc_kmsg_destroy` panics during reboot due to libdispatch workers having uninitialized `ith_messages`. Independent of which source builds the reboot binary; that's a mach.ko issue.

## Test plan

- [ ] Build green (fbsdglue builds sbin/reboot + sbin/shutdown from /usr/src cleanly).
- [ ] Boot + login + all existing markers pass.
- [ ] FreeBSD-runtime's /sbin/reboot + /sbin/halt + /sbin/shutdown overlayed by our builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)