### PR TITLE
busyState/waitQuiet (Phase 0): mach.ko bus_busy + mach_wait_quiet, hwregd quiescence flip, libIOKit APIs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -360,6 +360,39 @@ mkdir -p "$WORK/freebsd-src"
 tar -xJf "$DIST/src.txz" -C "$WORK/freebsd-src"
 
 #
+# 3a1. Patch the extracted STOCK src tree with the NEXTBSD kernel
+#      patches so mach.ko compiles against the SAME headers the ingested
+#      NEXTBSD kernel was built from. Critically this lands
+#      0002-newbus-device-match-quiesce-hook.patch, which adds the
+#      device_match_start / device_match_end declarations to
+#      sys/sys/eventhandler.h — without it mach_busystate.c fails to
+#      compile (no EVENTHANDLER_DECLARE for those events). Mirrors the
+#      "Apply patches to source" step in nextbsd-kernel-modules's
+#      build.yml: clone nextbsd-kernel (depth 1), apply each entry in
+#      patches/series with `git apply`, falling back to `patch -p1`.
+#      No syscalls.master regen is needed — mach.ko doesn't compile the
+#      generated syscall tables.
+#
+echo "==> applying NEXTBSD kernel patches to extracted src tree"
+NEXTBSD_KERNEL_REPO="${NEXTBSD_KERNEL_REPO:-https://github.com/nextbsd-redux/nextbsd-kernel.git}"
+NK_DIR="$WORK/nextbsd-kernel"
+rm -rf "$NK_DIR"
+git clone --depth 1 "$NEXTBSD_KERNEL_REPO" "$NK_DIR"
+for p in $(cat "$NK_DIR/patches/series"); do
+    echo "    applying $p"
+    if ! (cd "$WORK/freebsd-src/usr/src" && git apply "$NK_DIR/patches/$p"); then
+        echo "    git apply failed for $p — retrying with patch -p1"
+        (cd "$WORK/freebsd-src/usr/src" && patch -p1 < "$NK_DIR/patches/$p")
+    fi
+done
+echo "==> NEXTBSD kernel patches applied; verifying device_match_start landed"
+grep -q 'device_match_start' \
+    "$WORK/freebsd-src/usr/src/sys/sys/eventhandler.h" || {
+    echo "ERROR: device_match_start not present in patched eventhandler.h" >&2
+    exit 1
+}
+
+#
 # 3a2. The irreducibly-FreeBSD-only userland (kld*, UFS, devfs, ldconfig,
 #      mount, newfs, pw, login, su, ldd, geom, ... plus their prereq libs)
 #      now comes from the nextbsd-freebsd-compat from-source artifact,
@@ -726,6 +759,17 @@ cc -I"$WORK/rootfs/usr/include" \
    "$ROOT/src/mach_kmod/tests/test_task_special_port.c" \
    -lsystem_kernel
 ls -lh "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_task_special_port"
+
+# test_busystate — validates the bus-quiescence feature: reads
+# mach.bus.busy (must settle to 0 after boot probe finishes) and calls
+# mach_wait_quiet (must return promptly on a quiescent bus). Uses only
+# libc sysctlbyname + syscall, so no -lsystem_kernel needed. Failure
+# surfaces as BUSYSTATE-FAIL / WAITQUIET-FAIL.
+echo "==> building test_busystate"
+cc -I"$WORK/rootfs/usr/include" \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_busystate" \
+   "$ROOT/src/mach_kmod/tests/test_busystate.c"
+ls -lh "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_busystate"
 
 # test_host_bootstrap — Phase G2b validation: host_set_special_port
 # stores into realhost.special[HOST_BOOTSTRAP_PORT], and

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -103,6 +103,20 @@ else
     exit 1
 fi
 
+# 2c''. bus quiescence (device_match_start/end → mach.bus.busy +
+# mach_wait_quiet). By the time run.sh executes, the cold-boot device
+# probe has finished and hwregd has flipped to live mode, so the
+# kernel's in-flight probe->attach count (mach.bus.busy, maintained by
+# mach.ko's device_match_start/device_match_end eventhandler consumer)
+# must read 0, and mach_wait_quiet must return promptly. test_busystate
+# emits BUSYSTATE-OK + WAITQUIET-OK (or *-FAIL).
+if [ -x /usr/tests/freebsd-launchd-mach/test_busystate ]; then
+    /usr/tests/freebsd-launchd-mach/test_busystate || true  # markers gate in boot-test.sh
+else
+    echo "BUSYSTATE-FAIL: test_busystate binary not installed"
+    echo "WAITQUIET-FAIL: test_busystate binary not installed"
+fi
+
 # 2d. userland: bootstrap protocol round-trip (Phase G1). Hand-rolled
 # message-ID server loop dispatching CHECK_IN / LOOK_UP requests over
 # Mach IPC. The test spawns a pthread that runs bootstrap_server_run,

--- a/src/hwregd/hwregd.c
+++ b/src/hwregd/hwregd.c
@@ -102,18 +102,18 @@
 #define EVENT_LINE_MAX		1024
 
 /*
- * Initial-backlog drain quiet window. After reading the devctl
- * backlog hwregd waits this many milliseconds of no further nomatch
- * traffic before flipping to live mode + calling devctl_freeze /
- * kldload / devctl_thaw on the queued modules. 250 ms is empirically
- * comfortable: long enough that a slow CI VM's per-event read+match
- * cycle doesn't false-trigger the flip mid-backlog, short enough
- * that boot delay is bounded. The kernel's freeze/thaw is the real
- * safety primitive — see file header. This window only times the
- * "we've drained what the kernel queued" handoff, not how long the
- * kernel's probe takes.
+ * Pre-live quiescence poll cadence. After the devctl backlog has
+ * drained through us, the flip to live mode is gated on KERNEL
+ * bus-quiescence (mach.bus.busy == 0) rather than on a fixed devctl-
+ * silence timer: the NEXTBSD kernel's device_match_start/end
+ * eventhandlers (consumed by mach.ko's mach.bus.busy sysctl) tell us
+ * exactly when the device tree has stopped probing/attaching. We use
+ * this short select(2) timeout in pre-live mode purely to wake up and
+ * re-poll mach.bus.busy when no devctl traffic is pending. The kernel's
+ * devctl_freeze/thaw remains the real batching primitive — see the
+ * file header.
  */
