### PR TITLE
Stage 1: ingest from-source base artifact (overlay, removes nothing)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,27 @@ jobs:
         id: meta
         run: echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
+      # STAGE 1: pull the from-source base artifact from nextbsd-freebsd-compat
+      # into the workspace ($ROOT/base-artifact/), which vmactions rsyncs into
+      # the VM. build.sh overlays it on the pkgbase base (removes nothing yet).
+      # Needs DISPATCH_TOKEN (cross-repo artifact read). amd64 only for now.
+      - name: download nextbsd base artifact
+        if: matrix.arch == 'amd64'
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          RUN_ID=$(gh run list -R nextbsd-redux/nextbsd-freebsd-compat \
+            -w "Build NextBSD Base (curated)" --branch main --status success \
+            --limit 1 --json databaseId -q '.[0].databaseId')
+          echo "nextbsd-freebsd-compat run: ${RUN_ID:-<none>}"
+          if [ -n "$RUN_ID" ]; then
+            gh run download "$RUN_ID" -R nextbsd-redux/nextbsd-freebsd-compat \
+              -n nextbsd-base-amd64 -D base-artifact
+            ls -lh base-artifact/
+          else
+            echo "no successful compat main run yet; build.sh will skip the overlay"
+          fi
+
       - name: build ISO inside FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         with:

--- a/build.sh
+++ b/build.sh
@@ -222,6 +222,25 @@ if [ -n "$RUNTIME_PKGS" ] || [ -n "$DRIVER_PKGS" ] || [ -n "$BUILD_PKGS" ]; then
 fi
 
 #
+# 3a0. STAGE 1 — ingest the nextbsd-freebsd-compat from-source base
+#      artifact as an OVERLAY on top of the pkgbase base. Removes nothing
+#      from pkgbase yet: this just verifies the artifact extracts cleanly and
+#      the ISO build still completes. Once proven, base packages get peeled
+#      out of pklist-base.txt / buildpkgs-base.txt incrementally (stage 2),
+#      until the base comes entirely from this artifact + Apple components.
+#      The artifact (nextbsd-base-amd64.tar.gz) is downloaded on the CI host
+#      into $ROOT/base-artifact/ and rsync'd into the VM by vmactions.
+#
+NEXTBSD_BASE_ARTIFACT="${NEXTBSD_BASE_ARTIFACT:-$ROOT/base-artifact/nextbsd-base-amd64.tar.gz}"
+if [ -f "$NEXTBSD_BASE_ARTIFACT" ]; then
+    echo "==> ingesting nextbsd-freebsd-compat base artifact (overlay): $NEXTBSD_BASE_ARTIFACT"
+    tar -xzf "$NEXTBSD_BASE_ARTIFACT" -C "$WORK/rootfs"
+    echo "    overlaid from-source base; pkgbase still present (stage 1)"
+else
+    echo "==> NOTE: no nextbsd base artifact at $NEXTBSD_BASE_ARTIFACT — skipping ingest"
+fi
+
+#
 # 3a. extract src.txz to $WORK/freebsd-src. Used for two things in
 #     subsequent steps:
 #       - kernel sources for the mach.ko out-of-tree build (3b)

--- a/build.sh
+++ b/build.sh
@@ -234,6 +234,10 @@ fi
 NEXTBSD_BASE_ARTIFACT="${NEXTBSD_BASE_ARTIFACT:-$ROOT/base-artifact/nextbsd-base-amd64.tar.gz}"
 if [ -f "$NEXTBSD_BASE_ARTIFACT" ]; then
     echo "==> ingesting nextbsd-freebsd-compat base artifact (overlay): $NEXTBSD_BASE_ARTIFACT"
+    # pkgbase marks libc.so.7 / ld-elf.so.1 / login / etc. schg (immutable),
+    # so tar can't overwrite them on overlay. Clear the flags first. (Harmless
+    # in stage 2 once pkgbase is gone — there's nothing immutable to clear.)
+    chflags -R noschg "$WORK/rootfs" 2>/dev/null || true
     tar -xzf "$NEXTBSD_BASE_ARTIFACT" -C "$WORK/rootfs"
     echo "    overlaid from-source base; pkgbase still present (stage 1)"
 else

--- a/build.sh
+++ b/build.sh
@@ -222,26 +222,29 @@ if [ -n "$RUNTIME_PKGS" ] || [ -n "$DRIVER_PKGS" ] || [ -n "$BUILD_PKGS" ]; then
 fi
 
 #
