### PR TITLE
kext_tools: resolve executable from Info.plist (fix Phase 2 kextload)

### DIFF
--- a/src/kext_tools/kextload/kextload.c
+++ b/src/kext_tools/kextload/kextload.c
@@ -1,12 +1,19 @@
 /*
  * kextload — load a .kext bundle (NextBSD proof-of-concept).
  *
- * Opens the bundle with CFBundle, resolves Contents/MacOS/<executable>,
- * and kldload(2)s it. Apple's kextload drives OSKext/KXKextManager; for
- * NextBSD a .kext is packaging over the unmodified FreeBSD .ko, so kld
- * does the actual load. No codesign, no dependency resolution, no
- * IOKitPersonalities in this phase — proof-of-concept trio (nextbsd#183);
- * the faithful kext_tools/OSKext port is tracked in nextbsd#182.
+ * Reads CFBundleExecutable from the bundle's Info.plist (via CFBundle) and
+ * kldload(2)s Contents/MacOS/<executable> by full path. Apple's kextload
+ * drives OSKext/KXKextManager; for NextBSD a .kext is packaging over the
+ * unmodified FreeBSD .ko, so kld does the actual load. No codesign, no
+ * dependency resolution, no IOKitPersonalities in this phase — proof-of-
+ * concept trio (nextbsd#183); the faithful kext_tools/OSKext port is tracked
+ * in nextbsd#182.
+ *
+ * We construct the executable path from the known .kext layout rather than
+ * CFBundleCopyExecutableURL: swift-corelibs CFBundle on FreeBSD does not
+ * resolve the macOS Contents/MacOS/ executable location, but it does parse
+ * the Info.plist — so reading the key + building the path is both robust and
+ * faithful to the fixed bundle layout.
  */
 #include <CoreFoundation/CoreFoundation.h>
 
@@ -22,9 +29,10 @@ int
 main(int argc, char **argv)
 {
 	const char *bundlePath;
-	CFURLRef bundleURL, execURL;
+	CFURLRef bundleURL;
 	CFBundleRef bundle;
-	char execPath[MAXPATHLEN];
+	CFStringRef execName;
+	char exec[MAXPATHLEN], execPath[MAXPATHLEN];
 	int fileid;
 
 	if (argc != 2)
@@ -41,19 +49,19 @@ main(int argc, char **argv)
 	if (bundle == NULL)
 		errx(1, "%s: not a bundle", bundlePath);
 
-	execURL = CFBundleCopyExecutableURL(bundle);
-	if (execURL == NULL) {
+	execName = CFBundleGetValueForInfoDictionaryKey(bundle,
+	    CFSTR("CFBundleExecutable"));
+	if (execName == NULL ||
+	    CFGetTypeID(execName) != CFStringGetTypeID() ||
+	    !CFStringGetCString(execName, exec, sizeof(exec),
+	    kCFStringEncodingUTF8)) {
 		CFRelease(bundle);
-		errx(1, "%s: no executable (check CFBundleExecutable)", bundlePath);
+		errx(1, "%s: no CFBundleExecutable in Info.plist", bundlePath);
 	}
-	if (!CFURLGetFileSystemRepresentation(execURL, true,
-	    (UInt8 *)execPath, sizeof(execPath))) {
-		CFRelease(execURL);
-		CFRelease(bundle);
-		errx(1, "%s: cannot resolve executable path", bundlePath);
-	}
-	CFRelease(execURL);
 	CFRelease(bundle);
+
+	snprintf(execPath, sizeof(execPath), "%s/Contents/MacOS/%s",
+	    bundlePath, exec);
 
 	/* A full path bypasses kern.module_path; the .ko loads by content. */
 	fileid = kldload(execPath);

--- a/src/kext_tools/kextunload/kextunload.c
+++ b/src/kext_tools/kextunload/kextunload.c
@@ -1,9 +1,11 @@
 /*
  * kextunload — unload a .kext bundle's module (NextBSD proof-of-concept).
  *
- * Resolves the bundle's executable basename, finds the matching loaded
- * kld file, and kldunload(2)s it. kld-backed; proof-of-concept trio
- * (nextbsd#183), faithful kext_tools/OSKext port tracked in nextbsd#182.
+ * Reads CFBundleExecutable from the bundle's Info.plist (the .ko registers
+ * under that name when kextload kldload's Contents/MacOS/<executable>), finds
+ * the matching loaded kld file, and kldunload(2)s it. kld-backed; proof-of-
+ * concept trio (nextbsd#183), faithful kext_tools/OSKext port tracked in
+ * nextbsd#182.
  */
 #include <CoreFoundation/CoreFoundation.h>
 
@@ -19,9 +21,10 @@ int
 main(int argc, char **argv)
 {
 	const char *bundlePath;
-	CFURLRef bundleURL, execURL;
+	CFURLRef bundleURL;
 	CFBundleRef bundle;
-	char execPath[MAXPATHLEN], want[MAXPATHLEN];
+	CFStringRef execName;
+	char want[MAXPATHLEN];
 	int fileid;
 
 	if (argc != 2)
@@ -38,23 +41,18 @@ main(int argc, char **argv)
 	if (bundle == NULL)
 		errx(1, "%s: not a bundle", bundlePath);
 
-	execURL = CFBundleCopyExecutableURL(bundle);
-	if (execURL == NULL) {
+	execName = CFBundleGetValueForInfoDictionaryKey(bundle,
+	    CFSTR("CFBundleExecutable"));
+	if (execName == NULL ||
+	    CFGetTypeID(execName) != CFStringGetTypeID() ||
+	    !CFStringGetCString(execName, want, sizeof(want),
+	    kCFStringEncodingUTF8)) {
 		CFRelease(bundle);
-		errx(1, "%s: no executable (check CFBundleExecutable)", bundlePath);
+		errx(1, "%s: no CFBundleExecutable in Info.plist", bundlePath);
 	}
-	if (!CFURLGetFileSystemRepresentation(execURL, true,
-	    (UInt8 *)execPath, sizeof(execPath))) {
-		CFRelease(execURL);
-		CFRelease(bundle);
-		errx(1, "%s: cannot resolve executable path", bundlePath);
-	}
-	CFRelease(execURL);
 	CFRelease(bundle);
 
 	/* The kld file registers under the executable's basename. */
-	strlcpy(want, basename(execPath), sizeof(want));
-
 	for (fileid = kldnext(0); fileid > 0; fileid = kldnext(fileid)) {
 		struct kld_file_stat stat;
 		char name[MAXPATHLEN];


### PR DESCRIPTION
Follow-up to #184. The Phase 2 boot test (nextbsd-kernel-modules#4) booted, logged in, and ran `kextload`, which failed at exactly one spot:

```
kextload: /System/Library/Extensions/Nmdm.kext: no executable (check CFBundleExecutable)
```

`CFBundleCreate` succeeded (Info.plist parsed) but **`CFBundleCopyExecutableURL` returned NULL** — swift-corelibs `CFBundle` on FreeBSD doesn't implement the macOS `Contents/MacOS/` executable-location heuristic.

**Fix:** read `CFBundleExecutable` from the info dictionary and construct `<bundle>/Contents/MacOS/<exec>` directly — robust *and* more faithful to the fixed `.kext` layout (we know it; no need for CFBundle's platform heuristics). Applied to both `kextload` (build path → `kldload`) and `kextunload` (match basename → `kldunload`).

Everything else in the PoC path is already proven by modules#4: build → convert → image-inject → boot → login all worked; this was the only failure. Once this lands and `continuous` republishes, modules#4 re-runs to complete the proof (and confirm `kldload` accepts an extension-less kld by full path).