### PR TITLE
chore: drop FreeBSD-runtime transitive consumers, move to fbsdglue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2343,8 +2343,30 @@ if [ -n "$BUILD_PKGS" ] || [ -n "$BASE_BUILD_PKGS" ]; then
         chroot "$WORK/rootfs" env ASSUME_ALWAYS_YES=yes \
             pkg delete -y $BASE_BUILD_PKGS
     fi
-    chroot "$WORK/rootfs" env ASSUME_ALWAYS_YES=yes \
-        pkg autoremove -y || true
+    # pkg autoremove DISABLED 2026-05-27 — when no installed pkg
+    # requires FreeBSD-runtime (consumers libarchive/libexecinfo/mtree/
+    # ufs/geom/xz commented out, replaced by fbsdglue /usr/src builds),
+    # autoremove cleans up runtime AND its file manifest entries —
+    # which includes paths we overlay-overwrote with fbsdglue content
+    # (/lib/libutil.so.10, libmd, libnv, libelf, …). Those files get
+    # deleted, /sbin/launchd can no longer link, kernel panics with
+    # "Going nowhere without my init!"
+    #
+    # Skipping autoremove keeps the overlay-overwrite pattern intact:
+    # pkg DB still knows about FreeBSD-runtime + FreeBSD-pam-lib (they
+    # come in transitively via FreeBSD-pkg-bootstrap's libmd shlib dep),
+    # but our overlays survive because nothing tries to delete them.
+    #
+    # The "drop runtime + pam-lib from the pkg DB" goal is deferred
+    # — needs a robust solution that doesn't wipe our overlays. Tracked
+    # as a follow-up ticket. For now the practical state is unchanged
+    # from before this PR (runtime + pam-lib in pkg DB but content-
+    # overlay'd everywhere we care about); the WIN of this PR is moving
+    # libarchive/libexecinfo/mtree/ufs/geom/xz to fbsdglue so they no
+    # longer get installed as pkgs (one fewer manifest entry per).
+    #
+    # chroot "$WORK/rootfs" env ASSUME_ALWAYS_YES=yes \
+    #     pkg autoremove -y || true
 fi
 
 if [ -n "$RUNTIME_PKGS" ] || [ -n "$BUILD_PKGS" ]; then

--- a/build.sh
+++ b/build.sh
@@ -282,13 +282,17 @@ SRCBUILD_MAKE_FLAGS="__MAKE_CONF=/dev/null SRCCONF=/dev/null \
 # /etc/mtree/BSD.include.dist before make install). Without these
 # the `install` command exits 71 (EX_OSERR / no such directory).
 #
-#   casper/   ← lib/libcasper installs cap_*.h here
-#   bsm/      ← lib/libbsm installs <bsm/*.h> here
-#   editline/ ← lib/libedit installs <editline/readline/readline.h> here
+#   casper/         ← lib/libcasper installs cap_*.h here
+#   bsm/            ← lib/libbsm installs <bsm/*.h> here
+#   editline/       ← lib/libedit installs <editline/readline/readline.h>
+#   lzma/           ← lib/liblzma installs <lzma/*.h>
+#   libdata/pkgconfig/ ← lib/liblzma installs liblzma.pc here
 mkdir -p "$WORK/rootfs/usr/include/casper" \
          "$WORK/rootfs/usr/include/bsm" \
          "$WORK/rootfs/usr/include/editline" \
-         "$WORK/rootfs/usr/include/editline/readline"
+         "$WORK/rootfs/usr/include/editline/readline" \
+         "$WORK/rootfs/usr/include/lzma" \
+         "$WORK/rootfs/usr/libdata/pkgconfig"
 
 for DIR in $FBSDGLUE_LIST; do
     SRC="$WORK/freebsd-src/usr/src/$DIR"

--- a/pkglist-base.txt
+++ b/pkglist-base.txt
@@ -66,13 +66,20 @@ FreeBSD-clibs
 FreeBSD-vt-data
 
 # ---- filesystems ----
-# UFS userland (mount_ufs, fsck_ffs, newfs) — /init.sh mounts the uzip
-# as ufs ro at /sysroot.
-FreeBSD-ufs
+# UFS userland (mount_ufs, fsck_ffs, newfs) — DROPPED 2026-05-27:
+#   binaries now from srclist-fbsdglue.txt (sbin/fsck_ffs, sbin/newfs,
+#   sbin/tunefs, sbin/mount, sbin/umount) + lib/libufs. Removes the
+#   FreeBSD-ufs→libedit→FreeBSD-runtime chain.
+#FreeBSD-ufs
 
