### PR TITLE
feat(hostnamed): iter 3b — mDNS PTR tier

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2243,7 +2243,28 @@ cc -fblocks \
    -lsystem_kernel -lpthread
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnamedhcpset" \
     || { echo "FAIL: hostnamedhcpset not built"; exit 1; }
-echo "==> hostnamed + hostnametest + hostnameprefset + hostnamedhcpset built"
+
+# hostnamedmdnsset — iter 3b CI fixture. Discovers the bound IPv4 via
+# the same State:/Network/Service/<UUID>/IPv4 path hostnamed will use,
+# registers a forced-multicast PTR record (<reverse>.in-addr.arpa ->
+# <fixture>.local) via libdns_sd, then holds the registration open
+# until SIGTERM. The next hostnamed run's try_mdns() picks up the
+# record over loopback mDNS via mDNSResponder. Same -fblocks + CF/SC
+# linkage as the iter 3a fixture, plus -ldns_sd.
+echo "==> building hostnamedmdnsset"
+cc -fblocks \
+   -I"$ROOT/src/launchd/liblaunch" \
+   -I"$ROOT/src/launchd/freebsd-shims" \
+   -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnamedmdnsset" \
+   "$ROOT/src/hostnamed/hostnamedmdnsset.c" \
+   -lSystemConfiguration -lCoreFoundation -ldispatch -lBlocksRuntime \
+   -ldns_sd -lsystem_kernel -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnamedmdnsset" \
+    || { echo "FAIL: hostnamedmdnsset not built"; exit 1; }
+echo "==> hostnamed + hostnametest + hostnameprefset + hostnamedhcpset + hostnamedmdnsset built"
 
 #
 # 3y2. PAM port iter 1 — vendor Apple OpenPAM (issue #93). Builds

--- a/build.sh
+++ b/build.sh
@@ -2252,10 +2252,14 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnamedhcpset" \
 # record over loopback mDNS via mDNSResponder. Same -fblocks + CF/SC
 # linkage as the iter 3a fixture, plus -ldns_sd.
 echo "==> building hostnamedmdnsset"
+# SYSROOT include path FIRST so libdns_sd's real dns_sd.h shadows the
+# empty stub at src/launchd/freebsd-shims/dns_sd.h (same fix the
+# hostnamed Makefile applies — the shim was a launchctl-only stub
+# that wins the include race if listed first).
 cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
    -I"$ROOT/src/launchd/liblaunch" \
    -I"$ROOT/src/launchd/freebsd-shims" \
-   -I"$WORK/rootfs/usr/include" \
    -L"$WORK/rootfs/usr/lib/system" \
    -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
    -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnamedmdnsset" \

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -1381,7 +1381,7 @@ fi
 # workaround syslogd's run.sh-side spawn uses. A later iter restores
 # RunAtLoad after the launchd MachServices/checkin race is fixed.
 #
-# Two test rounds prove the precedence chain:
+# Four test rounds prove the precedence chain:
 #   ROUND 1 (iter 1 regression): no SCPrefs ComputerName set; hostnamed
 #     synthesizes "${slug}-${suffix}" from SMBIOS+MAC. hostnametest
 #     (no arg) emits HOSTNAMED-OK / HOSTNAMED-FAIL.
@@ -1390,6 +1390,14 @@ fi
 #     value, sethostname()s to it (bypassing synthesis). hostnametest
 #     with the same expected fixture emits HOSTNAMED-PREFS-OK /
 #     HOSTNAMED-PREFS-FAIL.
