### PR TITLE
openssh sshd + make the box reachable by name (.local / .home.local / bare hostname)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2460,6 +2460,24 @@ test -x "$WORK/rootfs/usr/bin/ssh-keygen" \
     || { echo "FAIL: /usr/bin/ssh-keygen not installed or not executable"; exit 1; }
 echo "==> OpenSSH built + installed (sshd, ssh, ssh-keygen)"
 
+# sshd-mdns-register — tiny libdns_sd co-process that advertises
+# _ssh._tcp so mDNSResponder publishes the host's <name>.local record
+# (mDNSCore only advertises host records when an AutoTarget service is
+# registered; a headless box otherwise advertises nothing). Started by
+# sshd-keygen-wrapper just before `exec sshd -D` and tied to sshd's
+# lifetime via getppid(). Depends on libdns_sd + dns_sd.h built in
+# Phase K (above). Same link shape as dnssdtest.
+echo "==> building sshd-mdns-register (src/ssh-bonjour, _ssh._tcp advertiser)"
+cc -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/libexec/sshd-mdns-register" \
+   "$ROOT/src/ssh-bonjour/sshd-mdns-register.c" \
+   -ldns_sd
+test -x "$WORK/rootfs/usr/libexec/sshd-mdns-register" \
+    || { echo "FAIL: /usr/libexec/sshd-mdns-register not built"; exit 1; }
+echo "==> sshd-mdns-register built + installed"
+
 # /var/empty must exist, be root-owned, and NOT be group/world writable
 # or sshd refuses it for privsep. It already exists in the rootfs
 # (base-provided, root-owned 0755 — exactly what sshd wants) and OpenSSH's

--- a/overlays/usr/libexec/sshd-keygen-wrapper
+++ b/overlays/usr/libexec/sshd-keygen-wrapper
@@ -15,4 +15,18 @@
 # more robust shape for a rescue/diagnosis shell.
 set -e
 /usr/bin/ssh-keygen -A
+
+# Advertise sshd over Bonjour (_ssh._tcp) before handing off to sshd.
+# This also makes mDNSResponder publish the host's <name>.local address
+# record, which it otherwise withholds on a box with no registered
+# services — so the box becomes reachable by <name>.local. The helper
+# watches our pid (we exec sshd below, so it becomes its parent) and
+# exits when sshd does, keeping the advertisement tied to sshd. It is
+# backgrounded and guarded so a missing/failed helper never blocks the
+# rescue shell. (.home.local / the bare hostname resolve via the router
+# off DHCP, independent of this — see ipconfigd.)
+if [ -x /usr/libexec/sshd-mdns-register ]; then
+	/usr/libexec/sshd-mdns-register &
+fi
+
 exec /usr/sbin/sshd -D

--- a/src/IPConfiguration/dhcp_discover.c
+++ b/src/IPConfiguration/dhcp_discover.c
@@ -323,6 +323,34 @@ build_dhcp_msg(uint8_t *buf, const uint8_t mac[6], uint32_t xid,
 		}
 	}
 
+	/* 12 host name — advertise our hostname so the DHCP server (the
+	 * home router, typically) registers it in LAN DNS. Without this the
+	 * router has no name to map, so neither the bare hostname nor
+	 * <hostname>.<router-domain> (e.g. .home.local) resolves. RFC 2132
+	 * §3.14: the option carries the client's name; we send the short
+	 * (label-only) form, which is what routers register. Sent on
+	 * DISCOVER and REQUEST (incl. renew); skipped on DECLINE/RELEASE.
+	 * gethostname(3) returns the synthesised name launchd PID-1 set at
+	 * early init (see hostnamed / freebsd_synthesize_hostname). */
+	if (msgtype == DHCP_MTYPE_DISCOVER || msgtype == DHCP_MTYPE_REQUEST) {
+		char hn[256];
+
+		if (gethostname(hn, sizeof(hn)) == 0 && hn[0] != '\0') {
+			char *dot = strchr(hn, '.');
+			size_t hlen;
+
+			if (dot != NULL)
+				*dot = '\0';	/* strip domain — label only */
+			hlen = strlen(hn);
+			if (hlen > 0 && hlen <= 255) {
+				*opt++ = DHCP_OPT_HOST_NAME;
+				*opt++ = (uint8_t)hlen;
+				(void)memcpy(opt, hn, hlen);
+				opt += hlen;
+			}
+		}
+	}
+
 	/* 55 parameter request list — what we want in the OFFER/ACK. */
 	*opt++ = DHCP_OPT_PARAM_REQUEST;
 	*opt++ = 5;

