### PR TITLE
Drop init_path + vfs.root.mountfrom — baked into the kernel (#180)

### DIFF
--- a/overlays/boot/loader.conf.d/freebsd-launchd-mach.conf
+++ b/overlays/boot/loader.conf.d/freebsd-launchd-mach.conf
@@ -21,16 +21,12 @@
 # still ships an unused mach.ko in /boot/kernel until the mach_kmod build is
 # dropped — #180 cleanup.)
 
-# PID 1 = launchd. The kernel execs it directly. No /rescue/init
-# fallback — the boot path is purely launchd, no rc.d anywhere.
-init_path="/sbin/launchd"
-
-# Root = the freebsd-ufs partition, located by the UFS label "ROOTFS"
-# baked in by makefs — independent of the disk's device name (ada0 /
-# vtbd0 / da0 / nvd0). The FreeBSD kernel always mounts / read-only and
-# discards a "rw" option here, so there is none: launchd PID 1 remounts
-# / read-write itself before starting any daemon.
-vfs.root.mountfrom="ufs:/dev/ufs/ROOTFS"
+# PID 1 = launchd, and root = the freebsd-ufs "ROOTFS" label, are now BAKED
+# INTO the kernel (options INIT_PATH=/sbin/launchd, ROOTDEVNAME="ufs:/dev/ufs/
+# ROOTFS"; nextbsd-kernel#11 / #180). The kernel execs launchd directly and
+# mounts root from the label with no loader tunables — so init_path= and
+# vfs.root.mountfrom= are gone. (launchd PID 1 still remounts / read-write
+# itself; the kernel mounts read-only first, as always.)
 
 # Console: no explicit console/comconsole settings — the UEFI/BIOS
 # default consoles work for laptops and VMs. CI re-enables the serial


### PR DESCRIPTION
Follow-up to **nextbsd-kernel#11**. `ROOTDEVNAME="ufs:/dev/ufs/ROOTFS"` and `INIT_PATH=/sbin/launchd` are now compiled into the `NEXTBSD` kernel, so it mounts root from the ROOTFS label and execs `/sbin/launchd` with **no loader tunables**. This removes `init_path=` and `vfs.root.mountfrom=` from `loader.conf.d`.

**The proof:** the boot smoke test boots with these lines gone, on the kernel's compiled-in defaults — a green boot means the kernel finds root + launches PID 1 with no loader help. The kernel `continuous` carrying these options was republished (asset 2026-06-04T06:43Z), which this build ingests.

After this, `loader.conf.d` is down to just loader-UI tunables (`beastie_disable`, `autoboot_delay`) + the nvidia kenv — the bulk of #180 (eliminate loader.conf) is done.