+#   ROUND 3 (iter 3a Tier-3a DHCP): hostnamedhcpset injects Option_12
+#     into the live State:/Network/Service/<UUID>/DHCP dict; hostnamed
+#     consumes it via try_dhcp(). Marker HOSTNAMED-DHCP-OK / -FAIL.
+#   ROUND 4 (iter 3b Tier-3b mDNS): hostnamedhcpset --clear strips
+#     Option_12; hostnamedmdnsset registers a PTR for our bound IPv4
+#     over mDNS; hostnamed's try_mdns() forced-multicast PTR query
+#     hits the local mDNSResponder and adopts the first label of the
+#     returned name. Marker HOSTNAMED-MDNS-OK / -FAIL.
 
 run_hostnamed() {
     label="$1"
@@ -1454,6 +1462,52 @@ if [ -x /usr/tests/freebsd-launchd-mach/hostnamedhcpset ]; then
     fi
 else
     echo "HOSTNAMED-DHCP-FAIL: hostnamedhcpset binary not installed"
+fi
+
+# ROUND 4: mDNS Tier-3b read (iter 3b). With prefs.plist cleared and
+# Option_12 stripped from any /DHCP dict (so DHCP doesn't short-circuit),
+# hostnamed's precedence chain falls through to try_mdns(), which issues
+# a forced-multicast PTR query for our bound IPv4 via libdns_sd.
+# hostnamedmdnsset is backgrounded; it registers the matching PTR
+# (<reverse>.in-addr.arpa -> <fixture>.local) against the local
+# mDNSResponder, then sleeps. Once it prints MDNSSET-READY: the
+# registration is live and hostnamed will see it.
+HOSTNAMED_MDNS_FIXTURE="hostnamed-iter3b-fixture"
+rm -f /Library/Preferences/SystemConfiguration/preferences.plist
+if [ -x /usr/tests/freebsd-launchd-mach/hostnamedhcpset ]; then
+    /usr/tests/freebsd-launchd-mach/hostnamedhcpset --clear || true
+fi
+if [ -x /usr/tests/freebsd-launchd-mach/hostnamedmdnsset ]; then
+    /usr/tests/freebsd-launchd-mach/hostnamedmdnsset \
+        "$HOSTNAMED_MDNS_FIXTURE" > /var/log/hostnamedmdnsset.stdout \
+        2> /var/log/hostnamedmdnsset.stderr &
+    HOSTNAMED_MDNSSET_PID=$!
+    # Wait up to 10s for MDNSSET-READY (mDNSResponder's register
+    # callback fires the moment it accepts the record).
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        if grep -q "MDNSSET-READY" /var/log/hostnamedmdnsset.stdout \
+            2>/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+    echo "--- /var/log/hostnamedmdnsset.stdout ---"
+    cat /var/log/hostnamedmdnsset.stdout 2>/dev/null
+    echo "--- /var/log/hostnamedmdnsset.stderr ---"
+    cat /var/log/hostnamedmdnsset.stderr 2>/dev/null
+    echo "--- end hostnamedmdnsset logs ---"
+    if grep -q "MDNSSET-READY" /var/log/hostnamedmdnsset.stdout \
+        2>/dev/null; then
+        run_hostnamed "iter 3b mDNS PTR read"
+        /usr/tests/freebsd-launchd-mach/hostnametest \
+            "$HOSTNAMED_MDNS_FIXTURE" MDNS
+    else
+        echo "HOSTNAMED-MDNS-FAIL: hostnamedmdnsset never reached READY"
+    fi
+    kill "$HOSTNAMED_MDNSSET_PID" 2>/dev/null || true
+    wait "$HOSTNAMED_MDNSSET_PID" 2>/dev/null || true
+else
+    echo "HOSTNAMED-MDNS-FAIL: hostnamedmdnsset binary not installed"
 fi
 
 # PAM-FRAMEWORK — PAM port iter 1 (issue #93). Verifies our vendored

--- a/src/hostnamed/Makefile
+++ b/src/hostnamed/Makefile
@@ -32,6 +32,19 @@ CFLAGS+=	-O2 -pipe -fblocks
 CFLAGS+=	-Wall -Wextra -Wshadow -Wstrict-prototypes
 CFLAGS+=	-Wmissing-prototypes -Wpointer-arith
 
+# SYSROOT include path FIRST so real Apple-source headers (dns_sd.h
+# from libdns_sd, IOKit, ...) shadow the empty stubs that
+# launchd/freebsd-shims carries for launchctl's dead includes — iter 3b
+# added a real <dns_sd.h> dependency, and the launchd/freebsd-shims
+# /dns_sd.h stub would otherwise win the include-path race.
+SYSROOT?=
+.if !empty(SYSROOT)
+CFLAGS+=	-I${SYSROOT}/usr/include
+LDFLAGS+=	-L${SYSROOT}/usr/lib/system
+LDFLAGS+=	-Wl,-rpath,/usr/lib/system
+LDFLAGS+=	-Wl,--allow-shlib-undefined
+.endif
+
 # liblaunch / launchd-shims pulled for parity with other daemons even
 # though iter 1 doesn't call bootstrap_check_in — the CF umbrella
 # transitively wants the same shim availability macros. libnotify
@@ -40,14 +53,6 @@ CFLAGS+=	-Wmissing-prototypes -Wpointer-arith
 CFLAGS+=	-I${.CURDIR}/../launchd/liblaunch
 CFLAGS+=	-I${.CURDIR}/../launchd/freebsd-shims
 CFLAGS+=	-I${.CURDIR}/../Libnotify/freebsd-shims
-
-SYSROOT?=
-.if !empty(SYSROOT)
-CFLAGS+=	-I${SYSROOT}/usr/include
-LDFLAGS+=	-L${SYSROOT}/usr/lib/system
-LDFLAGS+=	-Wl,-rpath,/usr/lib/system
-LDFLAGS+=	-Wl,--allow-shlib-undefined
-.endif
 
 # -lSystemConfiguration: SCDynamicStoreCreate / SCDynamicStoreSetValue
 # / SCErrorString — the configd publish surface.

--- a/src/hostnamed/Makefile
+++ b/src/hostnamed/Makefile
@@ -55,6 +55,9 @@ LDFLAGS+=	-Wl,--allow-shlib-undefined
 # shape we build for Setup:/System + Setup:/Network/HostNames.
 # -lnotify: notify_post("com.apple.system.hostname") — Apple-canonical
 # hostname-change broadcast.
+# -ldns_sd: libdns_sd client API — DNSServiceQueryRecord for the iter 3b
+# mDNS PTR tier. The library is built by src/mDNSResponder/libdns_sd
+# and installed to /usr/lib/system/libdns_sd.so.1 alongside dns_sd.h.
 # -ldispatch -lBlocksRuntime: transitively pulled by the SC umbrella
 # (SCDynamicStoreSetDispatchQueue ABI surface).
 # -lsystem_kernel: kenv(2) syscall trampoline + the FreeBSD libc base
@@ -62,6 +65,7 @@ LDFLAGS+=	-Wl,--allow-shlib-undefined
 LDADD+=		-lsystem_kernel
 LDADD+=		-lSystemConfiguration -lCoreFoundation
 LDADD+=		-lnotify
+LDADD+=		-ldns_sd
 LDADD+=		-ldispatch -lBlocksRuntime -lpthread
 
 BINDIR=		/usr/sbin

--- a/src/hostnamed/hostnamed.c
+++ b/src/hostnamed/hostnamed.c
@@ -28,13 +28,18 @@
 #include <SystemConfiguration/SCPreferences.h>
 #include <CoreFoundation/CoreFoundation.h>
 
+#include <dns_sd.h>
+
 #include <sys/types.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/sysctl.h>
 
 #include <net/if.h>
 #include <net/if_dl.h>
 #include <net/if_types.h>
+
+#include <netinet/in.h>
 
 #include <ctype.h>
 #include <errno.h>
@@ -517,6 +522,256 @@ out:
 	return (rc);
 }
 