-#define HWREGD_BACKLOG_QUIET_MS	250
+#define HWREGD_QUIESCE_POLL_MS	250
 
 /* Mach service name hwregd checks in with launchd for its pub/sub bus. */
 #define HWREGD_SERVICE_NAME	"org.freebsd.hwregd"
@@ -513,6 +513,30 @@ drain_deferred_loads(void)
 	xlog("HWREG-AUTOLOAD-OK: drained queue "
 	    "(loaded=%d already=%d failed=%d)",
 	    loaded, existing, failed);
+}
+
+/*
+ * Kernel bus-quiescence probe. Reads mach.bus.busy — the in-flight
+ * device_probe_and_attach() count maintained by mach.ko's
+ * device_match_start/device_match_end eventhandler consumer. Returns
+ * true when the device tree is quiescent (busy == 0).
+ *
+ * If the sysctl is unavailable (mach.ko not loaded, or an older kernel
+ * without the device_match_* hook), we treat the bus as quiescent so
+ * hwregd still flips to live mode after the devctl backlog drains —
+ * degrading to the pre-quiescence behavior rather than wedging boot.
+ */
+static bool
+bus_is_quiescent(void)
+{
+	int busy = 0;
+	size_t len = sizeof(busy);
+
+	if (sysctlbyname("mach.bus.busy", &busy, &len, NULL, 0) < 0) {
+		/* sysctl missing — assume quiescent (see comment). */
+		return (true);
+	}
+	return (busy == 0);
 }
 
 /* --- linker.hints reader (ported from devmatch.c) ----------------- */
