### PR TITLE
ci: add base-updated trigger (rebuild ISO when from-source base changes)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,12 @@ on:
       - '**/*.md'
       - 'LICENSE'
       - 'NOTICE'
+  # Rebuild the ISO when the from-source base it ingests changes. Sent by
+  # nextbsd-freebsd-compat at the end of a successful main base build, which
+  # is itself triggered by the toolchain on a releng/15.0 update. Full chain:
+  # releng/15.0 -> toolchain -> compat -> (base-updated) -> nextbsd.
+  repository_dispatch:
+    types: [base-updated]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Adds `repository_dispatch: [base-updated]`, sent by nextbsd-freebsd-compat at the end of a successful main base build (itself triggered by the toolchain on a releng/15.0 update). Completes the cascade so a freebsd-src releng/15.0 update flows to a fresh ISO: `releng/15.0 → toolchain → compat → nextbsd`.

Pairs with toolchain PR (toolchain→compat dispatch) and compat PR #7 (compat→nextbsd dispatch). Isolated trigger-only change — independent of the unmerged stage-2 base-from-source work; safe to merge on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)