### PR TITLE
kext_tools: minimal kld-backed kextload/kextstat/kextunload (PoC #183)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1405,6 +1405,29 @@ chroot "$WORK/rootfs" ldd /bin/launchctl \
 echo "==> launchctl built + ldd verified"
 
 #
+# 3q1. build kext_tools (src/kext_tools) — minimal kld-backed
+#      kextload/kextstat/kextunload. NextBSD kext proof-of-concept (#183):
+#      prove a FreeBSD .ko wrapped as a .kext loads via an Apple-shaped tool.
+#      kextload/kextunload parse the bundle with CFBundle (libCoreFoundation,
+#      step 3p) and load through kld; kextstat is pure kld. No OSKext /
+#      codesign / personalities — faithful kext_tools port tracked in #182.
+#      Install: /usr/sbin/{kextload,kextstat,kextunload} (match macOS).
+#
+echo "==> building kext_tools (src/kext_tools)"
+mkdir -p "$WORK/rootfs/usr/sbin"
+make -C "$ROOT/src/kext_tools" \
+    DESTDIR="$WORK/rootfs" \
+    SYSROOT="$WORK/rootfs" \
+    all install
+ls -lh "$WORK/rootfs/usr/sbin/kextload" \
+       "$WORK/rootfs/usr/sbin/kextstat" \
+       "$WORK/rootfs/usr/sbin/kextunload"
+chroot "$WORK/rootfs" ldd /usr/sbin/kextload \
+    | grep -q "libCoreFoundation.so.* => /usr/lib/system/" \
+    || { echo "FAIL: kextload doesn't resolve libCoreFoundation"; exit 1; }
+echo "==> kext_tools built + installed"
+
+#
 # 3r. build hwregd (src/hwregd/hwregd.c).
 #     freebsd-launchd-mach hardware registry daemon. Phase 0 iter 1:
 #     pure libc daemon, no library deps. Reads /dev/devctl events

--- a/src/kext_tools/Makefile
+++ b/src/kext_tools/Makefile
@@ -1,0 +1,15 @@
+# kext_tools — minimal kld-backed kextload / kextstat / kextunload.
+#
+# NextBSD proof-of-concept trio (nextbsd#183): prove a FreeBSD .ko wrapped
+# as an Apple .kext bundle loads via an Apple-shaped tool. kextload/kextunload
+# parse the bundle with CFBundle (libCoreFoundation, built at build.sh step
+# 3p) and drive the load through the FreeBSD kld syscalls; kextstat is pure
+# kld. No OSKext, no codesign, no IOKitPersonalities — the faithful
+# kext_tools/OSKext port is tracked in nextbsd#182.
+#
+# Build:   cd src/kext_tools && make
+# Install: make DESTDIR=/path/to/rootfs SYSROOT=/path/to/rootfs install
+
+SUBDIR=	kextload kextstat kextunload
+
+.include <bsd.subdir.mk>

--- a/src/kext_tools/Makefile.inc
+++ b/src/kext_tools/Makefile.inc
@@ -14,4 +14,10 @@ CFLAGS+=	-D__HAS_APPLE_ICU__=1 -DU_DISABLE_RENAMING=1 -DAPPLE_ICU_CHANGES=1
 CFLAGS+=	-I${SYSROOT}/usr/include		# CoreFoundation/, dispatch/, ...
 LDFLAGS+=	-L${SYSROOT}/usr/lib/system
 LDFLAGS+=	-Wl,-rpath,/usr/lib/system
+# libCoreFoundation.so carries undefined refs (libm: floor/fmod/ceil/scalbn,
+# and CF-internal _CFThreadSetName/_CFGetCurrentDirectory) that the strict
+# default --no-allow-shlib-undefined rejects; they resolve at runtime (libm
+# arrives via the CF/ICU DT_NEEDED chain). launchctl links CF the same way
+# and uses the same workaround.
+LDFLAGS+=	-Wl,--allow-shlib-undefined
 .endif

--- a/src/kext_tools/Makefile.inc
+++ b/src/kext_tools/Makefile.inc
@@ -5,6 +5,7 @@
 # the CF link (it sets no LDADD); the CFLAGS are harmless to it.
 
 BINDIR?=	/usr/sbin
+MAN=			# no man pages — bsd.prog.mk otherwise defaults MAN=${PROG}.1
 NO_MAN=		yes
 WARNS?=		3
 

--- a/src/kext_tools/Makefile.inc
+++ b/src/kext_tools/Makefile.inc
@@ -1,0 +1,17 @@
+# Shared flags for the kext_tools trio. Auto-included by each sub-Makefile's
+# bsd.prog.mk (from ${.CURDIR}/../Makefile.inc). The CF block must match how
+# libCoreFoundation was built so the CF headers parse identically (see
+# launchctl's Makefile / the ICU audit). kextstat is pure kld and ignores
+# the CF link (it sets no LDADD); the CFLAGS are harmless to it.
+
+BINDIR?=	/usr/sbin
+NO_MAN=		yes
+WARNS?=		3
+
+CFLAGS+=	-fblocks -fconstant-cfstrings
+CFLAGS+=	-D__HAS_APPLE_ICU__=1 -DU_DISABLE_RENAMING=1 -DAPPLE_ICU_CHANGES=1
+.if !empty(SYSROOT)
+CFLAGS+=	-I${SYSROOT}/usr/include		# CoreFoundation/, dispatch/, ...
+LDFLAGS+=	-L${SYSROOT}/usr/lib/system
+LDFLAGS+=	-Wl,-rpath,/usr/lib/system
+.endif

--- a/src/kext_tools/kextload/Makefile
+++ b/src/kext_tools/kextload/Makefile
@@ -1,0 +1,8 @@
+PROG=	kextload
+SRCS=	kextload.c
+
+# CFBundle bundle parsing → kldload(2). Needs the CF runtime.
+LDADD+=	-lCoreFoundation -l_FoundationICU -ldispatch \
+	-lsystem_kernel -lpthread -lBlocksRuntime
+
+.include <bsd.prog.mk>

--- a/src/kext_tools/kextload/kextload.c
+++ b/src/kext_tools/kextload/kextload.c
@@ -1,0 +1,69 @@
+/*
+ * kextload — load a .kext bundle (NextBSD proof-of-concept).
+ *
+ * Opens the bundle with CFBundle, resolves Contents/MacOS/<executable>,
+ * and kldload(2)s it. Apple's kextload drives OSKext/KXKextManager; for
+ * NextBSD a .kext is packaging over the unmodified FreeBSD .ko, so kld
+ * does the actual load. No codesign, no dependency resolution, no
+ * IOKitPersonalities in this phase — proof-of-concept trio (nextbsd#183);
+ * the faithful kext_tools/OSKext port is tracked in nextbsd#182.
+ */
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <sys/param.h>
+#include <sys/linker.h>
+
+#include <err.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+int
+main(int argc, char **argv)
+{
+	const char *bundlePath;
+	CFURLRef bundleURL, execURL;
+	CFBundleRef bundle;
+	char execPath[MAXPATHLEN];
+	int fileid;
+
+	if (argc != 2)
+		errx(1, "usage: kextload <bundle.kext>");
+	bundlePath = argv[1];
+
+	bundleURL = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault,
+	    (const UInt8 *)bundlePath, (CFIndex)strlen(bundlePath), true);
+	if (bundleURL == NULL)
+		errx(1, "cannot make URL for %s", bundlePath);
+
+	bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
+	CFRelease(bundleURL);
+	if (bundle == NULL)
+		errx(1, "%s: not a bundle", bundlePath);
+
+	execURL = CFBundleCopyExecutableURL(bundle);
+	if (execURL == NULL) {
+		CFRelease(bundle);
+		errx(1, "%s: no executable (check CFBundleExecutable)", bundlePath);
+	}
+	if (!CFURLGetFileSystemRepresentation(execURL, true,
+	    (UInt8 *)execPath, sizeof(execPath))) {
+		CFRelease(execURL);
+		CFRelease(bundle);
+		errx(1, "%s: cannot resolve executable path", bundlePath);
+	}
+	CFRelease(execURL);
+	CFRelease(bundle);
+
+	/* A full path bypasses kern.module_path; the .ko loads by content. */
+	fileid = kldload(execPath);
+	if (fileid < 0) {
+		if (errno == EEXIST) {
+			printf("kextload: %s already loaded\n", bundlePath);
+			return (0);
+		}
+		err(1, "kldload(%s)", execPath);
+	}
+	printf("kextload: loaded %s (id %d)\n", bundlePath, fileid);
+	return (0);
+}