@@ -1650,17 +1674,19 @@ main(int argc, char **argv)
 		FD_SET(fd, &rfds);
 
 		/*
-		 * Pre-live (initial backlog drain): use the short
-		 * HWREGD_BACKLOG_QUIET_MS select timeout. When select(2)
-		 * returns 0 (no more events queued), we've drained what the
-		 * kernel had buffered — flip to live mode + freeze/thaw the
-		 * kldload batch. Live mode uses a 5s timeout (idle ticking,
+		 * Pre-live (initial backlog drain): poll on a short
+		 * HWREGD_QUIESCE_POLL_MS select timeout. When select(2)
+		 * returns 0 (no more events queued) we've drained what the
+		 * kernel had buffered — but we now gate the flip to live mode
+		 * on KERNEL bus-quiescence (mach.bus.busy == 0) rather than on
+		 * the timer alone, so we never flip while a probe->attach is
+		 * still in flight. Live mode uses a 5s timeout (idle ticking,
 		 * no urgency).
 		 */
 		struct timeval tv = live_mode
 		    ? (struct timeval){ .tv_sec = 5, .tv_usec = 0 }
 		    : (struct timeval){ .tv_sec = 0,
-		      .tv_usec = HWREGD_BACKLOG_QUIET_MS * 1000 };
+		      .tv_usec = HWREGD_QUIESCE_POLL_MS * 1000 };
 		int r = select(fd + 1, &rfds, NULL, NULL, &tv);
 		if (r < 0) {
 			if (errno == EINTR)
@@ -1671,17 +1697,20 @@ main(int argc, char **argv)
 		if (r == 0) {
 			/*
 			 * Select timed out with no devctl events ready. In
-			 * pre-live mode that's the signal that the kernel's
-			 * boot-time backlog has fully drained through us —
-			 * flip to live mode + freeze/kldload/thaw the queued
-			 * modules. In live mode this is just an idle tick;
-			 * loop back and wait for the next event.
+			 * pre-live mode this is a poll tick: the devctl backlog
+			 * has drained through us, so flip to live mode IFF the
+			 * kernel reports the device tree quiescent — otherwise
+			 * keep polling until device_match_end has balanced the
+			 * last in-flight probe. In live mode this is just an
+			 * idle tick; loop back and wait for the next event.
 			 */
 			if (!live_mode) {
+				if (!bus_is_quiescent())
+					continue;	/* still probing — keep polling */
 				live_mode = true;
-				xlog("devctl backlog quiet for %dms — live mode: "
-				    "freeze + drain queued kldloads + thaw",
-				    HWREGD_BACKLOG_QUIET_MS);
+				xlog("devctl backlog drained + kernel bus "
+				    "quiescent (mach.bus.busy==0) — live mode: "
+				    "freeze + drain queued kldloads + thaw");
 				drain_deferred_loads();
 			}
 			continue;

--- a/src/launchd/freebsd-shims/IOKit/IOKitLib.h
+++ b/src/launchd/freebsd-shims/IOKit/IOKitLib.h
@@ -29,6 +29,9 @@
 #include <mach/mach_port.h>
 
 #include <sys/syscall.h>	/* NO_SYSCALL */
+#ifndef NO_SYSCALL
+#define NO_SYSCALL (-1)	/* kernel sentinel; sysctl reports -1 when a trap is unwired */
+#endif
 #include <sys/sysctl.h>		/* sysctlbyname */
 #include <stdint.h>
 #include <stdio.h>		/* snprintf */

--- a/src/launchd/freebsd-shims/IOKit/IOKitLib.h
+++ b/src/launchd/freebsd-shims/IOKit/IOKitLib.h
@@ -6,7 +6,12 @@
  * (load/unload/list/start/stop/etc.):
  *
  *   1. IOKitWaitQuiet — waits for kexts to settle before reboot.
- *      We don't have kexts. Stub returns kIOReturnSuccess.
+ *      We don't have kexts, but the NEXTBSD kernel + mach.ko track
+ *      in-flight device probe->attach (device_match_start/end) and
+ *      expose a mach_wait_quiet syscall; this shim resolves + calls it
+ *      so launchctl reboot waits for real bus quiescence. Returns
+ *      kIOReturnSuccess on quiesce / timeout (or if the syscall is
+ *      absent — nothing to wait for).
  *
  *   2. IORegistryEntry{FromPath,CreateCFProperty} + IOObjectRelease
  *      — looks up "IODeviceTree:/chosen" to read kBootRootActiveKey
@@ -22,6 +27,12 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <mach/mach_port.h>
+
+#include <sys/syscall.h>	/* NO_SYSCALL */
+#include <sys/sysctl.h>		/* sysctlbyname */
+#include <stdint.h>
+#include <stdio.h>		/* snprintf */
+#include <unistd.h>		/* syscall(2) */
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,9 +52,10 @@ typedef int32_t IOReturn;
 #define kIOReturnSuccess        0
 
 /* Wait-time spec used by IOKitWaitQuiet. macOS struct mach_timespec_t.
- * launchctl only ever passes a pointer to a stack value; the kext-quiet
- * stub doesn't consume it, so an opaque struct is fine. Use plain int
- * to avoid pulling in <mach/clock_types.h> (clock_res_t lives there). */
+ * launchctl only ever passes a pointer to a stack value (or NULL).
+ * IOKitWaitQuiet below sums tv_sec/tv_nsec into a nanosecond budget for
+ * the mach_wait_quiet syscall. Use plain int fields to avoid pulling in
+ * <mach/clock_types.h> (clock_res_t lives there). */
 typedef struct {
         unsigned int    tv_sec;
         int             tv_nsec;
@@ -52,10 +64,31 @@ typedef struct {
 #define mach_timespec_t freebsd_mach_timespec_t
 #endif
 
-/* Stub: kexts don't exist on FreeBSD; nothing to wait for. */
+/*
+ * IOKitWaitQuiet — wait for the host's device tree to quiesce before
+ * launchctl reboot proceeds. On FreeBSD there are no kexts, but the
+ * NEXTBSD kernel + mach.ko track in-flight device probe->attach via the
+ * device_match_start/device_match_end eventhandlers and expose a
+ * `mach_wait_quiet` syscall (resolved by number via `sysctl
+ * mach.syscall.mach_wait_quiet`). Resolve + call it here, self-contained
+ * (no libIOKit / libmach link dependency for launchctl). `wt` is summed
+ * to a nanosecond budget (NULL == wait indefinitely). Returns
+ * kIOReturnSuccess on quiesce, deadline, or if the syscall is
+ * unavailable (mach.ko not loaded — nothing to wait for, as before).
+ */
 static inline IOReturn
-IOKitWaitQuiet(mach_port_t mp __unused, mach_timespec_t *wt __unused)
+IOKitWaitQuiet(mach_port_t mp __unused, mach_timespec_t *wt)
 {
+        int num;
+        size_t len = sizeof(num);
+        uint64_t timeout_ns;
+
+        if (sysctlbyname("mach.syscall.mach_wait_quiet", &num, &len,
+            NULL, 0) != 0 || num < 0 || num == NO_SYSCALL)
+                return kIOReturnSuccess;	/* syscall absent — nothing to wait for */
+        timeout_ns = (wt == NULL) ? 0
+            : ((uint64_t)wt->tv_sec * 1000000000ULL + (uint64_t)wt->tv_nsec);
+        (void)syscall(num, timeout_ns);
         return kIOReturnSuccess;
 }
 

--- a/src/libIOKit/IOKit/IOKitLib.h
+++ b/src/libIOKit/IOKit/IOKitLib.h
@@ -298,6 +298,57 @@ kern_return_t	IOServiceAddMatchingNotification(
 		    void *refCon,
 		    io_iterator_t *notification);
 
+/*
+ * iter 5 — bus quiescence -----------------------------------------
+ *
+ * mach_timespec_t — Apple's IOKit wait-timeout struct (normally from
+ * <mach/clock_types.h>). Declared inline here to avoid dragging in the
+ * whole clock-types header (clock_res_t et al.) just for the two
+ * fields IOServiceWaitQuiet / IOKitWaitQuiet consume. tv_sec/tv_nsec
+ * are summed to a nanosecond budget and handed to the mach_wait_quiet
+ * syscall.
+ */
+#ifndef _MACH_CLOCK_TYPES_H_
+typedef struct mach_timespec {
+	unsigned int	tv_sec;
+	int		tv_nsec;
+} mach_timespec_t;
+#endif
+
+/*
+ * IORegistryEntryGetBusyState — *busyState = the number of in-flight
+ * device probe->attach operations on the host.
+ *
+ * GLOBAL-APPROXIMATION DIVERGENCE FROM APPLE: on macOS this reports the
+ * busy count of a SPECIFIC IORegistryEntry's subtree. This facade has
+ * no kernel IOService tree to walk per-entry; it reports the GLOBAL
+ * kernel bus-busy count from `sysctl mach.bus.busy` (the in-flight
+ * device_probe_and_attach() depth maintained by mach.ko's
+ * device_match_start/device_match_end eventhandler consumer). The
+ * `entry` argument is therefore accepted for source compatibility and
+ * IGNORED — busyState is host-wide, not subtree-scoped. Returns
+ * kIOReturnSuccess (0) once the count was read; non-zero kern_return_t
+ * if the sysctl is unavailable (mach.ko not loaded).
+ */
+kern_return_t	IORegistryEntryGetBusyState(mach_port_t mainPort,
+		    io_registry_entry_t entry, uint32_t *busyState);
+
+/*
+ * IOServiceWaitQuiet / IOKitWaitQuiet — block until the host's device
+ * tree quiesces (global mach.bus.busy reaches 0), or until `timeout`
+ * elapses (NULL == wait indefinitely). Both resolve the mach_wait_quiet
+ * syscall via `sysctl mach.syscall.mach_wait_quiet` and call it with the
+ * timeout converted to nanoseconds. Like Apple's APIs they return
+ * success on EITHER quiescence or the deadline elapsing
+ * (kIOReturnSuccess); a resolution failure maps to kIOReturnError.
+ *
+ * Per the GLOBAL-APPROXIMATION note above, IOServiceWaitQuiet ignores
+ * its `service` argument — the wait is host-wide.
+ */
+kern_return_t	IOServiceWaitQuiet(io_service_t service,
+		    mach_timespec_t *timeout);
+IOReturn	IOKitWaitQuiet(mach_port_t mainPort, mach_timespec_t *timeout);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libIOKit/IOKitLib.c
+++ b/src/libIOKit/IOKitLib.c
@@ -17,6 +17,9 @@
 #include <servers/bootstrap.h>
 
 #include <sys/syscall.h>	/* NO_SYSCALL */
+#ifndef NO_SYSCALL
+#define NO_SYSCALL (-1)	/* kernel sentinel; sysctl reports -1 when a trap is unwired */
+#endif
 #include <sys/sysctl.h>		/* sysctlbyname (mach.bus.busy / mach.syscall.*) */
 
 #include <pthread.h>

--- a/src/libIOKit/IOKitLib.c
+++ b/src/libIOKit/IOKitLib.c
@@ -16,10 +16,15 @@
 #include <mach/mach.h>
 #include <servers/bootstrap.h>
 
+#include <sys/syscall.h>	/* NO_SYSCALL */
+#include <sys/sysctl.h>		/* sysctlbyname (mach.bus.busy / mach.syscall.*) */
+
 #include <pthread.h>
 #include <stdatomic.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>		/* syscall(2) */
 
 /* hwregd send right — cached after the first bootstrap_look_up. */
 static pthread_once_t	hwregd_once = PTHREAD_ONCE_INIT;
@@ -199,4 +204,92 @@ IOObjectRelease(io_object_t object)
 		free(object->ids);
 	free(object);
 	return (KERN_SUCCESS);
+}
+
+/*
+ * iter 5 — bus quiescence.
+ *
+ * These do NOT use hwregd's MIG RPC: bus-busy state lives in the kernel
+ * (mach.ko's device_match_start/device_match_end consumer), so we read
+ * `sysctl mach.bus.busy` and resolve+call the `mach_wait_quiet` syscall
+ * directly — the same lazy "resolve via sysctl mach.syscall.<name>,
+ * cache the number" pattern libmach uses. See the header for the
+ * GLOBAL-APPROXIMATION divergence from Apple (per-entry busy state is
+ * reported host-wide).
+ */
+
+/* resolve_mach_syscall — read sysctl mach.syscall.<name> -> syscall #. */
+static int
+resolve_mach_syscall(const char *name)
+{
+	char oid[64];
+	int num;
+	size_t len = sizeof(num);
+
+	if (snprintf(oid, sizeof(oid), "mach.syscall.%s", name) >=
+	    (int)sizeof(oid))
+		return (NO_SYSCALL);
+	if (sysctlbyname(oid, &num, &len, NULL, 0) != 0)
+		return (NO_SYSCALL);
+	if (num < 0)
+		return (NO_SYSCALL);
+	return (num);
+}
+
+kern_return_t
+IORegistryEntryGetBusyState(mach_port_t mainPort __unused,
+    io_registry_entry_t entry __unused, uint32_t *busyState)
+{
+	int busy = 0;
+	size_t len = sizeof(busy);
+
+	if (busyState == NULL)
+		return (KERN_INVALID_ARGUMENT);
+	/* `entry` ignored — host-wide approximation (see header). */
+	if (sysctlbyname("mach.bus.busy", &busy, &len, NULL, 0) != 0)
+		return (kIOReturnError);
+	*busyState = (uint32_t)busy;
+	return (kIOReturnSuccess);
+}
+
+/*
+ * __io_wait_quiet_ns — resolve+invoke mach_wait_quiet with a nanosecond
+ * budget (0 == wait indefinitely). Returns kIOReturnSuccess on quiesce
+ * or deadline; kIOReturnError if the syscall can't be resolved.
+ */
+static IOReturn
+__io_wait_quiet_ns(uint64_t timeout_ns)
+{
+	static int num = NO_SYSCALL;
+
+	if (num == NO_SYSCALL) {
+		num = resolve_mach_syscall("mach_wait_quiet");
+		if (num == NO_SYSCALL)
+			return (kIOReturnError);
+	}
+	if (syscall(num, timeout_ns) != 0)
+		return (kIOReturnError);
+	return (kIOReturnSuccess);
+}
+
+/* mach_timespec_t -> nanoseconds; NULL == 0 == wait indefinitely. */
+static uint64_t
+__io_timespec_to_ns(mach_timespec_t *ts)
+{
+	if (ts == NULL)
+		return (0);
+	return ((uint64_t)ts->tv_sec * 1000000000ULL + (uint64_t)ts->tv_nsec);
+}
+
+IOReturn
+IOKitWaitQuiet(mach_port_t mainPort __unused, mach_timespec_t *timeout)
+{
+	return (__io_wait_quiet_ns(__io_timespec_to_ns(timeout)));
+}
+
+kern_return_t
+IOServiceWaitQuiet(io_service_t service __unused, mach_timespec_t *timeout)
+{
+	/* `service` ignored — host-wide approximation (see header). */
+	return (__io_wait_quiet_ns(__io_timespec_to_ns(timeout)));
 }

--- a/src/mach_kmod/Makefile
+++ b/src/mach_kmod/Makefile
@@ -90,6 +90,12 @@ SRCS+=	mach_syscall_wire.c
 # mach.stats.kmsgs_in_use. Phase B / Tier 1 task C.
 SRCS+=	mach_stats.c
 
+# Out-of-tree bus-quiescence busy counter + mach_wait_quiet syscall,
+# built on the NEXTBSD kernel's device_match_start/device_match_end
+# eventhandler pair. Exposes mach.bus.busy / mach.bus.quiesce_gen and
+# the mach_wait_quiet syscall (backs IOKitWaitQuiet / IOServiceWaitQuiet).
+SRCS+=	mach_busystate.c
+
 # Include paths:
 #   include/apple/  — Apple-ism headers (proc_info.h, kern_event.h, ...)
 #   include/       — top-level so '#include <sys/mach/...>' resolves to

--- a/src/mach_kmod/include/sys/mach/_mach_sysproto.h
+++ b/src/mach_kmod/include/sys/mach/_mach_sysproto.h
@@ -201,6 +201,15 @@ struct register_event_bell_trap_args {
 struct unregister_event_bell_trap_args {
 	char port_l_[PADL_(mach_port_name_t)]; mach_port_name_t port; char port_r_[PADR_(mach_port_name_t)];
 };
+/*
+ * mach_wait_quiet — block until the device tree quiesces (mach.bus.busy
+ * reaches 0). `timeout` is a nanosecond budget; 0 means wait
+ * indefinitely. Backs Apple's IOKitWaitQuiet / IOServiceWaitQuiet. See
+ * src/mach_kmod/src/mach_busystate.c.
+ */
+struct mach_wait_quiet_args {
+	char timeout_l_[PADL_(uint64_t)]; uint64_t timeout; char timeout_r_[PADR_(uint64_t)];
+};
 struct mach_msg_trap_args {
 	char msg_l_[PADL_(mach_msg_header_t *)]; mach_msg_header_t * msg; char msg_r_[PADR_(mach_msg_header_t *)];
 	char option_l_[PADL_(mach_msg_option_t)]; mach_msg_option_t option; char option_r_[PADR_(mach_msg_option_t)];

--- a/src/mach_kmod/src/mach_busystate.c
+++ b/src/mach_kmod/src/mach_busystate.c
@@ -47,7 +47,7 @@
  * decremented on device_match_end; the 1->0 transition bumps
  * bus_quiesce_gen and wakes any thread sleeping in mach_wait_quiet.
  */
-static volatile int	bus_busy;
+static int bus_busy;
 static int		bus_quiesce_gen;
 
 static eventhandler_tag	mach_busy_start_tag;

--- a/src/mach_kmod/src/mach_busystate.c
+++ b/src/mach_kmod/src/mach_busystate.c
@@ -1,0 +1,155 @@
+/*
+ * mach_busystate.c — bus-quiescence busy counter + mach_wait_quiet
+ * syscall, layered on the NEXTBSD kernel's balanced
+ * device_match_start / device_match_end eventhandler pair.
+ *
+ * The patched kernel (nextbsd-kernel patches/series:
+ * 0002-newbus-device-match-quiesce-hook.patch) brackets every
+ * device_probe_and_attach() with EVENTHANDLER_DIRECT_INVOKE of
+ * device_match_start on entry and device_match_end on exit. Because the
+ * bracketing is single-entry/single-exit it is perfectly paired across
+ * every return path and nests under recursion, so a simple ++/--
+ * in-flight counter (bus_busy) returns to 0 exactly when the device
+ * tree quiesces.
+ *
+ * We expose that state two ways:
+ *
+ *   mach.bus.busy        (RD) — current in-flight probe->attach count
+ *   mach.bus.quiesce_gen (RD) — bumped once on each 1->0 transition
+ *
+ * and a mach_wait_quiet syscall (Apple IOKit IOKitWaitQuiet /
+ * IOServiceWaitQuiet shape) that blocks until bus_busy == 0.
+ *
+ * Out-of-tree-only: not part of the ravynOS source tree. Models on the
+ * fork eventhandler in src/kern/task.c (registration shape) and on
+ * mach_stats.c (the _mach sysctl root).
+ */
+
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/kernel.h>
+#include <sys/systm.h>
+#include <sys/proc.h>
+#include <sys/sysctl.h>
+#include <sys/eventhandler.h>
+#include <sys/bus.h>
+#include <sys/limits.h>		/* INT_MAX */
+
+#include <machine/atomic.h>
+
+#include <sys/sysproto.h>		/* canonical PADL_/PADR_ macros — */
+					/* MUST come before _mach_sysproto */
+#include <sys/mach/_mach_sysproto.h>	/* mach_wait_quiet_args */
+#include <sys/mach/kern_return.h>	/* KERN_SUCCESS */
+
+/*
+ * In-flight probe->attach counter. Incremented on device_match_start,
+ * decremented on device_match_end; the 1->0 transition bumps
+ * bus_quiesce_gen and wakes any thread sleeping in mach_wait_quiet.
+ */
+static volatile int	bus_busy;
+static int		bus_quiesce_gen;
+
+static eventhandler_tag	mach_busy_start_tag;
+static eventhandler_tag	mach_busy_end_tag;
+
+/*
+ * eventhandler callbacks. Signature matches the kernel's
+ * device_match_start_fn / device_match_end_fn typedefs
+ * (void (*)(void *, device_t)); the device_t is unused — we only
+ * track the in-flight depth.
+ */
+static void
+mach_bus_match_start(void *arg __unused, device_t dev __unused)
+{
+	atomic_add_int(&bus_busy, 1);
+}
+
+static void
+mach_bus_match_end(void *arg __unused, device_t dev __unused)
+{
+	if (atomic_fetchadd_int(&bus_busy, -1) == 1) {
+		atomic_add_int(&bus_quiesce_gen, 1);
+		wakeup(&bus_busy);
+	}
+}
+
+SYSCTL_DECL(_mach);
+static SYSCTL_NODE(_mach, OID_AUTO, bus, CTLFLAG_RD, 0,
+    "Bus-quiescence state (device_match_start/end busy counter)");
+
+SYSCTL_INT(_mach_bus, OID_AUTO, busy, CTLFLAG_RD, &bus_busy, 0,
+    "Current count of in-flight device_probe_and_attach() calls "
+    "(0 == device tree quiescent)");
+
+SYSCTL_INT(_mach_bus, OID_AUTO, quiesce_gen, CTLFLAG_RD,
+    &bus_quiesce_gen, 0,
+    "Generation counter bumped once on each busy 1->0 transition");
+
+/*
+ * mach_wait_quiet — block until the device tree quiesces (bus_busy == 0).
+ *
+ * uap->timeout is a nanosecond budget (Apple's IOKitWaitQuiet passes a
+ * mach_timespec_t; libIOKit converts it to ns). 0 means "no backstop —
+ * wait indefinitely" (clamped to INT_MAX ticks so a single tsleep can't
+ * overflow the tick argument). On timeout we return KERN_SUCCESS with
+ * bus_busy possibly still non-zero — same lenient contract Apple's
+ * IOKitWaitQuiet has (it returns kIOReturnSuccess on either quiesce or
+ * the caller-supplied deadline elapsing).
+ */
+int
+sys_mach_wait_quiet(struct thread *td, struct mach_wait_quiet_args *uap)
+{
+	int timo;
+	int error;
+
+	if (uap->timeout == 0) {
+		timo = INT_MAX;		/* no caller backstop */
+	} else {
+		/* ns -> ticks; round up so a sub-tick budget waits >= 1 tick. */
+		uint64_t ns = uap->timeout;
+		uint64_t ticks_budget =
+		    (ns + (1000000000ULL / hz) - 1) / (1000000000ULL / hz);
+
+		if (ticks_budget == 0)
+			ticks_budget = 1;
+		if (ticks_budget > INT_MAX)
+			ticks_budget = INT_MAX;
+		timo = (int)ticks_budget;
+	}
+
+	while (atomic_load_int(&bus_busy) != 0) {
+		error = tsleep(&bus_busy, PCATCH, "mwquiet", timo);
+		if (error == EWOULDBLOCK)
+			break;		/* deadline elapsed — lenient success */
+		if (error)
+			return (error);	/* EINTR / ERESTART — propagate */
+	}
+
+	td->td_retval[0] = KERN_SUCCESS;
+	return (0);
+}
+
+static void
+mach_busystate_sysinit(void *arg __unused)
+{
+	mach_busy_start_tag = EVENTHANDLER_REGISTER(device_match_start,
+	    mach_bus_match_start, NULL, EVENTHANDLER_PRI_ANY);
+	mach_busy_end_tag = EVENTHANDLER_REGISTER(device_match_end,
+	    mach_bus_match_end, NULL, EVENTHANDLER_PRI_ANY);
+}
+
+static void
+mach_busystate_sysuninit(void *arg __unused)
+{
+	if (mach_busy_end_tag != NULL)
+		EVENTHANDLER_DEREGISTER(device_match_end, mach_busy_end_tag);
+	if (mach_busy_start_tag != NULL)
+		EVENTHANDLER_DEREGISTER(device_match_start, mach_busy_start_tag);
+}
+
+/* before SI_SUB_INTRINSIC and after SI_SUB_EVENTHANDLER (matches task.c) */
+SYSINIT(mach_busystate, SI_SUB_KLD, SI_ORDER_ANY,
+    mach_busystate_sysinit, NULL);
+SYSUNINIT(mach_busystate, SI_SUB_KLD, SI_ORDER_ANY,
+    mach_busystate_sysuninit, NULL);

--- a/src/mach_kmod/src/mach_syscall_wire.c
+++ b/src/mach_kmod/src/mach_syscall_wire.c
@@ -58,6 +58,7 @@ struct host_set_special_port_trap_args;
 struct _kernelrpc_mach_port_move_member_trap_args;
 struct register_event_bell_trap_args;
 struct unregister_event_bell_trap_args;
+struct mach_wait_quiet_args;
 
 SYSCTL_DECL(_mach);
 static SYSCTL_NODE(_mach, OID_AUTO, syscall, CTLFLAG_RW, 0,
@@ -97,6 +98,7 @@ int sys_register_event_bell_trap(struct thread *,
     struct register_event_bell_trap_args *);
 int sys_unregister_event_bell_trap(struct thread *,
     struct unregister_event_bell_trap_args *);
+int sys_mach_wait_quiet(struct thread *, struct mach_wait_quiet_args *);
 
 /*
  * Phase C2: lazy Mach init. If the calling process/thread has no
@@ -337,6 +339,19 @@ sys_unregister_event_bell_trap_guarded(struct thread *td,
 	return (sys_unregister_event_bell_trap(td, uap));
 }
 
+/*
+ * mach_wait_quiet — block until the device tree quiesces (mach.bus.busy
+ * == 0). Unlike the Mach traps above, the handler reaches no Mach
+ * task/thread state (it only sleeps on the busystate counter), so no
+ * lazy-init / NULL-guard is needed; the wrapper is a thin pass-through
+ * kept for symmetry with the other wired syscalls.
+ */
+static int
+sys_mach_wait_quiet_guarded(struct thread *td, struct mach_wait_quiet_args *uap)
+{
+	return (sys_mach_wait_quiet(td, uap));
+}
+
 static struct sysent mach_reply_port_sysent = {
 	.sy_narg	= 0,
 	.sy_call	= (sy_call_t *)sys_mach_reply_port_guarded,
@@ -472,6 +487,18 @@ static struct sysent unregister_event_bell_sysent = {
 	.sy_flags	= 0,
 };
 
+/*
+ * mach_wait_quiet sysent. 1 arg: (timeout) — a uint64_t nanosecond
+ * budget (0 == wait indefinitely). Backs IOKitWaitQuiet /
+ * IOServiceWaitQuiet.
+ */
+static struct sysent mach_wait_quiet_sysent = {
+	.sy_narg	= 1,
+	.sy_call	= (sy_call_t *)sys_mach_wait_quiet_guarded,
+	.sy_auevent	= AUE_NULL,
+	.sy_flags	= 0,
+};
+
 static int mach_reply_port_offset = NO_SYSCALL;
 static struct sysent mach_reply_port_old_sysent;
 
@@ -513,6 +540,9 @@ static struct sysent register_event_bell_old_sysent;
 
 static int unregister_event_bell_offset = NO_SYSCALL;
 static struct sysent unregister_event_bell_old_sysent;
+
+static int mach_wait_quiet_offset = NO_SYSCALL;
+static struct sysent mach_wait_quiet_old_sysent;
 
 SYSCTL_INT(_mach_syscall, OID_AUTO, mach_reply_port, CTLFLAG_RD,
     &mach_reply_port_offset, 0,
@@ -601,6 +631,11 @@ SYSCTL_INT(_mach_syscall, OID_AUTO, register_event_bell, CTLFLAG_RD,
 SYSCTL_INT(_mach_syscall, OID_AUTO, unregister_event_bell, CTLFLAG_RD,
     &unregister_event_bell_offset, 0,
     "Dynamically-allocated FreeBSD syscall number for unregister_event_bell "
+    "(1-arg syscall; -1 if registration failed)");
+
+SYSCTL_INT(_mach_syscall, OID_AUTO, mach_wait_quiet, CTLFLAG_RD,
+    &mach_wait_quiet_offset, 0,
+    "Dynamically-allocated FreeBSD syscall number for mach_wait_quiet "
     "(1-arg syscall; -1 if registration failed)");
 
 static void
@@ -700,12 +735,16 @@ mach_syscall_wire_register(void *arg __unused)
 	    &register_event_bell_sysent, &register_event_bell_old_sysent);
 	wire_one("unregister_event_bell", &unregister_event_bell_offset,
 	    &unregister_event_bell_sysent, &unregister_event_bell_old_sysent);
+	wire_one("mach_wait_quiet", &mach_wait_quiet_offset,
+	    &mach_wait_quiet_sysent, &mach_wait_quiet_old_sysent);
 }
 
 static void
 mach_syscall_wire_deregister(void *arg __unused)
 {
 
+	unwire_one("mach_wait_quiet", &mach_wait_quiet_offset,
+	    &mach_wait_quiet_old_sysent);
 	unwire_one("unregister_event_bell",
 	    &unregister_event_bell_offset,
 	    &unregister_event_bell_old_sysent);

--- a/src/mach_kmod/tests/test_busystate.c
+++ b/src/mach_kmod/tests/test_busystate.c
@@ -1,0 +1,98 @@
+/*
+ * test_busystate — validate the bus-quiescence feature mach.ko exposes
+ * on top of the NEXTBSD kernel's device_match_start/device_match_end
+ * eventhandler pair.
+ *
+ * Two checks, two markers (printed for the boot-test expect harness):
+ *
+ *   BUSYSTATE-OK / BUSYSTATE-FAIL
+ *     Read `sysctl mach.bus.busy`. By the time run.sh executes (well
+ *     after the cold-boot device probe has finished and hwregd has
+ *     flipped to live mode) the device tree is quiescent, so the count
+ *     must read 0. We poll a few times to absorb any late, transient
+ *     probe (e.g. a deferred kldload's attach).
+ *
+ *   WAITQUIET-OK / WAITQUIET-FAIL
+ *     Resolve mach_wait_quiet via `sysctl mach.syscall.mach_wait_quiet`
+ *     and call it with a 1s nanosecond budget. Because the bus is
+ *     already quiescent it must return promptly (well under the budget)
+ *     with rc 0.
+ *
+ * Exit codes:
+ *   0 — both checks passed
+ *   1 — mach.bus.busy sysctl unavailable
+ *   2 — mach.bus.busy never settled to 0
+ *   3 — mach.syscall.mach_wait_quiet unavailable
+ *   4 — mach_wait_quiet returned non-zero / didn't return promptly
+ */
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <sys/sysctl.h>
+#include <sys/time.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+int
+main(void)
+{
+	int busy = -1;
+	size_t len = sizeof(busy);
+	int i;
+
+	/* 1. mach.bus.busy must exist and settle to 0. */
+	for (i = 0; i < 50; i++) {
+		len = sizeof(busy);
+		if (sysctlbyname("mach.bus.busy", &busy, &len, NULL, 0) != 0) {
+			printf("BUSYSTATE-FAIL: sysctl mach.bus.busy "
+			    "unavailable (mach.ko not loaded / no "
+			    "device_match hook?)\n");
+			return (1);
+		}
+		printf("mach.bus.busy = %d\n", busy);
+		if (busy == 0)
+			break;
+		usleep(100000);	/* 100ms — absorb a late transient probe */
+	}
+	if (busy != 0) {
+		printf("BUSYSTATE-FAIL: mach.bus.busy never settled to 0 "
+		    "(last=%d)\n", busy);
+		return (2);
+	}
+	printf("BUSYSTATE-OK: mach.bus.busy == 0 (device tree quiescent)\n");
+
+	/* 2. mach_wait_quiet must resolve and return promptly. */
+	int num;
+	len = sizeof(num);
+	if (sysctlbyname("mach.syscall.mach_wait_quiet", &num, &len,
+	    NULL, 0) != 0 || num < 0) {
+		printf("WAITQUIET-FAIL: sysctl mach.syscall.mach_wait_quiet "
+		    "unavailable\n");
+		return (3);
+	}
+	printf("mach.syscall.mach_wait_quiet = %d\n", num);
+
+	struct timespec t0, t1;
+	(void)clock_gettime(CLOCK_MONOTONIC, &t0);
+	/* 1s budget in ns — quiescent bus should return well under it. */
+	long rc = syscall(num, (uint64_t)1000000000ULL);
+	(void)clock_gettime(CLOCK_MONOTONIC, &t1);
+
+	double ms = (t1.tv_sec - t0.tv_sec) * 1000.0 +
+	    (t1.tv_nsec - t0.tv_nsec) / 1000000.0;
+	printf("mach_wait_quiet rc=%ld elapsed=%.1fms\n", rc, ms);
+
+	if (rc != 0) {
+		printf("WAITQUIET-FAIL: mach_wait_quiet returned %ld\n", rc);
+		return (4);
+	}
+	if (ms > 500.0) {
+		printf("WAITQUIET-FAIL: mach_wait_quiet blocked %.1fms on an "
+		    "already-quiescent bus\n", ms);
+		return (4);
+	}
+	printf("WAITQUIET-OK: mach_wait_quiet returned promptly (%.1fms)\n", ms);
+	return (0);
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -281,6 +281,28 @@ expect {
 }
 expect {
     timeout {
+        puts "\nFAIL: BUSYSTATE marker not seen"
+        exit 1
+    }
+    "BUSYSTATE-FAIL" {
+        puts "\nFAIL: mach.bus.busy did not settle to 0 (bus not quiescent / mach.ko hook missing)"
+        exit 1
+    }
+    "BUSYSTATE-OK" { puts "\nOK: mach.bus.busy quiescent (device_match_start/end counter works)" }
+}
+expect {
+    timeout {
+        puts "\nFAIL: WAITQUIET marker not seen"
+        exit 1
+    }
+    "WAITQUIET-FAIL" {
+        puts "\nFAIL: mach_wait_quiet did not return promptly on a quiescent bus"
+        exit 1
+    }
+    "WAITQUIET-OK" { puts "\nOK: mach_wait_quiet returns on quiescence" }
+}
+expect {
+    timeout {
         puts "\nFAIL: BOOTSTRAP marker not seen"
         exit 1
     }


### PR DESCRIPTION
**Phase 0** of the Apple-shaped device-matching convergence (umbrella #177), implementing the userland/mach.ko **consumer** of the kernel quiescence hook. The kernel side — the balanced `device_match_start`/`device_match_end` hook — is already merged (nextbsd-kernel#8) and live in the kernel `continuous` release. Tracks #176. Plan: https://pkgdemon.github.io/freebsd-hwregd-busystate-impl-plan.html

## What
- **mach.ko** — new `src/mach_kmod/src/mach_busystate.c`: an atomic `bus_busy` counter driven by the `device_match_start` (++) / `device_match_end` (−−) eventhandlers (the `IOService::_adjustBusy` analog); `mach.bus.busy` + `mach.bus.quiesce_gen` sysctls; and **`mach_wait_quiet(timeout)`** as a dedicated blocking syscall (wired via the per-trap pattern: arg struct, guarded wrapper, sysent, `wire_one`, `sysctl mach.syscall.mach_wait_quiet`), `tsleep` on `&bus_busy` woken at the 0-crossing.
- **hwregd** — keeps the `devctl_freeze()`→`kldload`→`devctl_thaw()` batching; replaces the 250 ms backlog→live **flip trigger** with the `bus_busy==0` quiescence signal (the `HWREGD_BACKLOG_QUIET_MS` timer is removed).
- **libIOKit** — implements `IOServiceWaitQuiet`/`IOKitWaitQuiet` → `mach_wait_quiet`, and `IORegistryEntryGetBusyState` → read `mach.bus.busy` (global approximation, documented). Re-points the launchd `IOKitWaitQuiet` no-op stub.
- **build.sh** — applies the nextbsd-kernel `patches/series` to `$WORK/freebsd-src/usr/src` before building `mach.ko`, so it compiles against the patched `eventhandler.h` (which now declares `device_match_start`/`device_match_end`). Hard-fails if the declaration didn't land.

## Dependency status
Kernel hook (nextbsd-kernel#8) **merged** and in `continuous` (22:03). The `build.sh` apply-step pulls the current series at build time, so `mach.ko` sees the hook.

## Acceptance (boot test)
New markers `BUSYSTATE-OK` (`mach.bus.busy` settles to 0 after boot) and `WAITQUIET-OK` (`mach_wait_quiet` returns promptly), plus autoload still emits `HWREG-AUTOLOAD-OK` with the flip now gated on quiescence (no 250 ms timer).

## Scope note
This is the busyState/`waitQuiet` *foundation*; it does **not** retire hwregd (that's later phases of #177 — `EVFILT_MACHPORT`, kernel match-notifications, then folding hwregd's jobs into configd + a ported `kextd` loader). hwregd here just changes its flip trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)