--- a/src/hostnamed/freebsd-shim/shim.c
+++ b/src/hostnamed/freebsd-shim/shim.c
@@ -9,13 +9,13 @@
  *      hostnamed_xlog_cf (the my_log macro target).
  *   2. SCPrivate.h SPI subset — _SC_string_to_sockaddr,
  *      _SC_cfstring_to_cstring, _SC_CFStringIsValidDNSName.
- *   3. freebsd_synthesize_hostname — slug+suffix synthesis for the
- *      "localhost" fallback substitution.
+ *   3. freebsd_synthesize_hostname — slug synthesis (SMBIOS model
+ *      slug, e.g. "ThinkPad-T460s") for the "localhost" fallback
+ *      substitution. No serial/MAC suffix is appended.
  *   4. The synthesis helper machinery itself (derive_slug,
- *      derive_suffix, sanitize_slug, etc.), extracted from
- *      hostnamed.c — the new minimal hostnamed.c calls these for its
- *      boot-time prefs_monitor initial value, and the shim's
- *      freebsd_synthesize_hostname wraps them too.
+ *      sanitize_slug), extracted from hostnamed.c — the new minimal
+ *      hostnamed.c calls these for its boot-time prefs_monitor initial
+ *      value, and the shim's freebsd_synthesize_hostname wraps them too.
  *
  * Everything is in one file so the build picks up a small additional
  * SRCS surface; the individual responsibilities are demarcated by
@@ -56,7 +56,6 @@
 
 #define HOSTNAMED_MAX	64
 #define SLUG_MAX	40
-#define SUFFIX_LEN	6
 
 /* hostnamed's plain-C log surface (definition in hostnamed.c). */
 extern void	xlog(const char *fmt, ...);
@@ -87,7 +86,7 @@ hostnamed_xlog_cf(int level, CFStringRef format, ...)
 }
 
 #pragma mark -
-#pragma mark synthesis machinery (slug + suffix from SMBIOS + MAC)
+#pragma mark synthesis machinery (slug from SMBIOS)
 
 static int
 sh_read_kenv(const char *name, char *out, size_t outsz)
@@ -101,19 +100,6 @@ sh_read_kenv(const char *name, char *out, size_t outsz)
 		return (-1);
 	out[outsz - 1] = '\0';
 	return (n);
-}
-
-static int
-sh_read_sysctl_str(const char *name, char *out, size_t outsz)
-{
-	size_t n = outsz;
-
-	if (sysctlbyname(name, out, &n, NULL, 0) != 0 || n == 0)
-		return (-1);
-	out[outsz - 1] = '\0';
-	if (n > outsz)
-		n = outsz;
-	return ((int)n);
 }
 
 static size_t
@@ -140,113 +126,6 @@ sh_sanitize_slug(char *s)
 		j--;
 	s[j] = '\0';
 	return (j);