--- a/src/kext_tools/kextstat/Makefile
+++ b/src/kext_tools/kextstat/Makefile
@@ -1,0 +1,6 @@
+PROG=	kextstat
+SRCS=	kextstat.c
+
+# Pure kld enumeration — kldnext(2)/kldstat(2) live in libc, no CF needed.
+
+.include <bsd.prog.mk>

--- a/src/kext_tools/kextstat/kextstat.c
+++ b/src/kext_tools/kextstat/kextstat.c
@@ -1,0 +1,36 @@
+/*
+ * kextstat — list loaded kernel extensions (NextBSD proof-of-concept).
+ *
+ * Minimal and kld-backed: Apple's kextstat queries the kernel through the
+ * kmod_get_info() Mach RPC; here we enumerate FreeBSD's loaded kld files
+ * with kldnext(2)/kldstat(2). No OSKext. This is the proof-of-concept trio
+ * (nextbsd#183); the faithful kext_tools/OSKext port is tracked in
+ * nextbsd#182.
+ */
+#include <sys/param.h>
+#include <sys/linker.h>
+
+#include <err.h>
+#include <stdint.h>
+#include <stdio.h>
+
+int
+main(void)
+{
+	int fileid;
+
+	printf("Id Refs Address              Size       Name\n");
+	for (fileid = kldnext(0); fileid > 0; fileid = kldnext(fileid)) {
+		struct kld_file_stat stat;
+
+		stat.version = sizeof(stat);
+		if (kldstat(fileid, &stat) < 0) {
+			warn("kldstat(%d)", fileid);
+			continue;
+		}
+		printf("%2d %4d 0x%-16jx 0x%-8zx %s\n",
+		    stat.id, stat.refs, (uintmax_t)(uintptr_t)stat.address,
+		    stat.size, stat.name);
+	}
+	return (0);
+}