-# geom: gpart/glabel/etc. for any post-boot partitioning the user does.
-FreeBSD-geom
-FreeBSD-mtree
+# geom: DROPPED 2026-05-27 — gpart + glabel now from srclist-fbsdglue.txt
+#   (sbin/gpart, sbin/glabel) + lib/libgeom already there. Removes the
+#   FreeBSD-geom→libgeom/libmd/libutil→FreeBSD-runtime chain.
+#FreeBSD-geom
+# mtree: DROPPED 2026-05-27 — /usr/sbin/mtree now from srclist-fbsdglue.txt
+#   (usr.sbin/mtree). Removes the FreeBSD-mtree→libmd/libutil→FreeBSD-
+#   runtime chain.
+#FreeBSD-mtree
 
 # ---- network ----
 # (Empty post-2026-05-16: FreeBSD-ssh, -resolvconf, -syslogd removed;
@@ -84,7 +91,12 @@ FreeBSD-pkg-bootstrap
 FreeBSD-fetch
 FreeBSD-libsqlite3
 FreeBSD-libucl
-FreeBSD-libarchive
+# libarchive: DROPPED 2026-05-27 — libarchive.so now from srclist-fbsdglue.
+#   txt (lib/libarchive). Removes the FreeBSD-libarchive→libbsdxml→
+#   FreeBSD-runtime chain. pkg(8) links libarchive at runtime; rtld
+#   resolves from /usr/lib/libarchive.so (our fbsdglue file) regardless
+#   of whether there's a pkg-DB entry.
+#FreeBSD-libarchive
 
 # ---- TLS / certs (sshd, pkg, dhcpcd) ----
 FreeBSD-openssl
@@ -97,7 +109,10 @@ FreeBSD-caroot
 
 # ---- compression ----
 FreeBSD-zlib
-FreeBSD-xz
+# xz: DROPPED 2026-05-27 — /usr/bin/xz from srclist-fbsdglue.txt
+#   (usr.bin/xz); liblzma.so from lib/liblzma. Removes the
+#   FreeBSD-xz-lib→libmd→FreeBSD-runtime chain.
+#FreeBSD-xz
 FreeBSD-bzip2
 
 # ---- pam / login ----
@@ -130,7 +145,11 @@ FreeBSD-bzip2
 #FreeBSD-libcasper
 # Note: there is no FreeBSD-libcompiler_rt runtime pkg — only the -dev
 # variant. The runtime libcompiler_rt.so is bundled in FreeBSD-clibs.
-FreeBSD-libexecinfo
+# libexecinfo: DROPPED 2026-05-27 — libexecinfo.so from srclist-fbsdglue.
+#   txt (lib/libexecinfo). syslogd / libdispatch / libmach use backtrace_
+#   symbols; rtld resolves from our overlay. Removes the FreeBSD-libexec
+#   info→libelf→FreeBSD-runtime chain.
+#FreeBSD-libexecinfo
 
 # ---- locale / timezone ----
 # zoneinfo: many libs misbehave without /usr/share/zoneinfo/UTC.

--- a/srclist-fbsdglue.txt
+++ b/srclist-fbsdglue.txt
@@ -143,8 +143,9 @@ lib/libarchive
 lib/libexecinfo
 lib/libufs
 lib/liblzma
-sbin/gpart
-sbin/glabel
+# sbin/geom builds the geom(8) multi-tool framework (gpart, glabel,
+# geli, etc.) — single entry replaces what FreeBSD-geom pkg provided.
+sbin/geom
 usr.sbin/mtree
 # xz tool (companion to lib/liblzma above)
 usr.bin/xz

--- a/srclist-fbsdglue.txt
+++ b/srclist-fbsdglue.txt
@@ -146,7 +146,7 @@ lib/liblzma
 # sbin/geom builds the geom(8) multi-tool framework (gpart, glabel,
 # geli, etc.) — single entry replaces what FreeBSD-geom pkg provided.
 sbin/geom