-}
-
-static int
-sh_serial_is_placeholder(const char *s)
-{
-	static const char *const placeholders[] = {
-		"", "None", "To be filled by O.E.M.",
-		"To Be Filled By O.E.M.", "Default string", "0",
-		"0123456789", "System Serial Number", "Not Specified",
-		NULL,
-	};
-	int i;
-
-	if (s == NULL)
-		return (1);
-	for (i = 0; placeholders[i] != NULL; i++)
-		if (strcmp(s, placeholders[i]) == 0)
-			return (1);
-	return (0);
-}
-
-static int
-sh_last_alnum_suffix(const char *src, char *out)
-{
-	char filtered[128];
-	size_t i, j, n;
-
-	j = 0;
-	for (i = 0; src[i] != '\0' && j < sizeof(filtered) - 1; i++)
-		if (isalnum((unsigned char)src[i]))
-			filtered[j++] = src[i];
-	filtered[j] = '\0';
-	if (j < SUFFIX_LEN)
-		return (-1);
-	n = j - SUFFIX_LEN;
-	(void)memcpy(out, filtered + n, SUFFIX_LEN);
-	out[SUFFIX_LEN] = '\0';
-	return (0);
-}
-
-static int
-sh_first_nic_mac(uint8_t mac[6])
-{
-	struct ifaddrs *ifa, *p;
-	int ok = -1;
-
-	if (getifaddrs(&ifa) != 0)
-		return (-1);
-	for (p = ifa; p != NULL; p = p->ifa_next) {
-		const struct sockaddr_dl *dl;
-		int zero;
-		size_t i;
-
-		if (p->ifa_addr == NULL ||
-		    p->ifa_addr->sa_family != AF_LINK)
-			continue;
-		dl = (const struct sockaddr_dl *)(const void *)p->ifa_addr;
-		if (dl->sdl_type != IFT_ETHER || dl->sdl_alen != 6)
-			continue;
-		zero = 1;
-		for (i = 0; i < 6; i++)
-			if (((const uint8_t *)LLADDR(dl))[i] != 0) {
-				zero = 0;
-				break;
-			}
-		if (zero)
-			continue;
-		(void)memcpy(mac, LLADDR(dl), 6);
-		ok = 0;
-		break;
-	}
-	freeifaddrs(ifa);
-	return (ok);
-}
-
-static int
-sh_derive_suffix(char out[SUFFIX_LEN + 1])
-{
-	char buf[256];
-	uint8_t mac[6];
-
-	if (sh_read_kenv("smbios.system.serial", buf, sizeof(buf)) > 0 &&
-	    !sh_serial_is_placeholder(buf) &&
-	    sh_last_alnum_suffix(buf, out) == 0)
-		return (0);
-	if (sh_first_nic_mac(mac) == 0) {
-		(void)snprintf(out, SUFFIX_LEN + 1, "%02x%02x%02x",
-		    mac[3], mac[4], mac[5]);
-		return (0);
-	}
-	if (sh_read_sysctl_str("kern.hostuuid", buf, sizeof(buf)) > 0) {
-		char filtered[64];
-		size_t i, j;
-		j = 0;
-		for (i = 0; buf[i] != '\0' && j < sizeof(filtered) - 1; i++) {
-			unsigned char c = (unsigned char)buf[i];
-			if (isxdigit(c))
-				filtered[j++] = (char)tolower(c);
-		}
-		filtered[j] = '\0';
-		if (j >= SUFFIX_LEN) {
-			(void)memcpy(out, filtered, SUFFIX_LEN);
-			out[SUFFIX_LEN] = '\0';
-			return (0);
-		}
-	}
-	return (-1);
 }
 
 static void