+/* Tier 3b: mDNS PTR lookup. Find our bound IPv4 via
+ * State:/Network/Service/<UUID>/IPv4 (Addresses array element 0), build
+ * the reverse in-addr.arpa name, issue a PTR query via libdns_sd with
+ * kDNSServiceFlagsForceMulticast so it hits mDNS not unicast DNS, and
+ * extract the first label from the returned name. If a peer on the link
+ * has registered an A record for our IP, the returned PTR tells us the
+ * .local name they know us by — we adopt that first label as our
+ * hostname. Returns 1 if a usable PTR answer was decoded; 0 on no IPv4
+ * yet / timeout / decode failure / validation reject. Always falls
+ * through to synthesis on failure — never aborts the daemon. */
+#define MDNS_QUERY_TIMEOUT	5	/* seconds wall-clock budget */
+
+struct mdns_ctx {
+	char *out;
+	size_t outsz;
+	int got_answer;
+	int success;
+};
+
+static void DNSSD_API
+mdns_ptr_cb(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t ifIdx,
+    DNSServiceErrorType err, const char *fullname, uint16_t rrtype,
+    uint16_t rrclass, uint16_t rdlen, const void *rdata, uint32_t ttl,
+    void *context)
+{
+	struct mdns_ctx *ctx = (struct mdns_ctx *)context;
+	const uint8_t *p;
+	uint8_t label_len;
+	char label[64];
+
+	(void)sdRef;
+	(void)flags;
+	(void)ifIdx;
+	(void)fullname;
+	(void)rrtype;
+	(void)rrclass;
+	(void)ttl;
+
+	ctx->got_answer = 1;
+	if (err != kDNSServiceErr_NoError) {
+		xlog("try_mdns: callback err=%d", (int)err);
+		return;
+	}
+	if (rdata == NULL || rdlen < 2) {
+		xlog("try_mdns: rdata empty (rdlen=%u)", (unsigned)rdlen);
+		return;
+	}
+	p = (const uint8_t *)rdata;
+	label_len = p[0];
+	/* Reject DNS compression pointers (top two bits set, 0xC0+) — they
+	 * shouldn't appear in libdns_sd callbacks (uds_daemon delivers
+	 * decompressed labels) but defend anyway. Also reject 0-length and
+	 * any length that would overrun rdata. */
+	if (label_len == 0 || label_len >= 64 ||
+	    (uint16_t)(1 + label_len) > rdlen) {
+		xlog("try_mdns: rdata first label invalid "
+		    "(label_len=%u rdlen=%u)",
+		    (unsigned)label_len, (unsigned)rdlen);
+		return;
+	}
+	(void)memcpy(label, p + 1, label_len);
+	label[label_len] = '\0';
+	if (!validate_and_normalize(label, "mDNS PTR",
+	    ctx->out, ctx->outsz))
+		return;
+	ctx->success = 1;
+}
+
+/* Find a usable bound IPv4 in State:/Network/Service/<UUID>/IPv4 's
+ * Addresses array (key + dict shape per src/IPConfiguration/sc_publish.c:
+ * 199-220). Skips loopback, unspecified, and link-local. Returns 1 if a
+ * dotted-quad was copied into out; 0 otherwise. iter 3b doesn't yet
+ * consult State:/Network/Global/IPv4 to pick the primary service —
+ * same as iter 3a's try_dhcp, deferred. */
+static int
+pick_primary_ipv4(SCDynamicStoreRef store, char *out, size_t outsz)
+{
+	CFStringRef pattern = NULL, k_addresses = NULL;
+	CFArrayRef keys = NULL;
+	CFIndex i, n;
+	int rc = 0;
+
+	pattern = mkstr("State:/Network/Service/[^/]+/IPv4");
+	k_addresses = mkstr("Addresses");
+	if (pattern == NULL || k_addresses == NULL)
+		goto out;
+
+	keys = SCDynamicStoreCopyKeyList(store, pattern);
+	if (keys == NULL)
+		goto out;
+	n = CFArrayGetCount(keys);
+	for (i = 0; i < n; i++) {
+		CFStringRef key;
+		CFPropertyListRef plist;
+		CFArrayRef addrs;
+		CFStringRef addr0;
+		char buf[INET_ADDRSTRLEN];
+
+		key = (CFStringRef)CFArrayGetValueAtIndex(keys, i);
+		if (key == NULL)
+			continue;
+		plist = SCDynamicStoreCopyValue(store, key);
+		if (plist == NULL)
+			continue;
+		if (CFGetTypeID(plist) != CFDictionaryGetTypeID()) {
+			CFRelease(plist);
+			continue;
+		}
+		addrs = CFDictionaryGetValue((CFDictionaryRef)plist,
+		    k_addresses);
+		if (addrs == NULL ||
+		    CFGetTypeID(addrs) != CFArrayGetTypeID() ||
+		    CFArrayGetCount(addrs) == 0) {
+			CFRelease(plist);
+			continue;
+		}
+		addr0 = (CFStringRef)CFArrayGetValueAtIndex(addrs, 0);
+		if (addr0 == NULL ||
+		    CFGetTypeID(addr0) != CFStringGetTypeID()) {
+			CFRelease(plist);
+			continue;
+		}
+		if (!CFStringGetCString(addr0, buf, sizeof(buf),
+		    kCFStringEncodingUTF8)) {
+			CFRelease(plist);
+			continue;
+		}
+		CFRelease(plist);
+		if (strncmp(buf, "127.", 4) == 0 ||
+		    strcmp(buf, "0.0.0.0") == 0 ||
+		    strncmp(buf, "169.254.", 8) == 0)
+			continue;
+		(void)strncpy(out, buf, outsz - 1);
+		out[outsz - 1] = '\0';
+		rc = 1;
+		break;
+	}
+out:
+	if (keys != NULL) CFRelease(keys);
+	if (k_addresses != NULL) CFRelease(k_addresses);
+	if (pattern != NULL) CFRelease(pattern);
+	return (rc);
+}
+
+/* Build reverse in-addr.arpa name from a dotted-quad IPv4 string.
+ * "10.0.2.15" -> "15.2.0.10.in-addr.arpa". */
+static int
+build_reverse_inaddr(const char *ipv4, char *out, size_t outsz)
+{
+	unsigned a, b, c, d;
+	int n;
+
+	if (sscanf(ipv4, "%u.%u.%u.%u", &a, &b, &c, &d) != 4)
+		return (0);
+	if (a > 255 || b > 255 || c > 255 || d > 255)
+		return (0);
+	n = snprintf(out, outsz, "%u.%u.%u.%u.in-addr.arpa",
+	    d, c, b, a);
+	return (n > 0 && (size_t)n < outsz);
+}
+
+static int
+try_mdns(char *out, size_t outsz)
+{
+	SCDynamicStoreRef store = NULL;
+	CFStringRef session = NULL;
+	DNSServiceRef sd_ref = NULL;
+	DNSServiceErrorType derr;
+	struct mdns_ctx ctx;
+	char ipv4[INET_ADDRSTRLEN];
+	char reverse[128];
+	int sock_fd;
+	time_t deadline;
+	int rc = 0;
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.out = out;
+	ctx.outsz = outsz;
+
+	session = mkstr("com.apple.hostnamed");
+	if (session == NULL)
+		goto out;
+	store = SCDynamicStoreCreate(NULL, session, NULL, NULL);
+	if (store == NULL) {
+		xlog("try_mdns: SCDynamicStoreCreate failed: %s "
+		    "(falling through to synthesis)",
+		    SCErrorString(SCError()));
+		goto out;
+	}
+	if (!pick_primary_ipv4(store, ipv4, sizeof(ipv4))) {
+		xlog("try_mdns: no usable IPv4 in "
+		    "State:/Network/Service/<UUID>/IPv4 yet");
+		goto out;
+	}
+	if (!build_reverse_inaddr(ipv4, reverse, sizeof(reverse))) {
+		xlog("try_mdns: build_reverse_inaddr failed for '%s'", ipv4);
+		goto out;
+	}
+	xlog("try_mdns: PTR query %s (primary IPv4 %s)", reverse, ipv4);
+
+	derr = DNSServiceQueryRecord(&sd_ref,
+	    kDNSServiceFlagsForceMulticast | kDNSServiceFlagsTimeout,
+	    0 /* any interface */, reverse,
+	    kDNSServiceType_PTR, kDNSServiceClass_IN,
+	    mdns_ptr_cb, &ctx);
+	if (derr != kDNSServiceErr_NoError) {
+		xlog("try_mdns: DNSServiceQueryRecord returned %d",
+		    (int)derr);
+		goto out;
+	}
+	sock_fd = DNSServiceRefSockFD(sd_ref);
+	if (sock_fd < 0) {
+		xlog("try_mdns: DNSServiceRefSockFD returned %d", sock_fd);
+		goto out;
+	}
+
+	/* Drive the libdns_sd socket through select() with a 5s wall-clock
+	 * deadline (mirrors dnssdtest.c). kDNSServiceFlagsTimeout drives a
+	 * system-side timeout independently — whichever fires first ends
+	 * the wait by firing the callback with err=Timeout. */
+	deadline = time(NULL) + MDNS_QUERY_TIMEOUT;
+	while (!ctx.got_answer && time(NULL) < deadline) {
+		fd_set rfds;
+		struct timeval tv;
+		int r;
+
+		FD_ZERO(&rfds);
+		FD_SET(sock_fd, &rfds);
+		tv.tv_sec = 1;
+		tv.tv_usec = 0;
+		r = select(sock_fd + 1, &rfds, NULL, NULL, &tv);
+		if (r > 0 && FD_ISSET(sock_fd, &rfds))
+			(void)DNSServiceProcessResult(sd_ref);
+	}
+	if (!ctx.got_answer) {
+		xlog("try_mdns: PTR %s timed out after %ds",
+		    reverse, MDNS_QUERY_TIMEOUT);
+		goto out;
+	}
+	if (ctx.success) {
+		xlog("hostname from mDNS PTR %s -> '%s'", reverse, out);
+		rc = 1;
+	}
+out:
+	if (sd_ref != NULL) DNSServiceRefDeallocate(sd_ref);
+	if (store != NULL) CFRelease(store);
+	if (session != NULL) CFRelease(session);
+	return (rc);
+}
+
 /* Compose the final hostname into out (HOSTNAMED_MAX chars). */
 static void
 synthesize(char *out, size_t outsz)
