### PR TITLE
drop mach_load=YES — mach is built into the kernel now (#181/#180)

### DIFF
--- a/overlays/boot/loader.conf.d/freebsd-launchd-mach.conf
+++ b/overlays/boot/loader.conf.d/freebsd-launchd-mach.conf
@@ -19,9 +19,12 @@ virtio_blk_load="YES"
 virtio_scsi_load="YES"
 mfi_load="YES"
 
-# mach.ko — out-of-tree Mach IPC kernel module from src/mach_kmod/.
-# Preloaded so Mach syscalls are available before any userland starts.
-mach_load="YES"
+# mach — now compiled INTO the NEXTBSD kernel (options COMPAT_MACH,
+# nextbsd-kernel#10 / #181), so Mach syscalls are registered by a SYSINIT at
+# boot, before PID 1 — no loader preload needed. The old `mach_load="YES"` is
+# gone: this is the first step of eliminating loader.conf (#180). (The kernel
+# still ships an unused mach.ko in /boot/kernel until the mach_kmod build is
+# dropped — #180 cleanup.)
 
 # PID 1 = launchd. The kernel execs it directly. No /rescue/init
 # fallback — the boot path is purely launchd, no rc.d anywhere.


### PR DESCRIPTION
Follow-up to **nextbsd-kernel#10** (mach-into-kernel). mach now compiles into the `NEXTBSD` kernel (`options COMPAT_MACH`), registering its syscalls via a `SYSINIT` at boot — so the loader no longer needs to preload `mach.ko`. This removes `mach_load="YES"` from `overlays/boot/loader.conf.d/freebsd-launchd-mach.conf`.

**The proof:** the boot smoke test now boots with **built-in mach and no `mach.ko` preload** — if mach syscalls still work (MACH-SMOKE-OK, LIBSYSTEM-KERNEL-OK, MACH-PORT-OK, …), built-in mach is doing the job end-to-end. This is the first concrete step of eliminating `loader.conf` (#180).

The kernel `continuous` already carries built-in mach (republished 2026-06-04T05:34Z), which this build ingests.

Still ships an unused `mach.ko` in `/boot/kernel` until the out-of-tree `mach_kmod` build is dropped from `build.sh` — that's #180 cleanup, kept separate to keep this change minimal and the proof clean.