@@ -279,16 +158,15 @@ CFStringRef
 freebsd_synthesize_hostname(void)
 {
 	char slug[SLUG_MAX + 1];
-	char suffix[SUFFIX_LEN + 1];
 	char name[HOSTNAMED_MAX];
 
+	/* slug only — derived from the SMBIOS system version/product
+	 * (e.g. "ThinkPad-T460s"). No serial/MAC suffix is appended: the
+	 * name is the bare model slug. sh_derive_slug always yields a
+	 * non-empty value ("freebsd" as a last resort). */
 	sh_derive_slug(slug, sizeof(slug));
-	if (sh_derive_suffix(suffix) != 0) {
-		(void)strncpy(name, "freebsd", sizeof(name) - 1);
-		name[sizeof(name) - 1] = '\0';
-	} else {
-		(void)snprintf(name, sizeof(name), "%s-%s", slug, suffix);
-	}
+	(void)strncpy(name, slug, sizeof(name) - 1);
+	name[sizeof(name) - 1] = '\0';
 	if (strlen(name) > 63)
 		name[63] = '\0';
 	xlog("freebsd_synthesize_hostname -> '%s'", name);

--- a/src/launchd/src/launchd_early.c
+++ b/src/launchd/src/launchd_early.c
@@ -4,8 +4,8 @@
  * Two boot-readiness primitives the LaunchDaemon scan needs done
  * BEFORE it dispatches any plist:
  *
- *  1. launchd_early_sethostname() — synthesize a per-machine hostname
- *     from SMBIOS + first NIC MAC + kern.hostuuid, sethostname(2) it.
+ *  1. launchd_early_sethostname() — synthesize a hostname from the
+ *     SMBIOS model slug (e.g. "ThinkPad-T460s"), sethostname(2) it.
  *     getty (system_cmds/getty/main.c:202) reads gethostname() once
  *     at process start and caches it in a process-global; without
  *     this early set, getty's first login banner shows the FreeBSD
@@ -30,10 +30,9 @@
  *     is intentionally leaked — we just need logopen() to fire once.
  *
  * Synthesis machinery is duplicated from
- * src/hostnamed/freebsd-shim/shim.c (sh_derive_slug, sh_derive_suffix,
- * sh_first_nic_mac, sh_sanitize_slug, sh_last_alnum_suffix,
- * sh_serial_is_placeholder, sh_read_kenv, sh_read_sysctl_str) instead
- * of linked — PID 1 is the foundation, every transitive .so it pulls
+ * src/hostnamed/freebsd-shim/shim.c (sh_derive_slug, sh_sanitize_slug,
+ * sh_read_kenv) instead of linked — PID 1 is the foundation, every
+ * transitive .so it pulls
  * is one more thing that has to be present and loadable on a degraded
  * boot. Direct C means no CoreFoundation, no SCDS, no Libnotify;
  * only libc + libthr.
@@ -61,7 +60,6 @@
 #include <unistd.h>
 
 #define EARLY_SLUG_MAX		48
-#define EARLY_SUFFIX_LEN	6
 #define EARLY_NAME_MAX		64	/* DNS label limit */
 
 #include "launchd_early.h"
@@ -80,19 +78,6 @@ early_read_kenv(const char *name, char *out, size_t outsz)
 		return (-1);
 	out[outsz - 1] = '\0';
 	return (n);
-}
-
-static int
-early_read_sysctl_str(const char *name, char *out, size_t outsz)
-{
-	size_t n = outsz;
-
-	if (sysctlbyname(name, out, &n, NULL, 0) != 0 || n == 0)
-		return (-1);
-	out[outsz - 1] = '\0';
-	if (n > outsz)
-		n = outsz;
-	return ((int)n);
 }
 
 static size_t
@@ -119,113 +104,6 @@ early_sanitize_slug(char *s)
 		j--;
 	s[j] = '\0';
 	return (j);