@@ -529,6 +784,8 @@ synthesize(char *out, size_t outsz)
 	if (try_scprefs(out, outsz))
 		return;
 	if (try_dhcp(out, outsz))
+		return;
+	if (try_mdns(out, outsz))
 		return;
 
 	derive_slug(slug, sizeof(slug));

--- a/src/hostnamed/hostnamedhcpset.c
+++ b/src/hostnamed/hostnamedhcpset.c
@@ -1,13 +1,19 @@
 /*
- * hostnamedhcpset — CI fixture helper for hostnamed iter 3a.
+ * hostnamedhcpset — CI fixture helper for hostnamed iter 3a / 3b.
  *
  * Usage:  hostnamedhcpset <option-12-value>
+ *         hostnamedhcpset --clear
  *
- * Finds the State:/Network/Service/<UUID>/DHCP dict that ipconfigd
- * already published (issue #88), adds Option_12=<argv[1]> to it, and
- * writes the augmented dict back to SCDynamicStore. The next hostnamed
- * run will read that value via its DHCP tier (try_dhcp) and use it,
- * proving Tier-3a fires.
+ * With a value: finds the State:/Network/Service/<UUID>/DHCP dict that
+ * ipconfigd already published (issue #88), adds Option_12=<argv[1]> to
+ * it, and writes the augmented dict back to SCDynamicStore. The next
+ * hostnamed run will read that value via its DHCP tier (try_dhcp) and
+ * use it, proving Tier-3a fires.
+ *
+ * With --clear: enumerates all matching /DHCP dicts and removes
+ * Option_12 from each, so a previously-injected fixture does not
+ * short-circuit later tiers (iter 3b's ROUND 4 needs this to exercise
+ * the mDNS path with the DHCP tier guaranteed empty).
  *
  * Why we modify ipconfigd's existing /DHCP key rather than minting our
  * own: the live key is already shaped correctly (InterfaceName +
@@ -28,6 +34,61 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Clear Option_12 from every matching /DHCP dict. Returns 0 on success
+ * (even when no dicts contained Option_12 — the empty-key case is fine
+ * for run.sh which calls --clear unconditionally). Returns 1 on SCDS
+ * error. */
+static int
+clear_all_option12(SCDynamicStoreRef store, CFStringRef pattern,
+    CFStringRef k_opt12)
+{
+	CFArrayRef keys;
+	CFIndex i, n;
+	int cleared = 0;
+
+	keys = SCDynamicStoreCopyKeyList(store, pattern);
+	if (keys == NULL)
+		return (0);	/* no /DHCP keys at all — nothing to clear */
+	n = CFArrayGetCount(keys);
+	for (i = 0; i < n; i++) {
+		CFStringRef key;
+		CFPropertyListRef plist;
+		CFMutableDictionaryRef dict;
+
+		key = (CFStringRef)CFArrayGetValueAtIndex(keys, i);
+		if (key == NULL)
+			continue;
+		plist = SCDynamicStoreCopyValue(store, key);
+		if (plist == NULL)
+			continue;
+		if (CFGetTypeID(plist) != CFDictionaryGetTypeID() ||
+		    !CFDictionaryContainsKey((CFDictionaryRef)plist, k_opt12)) {
+			CFRelease(plist);
+			continue;
+		}
+		dict = CFDictionaryCreateMutableCopy(NULL, 0,
+		    (CFDictionaryRef)plist);
+		CFRelease(plist);
+		if (dict == NULL)
+			continue;
+		CFDictionaryRemoveValue(dict, k_opt12);
+		if (SCDynamicStoreSetValue(store, key, dict)) {
+			char keybuf[256];
+			if (CFStringGetCString(key, keybuf, sizeof(keybuf),
+			    kCFStringEncodingUTF8))
+				(void)printf("hostnamedhcpset: cleared "
+				    "Option_12 from %s\n", keybuf);
+			cleared++;
+		}
+		CFRelease(dict);
+	}
+	CFRelease(keys);
+	if (cleared == 0)
+		(void)printf("hostnamedhcpset: no /DHCP dict carried "
+		    "Option_12 (already clear)\n");
+	return (0);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -38,13 +99,17 @@ main(int argc, char **argv)
 	CFPropertyListRef plist = NULL;
 	CFMutableDictionaryRef dict = NULL;
 	CFIndex n;
+	int clear_mode = 0;
 	int rc = 1;
 
 	if (argc != 2 || argv[1][0] == '\0') {
 		(void)fprintf(stderr,
-		    "usage: %s <option-12-value>\n", argv[0]);
+		    "usage: %s <option-12-value>\n"
+		    "       %s --clear\n", argv[0], argv[0]);
 		return (2);
 	}
