### PR TITLE
ci: publish continuous ISO on upstream cascade too, not just repo pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,9 +234,12 @@ jobs:
   release:
     name: release (FreeBSD ${{ matrix.variant }} ${{ matrix.arch }})
     needs: [build, test]
-    # Only publish when both jobs pass on a push to main. PRs and other
-    # branches build + test but never publish.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Publish when both jobs pass on main — either from a push to this repo or
+    # from an upstream cascade (repository_dispatch: base-updated), so an
+    # upstream change (releng -> toolchain -> compat -> nextbsd) refreshes the
+    # published continuous ISO, not just nextbsd-repo pushes. PRs and other
+    # branches build + test but never publish (ref is not refs/heads/main).
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'repository_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The cascade test surfaced this: a `repository_dispatch: base-updated` run **built and boot-tested** the ISO but the `release` job was **skipped**, because it was gated push-only:

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

So an upstream change (releng → toolchain → compat → nextbsd) refreshed every upstream `continuous` release but **not** the published ISO — only a push to this repo did. This widens the gate to also publish on the cascade:

```yaml
if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'repository_dispatch')
```

## PR isolation is preserved
`refs/heads/main` is still a **required** condition (AND'd with the event check). A PR's `github.ref` is `refs/pull/<N>/merge`, so PRs still build + test but **never** publish — same as before, same as every other repo's publish job. This change only widens *which main events* publish (push **or** upstream cascade), not *which refs*.

Verified just now: the `base-updated` cascade run built + passed the boot test; with this change it would also publish the refreshed `NextBSD-<arch>-<date>.img.zip` to the `continuous` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)