-}
-
-static int
-early_serial_is_placeholder(const char *s)
-{
-	static const char *const placeholders[] = {
-		"", "None", "To be filled by O.E.M.",
-		"To Be Filled By O.E.M.", "Default string", "0",
-		"0123456789", "System Serial Number", "Not Specified",
-		NULL,
-	};
-	int i;
-
-	if (s == NULL)
-		return (1);
-	for (i = 0; placeholders[i] != NULL; i++)
-		if (strcmp(s, placeholders[i]) == 0)
-			return (1);
-	return (0);
-}
-
-static int
-early_last_alnum_suffix(const char *src, char *out)
-{
-	char filtered[128];
-	size_t i, j, n;
-
-	j = 0;
-	for (i = 0; src[i] != '\0' && j < sizeof(filtered) - 1; i++)
-		if (isalnum((unsigned char)src[i]))
-			filtered[j++] = src[i];
-	filtered[j] = '\0';
-	if (j < EARLY_SUFFIX_LEN)
-		return (-1);
-	n = j - EARLY_SUFFIX_LEN;
-	(void)memcpy(out, filtered + n, EARLY_SUFFIX_LEN);
-	out[EARLY_SUFFIX_LEN] = '\0';
-	return (0);
-}
-
-static int
-early_first_nic_mac(uint8_t mac[6])
-{
-	struct ifaddrs *ifa, *p;
-	int ok = -1;
-
-	if (getifaddrs(&ifa) != 0)
-		return (-1);
-	for (p = ifa; p != NULL; p = p->ifa_next) {
-		const struct sockaddr_dl *dl;
-		int zero;
-		size_t i;
-
-		if (p->ifa_addr == NULL ||
-		    p->ifa_addr->sa_family != AF_LINK)
-			continue;
-		dl = (const struct sockaddr_dl *)(const void *)p->ifa_addr;
-		if (dl->sdl_type != IFT_ETHER || dl->sdl_alen != 6)
-			continue;
-		zero = 1;
-		for (i = 0; i < 6; i++)
-			if (((const uint8_t *)LLADDR(dl))[i] != 0) {
-				zero = 0;
-				break;
-			}
-		if (zero)
-			continue;
-		(void)memcpy(mac, LLADDR(dl), 6);
-		ok = 0;
-		break;
-	}
-	freeifaddrs(ifa);
-	return (ok);
-}
-
-static int
-early_derive_suffix(char out[EARLY_SUFFIX_LEN + 1])
-{
-	char buf[256];
-	uint8_t mac[6];
-
-	if (early_read_kenv("smbios.system.serial", buf, sizeof(buf)) > 0 &&
-	    !early_serial_is_placeholder(buf) &&
-	    early_last_alnum_suffix(buf, out) == 0)
-		return (0);
-	if (early_first_nic_mac(mac) == 0) {
-		(void)snprintf(out, EARLY_SUFFIX_LEN + 1, "%02x%02x%02x",
-		    mac[3], mac[4], mac[5]);
-		return (0);
-	}
-	if (early_read_sysctl_str("kern.hostuuid", buf, sizeof(buf)) > 0) {
-		char filtered[64];
-		size_t i, j;
-		j = 0;
-		for (i = 0; buf[i] != '\0' && j < sizeof(filtered) - 1; i++) {
-			unsigned char c = (unsigned char)buf[i];
-			if (isxdigit(c))
-				filtered[j++] = (char)tolower(c);
-		}
-		filtered[j] = '\0';
-		if (j >= EARLY_SUFFIX_LEN) {
-			(void)memcpy(out, filtered, EARLY_SUFFIX_LEN);
-			out[EARLY_SUFFIX_LEN] = '\0';
-			return (0);
-		}
-	}
-	return (-1);
 }
 
 static void