+	if (strcmp(argv[1], "--clear") == 0)
+		clear_mode = 1;
 
 	session = CFStringCreateWithCString(NULL, "hostnamedhcpset",
 	    kCFStringEncodingUTF8);
@@ -52,10 +117,11 @@ main(int argc, char **argv)
 	    "State:/Network/Service/[^/]+/DHCP", kCFStringEncodingUTF8);
 	k_opt12 = CFStringCreateWithCString(NULL, "Option_12",
 	    kCFStringEncodingUTF8);
-	value = CFStringCreateWithCString(NULL, argv[1],
-	    kCFStringEncodingUTF8);
+	if (!clear_mode)
+		value = CFStringCreateWithCString(NULL, argv[1],
+		    kCFStringEncodingUTF8);
 	if (session == NULL || pattern == NULL || k_opt12 == NULL ||
-	    value == NULL) {
+	    (!clear_mode && value == NULL)) {
 		(void)fprintf(stderr, "CFString allocation failed\n");
 		goto out;
 	}
@@ -64,6 +130,11 @@ main(int argc, char **argv)
 	if (store == NULL) {
 		(void)fprintf(stderr, "SCDynamicStoreCreate failed: %s\n",
 		    SCErrorString(SCError()));
+		goto out;
+	}
+
+	if (clear_mode) {
+		rc = clear_all_option12(store, pattern, k_opt12);
 		goto out;
 	}
 