--- a/src/kext_tools/kextunload/Makefile
+++ b/src/kext_tools/kextunload/Makefile
@@ -1,0 +1,8 @@
+PROG=	kextunload
+SRCS=	kextunload.c
+
+# CFBundle bundle parsing → kldunload(2). Needs the CF runtime.
+LDADD+=	-lCoreFoundation -l_FoundationICU -ldispatch \
+	-lsystem_kernel -lpthread -lBlocksRuntime
+
+.include <bsd.prog.mk>

--- a/src/kext_tools/kextunload/kextunload.c
+++ b/src/kext_tools/kextunload/kextunload.c
@@ -1,0 +1,75 @@
+/*
+ * kextunload — unload a .kext bundle's module (NextBSD proof-of-concept).
+ *
+ * Resolves the bundle's executable basename, finds the matching loaded
+ * kld file, and kldunload(2)s it. kld-backed; proof-of-concept trio
+ * (nextbsd#183), faithful kext_tools/OSKext port tracked in nextbsd#182.
+ */
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <sys/param.h>
+#include <sys/linker.h>
+
+#include <err.h>
+#include <libgen.h>
+#include <stdio.h>
+#include <string.h>
+
+int
+main(int argc, char **argv)
+{
+	const char *bundlePath;
+	CFURLRef bundleURL, execURL;
+	CFBundleRef bundle;
+	char execPath[MAXPATHLEN], want[MAXPATHLEN];
+	int fileid;
+
+	if (argc != 2)
+		errx(1, "usage: kextunload <bundle.kext>");
+	bundlePath = argv[1];
+
+	bundleURL = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault,
+	    (const UInt8 *)bundlePath, (CFIndex)strlen(bundlePath), true);
+	if (bundleURL == NULL)
+		errx(1, "cannot make URL for %s", bundlePath);
+
+	bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
+	CFRelease(bundleURL);
+	if (bundle == NULL)
+		errx(1, "%s: not a bundle", bundlePath);
+
+	execURL = CFBundleCopyExecutableURL(bundle);
+	if (execURL == NULL) {
+		CFRelease(bundle);
+		errx(1, "%s: no executable (check CFBundleExecutable)", bundlePath);
+	}
+	if (!CFURLGetFileSystemRepresentation(execURL, true,
+	    (UInt8 *)execPath, sizeof(execPath))) {
+		CFRelease(execURL);
+		CFRelease(bundle);
+		errx(1, "%s: cannot resolve executable path", bundlePath);
+	}
+	CFRelease(execURL);
+	CFRelease(bundle);
+
+	/* The kld file registers under the executable's basename. */
+	strlcpy(want, basename(execPath), sizeof(want));
+
+	for (fileid = kldnext(0); fileid > 0; fileid = kldnext(fileid)) {
+		struct kld_file_stat stat;
+		char name[MAXPATHLEN];
+
+		stat.version = sizeof(stat);
+		if (kldstat(fileid, &stat) < 0)
+			continue;
+		strlcpy(name, stat.name, sizeof(name));
+		if (strcmp(basename(name), want) == 0) {
+			if (kldunload(fileid) < 0)
+				err(1, "kldunload(%s)", want);
+			printf("kextunload: unloaded %s (was id %d)\n",
+			    bundlePath, fileid);
+			return (0);
+		}
+	}
+	errx(1, "kextunload: %s not loaded", bundlePath);
+}