@@ -255,16 +133,16 @@ int
 launchd_early_sethostname(char *out, size_t outsz)
 {
 	char slug[EARLY_SLUG_MAX + 1];
-	char suffix[EARLY_SUFFIX_LEN + 1];
 	char name[EARLY_NAME_MAX + 1];
 
+	/* slug only — no serial/MAC suffix. Must match hostnamed's
+	 * freebsd_synthesize_hostname (shim.c) so the kernel hostname set
+	 * here, the name hostnamed publishes to SCDS, the DHCP host-name
+	 * option ipconfigd sends, and mDNSResponder's .local label all
+	 * agree. e.g. "ThinkPad-T460s". */
 	early_derive_slug(slug, sizeof(slug));
-	if (early_derive_suffix(suffix) != 0) {
-		(void)strncpy(name, "freebsd", sizeof(name) - 1);
-		name[sizeof(name) - 1] = '\0';
-	} else {
-		(void)snprintf(name, sizeof(name), "%s-%s", slug, suffix);
-	}
+	(void)strncpy(name, slug, sizeof(name) - 1);
+	name[sizeof(name) - 1] = '\0';
 	if (sethostname(name, (int)strlen(name)) != 0)
 		return (-1);
 	if (out != NULL && outsz > 0) {

--- a/src/ssh-bonjour/sshd-mdns-register.c
+++ b/src/ssh-bonjour/sshd-mdns-register.c
@@ -1,0 +1,155 @@
+/*
+ * sshd-mdns-register — advertise this host's sshd over Bonjour (_ssh._tcp).
+ *
+ * Why this exists: mDNSResponder publishes the host's <name>.local
+ * address record only once at least one service that targets the local
+ * hostname is registered — mDNSCore's AdvertiseInterfaceIfNeeded() gates
+ * the per-interface A/PTR records on m->AutoTargetServices > 0. A
+ * headless box with no registered services advertises nothing, so it
+ * can't be reached by <name>.local at all (its Auth Records list is
+ * empty). Registering _ssh._tcp here bumps AutoTargetServices, which
+ *   (a) makes mDNSResponder advertise the host A/PTR records, so
+ *       <name>.local resolves, and
+ *   (b) makes the box discoverable as an SSH service in Bonjour
+ *       browsers (alongside other _ssh._tcp hosts on the LAN).
+ *
+ * Lifecycle: sshd-keygen-wrapper starts this in the background right
+ * before exec'ing `sshd -D`, so our parent becomes the sshd process.
+ * We pump the registration socket and watch our parent; when sshd goes
+ * away we are reparented to launchd (PID 1), and getppid() == 1 is our
+ * cue to deregister and exit. Deregistering drops AutoTargetServices
+ * back toward zero, so the host's .local advertisement is tied to sshd
+ * being up — matching the rescue-daemon design (see com.openssh.sshd
+ * .plist). .home.local / the bare hostname do NOT depend on this: those
+ * resolve via the router's DNS off the DHCP host-name option (see
+ * ipconfigd / dhcp_discover.c), independent of mDNS and sshd.
+ *
+ * Apple's launchd advertises _ssh._tcp via the ssh plist's Bonjour key;
+ * this image's launchd has no Bonjour key, so we register from a tiny
+ * co-process using the same libdns_sd client API instead.
+ */
+#include "dns_sd.h"
+
+#include <arpa/inet.h>		/* htons */
+
+#include <signal.h>
+#include <stdio.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#define SSH_SVC_TYPE	"_ssh._tcp"
+#define SSH_SVC_PORT	22
+#define PARENT_POLL_SEC	2
+
+static volatile sig_atomic_t g_stop;
+
+static void
+on_term(int sig)
+{
+	(void)sig;
+	g_stop = 1;
+}
+
+static void DNSSD_API
+register_cb(DNSServiceRef sdRef, DNSServiceFlags flags,
+    DNSServiceErrorType errorCode, const char *name, const char *regtype,
+    const char *domain, void *context)
+{
+	(void)sdRef;
+	(void)flags;
+	(void)context;
+	(void)fprintf(stderr,
+	    "sshd-mdns-register: register cb err=%d name=%s type=%s domain=%s\n",
+	    (int)errorCode, name ? name : "?", regtype ? regtype : "?",
+	    domain ? domain : "?");
+	(void)fflush(stderr);
+}
+
+int
+main(void)
+{
+	DNSServiceRef ref = NULL;
+	DNSServiceErrorType err;
+	int fd;
+
+	(void)signal(SIGTERM, on_term);
+	(void)signal(SIGINT, on_term);
+
+	/*
+	 * name=NULL -> mDNSResponder uses the host's .local name; host=NULL
+	 * -> the service targets the daemon's own hostname (AutoTarget).
+	 * That AutoTarget SRV is what bumps AutoTargetServices and triggers
+	 * host-record advertisement.
+	 *
+	 * Retry until it succeeds: mDNSResponder and sshd are both
+	 * RunAtLoad, and if sshd wins the boot race the daemon's
+	 * /var/run/mDNSResponder socket may not exist yet, so the register
+	 * (or the implicit connection) fails. We are not launchd-managed —
+	 * sshd-keygen-wrapper backgrounded us — so nothing would restart us
+	 * until sshd itself respawned. Loop instead, giving up only if sshd
+	 * (our parent) goes away (getppid()==1) or we are signalled. */
+	for (;;) {
+		err = DNSServiceRegister(&ref, 0, 0,
+		    NULL,		/* name = host's .local name */
+		    SSH_SVC_TYPE,
+		    NULL,		/* domain = ".local." */
+		    NULL,		/* host = this host (AutoTarget) */
+		    htons(SSH_SVC_PORT),
+		    0, NULL,		/* txt record */
+		    register_cb, NULL);
+		if (err == kDNSServiceErr_NoError)
+			break;
+		if (g_stop || getppid() == 1) {
+			(void)fprintf(stderr, "sshd-mdns-register: giving up "
+			    "(register err=%d, sshd gone/stopped)\n", (int)err);
+			return (1);
+		}
+		(void)fprintf(stderr, "sshd-mdns-register: DNSServiceRegister "
+		    "failed (err=%d) — mDNSResponder not up yet? retrying\n",
+		    (int)err);
+		(void)fflush(stderr);
+		(void)sleep(PARENT_POLL_SEC);
+	}
+
+	fd = DNSServiceRefSockFD(ref);
+	if (fd < 0) {
+		(void)fprintf(stderr, "sshd-mdns-register: DNSServiceRefSockFD "
+		    "failed\n");
+		DNSServiceRefDeallocate(ref);
+		return (1);
+	}
+
+	(void)fprintf(stderr, "sshd-mdns-register: advertising " SSH_SVC_TYPE
+	    " on port %d (tied to sshd pid %ld)\n", SSH_SVC_PORT,
+	    (long)getppid());
+	(void)fflush(stderr);
+
+	/*
+	 * Pump the registration socket and watch our parent. We were
+	 * backgrounded by sshd-keygen-wrapper just before it exec'd sshd,
+	 * so getppid() is the sshd pid. When sshd exits we are reparented
+	 * to launchd (PID 1); getppid() == 1 is the signal to deregister
+	 * and exit so the _ssh._tcp advertisement (and the host .local
+	 * record it carries) goes away with sshd.
+	 */
+	while (!g_stop && getppid() != 1) {
+		fd_set rfds;
+		struct timeval tv;
+		int r;
+
+		FD_ZERO(&rfds);
+		FD_SET(fd, &rfds);
+		tv.tv_sec = PARENT_POLL_SEC;
+		tv.tv_usec = 0;
+		r = select(fd + 1, &rfds, NULL, NULL, &tv);
+		if (r > 0 && FD_ISSET(fd, &rfds))
+			(void)DNSServiceProcessResult(ref);
+	}
+
+	(void)fprintf(stderr, "sshd-mdns-register: sshd gone (getppid=%ld) — "
+	    "deregistering " SSH_SVC_TYPE "\n", (long)getppid());
+	(void)fflush(stderr);
+	DNSServiceRefDeallocate(ref);
+	return (0);
+}


### PR DESCRIPTION
## Why

On a real first boot the box was reachable by **IP** but **no name resolved** — `ThinkPad-T460s-0L3CA7`, `…​.local`, and `…​.home.local` all failed to ping. Diagnosis on the live box (sshd from this branch) traced it to three independent gaps, fixed by the three `fix/feat` commits at the tip of this branch.

## Root causes & fixes (top 3 commits)

1. **`.local` never resolved** — mDNSResponder publishes the host's `<name>.local` A record only once a Bonjour service targeting the local hostname is registered (`AdvertiseInterfaceIfNeeded` gates on `m->AutoTargetServices > 0`). This headless image registered **no services**, so its Auth Records list was empty and it answered no `.local` query (even `Computer.local` → `NoSuchRecord`), while its cache of other LAN devices was healthy. **Fix:** `sshd-mdns-register`, a tiny `libdns_sd` co-process started by `sshd-keygen-wrapper` that registers `_ssh._tcp`; this bumps `AutoTargetServices` so the host A/PTR records advertise (and the box becomes SSH-discoverable). It watches `getppid()` and deregisters/exits when sshd goes away, so `.local` is tied to sshd's lifetime. Retries until mDNSResponder is up to survive the boot race.

2. **bare hostname + `.home.local` never resolved** — `ipconfigd`'s `build_dhcp_msg` never sent DHCP **Option 12 (Host Name)**, so the router had no name to register in LAN DNS. **Fix:** send option 12 (short hostname from `gethostname`) on DISCOVER/REQUEST. Independent of mDNS/sshd — these resolve via the router's DNS regardless.

3. **Serial in the hostname** — synthesis produced `ThinkPad-T460s-0L3CA7` (SMBIOS-serial suffix). **Fix:** use the bare model slug → `ThinkPad-T460s`, changed in lockstep in both synthesis copies (`hostnamed` shim + `launchd_early` PID-1) so kernel hostname, SCDS, DHCP option, and mDNS label all agree.

## Test plan

- [ ] CI `build.yml` green (build + QEMU boot test; hostnamed consistency rounds unaffected — they check name consistency, not suffix format).
- [ ] On real HW after a USB rebuild: `ping ThinkPad-T460s.local`, `ping ThinkPad-T460s.home.local`, `ping ThinkPad-T460s` all succeed; `dns-sd -B _ssh._tcp` lists the box.