--- a/src/hostnamed/hostnamedmdnsset.c
+++ b/src/hostnamed/hostnamedmdnsset.c
@@ -1,0 +1,317 @@
+/*
+ * hostnamedmdnsset — CI fixture helper for hostnamed iter 3b.
+ *
+ * Usage:  hostnamedmdnsset <fixture-hostname>
+ *
+ * Publishes an mDNS PTR record so the next hostnamed run exercises
+ * its iter-3b Tier-3b try_mdns() path:
+ *
+ *   Discovers our bound IPv4 via State:/Network/Service/<UUID>/IPv4
+ *   (the Addresses array element 0 — same key ipconfigd publishes per
+ *   src/IPConfiguration/sc_publish.c:199-220), builds the reverse
+ *   in-addr.arpa name, and registers a PTR record over mDNS via
+ *   libdns_sd:
+ *
+ *     15.2.0.10.in-addr.arpa.   PTR   <fixture>.local.
+ *
+ *   When hostnamed runs, its try_mdns() issues a forced-multicast PTR
+ *   query for the same reverse name. The local mDNSResponder answers
+ *   from this registration; hostnamed extracts the first label
+ *   ("<fixture>") and adopts it as the hostname.
+ *
+ * Foreground — run.sh backgrounds with `&` and kills via the printed
+ * pid. Prints "MDNSSET-READY:" once the register callback fires so
+ * run.sh can sequence without a fixed sleep.
+ *
+ * Not shipped to real images (CI-only); lives under
+ * /usr/tests/freebsd-launchd-mach/ alongside hostnametest /
+ * hostnameprefset / hostnamedhcpset.
+ *
+ * Issue: hostnamed iter 3b — mDNS PTR tier.
+ */
+
+#include <SystemConfiguration/SCDynamicStore.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <dns_sd.h>
+
+#include <sys/select.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+#include <netinet/in.h>
+
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define REGISTER_TIMEOUT	5	/* seconds to wait for register cb */
+
+static volatile sig_atomic_t got_register_cb;
+static volatile sig_atomic_t register_ok;
+
+static void
+on_term(int sig)
+{
+	(void)sig;
+	_exit(0);
+}
+
+/* Discover the bound IPv4 via SCDynamicStore — same iteration shape
+ * hostnamed's try_mdns + iter-3a's try_dhcp use. */
+static int
+pick_ipv4(char *out, size_t outsz)
+{
+	SCDynamicStoreRef store = NULL;
+	CFStringRef session = NULL, pattern = NULL, k_addresses = NULL;
+	CFArrayRef keys = NULL;
+	CFIndex i, n;
+	int rc = 0;
+
+	session = CFStringCreateWithCString(NULL, "hostnamedmdnsset",
+	    kCFStringEncodingUTF8);
+	pattern = CFStringCreateWithCString(NULL,
+	    "State:/Network/Service/[^/]+/IPv4", kCFStringEncodingUTF8);
+	k_addresses = CFStringCreateWithCString(NULL, "Addresses",
+	    kCFStringEncodingUTF8);
+	if (session == NULL || pattern == NULL || k_addresses == NULL)
+		goto out;
+
+	store = SCDynamicStoreCreate(NULL, session, NULL, NULL);
+	if (store == NULL) {
+		(void)fprintf(stderr, "SCDynamicStoreCreate failed\n");
+		goto out;
+	}
+
+	keys = SCDynamicStoreCopyKeyList(store, pattern);
+	if (keys == NULL || (n = CFArrayGetCount(keys)) == 0) {
+		(void)fprintf(stderr,
+		    "no State:/Network/Service/<UUID>/IPv4 key found "
+		    "(is ipconfigd bound?)\n");
+		goto out;
+	}
+	for (i = 0; i < n; i++) {
+		CFStringRef key;
+		CFPropertyListRef plist;
+		CFArrayRef addrs;
+		CFStringRef addr0;
+		char buf[INET_ADDRSTRLEN];
+
+		key = (CFStringRef)CFArrayGetValueAtIndex(keys, i);
+		if (key == NULL)
+			continue;
+		plist = SCDynamicStoreCopyValue(store, key);
+		if (plist == NULL)
+			continue;
+		if (CFGetTypeID(plist) != CFDictionaryGetTypeID()) {
+			CFRelease(plist);
+			continue;
+		}
+		addrs = CFDictionaryGetValue((CFDictionaryRef)plist,
+		    k_addresses);
+		if (addrs == NULL ||
+		    CFGetTypeID(addrs) != CFArrayGetTypeID() ||
+		    CFArrayGetCount(addrs) == 0) {
+			CFRelease(plist);
+			continue;
+		}
+		addr0 = (CFStringRef)CFArrayGetValueAtIndex(addrs, 0);
+		if (addr0 == NULL ||
+		    CFGetTypeID(addr0) != CFStringGetTypeID() ||
+		    !CFStringGetCString(addr0, buf, sizeof(buf),
+		    kCFStringEncodingUTF8)) {
+			CFRelease(plist);
+			continue;
+		}
+		CFRelease(plist);
+		if (strncmp(buf, "127.", 4) == 0 ||
+		    strcmp(buf, "0.0.0.0") == 0 ||
+		    strncmp(buf, "169.254.", 8) == 0)
+			continue;
+		(void)strncpy(out, buf, outsz - 1);
+		out[outsz - 1] = '\0';
+		rc = 1;
+		break;
+	}
+out:
+	if (keys != NULL) CFRelease(keys);
+	if (store != NULL) CFRelease(store);
+	if (k_addresses != NULL) CFRelease(k_addresses);
+	if (pattern != NULL) CFRelease(pattern);
+	if (session != NULL) CFRelease(session);
+	return (rc);
+}
+
+static int
+build_reverse_inaddr(const char *ipv4, char *out, size_t outsz)
+{
+	unsigned a, b, c, d;
+	int n;
+
+	if (sscanf(ipv4, "%u.%u.%u.%u", &a, &b, &c, &d) != 4)
+		return (0);
+	if (a > 255 || b > 255 || c > 255 || d > 255)
+		return (0);
+	n = snprintf(out, outsz, "%u.%u.%u.%u.in-addr.arpa", d, c, b, a);
+	return (n > 0 && (size_t)n < outsz);
+}
+
+/* Encode "<label>.local" as DNS wire-format length-prefixed labels
+ * with a terminating 0. Returns wire length, or 0 on overflow. */
+static size_t
+encode_local_name(const char *label, uint8_t *out, size_t outsz)
+{
+	size_t llen = strlen(label);
+	size_t need = 1 + llen + 1 + 5 + 1;	/* len+label + 5+"local" + 0 */
+
+	if (llen == 0 || llen > 63 || need > outsz)
+		return (0);
+	out[0] = (uint8_t)llen;
+	(void)memcpy(out + 1, label, llen);
+	out[1 + llen] = 5;
+	(void)memcpy(out + 2 + llen, "local", 5);
+	out[1 + llen + 1 + 5] = 0;
+	return (need);
+}
+
+static void DNSSD_API
+register_cb(DNSServiceRef sdRef, DNSRecordRef recRef, DNSServiceFlags flags,
+    DNSServiceErrorType err, void *context)
+{
+	(void)sdRef;
+	(void)recRef;
+	(void)flags;
+	(void)context;
+	got_register_cb = 1;
+	register_ok = (err == kDNSServiceErr_NoError);
+	if (err != kDNSServiceErr_NoError)
+		(void)fprintf(stderr,
+		    "hostnamedmdnsset: register callback err=%d\n",
+		    (int)err);
+}
+
+int
+main(int argc, char **argv)
+{
+	DNSServiceRef sd_ref = NULL;
+	DNSRecordRef rec_ref = NULL;
+	DNSServiceErrorType derr;
+	char ipv4[INET_ADDRSTRLEN];
+	char reverse[128];
+	uint8_t rdata[64];
+	size_t rdlen;
+	int sock_fd;
+	time_t deadline;
+
+	if (argc != 2 || argv[1][0] == '\0' || strlen(argv[1]) > 63) {
+		(void)fprintf(stderr,
+		    "usage: %s <fixture-hostname>\n", argv[0]);
+		return (2);
+	}
+	(void)signal(SIGTERM, on_term);
+	(void)signal(SIGINT, on_term);
+
+	if (!pick_ipv4(ipv4, sizeof(ipv4))) {
+		(void)fprintf(stderr, "MDNSSET-FAIL: no usable IPv4\n");
+		return (1);
+	}
+	if (!build_reverse_inaddr(ipv4, reverse, sizeof(reverse))) {
+		(void)fprintf(stderr,
+		    "MDNSSET-FAIL: build_reverse_inaddr('%s')\n", ipv4);
+		return (1);
+	}
+	rdlen = encode_local_name(argv[1], rdata, sizeof(rdata));
+	if (rdlen == 0) {
+		(void)fprintf(stderr,
+		    "MDNSSET-FAIL: encode_local_name('%s')\n", argv[1]);
+		return (1);
+	}
+
+	derr = DNSServiceCreateConnection(&sd_ref);
+	if (derr != kDNSServiceErr_NoError) {
+		(void)fprintf(stderr,
+		    "MDNSSET-FAIL: DNSServiceCreateConnection=%d\n",
+		    (int)derr);
+		return (1);
+	}
+	derr = DNSServiceRegisterRecord(sd_ref, &rec_ref,
+	    kDNSServiceFlagsShared | kDNSServiceFlagsForceMulticast,
+	    0 /* any interface */, reverse,
+	    kDNSServiceType_PTR, kDNSServiceClass_IN,
+	    (uint16_t)rdlen, rdata, 120 /* ttl */,
+	    register_cb, NULL);
+	if (derr != kDNSServiceErr_NoError) {
+		(void)fprintf(stderr,
+		    "MDNSSET-FAIL: DNSServiceRegisterRecord=%d\n",
+		    (int)derr);
+		DNSServiceRefDeallocate(sd_ref);
+		return (1);
+	}
+	sock_fd = DNSServiceRefSockFD(sd_ref);
+	if (sock_fd < 0) {
+		(void)fprintf(stderr,
+		    "MDNSSET-FAIL: DNSServiceRefSockFD=%d\n", sock_fd);
+		DNSServiceRefDeallocate(sd_ref);
+		return (1);
+	}
+
+	(void)fprintf(stderr,
+	    "hostnamedmdnsset: registering PTR %s -> %s.local "
+	    "(pid=%d, IPv4=%s)\n",
+	    reverse, argv[1], (int)getpid(), ipv4);
+
+	/* Drive the libdns_sd socket; the register callback fires the
+	 * moment mDNSResponder accepts the record. Then loop forever
+	 * holding the registration; SIGTERM from run.sh exits the
+	 * loop via on_term -> _exit(0). */
+	deadline = time(NULL) + REGISTER_TIMEOUT;
+	while (!got_register_cb && time(NULL) < deadline) {
+		fd_set rfds;
+		struct timeval tv;
+		int r;
+
+		FD_ZERO(&rfds);
+		FD_SET(sock_fd, &rfds);
+		tv.tv_sec = 1;
+		tv.tv_usec = 0;
+		r = select(sock_fd + 1, &rfds, NULL, NULL, &tv);
+		if (r > 0 && FD_ISSET(sock_fd, &rfds))
+			(void)DNSServiceProcessResult(sd_ref);
+	}
+	if (!got_register_cb) {
+		(void)fprintf(stderr,
+		    "MDNSSET-FAIL: register callback timeout (%ds)\n",
+		    REGISTER_TIMEOUT);
+		DNSServiceRefDeallocate(sd_ref);
+		return (1);
+	}
+	if (!register_ok) {
+		DNSServiceRefDeallocate(sd_ref);
+		return (1);
+	}
+
+	(void)printf("MDNSSET-READY: PTR %s -> %s.local (pid=%d)\n",
+	    reverse, argv[1], (int)getpid());
+	(void)fflush(stdout);
+
+	/* Hold the registration alive. mDNSResponder serves PTR answers
+	 * from this connection's cache until we exit. */
+	for (;;) {
+		fd_set rfds;
+		struct timeval tv;
+		int r;
+
+		FD_ZERO(&rfds);
+		FD_SET(sock_fd, &rfds);
+		tv.tv_sec = 60;
+		tv.tv_usec = 0;
+		r = select(sock_fd + 1, &rfds, NULL, NULL, &tv);
+		if (r > 0 && FD_ISSET(sock_fd, &rfds))
+			(void)DNSServiceProcessResult(sd_ref);
+	}
+	/* NOTREACHED */
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -1158,6 +1158,29 @@ expect {
     }
 }
 