-usr.sbin/mtree
+usr.sbin/nmtree
 # xz tool (companion to lib/liblzma above)
 usr.bin/xz
 # Remaining FreeBSD-runtime shlibs — finishing the foundational-shlib

--- a/srclist-fbsdglue.txt
+++ b/srclist-fbsdglue.txt
@@ -127,6 +127,27 @@ lib/libbsm
 lib/libmd
 lib/libutil
 lib/libnv
+# Added 2026-05-27 to drop the pkgbase pkgs whose .so / binary content
+# we want to own ourselves (FreeBSD-libarchive, FreeBSD-libexecinfo,
+# FreeBSD-mtree, FreeBSD-ufs, FreeBSD-geom, FreeBSD-xz/-xz-lib). Each
+# entry below corresponds to commenting one explicit FreeBSD-* pkg out
+# in pkglist-base.txt; the pkg-DB chain that pulls in FreeBSD-runtime
+# via these consumers' shlib manifests goes away.
+#
+# Still pulls FreeBSD-runtime: ports `pkg` itself (libelf/libjail/libmd
+# shlib deps in its ports manifest — can't be resolved by fbsdglue's
+# on-disk files alone). Tracked separately; needs either a shadow-
+# manifest local repo OR dropping pkg from the booted image. Out of
+# scope for this PR.
+lib/libarchive
+lib/libexecinfo
+lib/libufs
+lib/liblzma
+sbin/gpart
+sbin/glabel
+usr.sbin/mtree
+# xz tool (companion to lib/liblzma above)
+usr.bin/xz
 # Remaining FreeBSD-runtime shlibs — finishing the foundational-shlib
 # set so on-disk content at /lib/lib*.so.* is all from our build, even
 # though FreeBSD-runtime stays in the pkg DB (shlib-manifest reasons).

--- a/srclist-fbsdglue.txt
+++ b/srclist-fbsdglue.txt
@@ -143,6 +143,9 @@ lib/libarchive
 lib/libexecinfo
 lib/libufs
 lib/liblzma
+# libnetbsd: NetBSD compatibility shim required by usr.sbin/nmtree
+#   (FreeBSD's mtree is the NetBSD port, links -lnetbsd_pie).
+lib/libnetbsd
 # sbin/geom builds the geom(8) multi-tool framework (gpart, glabel,
 # geli, etc.) — single entry replaces what FreeBSD-geom pkg provided.
 sbin/geom


### PR DESCRIPTION
## Summary

Moves 6 FreeBSD-runtime consumers to `srclist-fbsdglue.txt` so they no longer install as pkgs:

- `lib/libarchive` (replaces FreeBSD-libarchive)
- `lib/libexecinfo` (replaces FreeBSD-libexecinfo)
- `lib/libufs` + `sbin/geom` (replace FreeBSD-ufs + FreeBSD-geom)
- `lib/liblzma` + `usr.bin/xz` (replace FreeBSD-xz)
- `usr.sbin/nmtree` + `lib/libnetbsd` (replace FreeBSD-mtree)

Each consumer pkg is commented out in `pkglist-base.txt`. Content is now under our build (one less pkg-DB manifest entry each).

## Important: rescoped from original goal

Original intent was also to drop `FreeBSD-runtime` + `FreeBSD-pam-lib` themselves. CI surfaced that `pkg autoremove` deletes overlay files via runtime's manifest entries — wiping `/lib/libutil.so.10` etc. and causing a kernel init-link panic.

**Workaround in this PR:** disabled `pkg autoremove`. FreeBSD-runtime + FreeBSD-pam-lib stay in the pkg DB (transitively pulled by FreeBSD-pkg-bootstrap), content-overlay'd as before. State wrt runtime/pam-lib presence is unchanged from pre-PR; the win is the 6 consumer pkgs going away.

**Tracked separately:** #153 — needs an autoremove-safe solution before we can drop runtime + pam-lib from pkg DB.

## Test plan

- [ ] CI build green
- [ ] CI boot test green (boots launchd PID 1, syslog markers fire)
- [ ] `ls /var/db/pkg/local.sqlite | xargs pkg info` no longer shows FreeBSD-libarchive/libexecinfo/ufs/geom/mtree/xz
- [ ] `ldd /sbin/launchd` resolves all shlibs

🤖 Generated with [Claude Code](https://claude.com/claude-code)