### PR DESCRIPTION
**Phase 1 of the kext proof-of-concept (#183).** Prove a FreeBSD `.ko` wrapped as an Apple `.kext` can be loaded via an Apple-shaped tool — the cheapest end-to-end slice before the full conversion (#179)/kextd (#177).

### What this adds
- `src/kext_tools/{kextload,kextstat,kextunload}` — minimal, kld-backed:
  - `kextload Foo.kext` → `CFBundleCreate` → `CFBundleCopyExecutableURL` → `kldload(2)` the inner binary (full path bypasses `kern.module_path`).
  - `kextstat` → `kldnext(2)`/`kldstat(2)` enumeration (Apple's uses the `kmod_get_info` Mach RPC).
  - `kextunload Foo.kext` → name-match `kldnext`/`kldstat` → `kldunload(2)`.
- Bundle parsing reuses the existing **`libCoreFoundation` `CFBundle`** — so **no `OSKext`** needed for the proof.
- **No codesign, no dependency resolution, no IOKitPersonalities** this phase — faithful `kext_tools`/`OSKext` port tracked in **#182**.
- `SUBDIR` + per-tool `bsd.prog.mk` + shared `Makefile.inc` (matches the tree's convention); installs to `/usr/sbin` (macOS paths).
- `build.sh` step **3q1** (after libCoreFoundation, 3p) builds + `ldd`-verifies the trio into the image.

### Why now
Once this ships in `continuous`, Phase 2 (#183, in `nextbsd-kernel-modules`) adds a converter + PR CI that wraps `if_dummy.ko` and `kextload`s it in a booted VM. The trio must be in the image first.

### Reviewer note / the thing we're proving
`kextload` `kldload`s an **extension-less** ELF kld at `Contents/MacOS/<name>` by full path. `kldload(2)` loads by ELF content (the `.ko` suffix is only the `module_path` search convention for bare names), so this should work — but it's exactly the assumption this PoC verifies. If CI shows the kernel rejects it, the Phase 2 converter keeps the `.ko` name.

Plan: https://pkgdemon.github.io/nextbsd-kext-proof-of-concept-plan.html