### PR TITLE
Drop redundant disk-driver *_load lines (#180)

### DIFF
--- a/overlays/boot/loader.conf.d/freebsd-launchd-mach.conf
+++ b/overlays/boot/loader.conf.d/freebsd-launchd-mach.conf
@@ -7,17 +7,12 @@
 # below) and execs /sbin/launchd as PID 1 — no cd9660, no uzip, no
 # unionfs, no ramdisk pivot, no rc.d.
 
-# Disk drivers — preloaded so the kernel can reach the root partition
-# at vfs_mountroot time regardless of how the disk is attached: qemu
-# virtio, VirtualBox / real-hardware AHCI, NVMe, or LSI RAID. Harmless
-# if the running kernel already has any of them built in.
-ahci_load="YES"
-nvme_load="YES"
-virtio_load="YES"
-virtio_pci_load="YES"
-virtio_blk_load="YES"
-virtio_scsi_load="YES"
-mfi_load="YES"
+# Disk drivers are built into the NEXTBSD kernel (= GENERIC: ahci, nvme,
+# virtio/vtblk/vtscsi, mfi all are `device` entries), so the kernel reaches
+# the root partition at vfs_mountroot without any preload — qemu virtio,
+# VirtualBox / real-hardware AHCI/NVMe, or LSI RAID alike. The old
+# *_load="YES" lines were admittedly redundant ("harmless if built in"); they
+# are dropped as part of shrinking loader.conf toward elimination (#180).
 
 # mach — now compiled INTO the NEXTBSD kernel (options COMPAT_MACH,
 # nextbsd-kernel#10 / #181), so Mach syscalls are registered by a SYSINIT at


### PR DESCRIPTION
GENERIC (= NEXTBSD) builds in `ahci`, `nvme`, `virtio`/`vtblk`/`vtscsi`, `mfi` as `device` entries, so the kernel reaches root at `vfs_mountroot` with **no preload**. The `*_load="YES"` lines in `loader.conf.d` were redundant (the comment itself said "harmless if built in") — dropping them shrinks `loader.conf` toward elimination (#180).

The qemu boot smoke test runs with `-drive if=virtio`, exercising the built-in virtio block path; a green boot confirms the kernel reaches root without the preload.

Part of #180 (eliminate loader.conf), following #181 (mach built-in).