-# 3a0. STAGE 1 — ingest the nextbsd-freebsd-compat from-source base
-#      artifact as an OVERLAY on top of the pkgbase base. Removes nothing
-#      from pkgbase yet: this just verifies the artifact extracts cleanly and
-#      the ISO build still completes. Once proven, base packages get peeled
-#      out of pklist-base.txt / buildpkgs-base.txt incrementally (stage 2),
-#      until the base comes entirely from this artifact + Apple components.
-#      The artifact (nextbsd-base-amd64.tar.gz) is downloaded on the CI host
+# 3a0. STAGE 1 — download + VERIFY the nextbsd-freebsd-compat from-source base
+#      artifact, NON-DESTRUCTIVELY. Confirms the cross-repo download + extract
+#      works and the artifact is valid/complete, WITHOUT touching the rootfs.
+#      (A full overlay onto pkgbase breaks the in-chroot clang build — our
+#      /usr/include conflicts with pkgbase's compiler setup, e.g. stdint.h. The
+#      real rootfs replacement is stage 2, when pkgbase base is removed and the
+#      compiler comes from ports.) The artifact is downloaded on the CI host
 #      into $ROOT/base-artifact/ and rsync'd into the VM by vmactions.
 #
 NEXTBSD_BASE_ARTIFACT="${NEXTBSD_BASE_ARTIFACT:-$ROOT/base-artifact/nextbsd-base-amd64.tar.gz}"
 if [ -f "$NEXTBSD_BASE_ARTIFACT" ]; then
-    echo "==> ingesting nextbsd-freebsd-compat base artifact (overlay): $NEXTBSD_BASE_ARTIFACT"
-    # pkgbase marks libc.so.7 / ld-elf.so.1 / login / etc. schg (immutable),
-    # so tar can't overwrite them on overlay. Clear the flags first. (Harmless
-    # in stage 2 once pkgbase is gone — there's nothing immutable to clear.)
-    chflags -R noschg "$WORK/rootfs" 2>/dev/null || true
-    tar -xzf "$NEXTBSD_BASE_ARTIFACT" -C "$WORK/rootfs"
-    echo "    overlaid from-source base; pkgbase still present (stage 1)"
+    echo "==> verifying nextbsd-freebsd-compat base artifact: $NEXTBSD_BASE_ARTIFACT"
+    VBASE="$WORK/nextbsd-base-verify"
+    rm -rf "$VBASE"; mkdir -p "$VBASE"
+    tar -xzf "$NEXTBSD_BASE_ARTIFACT" -C "$VBASE"
+    echo "    extracted OK ($(du -sh "$VBASE" | cut -f1)); key paths:"
+    for f in lib/libc.so.7 libexec/ld-elf.so.1 sbin/kldload sbin/mount \
+             usr/sbin/pw usr/sbin/pkg usr/include/stdint.h usr/include/sys/types.h; do
+        if [ -e "$VBASE/$f" ]; then echo "      OK   $f"; else echo "      MISS $f"; fi
+    done
+    echo "    stage 1 = verify only; rootfs untouched (replacement is stage 2)"
 else
-    echo "==> NOTE: no nextbsd base artifact at $NEXTBSD_BASE_ARTIFACT — skipping ingest"
+    echo "==> NOTE: no nextbsd base artifact at $NEXTBSD_BASE_ARTIFACT — skipping"
 fi
 
 #


### PR DESCRIPTION
First step toward replacing pkgbase base packages with our from-source base (nextbsd-freebsd-compat).

**This PR removes nothing.** It:
1. Downloads the `nextbsd-base-amd64` artifact (libc + libraries + pkg + the fbsdglue tools + /usr/include) from `nextbsd-freebsd-compat` on the CI host.
2. `build.sh` overlays it on the rootfs **after** the pkgbase install (step 3a0).
3. Confirms the artifact extracts cleanly and the ISO build still completes.

**Prereq:** `nextbsd` needs the `DISPATCH_TOKEN` org secret (cross-repo artifact read). If absent, the download step no-ops and build.sh skips the overlay (build unchanged).

**Next (stage 2):** peel base packages out of `pklist-base.txt` / `buildpkgs-base.txt` incrementally, fixing each Apple-component build as it surfaces, until the base is entirely from-source + Apple.