+# HOSTNAMED-MDNS — iter 3b gate. ROUND 4 in run.sh: hostnamedhcpset
+# --clear strips iter-3a's Option_12 fixture from /DHCP dicts;
+# hostnamedmdnsset registers a forced-multicast PTR for our bound IPv4
+# pointing at "hostnamed-iter3b-fixture.local"; hostnamed's try_mdns()
+# issues a forced-multicast PTR query via libdns_sd, mDNSResponder
+# answers locally, and hostnamed adopts the first label of the
+# returned name. hostnametest verifies all publish surfaces carry the
+# fixture (proving mDNS PTR beats synthesis but loses to DHCP, SCPrefs,
+# and kenv override).
+expect {
+    timeout {
+        puts "\nFAIL: HOSTNAMED-MDNS marker not seen"
+        exit 1
+    }
+    "HOSTNAMED-MDNS-FAIL" {
+        puts "\nFAIL: hostnamed Tier-3b mDNS PTR read did not override synthesis"
+        exit 1
+    }
+    "HOSTNAMED-MDNS-OK" {
+        puts "\nOK: hostnamed Tier-3b mDNS PTR beats synthesis (libdns_sd round-trips via mDNSResponder, kernel + Setup:/System + Setup:/Network/HostNames all carry the fixture value)"
+    }
+}
+
 # PAM-FRAMEWORK — issue #93 iter 1 gate. pamframeworktest exercises
 # /usr/lib/libpam.so.6 (our vendored Apple OpenPAM-35) by pam_start
 # against /etc/pam.d/test_iter1 (which references pam_deny.so) and


