### PR TITLE
chore: add usr.bin/login to fbsdglue

### DIFF
--- a/srclist-fbsdglue.txt
+++ b/srclist-fbsdglue.txt
@@ -70,6 +70,15 @@ usr.bin/ldd
 # revealed PAM-LOGIN-FAIL: /usr/bin/su missing after FreeBSD-utilities
 # was dropped.
 usr.bin/su
+# login: /usr/bin/login from FreeBSD's usr.bin/login. Apple's vendored
+#   system_cmds/login has drifted from upstream FreeBSD (auth_pam
+#   signature, USE_PAM/LOGIN_CAP gating) AND the Apple-specific
+#   features (BSM audit session, Open Directory, kicker per-user
+#   launchd) are all dead code on this system (no auditd, no OD,
+#   no Aqua-style per-user sessions). Skip the source patching;
+#   FreeBSD's login does the same core PAM-auth-then-exec-shell job
+#   against our Apple OpenPAM overlay.
+usr.bin/login
 
 # --- usr.sbin/ FreeBSD HW/FS introspection + user mgmt ---
 usr.sbin/crashinfo


### PR DESCRIPTION
## Summary

One-line addition: routes \`/usr/bin/login\` through srclist-fbsdglue.txt. Replaces FreeBSD-runtime's copy with the same code built from \`/usr/src/usr.bin/login\`.

Apple's vendored \`system_cmds/login\` is in the tree but its \`!__APPLE__\` branch has drifted (auth_pam signature, USE_PAM/LOGIN_CAP gating) and all the Apple-specific features it adds (BSM audit sessions, Open Directory lookup, kicker per-user launchd, TouchID hooks) are dead code on this system. fbsdglue's FreeBSD login does the same core PAM-auth-then-exec-shell job against our Apple OpenPAM overlay.

## Test plan

- [ ] Build green.
- [ ] Boot + login + PAM-LOGIN-OK round-trip — our overlay PAM stack still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)