### PR DESCRIPTION
## Summary

- Adds a fourth precedence tier to hostnamed between DHCP Option_12 and slug+suffix synthesis: a mDNS PTR query on our bound IPv4 over the local link. First label of the returned name becomes the hostname.
- Uses libdns_sd's `DNSServiceQueryRecord` with `kDNSServiceFlagsForceMulticast`, picks up answers from the local mDNSResponder (which is the only mDNS speaker on QEMU/SLIRP's link).
- First time hostnamed talks to mDNSResponder as a libdns_sd client — load-bearing prereq for iter 4 (Bonjour conflict-rename feedback).

## New precedence chain

1. `kenv hostname.override` (iter 1)
2. SCPrefs `/System/System/ComputerName` (iter 2)
3. DHCP `Option_12` (iter 3a)
4. **mDNS PTR (NEW)** (iter 3b)
5. `${slug}-${suffix}` synthesis (iter 1)

## What's in the diff

- `src/hostnamed/hostnamed.c` — new `try_mdns()` + `pick_primary_ipv4()` + `build_reverse_inaddr()` + `mdns_ptr_cb`. Inserted call site in `synthesize()` between `try_dhcp` and slug. PTR rdata decoded as raw wire-format length-prefixed labels (per `dns_sd.h` contract); first label runs through the existing `validate_and_normalize` whitelist.
- `src/hostnamed/hostnamedmdnsset.c` — new CI fixture (~270 LOC). Discovers bound IPv4 via the same SCDS key hostnamed uses, registers a forced-multicast PTR via `DNSServiceCreateConnection` + `DNSServiceRegisterRecord`, holds it until SIGTERM. Prints `MDNSSET-READY:` once the register callback fires so run.sh can sequence without a fixed sleep.
- `src/hostnamed/hostnamedhcpset.c` — adds `--clear` mode to strip `Option_12` from any /DHCP dict, so iter-3a's fixture from ROUND 3 doesn't short-circuit iter-3b's ROUND 4.
- `src/hostnamed/Makefile`, `build.sh` — wire `-ldns_sd` and the new fixture build line.
- `overlays/usr/tests/freebsd-launchd-mach/run.sh` — new ROUND 4 (after the DHCP round): clears prefs + Option_12, backgrounds the fixture, polls for `MDNSSET-READY` (up to 10s), invokes hostnamed, runs `hostnametest hostnamed-iter3b-fixture MDNS`, kills the fixture.
- `tests/boot-test.sh` — new expect block gating `HOSTNAMED-MDNS-OK` / `HOSTNAMED-MDNS-FAIL`.

## Scope (deferred)

- **Unicast PTR** via `/etc/resolv.conf` — not built. Needs a stub local resolver to exercise in QEMU/SLIRP, and is orthogonal to iter 4's prereq value (which is getting hostnamed onto libdns_sd at all). Will revisit alongside iter 3c (persistent loop).
- **Primary-service selection** via `State:/Network/Global/IPv4` — iter 3b enumerates `/IPv4` keys the same way iter 3a enumerates `/DHCP`. Cross-cutting fix for multi-NIC machines.
- **Persistent loop / KeepAlive=true** — hostnamed remains one-shot. iter 3c.

## Test plan

- [ ] CI: `HOSTNAMED-OK`, `HOSTNAMED-PREFS-OK`, `HOSTNAMED-DHCP-OK` remain green (no regression in iter 1/2/3a).
- [ ] CI: new `HOSTNAMED-MDNS-OK` lands green — verifies that mDNSResponder + libdns_sd + the new tier round-trip the fixture name onto the kernel hostname.
- [ ] Check `/var/log/hostnamedmdnsset.std{out,err}` in CI artifacts for the `MDNSSET-READY:` line and the resolved IPv4.
- [ ] Check `/var/log/hostnamed.stderr` for the ROUND-4 invocation — should show `try_mdns: PTR ... (primary IPv4 ...)` and `hostname from mDNS PTR ... -> 'hostnamed-iter3b-fixture'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)