### PR TITLE
Vendor pre-SIP Apple OSKext (kext.subproj) — faithful port Phase 0 (#182)

### DIFF
--- a/src/kext_tools/kext.subproj/KextManager.c
+++ b/src/kext_tools/kext.subproj/KextManager.c
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) 2000-2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#include <mach/mach.h>
+#include <TargetConditionals.h>
+#include <mach/kmod.h>
+#include <sys/param.h>
+#include <mach/mach_error.h>
+#include <servers/bootstrap.h>
+#include <bootstrap_priv.h>
+#include <syslog.h>
+#include <stdarg.h>
+
+#include "OSKext.h"
+#include "misc_util.h"
+#include "KextManager.h"
+#include "KextManagerPriv.h"
+#include "kextmanager_mig.h"
+
+/*********************************************************************
+* IMPORTANT: All calls in this module should be simple RPCs to kextd
+* or use the OSKext library *without* creating any OSKext objects.
+*********************************************************************/
+
+static kern_return_t get_kextd_port(mach_port_t *kextd_port); // internal convenience function
+
+/*********************************************************************
+*********************************************************************/
+CFURLRef KextManagerCreateURLForBundleIdentifier(
+    CFAllocatorRef allocator,
+    CFStringRef    bundleIdentifier)
+{
+    CFURLRef bundleURL = NULL;  // returned
+
+    kern_return_t kern_result = kOSReturnError;
+    char bundle_id[KMOD_MAX_NAME] = "";
+
+    mach_port_t   kextd_port = MACH_PORT_NULL;
+
+    char bundle_path[MAXPATHLEN] = "";
+    CFStringRef bundlePath = NULL;  // must free
+    OSReturn kext_result = kOSReturnError;
+    kext_result_t tmpRes;
+
+    if (!bundleIdentifier) {
+        goto finish;
+    }
+
+    if (!CFStringGetCString(bundleIdentifier,
+        bundle_id, sizeof(bundle_id) - 1, kCFStringEncodingUTF8)) {
+        goto finish;
+    }
+
+    kern_result = get_kextd_port(&kextd_port);
+    if (kern_result != kOSReturnSuccess) {
+        goto finish;
+    }
+
+    kern_result = kextmanager_path_for_bundle_id(
+        kextd_port, bundle_id, bundle_path, &tmpRes);
+    kext_result = tmpRes;
+    if (kern_result != kOSReturnSuccess) {
+        goto finish;
+    }
+
+    if (kext_result != kOSReturnSuccess) {
+        goto finish;
+    }
+
+    bundlePath = CFStringCreateWithCString(kCFAllocatorDefault,
+        bundle_path, kCFStringEncodingUTF8);
+    if (!bundlePath) {
+        goto finish;
+    }
+
+    bundleURL = CFURLCreateWithFileSystemPath(allocator,
+        bundlePath, kCFURLPOSIXPathStyle, true);
+
+finish:
+
+    if (bundlePath)  CFRelease(bundlePath);
+
+    return bundleURL;
+}
+
+/*********************************************************************
+* Internal function for use by KextManagerLoadKextWithIdentifier()
+* and KextManagerLoadKextWithURL().
+*********************************************************************/
+OSReturn __KextManagerSendLoadKextRequest(
+    CFMutableDictionaryRef  requestDict,
+    CFArrayRef              dependencyKextAndFolderURLs)
+{
+    OSReturn           result           = kOSReturnError;
+    mach_port_t        kextd_port       = MACH_PORT_NULL;
+    CFDataRef          requestData      = NULL;  // must release
+    CFMutableArrayRef  dependencyPaths  = NULL;  // must release
+    CFURLRef           dependencyAbsURL = NULL;  // must release
+    CFStringRef        dependencyPath   = NULL;  // must release
+    CFErrorRef         error            = NULL;  // must release
+
+    if (!requestDict) {
+        result = kOSKextReturnInvalidArgument;
+        goto finish;
+    }
+
+    result = get_kextd_port(&kextd_port);
+    if (result != kOSReturnSuccess) {
+        goto finish;
+    }
+
+    if (dependencyKextAndFolderURLs &&
+        CFArrayGetCount(dependencyKextAndFolderURLs)) {
+
+        CFIndex count, index;
+        
+        dependencyPaths = CFArrayCreateMutable(kCFAllocatorDefault,
+            /* capacity */ 0, &kCFTypeArrayCallBacks);
+        if (!dependencyPaths) {
+            result = kOSKextReturnNoMemory;
+            goto finish;
+        }
+        CFDictionarySetValue(requestDict, kKextLoadDependenciesKey,
+            dependencyPaths);
+
+        count = CFArrayGetCount(dependencyKextAndFolderURLs);
+        for (index = 0; index < count; index++) {
+            CFURLRef thisURL = (CFURLRef)CFArrayGetValueAtIndex(
+                dependencyKextAndFolderURLs, index);
+
+            SAFE_RELEASE_NULL(dependencyPath);
+            SAFE_RELEASE_NULL(dependencyAbsURL);
+
+            dependencyAbsURL = CFURLCopyAbsoluteURL(thisURL);
+            if (!dependencyAbsURL) {
+                result = kOSKextReturnNoMemory;
+                goto finish;
+            }
+            dependencyPath = CFURLCopyFileSystemPath(dependencyAbsURL,
+                kCFURLPOSIXPathStyle);
+            if (!dependencyPath) {
+                result = kOSKextReturnNoMemory;
+                goto finish;
+            }
+
+            CFArrayAppendValue(dependencyPaths, dependencyPath);
+        }
+    }
+
+    requestData = CFPropertyListCreateData(kCFAllocatorDefault,
+         requestDict, kCFPropertyListBinaryFormat_v1_0,
+         /* options */ 0,
+         &error);
+    if (!requestData) {
+        // any point in logging error reason here? nothing caller can do....
+        result = kOSKextReturnSerialization;
+        goto finish;
+    }
+
+    result = kextmanager_load_kext(kextd_port,
+        (char *)CFDataGetBytePtr(requestData),
+        CFDataGetLength(requestData));
+
+finish:
+    SAFE_RELEASE(requestData);
+    SAFE_RELEASE(dependencyPaths);
+    SAFE_RELEASE(dependencyPath);
+    SAFE_RELEASE(dependencyAbsURL);
+    SAFE_RELEASE(error);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn KextManagerLoadKextWithIdentifier(
+    CFStringRef    kextIdentifier,
+    CFArrayRef     dependencyKextAndFolderURLs)
+{
+    OSReturn               result      = kOSReturnError;
+    CFMutableDictionaryRef requestDict = NULL;  // must release
+
+    if (!kextIdentifier) {
+        result = kOSKextReturnInvalidArgument;
+        goto finish;
+    }
+
+    requestDict = CFDictionaryCreateMutable(kCFAllocatorDefault,
+        /* capacity */ 0, &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks);
+    if (!requestDict) {
+        result = kOSKextReturnNoMemory;
+        goto finish;
+    }
+    
+    CFDictionarySetValue(requestDict, kKextLoadIdentifierKey,
+        kextIdentifier);
+
+    result = __KextManagerSendLoadKextRequest(requestDict,
+        dependencyKextAndFolderURLs);
+
+finish:
+    SAFE_RELEASE(requestDict);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn KextManagerLoadKextWithURL(
+    CFURLRef       kextURL,
+    CFArrayRef     dependencyKextAndFolderURLs)
+{
+    OSReturn               result      = kOSReturnError;
+    CFMutableDictionaryRef requestDict = NULL;  // must release
+    CFURLRef               absURL      = NULL;  // must release
+    CFStringRef            kextPath    = NULL;  // must release
+
+    if (!kextURL) {
+        result = kOSKextReturnInvalidArgument;
+        goto finish;
+    }
+
+    requestDict = CFDictionaryCreateMutable(kCFAllocatorDefault,
+        /* capacity */ 0, &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks);
+    if (!requestDict) {
+        result = kOSKextReturnNoMemory;
+        goto finish;
+    }
+    
+    absURL = CFURLCopyAbsoluteURL(kextURL);
+    if (!absURL) {
+        result = kOSKextReturnNoMemory;
+        goto finish;
+    }
+
+    kextPath = CFURLCopyFileSystemPath(absURL, kCFURLPOSIXPathStyle);
+    if (!kextPath) {
+        result = kOSKextReturnSerialization;
+        goto finish;
+    }
+    CFDictionarySetValue(requestDict, kKextLoadPathKey, kextPath);
+
+    result = __KextManagerSendLoadKextRequest(requestDict,
+        dependencyKextAndFolderURLs);
+
+finish:
+    SAFE_RELEASE(requestDict);
+    SAFE_RELEASE(absURL);
+    SAFE_RELEASE(kextPath);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn KextManagerUnloadKextWithIdentifier(
+    CFStringRef kextIdentifier)
+{
+    OSReturn      result           = kOSReturnError;
+    OSKextLogSpec oldUserLogSpec   = OSKextGetLogFilter(/* kernel? */ false);
+    OSKextLogSpec oldKernelLogSpec = OSKextGetLogFilter(/* kernel? */ true);
+
+    if (!kextIdentifier) {
+        result = kOSKextReturnInvalidArgument;
+        goto finish;
+    }
+
+    OSKextSetLogFilter(kOSKextLogSilentFilter, /* kernelFlag */ false);
+    OSKextSetLogFilter(kOSKextLogSilentFilter, /* kernelFlag */ true);
+
+    result = OSKextUnloadKextWithIdentifier(kextIdentifier,
+        /* terminateServicesAndRemovePersonalities */ TRUE);
+
+finish:
+
+    OSKextSetLogFilter(oldUserLogSpec, /* kernelFlag */ false);
+    OSKextSetLogFilter(oldKernelLogSpec, /* kernelFlag */ true);
+    return result;
+}
+
+/*********************************************************************
+* Use this applier function to strip out any info from the kernel
+* we don't want to expose in public API.
+*********************************************************************/
+void _removePrivateKextInfo(
+    const void * vKey __unused,
+    const void * vValue,
+          void * vContext __unused)
+{
+    CFMutableDictionaryRef kextInfo = (CFMutableDictionaryRef)vValue;
+    CFDictionaryRemoveValue(kextInfo, CFSTR("OSBundleMachOHeaders"));
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDictionaryRef KextManagerCopyLoadedKextInfo(
+    CFArrayRef  kextIdentifiers,
+    CFArrayRef  infoKeys)
+{
+    CFMutableDictionaryRef result     = NULL;
+    CFDictionaryRef        kextResult = NULL;  // must release
+
+    kextResult = OSKextCopyLoadedKextInfo(kextIdentifiers, infoKeys);
+    if (!kextResult) {
+        goto finish;
+    }
+
+   /* Copy and remove properties we don't want people to use.
+    */
+    result = CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, kextResult);
+    CFDictionaryApplyFunction(result, &_removePrivateKextInfo, /* context */ NULL);
+
+finish:
+    SAFE_RELEASE(kextResult);
+    return (CFDictionaryRef)result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef _KextManagerCreatePropertyValueArray(
+    CFAllocatorRef allocator __unused,
+    CFStringRef    propertyKey)
+{
+    CFMutableArrayRef valueArray = NULL;  // returned
+    CFDataRef         xmlData = NULL;  // must release
+    CFTypeRef	      cfObj;
+
+    kern_return_t kern_result = kOSReturnError;
+    property_key_t property_key = "";  // matches prop_key_t in .defs file
+
+    mach_port_t   kextd_port = MACH_PORT_NULL;
+
+    char      * xml_data = NULL;  // must vm_deallocate()
+    natural_t   xml_data_length = 0;
+
+    CFErrorRef error = NULL;  // must release
+
+    if (!propertyKey || PROPERTYKEY_LEN < 
+	    (CFStringGetMaximumSizeForEncoding(CFStringGetLength(propertyKey),
+	    kCFStringEncodingUTF8))) {
+        goto finish;
+    }
+
+    if (!CFStringGetCString(propertyKey,
+        property_key, sizeof(property_key) - 1, kCFStringEncodingUTF8)) {
+        goto finish;
+    }
+
+    kern_result = get_kextd_port(&kextd_port);
+    if (kern_result != kOSReturnSuccess) {
+        goto finish;
+    }
+
+    kern_result = kextmanager_create_property_value_array(kextd_port,
+        property_key, &xml_data, &xml_data_length);
+    if (kern_result != kOSReturnSuccess) {
+        goto finish;
+    }
+
+    xmlData = CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, (UInt8 *)xml_data,
+        xml_data_length, kCFAllocatorNull);
+    if (!xmlData) {
+        goto finish;
+    }
+
+    cfObj = CFPropertyListCreateWithData(kCFAllocatorDefault,
+        xmlData, /* options */ 0, /* format */ NULL, &error);
+    if (!cfObj) {
+        // any point in logging error reason here? nothing caller can do....
+        goto finish;
+    }
+
+    if (CFGetTypeID(cfObj) != CFArrayGetTypeID()) {
+        CFRelease(cfObj);
+        goto finish;
+    }
+    valueArray = (CFMutableArrayRef) cfObj;
+
+finish:
+
+    SAFE_RELEASE(error);
+    SAFE_RELEASE(xmlData);
+
+    if (xml_data) {
+        vm_deallocate(mach_task_self(), (vm_address_t)xml_data,
+            xml_data_length);
+    }
+    return valueArray;
+}
+
+/*********************************************************************
+*********************************************************************/
+static kern_return_t get_kextd_port(mach_port_t * kextd_port)
+{
+    kern_return_t kern_result = kOSReturnError;
+    mach_port_t   bootstrap_port = MACH_PORT_NULL;
+	
+    kern_result = task_get_bootstrap_port(mach_task_self(), &bootstrap_port);
+    if (kern_result == kOSReturnSuccess) {
+        kern_result = bootstrap_look_up2(bootstrap_port,
+                                         (char *)KEXTD_SERVER_NAME,
+                                         kextd_port,
+                                         0,
+                                         BOOTSTRAP_PRIVILEGED_SERVER);
+    }
+	
+    return kern_result;
+}

--- a/src/kext_tools/kext.subproj/KextManager.h
+++ b/src/kext_tools/kext.subproj/KextManager.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2000-2008, 2012 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#ifndef __KEXTMANAGER_H__
+#define __KEXTMANAGER_H__
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <libkern/OSReturn.h>
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+/*!
+ * @header KextManager.h
+ *
+ * @abstract
+ * The KextManager API provides a simple interface for applications
+ * to load kernel extensions (kexts) via RPC to kextd, and to look up the
+ * URLs for kexts by bundle identifier.
+ */
+ 
+/*!
+ * @function KextManagerCreateURLForBundleIdentifier
+ * @abstract Create a URL locating a kext with a given bundle identifier.
+ *
+ * @param    allocator
+ *           The allocator to use to allocate memory for the new object.
+ *           Pass <code>NULL</code> or <code>kCFAllocatorDefault</code>
+ *           to use the current default allocator.
+ * @param    kextIdentifier
+ *           The bundle identifier to look up.
+ *
+ * @result
+ * A CFURLRef locating a kext with the requested bundle identifier.
+ * Returns <code>NULL</code> if the kext cannot be found, or on error.
+ *
+ * @discussion
+ * Kexts are looked up first by whether they are loaded, second by version.
+ * Specifically, if <code>kextIdentifier</code> identifies a kext
+ * that is currently loaded,
+ * the returned URL will locate that kext if it's still present on disk.
+ * If the requested kext is not loaded,
+ * or if its bundle is not at the location it was originally loaded from,
+ * the returned URL will locate the latest version of the desired kext,
+ * if one can be found within the system extensions folder.
+ * If no version of the kext can be found, <code>NULL</code> is returned.
+ */
+CFURLRef KextManagerCreateURLForBundleIdentifier(
+    CFAllocatorRef allocator,
+    CFStringRef    kextIdentifier) AVAILABLE_MAC_OS_X_VERSION_10_2_AND_LATER;
+
+/*!
+ * @function KextManagerLoadKextWithIdentifier
+ * @abstract
+ * Request the kext loading system to load a kext with a given bundle identifier.
+ *
+ * @param    kextIdentifier
+ *           The bundle identifier of the kext to look up and load.
+ * @param    dependencyKextAndFolderURLs
+ *           An array of additional URLs, of individual kexts and
+ *           of folders that may contain kexts.
+ *
+ * @result
+ * <code>kOSReturnSuccess</code> if the kext is successfully loaded
+ * (or is already loaded), otherwise returns on error.
+ *
+ * @discussion
+ * <code>kextIdentifier</code> is looked up in the system extensions
+ * folder and among any kexts from <code>dependencyKextAndFolderURLs</code>.
+ * Any non-kext URLs in <code>dependencyKextAndFolderURLs</code>
+ * are scanned at the top level for kexts and plugins of kexts.
+ *
+ * Either the calling process must have an effective user id of 0 (superuser),
+ * or the kext being loaded and all its dependencies must reside in
+ * /System and have an OSBundleAllowUserLoad property of <code>true</code>.
+ */
+OSReturn KextManagerLoadKextWithIdentifier(
+    CFStringRef    kextIdentifier,
+    CFArrayRef     dependencyKextAndFolderURLs) AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER;
+
+/*!
+ * @function KextManagerLoadKextWithURL
+ * @abstract
+ * Request the kext loading system to load a kext with a given URL.
+ *
+ * @param    kextURL
+ *           The URL of the kext to load.
+ * @param    dependencyKextAndFolderURLs
+ *           An array of additional URLs, of individual kexts and
+ *           of folders that may contain kexts.
+ *
+ * @result
+ * <code>kOSReturnSuccess</code> if the kext is successfully loaded
+ * (or is already loaded), otherwise returns on error.
+ *
+ * @discussion
+ * Any non-kext URLs in <code>dependencyKextAndFolderURLs</code>
+ * are scanned at the top level for kexts and plugins of kexts.
+ *
+ * Either the calling process must have an effective user id of 0 (superuser),
+ * or the kext being loaded and all its dependencies must reside in
+ * /System and have an OSBundleAllowUserLoad property of <code>true</code>.
+ */
+OSReturn KextManagerLoadKextWithURL(
+    CFURLRef    kextURL,
+    CFArrayRef  dependencyKextAndFolderURLs) AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER;
+
+/*!
+ * @function KextManagerUnloadKextWithIdentifier
+ * @abstract
+ * Request the kernel to unload a kext with a given bundle identifier.
+ *
+ * @param    kextIdentifier
+ *           The bundle identifier of the kext to unload.
+ *
+ * @result
+ * <code>kOSReturnSuccess</code> if the kext is
+ * found and successfully unloaded,
+ * otherwise returns on error.
+ * See <code>/usr/include/libkern/OSKextLib.h</code>
+ * for error codes.
+ *
+ * @discussion
+ * The calling process must have an effective user id of 0 (superuser).
+ */
+OSReturn KextManagerUnloadKextWithIdentifier(
+    CFStringRef kextIdentifier) AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER;
+
+/*!
+ * @function KextManagerCopyLoadedKextInfo
+ * @abstract Returns information about loaded kexts in a dictionary.
+ *
+ * @param    kextIdentifiers   An array of kext identifiers to read from the kernel.
+ *                             Pass <code>NULL</code> to read info for all loaded kexts.
+ * @param    infoKeys          An array of info keys to read from the kernel.
+ *                             Pass <code>NULL</code> to read all information.
+ * @result
+ * A dictionary, keyed by bundle identifier,
+ * of dictionaries containing information about loaded kexts.
+ *
+ * @discussion
+ * The information keys returned by this function are listed below.
+ * Some are taken directly from the kext's information property list,
+ * and some are generated at run time.
+ * Never assume a given key will be present for a kext.
+ *
+ * <ul>
+ *   <li><code>CFBundleIdentifier</code> - CFString</li>
+ *   <li><code>CFBundleVersion</code> - CFString (note: version strings may be canonicalized
+ *       but their numeric values will be the same; "1.2.0" may become "1.2", for example)</li>
+ *   <li><code>OSBundleCompatibleVersion</code> - CFString</li>
+ *   <li><code>OSBundleIsInterface</code> - CFBoolean</li>
+ *   <li><code>OSKernelResource</code> - CFBoolean</li>
+ *   <li><code>OSBundleCPUType</code> - CFNumber</li>
+ *   <li><code>OSBundleCPUSubtype</code> - CFNumber</li>
+ *   <li><code>OSBundlePath</code> - CFString (this is merely a hint stored in the kernel;
+ *       the kext is not guaranteed to be at this path)</li>
+ *   <li><code>OSBundleExecutablePath</code> - CFString
+ *       (the absolute path to the executable within the kext bundle; a hint as above)</li>
+ *   <li><code>OSBundleUUID</code> - CFData (the UUID of the kext executable, if it has one)</li>
+ *   <li><code>OSBundleStarted</code> - CFBoolean (true if the kext is running)</li>
+ *   <li><code>OSBundlePrelinked</code> - CFBoolean (true if the kext is loaded from a prelinked kernel)</li>
+ *   <li><code>OSBundleLoadTag</code> - CFNumber (the "Index" given by kextstat)</li>
+ *   <li><code>OSBundleLoadAddress</code> - CFNumber</li>
+ *   <li><code>OSBundleLoadSize</code> - CFNumber</li>
+ *   <li><code>OSBundleWiredSize</code> - CFNumber</li>
+ *   <li><code>OSBundleDependencies</code> - CFArray of load tags identifying immediate link dependencies</li>
+ *   <li><code>OSBundleRetainCount</code> - CFNumber (the OSObject retain count of the kext itself)</li>
+ *   <li><code>OSBundleClasses</code> - CFArray of CFDictionary containing info on C++ classes
+ *       defined by the kext:</li>
+ *       <ul>
+ *         <li><code>OSMetaClassName</code> - CFString</li>
+ *         <li><code>OSMetaClassSuperclassName</code> - CFString, absent for root classes</li>
+ *         <li><code>OSMetaClassTrackingCount</code> - CFNumber giving the instance count
+ *             of the class itself, <i>plus</i> 1 for each direct subclass with any instances</li>
+ *       </ul>
+ * </ul>
+ */
+CFDictionaryRef KextManagerCopyLoadedKextInfo(
+    CFArrayRef  kextIdentifiers,
+    CFArrayRef  infoKeys) AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER;
+
+
+__END_DECLS
+
+#endif /* __KEXTMANAGER_H__ */

--- a/src/kext_tools/kext.subproj/KextManagerPriv.h
+++ b/src/kext_tools/kext.subproj/KextManagerPriv.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008, 2012 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+#ifndef __KEXTMANAGERPRIV_H__
+#define __KEXTMANAGERPRIV_H__
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <TargetConditionals.h>
+#if !TARGET_OS_IPHONE
+#include <Security/Authorization.h>
+#endif /* !TARGET_OS_IPHONE */
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+#define kKextLoadIdentifierKey   CFSTR("KextLoadIdentifier")
+#define kKextLoadPathKey         CFSTR("KextLoadPath")
+#define kKextLoadDependenciesKey CFSTR("KextLoadDependencyPaths")
+
+CFArrayRef _KextManagerCreatePropertyValueArray(
+    CFAllocatorRef allocator,
+    CFStringRef    propertyKey);
+
+__END_DECLS
+
+#endif /* __KEXTMANAGERPRIV_H__ */

--- a/src/kext_tools/kext.subproj/OSKext.c
+++ b/src/kext_tools/kext.subproj/OSKext.c
@@ -1,0 +1,15704 @@
+/*
+ * Copyright (c) 2008, 2012 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#include <CoreFoundation/CFRuntime.h>
+#include <CoreFoundation/CFBundlePriv.h>
+#include <IOKit/IOKitLib.h>
+#include <IOKit/IOCFSerialize.h>
+#include <IOKit/IOCFUnserialize.h>
+#include <IOKit/IOKitServer.h>
+
+#ifndef IOKIT_EMBEDDED
+#include <kxld.h>
+#endif
+
+#include <System/libkern/mkext.h>
+#include <System/libkern/kext_request_keys.h>
+#include <System/libkern/prelink.h>
+#include <System/libkern/OSKextLibPrivate.h>
+#include <Kernel/mach/vm_param.h>
+
+#include <fcntl.h>
+#include <libc.h>
+#include <pthread.h>
+#include <mach/host_priv.h>
+#include <zlib.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/sysctl.h>
+#include <uuid/uuid.h>
+
+#include "OSKext.h"
+#include "OSKextPrivate.h"
+#include "printPList_new.h"
+#include "fat_util.h"
+#include "macho_util.h"
+#include "misc_util.h"
+
+#define SHARED_EXECUTABLE 1
+
+#pragma mark Notes
+/*********************************************************************
+**********************************************************************
+Notes
+======================================================================
+Each kext instance will be stored in a non-retaining dict, sKextsByIdentifier:
+  - bundle-id -> matching kext, if there is only one, else
+                 array of matching kexts, in reverse version order
+----------------------------------------------------------------------
+Any time a kext is created, all kexts in the search path for the same bundle
+ID will be read. This is for sanity, and we don't expect to see duplicates
+much if at all, so there shouldn't be
+**********************************************************************
+*********************************************************************/
+
+#pragma mark OSKext Data Structures
+/*********************************************************************
+* OSKext Data Structures
+*********************************************************************/
+
+typedef struct __OSKextLoadInfo {
+   /* Used whenever a dependency graph is needed (generating an mkext,
+    * prelinked kernel, or linking/loading).
+    */
+    CFMutableArrayRef dependencies;    // may have some missing
+
+   /* These are used when checking the kernel for loaded kexts,
+    * or when loading/generating symbols from user space.
+    */
+    CFDictionaryRef   kernelLoadInfo;   // for lazy eval, cleared when we check
+    uint32_t          loadTag;
+    uint64_t          loadAddress;      // 64-bit for max coverage
+    uint64_t          sourceAddress;    // For prelinking: where it starts in memory
+    size_t            headerSize;       // xxx - needed?
+    size_t            loadSize;         // xxx - haxx; do we need wiredSize?
+
+   /* These only exist while loading from user space.
+    */
+    CFURLRef          executableURL;
+    CFDataRef         executable;
+    CFDataRef         linkedExecutable;
+    CFDataRef         prelinkedExecutable;
+    kmod_info_t     * kmod_info;
+    uint64_t          kmodInfoAddress;
+    uint64_t          linkStateAddress;
+    
+    struct {
+        unsigned int  hasRawKernelDependency:1;
+        unsigned int  hasKernelDependency:1;
+        unsigned int  hasKPIDependency:1;
+        unsigned int  hasPrivateKPIDependency:1;
+
+        unsigned int  hasAllDependencies:1;
+        unsigned int  dependenciesValid:1;
+        unsigned int  dependenciesAuthentic:1;
+
+        unsigned int  isLoaded:1;
+        unsigned int  isStarted:1;
+        unsigned int  otherCFBundleVersionIsLoaded:1;
+        unsigned int  otherUUIDIsLoaded:1; // otherVersion is also set if this is
+    } flags;
+} __OSKextLoadInfo;
+
+typedef struct __OSKextMkextInfo {
+    CFURLRef               mkextURL;
+    CFDataRef              mkextData;  // the whole mkext file!
+    CFDataRef              executable;
+    CFMutableDictionaryRef resources;
+} __OSKextMkextInfo;
+
+/*****
+ * Any failed diagnotic tests get their results put in one of these
+ * dictionaries. See the header file for what keys and values
+ * go in them. If the library does not perform full tests, then the
+ * first failure encountered will cease testing and any of
+ * these dictionaries will have exactly one entry. If the library
+ * does perform full tests, then as many errors as are found will
+ * be in each dictionary.
+ */
+typedef struct __OSKextDiagnostics {
+    CFMutableDictionaryRef validationFailures;
+    CFMutableDictionaryRef authenticationFailures;
+    CFMutableDictionaryRef dependencyFailures; // whether direct or indirect!
+    CFMutableDictionaryRef warnings;
+    CFMutableDictionaryRef bootLevel;
+} __OSKextDiagnostics;
+
+typedef struct __OSKext {
+
+   /* base CFType information. */
+    CFRuntimeBase         cfBase;
+
+   /* Read/retained at creation time. */
+    CFURLRef              bundleURL;
+    CFStringRef           bundleID;
+
+
+   /* Read by __OSKextProcessInfoDictionary(). */
+    OSKextVersion         version;
+    OSKextVersion         compatibleVersion;
+
+   /* May be flushed, may need to reload from disk.
+    */
+    CFDictionaryRef       infoDictionary;  // read with IOCFUnserialize()
+
+   /* Allocated and maintained as necessary. */
+    __OSKextDiagnostics * diagnostics;
+    __OSKextLoadInfo    * loadInfo;
+    __OSKextMkextInfo   * mkextInfo;
+
+    struct {
+        unsigned int      isPluginChecked:1;
+        unsigned int      isPlugin:1;
+
+        unsigned int      isFromIdentifierCache:1; // must __OSKextRealize on access
+        unsigned int      isFromMkext:1;      // i.e. *not* to be updated from bundleURL
+    } staticFlags;
+
+    struct {
+       /* Set by __OSKextProcessInfoDictionary() */
+        unsigned int      isKernelComponent:1;
+        unsigned int      isInterface:1;
+        unsigned int      declaresExecutable:1;
+        unsigned int      loggingEnabled:1;
+        unsigned int      plistHasEnableLoggingSet:1;
+        unsigned int      plistHasIOKitDebugFlags:1;
+        unsigned int      isLoadableInSafeBoot:1;
+
+       /* Set as determined or on demand. */
+        unsigned int      validated:1;  // all possible checks done
+        unsigned int      invalid:1;       // at least 1 failure, or fully validated
+        unsigned int      valid:1;         // all possible checks done & passed
+
+        unsigned int      authenticated:1; // all possible checks done
+        unsigned int      inauthentic:1;   // at least 1 failure, or all ok
+        unsigned int      authentic:1;     // should we ever cache this?
+
+        unsigned int      hasIOKitDebugProperty:1;
+        unsigned int      warnForMismatchedKmodInfo:1;
+        unsigned int      isSigned:1;
+    } flags;
+
+} __OSKext, * __OSKextRef;
+
+#pragma mark Internal Constants and Enums
+/*********************************************************************
+* Internal Constants and Enums
+*********************************************************************/
+
+#define __sOSKextFullBundleExtension     ".kext/"
+#define __kDSStoreFilename               CFSTR(".DS_Store")
+
+#define __kOSKextKernelIdentifier        CFSTR("__kernel__")
+#define __kOSKextUnknownIdentifier       "__unknown__"
+
+#define __kOSKextApplePrefix             CFSTR("com.apple.")
+#define __kOSKextKernelLibBundleID       CFSTR("com.apple.kernel")
+#define __kOSKextKernelLibPrefix         CFSTR("com.apple.kernel.")
+#define __kOSKextKPIPrefix               CFSTR("com.apple.kpi.")
+#define __kOSKextCompatibilityBundleID   "com.apple.kernel.6.0"
+#define __kOSKextPrivateKPI              CFSTR("com.apple.kpi.private")
+
+/* Used when generating symbols.
+ */
+#define __kOSKextSymbolFileSuffix        "sym"
+
+/* Used to validate a kext executable.
+ */
+#define __kOSKextKmodInfoSymbol         "_kmod_info"
+
+#define __kStringUnknown                 "(unknown)"
+
+#define __kOSKextMaxKextDisplacement_x86_64	(2 * 1024 * 1024 * 1024ULL)
+
+/*********************************************************************
+ * Kext Cache Stuff
+*********************************************************************/
+#define __kOSKextIdentifierCacheBasePathKey    "OSKextIdentifierCacheBasePath"
+#define __kOSKextIdentifierCacheKextInfoKey    "OSKextIdentifierCacheKextInfo"
+#define __kOSKextIdentifierCacheVersionKey     "OSKextIdentifierCacheVersion"
+#define __kOSKextIdentifierCacheCurrentVersion (1)
+
+
+#pragma mark Module Internal Variables
+/*********************************************************************
+* Module Internal Variables
+*********************************************************************/
+
+static pthread_once_t __sOSKextInitialized  = PTHREAD_ONCE_INIT;
+static Boolean        __sOSKextInitializing = false;
+
+/* Internal lookup collections.
+ * Created the first time any kext is; all functions that access should
+ * check for existence first!
+ *
+ * Values are NOT retained.
+ */
+static CFMutableArrayRef      __sOSAllKexts                = NULL;
+static CFMutableDictionaryRef __sOSKextsByURL              = NULL;
+static CFMutableDictionaryRef __sOSKextsByIdentifier       = NULL;
+
+/* The default log flags result in errors and the special explicit
+ * messages going out, and that's about it.
+ */
+static OSKextLogSpec          __sUserLogFilter             = kOSKextLogWarningLevel |
+                                                             kOSKextLogVerboseFlagsMask;
+static OSKextLogSpec          __sKernelLogFilter           = kOSKextLogWarningLevel |
+                                                             kOSKextLogVerboseFlagsMask;
+
+static const NXArchInfo       __sOSKextUnknownArchInfo         = {
+    .name        = "unknown",
+    .cputype     = CPU_TYPE_ANY,
+    .cpusubtype  = CPU_SUBTYPE_MULTIPLE,
+    .byteorder   = NX_UnknownByteOrder,
+    .description = "unknown CPU architecture",
+};
+static const NXArchInfo     * __sOSKextArchInfo                     = &__sOSKextUnknownArchInfo;
+static Boolean                __sOSKextSimulatedSafeBoot           = FALSE;
+static Boolean                __sOSKextUsesCaches                  = TRUE;
+static Boolean                __sOSKextStrictRecordingByLastOpened = FALSE;
+
+static CFArrayRef             __sOSKextPackageTypeValues       = NULL;
+static CFArrayRef             __sOSKextOSBundleRequiredValues  = NULL;
+
+static OSKextDiagnosticsFlags __sOSKextRecordsDiagnositcs      = kOSKextDiagnosticsFlagNone;
+
+// xxx - need a lock for thread safety
+
+static OSKextVersion          __sOSNewKmodInfoKernelVersion = -1;
+
+/* These are function protos but we need them ahead of their
+ * references.
+ */
+void __sOSKextDefaultLogFunction(
+    OSKextRef       aKext,
+    OSKextLogSpec   msgLogSpec,
+    const char     * format, ...);
+void __OSKextLogKernelMessages(
+    OSKextRef aKext,
+    CFTypeRef kernelMessages);
+
+void (*__sOSKextLogOutputFunction)(
+    OSKextRef       aKext,
+    OSKextLogSpec   msgLogSpec,
+    const char    * format, ...) =
+        &__sOSKextDefaultLogFunction;
+
+static const char * safe_mach_error_string(mach_error_t error_code);
+
+#pragma mark External Variables and Constants
+/*********************************************************************
+* External Constants and Enums
+*********************************************************************/
+static CFArrayRef        __sOSKextSystemExtensionsFolderURLs = NULL;
+static CFArrayRef        __sOSKextInfoEssentialKeys          = NULL;
+// xxx - This set is all except OSBundleExecutablePath, OSBundleMachOHeaders, and OSBundleClasses.
+
+const char * kOSKextLoadNotification   = "com.apple.kext.load";
+const char * kOSKextUnloadNotification = "com.apple.kext.unload";
+
+#pragma mark -
+/********************************************************************/
+#pragma mark Diagnostic Keys and Values
+/********************************************************************/
+const CFStringRef kOSKextDiagnosticsValidationKey =
+                  CFSTR("Validation Failures");
+const CFStringRef kOSKextDiagnosticsAuthenticationKey =
+                  CFSTR("Authentication Failures");
+const CFStringRef kOSKextDiagnosticsDependenciesKey =
+                  CFSTR("Dependency Resolution Failures");
+const CFStringRef kOSKextDiagnosticsWarningsKey =
+                  CFSTR("Warnings");
+const CFStringRef kOSKextDiagnosticsBootLevelKey =
+                  CFSTR("Boot Level Restrictions");
+
+#pragma mark Combo validation/authentication diagnostic strings
+/* Combo validation/authentication diagnostic strings.
+ */
+const CFStringRef kOSKextDiagnosticURLConversionKey =
+                  CFSTR("Internal error converting URL");
+const CFStringRef kOSKextDiagnosticFileNotFoundKey =
+                  CFSTR("File not found");
+const CFStringRef kOSKextDiagnosticStatFailureKey =
+                  CFSTR("Failed to get file info (stat failed)");
+const CFStringRef kOSKextDiagnosticFileAccessKey =
+                  CFSTR("File access failure; can't open, or I/O error");
+
+/* Validation diagnostic strings.
+ */
+const CFStringRef kOSKextDiagnosticNotABundleKey =
+                  CFSTR("Failed to open CFBundle (unknown error).");
+const CFStringRef kOSKextDiagnosticBadPropertyListXMLKey =
+                  CFSTR("Can't parse info dictionary XML");
+const CFStringRef kOSKextDiagnosticMissingPropertyKey =
+                  CFSTR("Info dictionary missing required property/value");
+const CFStringRef kOSKextDiagnosticBadSystemPropertyKey =
+                  CFSTR("A system kext has a property set that it shouldn't");
+const CFStringRef kOSKextDiagnosticPropertyIsIllegalTypeKey =
+                  CFSTR("Info dictionary property value is of illegal type");
+const CFStringRef kOSKextDiagnosticPropertyIsIllegalValueKey =
+                  CFSTR("Info dictionary property value is illegal");
+const CFStringRef kOSKextDiagnosticIdentifierOrVersionTooLongKey =
+                  CFSTR("CFBundleIdentifier and CFBundleVersion must be < 64 characters.");
+const CFStringRef kOSKextDiagnosticExecutableMissingKey =
+                  CFSTR("Kext has a CFBundleExecutable property but the executable can't be found");
+#if SHARED_EXECUTABLE
+const CFStringRef kOSKextDiagnosticSharedExecutableKextMissingKey =
+                  CFSTR("Kext claims a shared executable with named kext, "
+                  "but that kext can't be found");
+const CFStringRef kOSKextDiagnosticSharedExecutableAndExecutableKey =
+                  CFSTR("Kext declares both CFBundleExecutable and "
+                  "CFBundleSharedExecutableIdentifier; use only one.");
+#endif /* SHARED_EXECUTABLE */
+const CFStringRef kOSKextDiagnosticCompatibleVersionLaterThanVersionKey =
+                  CFSTR("Compatible version must be lower than current version.");
+const CFStringRef kOSKextDiagnosticExecutableBadKey =
+                  CFSTR("Executable file doesn't contain kernel extension code "
+                  "(no kmod_info symbol or bad Mach-O layout).");
+
+/* Authentication diagnostic strings.
+ */
+const CFStringRef kOSKextDiagnosticNoFileKey =
+                  CFSTR("Kext was not created from an URL and can't be authenticated");
+const CFStringRef kOSKextDiagnosticOwnerPermissionKey =
+                  CFSTR("File owner/permissions are incorrect "
+                  "(must be root:wheel, nonwritable by group/other)");
+
+/* Warning diagnostic strings.
+ */
+const CFStringRef kOSKextDiagnosticTypeWarningKey =
+                  CFSTR("Info dictionary property value is of incorrect type");
+
+const CFStringRef kOSKextDiagnosticKernelComponentNotInterfaceKey =
+                  CFSTR("Kext is a kernel component but OSBundleIsInterface "
+                  "is set to false; overriding");
+
+const CFStringRef kOSKextDiagnosticExecutableArchNotFoundKey =
+                  CFSTR("Executable does not contain code for architecture");
+
+const CFStringRef kOSKextDiagnosticSymlinkKey =
+                  CFSTR("The booter does not recognize symbolic links; "
+                  "confirm these files/directories aren't needed for startup");
+
+const CFStringRef kOSKextDiagnosticDeprecatedPropertyKey =
+                  CFSTR("Deprecated property (ignored)");
+const CFStringRef kOSKextDiagnosticPersonalityHasNoBundleIdentifierKey =
+                  CFSTR("Personality has no CFBundleIdentifier; "
+                  "the kext's identifier will be inserted when sending to the IOCatalogue");
+
+const CFStringRef kOSKextDiagnosticPersonalityNamesUnknownKextKey =
+                  CFSTR("Personality CFBundleIdentifier names a kext that "
+                  "can't be found");
+const CFStringRef kOSKextDiagnosticPersonalityNamesNonloadableKextKey =
+                  CFSTR("Personality CFBundleIdentifier names a kext that "
+                  "is not loadable (run kextutil(8) on it with -nt for more information)");
+const CFStringRef kOSKextDiagnosticPersonalityNamesKextWithNoExecutableKey =
+                  CFSTR("Personality CFBundleIdentifier names a kext that "
+                  "doesn't declare an executable");
+const CFStringRef kOSKextDiagnosticPersonalityHasDifferentBundleIdentifierKey =
+                  CFSTR("Personality CFBundleIdentifier differs from "
+                  "containing kext's (not necessarily a mistake, but rarely done)");
+const CFStringRef kOSKextDiagnosticNonuniqueIOResourcesMatchKey =
+                  CFSTR("Personality matches on IOResources "
+                  "but IOMatchCategory is missing or not equal to its IOClass; "
+                  "driver may be blocked from matching or may block others");
+
+const CFStringRef kOSKextDiagnosticCodelessWithLibrariesKey =
+                  CFSTR("Kext has no executable or compatible version, "
+                  "so it should not declare any OSBundleLibraries.");
+const CFStringRef kOSKextDiagnosticNoExplicitKernelDependencyKey =
+                  CFSTR("Kext declares no kernel/KPI libraries; "
+                  "if it references any kernel symbols, it may fail to link.");
+const CFStringRef kOSKextDiagnosticDeclaresNoKPIsWarningKey =
+                  CFSTR("Kext declares no com.apple.kpi.* libraries; "
+                  "if it references any kernel symbols, it may fail to link.");
+const CFStringRef kOSKextDiagnosticDeclaresBothKernelAndKPIDependenciesKey =
+                  CFSTR("Kexts should declare dependencies on either "
+                  "com.apple.kernel* or com.apple.kpi.* libraries, not both.");
+const CFStringRef kOSKextDiagnosticBundleIdentifierMismatchKey =
+                  CFSTR("Kexts with a kernel library < v6.0 must set MODULE_NAME "
+                  "the same as CFBundleIdentifier to load on kernel < v6.0.");
+const CFStringRef kOSKextDiagnosticBundleVersionMismatchKey =
+                  CFSTR("Kexts with a kernel library < v6.0 must set MODULE_VERSION "
+                  "the same as CFBundleVersion to load on kernel < v6.0.");
+
+const CFStringRef kOSKextDiagnosticsDependencyNotOSBundleRequired =
+                  CFSTR("Dependency lacks appropriate value for OSBundleRequired "
+                  "and may not be availalble during early boot");
+
+const CFStringRef kOSKextDiagnosticNotSignedKey =
+                  CFSTR("Kext is not signed");
+
+/* Dependency resolution diagnostic strings.
+ */
+const CFStringRef kOSKextDependencyUnavailable =
+                  CFSTR("No kexts found for these libraries");
+const CFStringRef kOSKextDependencyNoCompatibleVersion =
+                  CFSTR("Only incompatible kexts found for these libraries");
+const CFStringRef kOSKextDependencyCompatibleVersionUndeclared =
+                  CFSTR("Kexts found for these libraries lack valid "
+                  "OSBundleCompatibleVersion");
+const CFStringRef kOSKextDependencyLoadedIsIncompatible =
+                  CFSTR("Kexts already loaded for these libraries "
+                  "are not compatible with the requested version");
+const CFStringRef kOSKextDependencyLoadedCompatibleVersionUndeclared =
+                  CFSTR("Kexts already loaded for these libraries "
+                  "have no OSBundleCompatibleVersion");
+const CFStringRef kOSKextDependencyIndirectDependencyUnresolvable =
+                  CFSTR("Indirect dependencies can't be resolved");
+const CFStringRef kOSKextDependencyMultipleVersionsDetected =
+                  CFSTR("Multiple kexts for these libraries "
+                  "occur in the dependency graph");
+const CFStringRef kOSKextDependencyCircularReference =
+                  CFSTR("Some dependencies are causing circular references");
+const CFStringRef kOSKextDependencyRawAndComponentKernel =
+                  CFSTR("Libraries declared for both "
+                  "com.apple.kernel and a com.apple.kernel.* component.");
+const CFStringRef kOSKextDependencyInvalid =
+                  CFSTR("Dependencies have validation problems");
+const CFStringRef kOSKextDependencyInauthentic =
+                  CFSTR("Dependencies have incorrect owner/permissions");
+const CFStringRef kOSKextDiagnosticDeclaresNonKPIDependenciesKey =
+                  CFSTR("64-bit kexts must use com.apple.kpi.* libraries, "
+                  "not com.apple.kernel* libraries.");
+const CFStringRef kOSKextDiagnosticNonAppleKextDeclaresPrivateKPIDependencyKey =
+                  CFSTR("Only Apple kexts may link against com.apple.kpi.private.");
+const CFStringRef kOSKextDiagnosticRawKernelDependency =
+                  CFSTR("Kexts may not link against com.apple.kernel; "
+                  "use either com.apple.kpi.* libraries (recommended), "
+                  "or com.apple.kernel.* (for compatiblity with older releases).");
+const CFStringRef kOSKextDiagnosticsInterfaceDependencyCount =
+                  CFSTR("Interface kext must have exactly one dependency.");
+
+/* Boot-level (safe boot) diagnostic strings.
+ */
+const CFStringRef kOSKextDiagnosticIneligibleInSafeBoot =
+                  CFSTR("Kext isn't loadable during safe boot.");
+const CFStringRef kOSKextDependencyIneligibleInSafeBoot =
+                  CFSTR("Dependencies aren't loadable during safe boot");
+
+#pragma mark General Private Function Declarations
+/*********************************************************************
+* Private Function Declarations
+*********************************************************************/
+static void __OSKextInitialize(void);
+
+static OSKextRef   __OSKextAlloc(
+    CFAllocatorRef       allocator,
+    CFAllocatorContext * context);
+static void        __OSKextReleaseContents(CFTypeRef cf);
+static CFStringRef __OSKextCopyDebugDescription(CFTypeRef cf);
+
+Boolean __OSKextReadRegistryNumberProperty(
+    io_registry_entry_t ioObject,
+    CFStringRef         key,
+    CFNumberType        numberType,
+    void              * valuePtr);
+
+static Boolean __OSKextIsArchitectureLP64(void);
+
+static Boolean __OSKextInitWithURL(
+    OSKextRef aKext,
+    CFURLRef  anURL);
+static Boolean __OSKextInitFromMkext(
+    OSKextRef       aKext,
+    CFDictionaryRef infoDict,
+    CFURLRef        mkextURL,
+    CFDataRef       mkextData);
+static void    __OSKextReinit(OSKextRef aKext);
+
+static Boolean __OSKextRecordKext(OSKextRef aKext);
+static void __OSKextRemoveKext(OSKextRef aKext);
+static Boolean __OSKextRecordKextInIdentifierDict(
+    OSKextRef              aKext,
+    CFMutableDictionaryRef identifierDict);
+static void __OSKextRemoveKextFromIdentifierDict(
+    OSKextRef              aKext,
+    CFMutableDictionaryRef identifierDict);
+
+static CFMutableArrayRef __OSKextCreateKextsFromURL(
+    CFAllocatorRef allocator,
+    CFURLRef       anURL,
+    OSKextRef      aKext,  // if called by a kext looking for plugins
+    Boolean        createPluginsFlag);
+static CFMutableArrayRef __OSKextCreateKextsFromURLs(
+    CFAllocatorRef allocator,
+    CFArrayRef     arrayOfURLs,
+    Boolean        createPluginsFlag);
+    
+OSKextRef __OSKextCreateFromIdentifierCacheDict(
+    CFAllocatorRef  allocator,
+    CFDictionaryRef cacheDict,
+    CFStringRef     basePath,
+    CFIndex         entryIndex);
+void __OSKextRealize(const void * vKext, void * context __unused);
+void __OSKextRealizeKextsWithIdentifier(CFStringRef kextIdentifier);
+
+CFURLRef __OSKextCreateCacheFileURL(
+    CFTypeRef            folderURLsOrURL,
+    CFStringRef          cacheName,
+    const NXArchInfo   * arch,
+    _OSKextCacheFormat   format);
+Boolean __OSKextCacheNeedsUpdate(
+    CFURLRef  cacheURL,
+    CFTypeRef folderURLsOrURL);
+Boolean _OSKextCreateFolderForCacheURL(CFURLRef cacheURL);
+Boolean __OSKextURLIsSystemFolder(CFURLRef absURL);
+Boolean __OSKextStatURL(
+    CFURLRef      anURL,
+    Boolean     * missingOut,
+    struct stat * statOut);
+Boolean __OSKextStatURLsOrURL(
+    CFTypeRef     folderURLsOrURL,
+    Boolean     * missingOut,
+    struct stat * latestStatOut);
+
+void __OSKextRemoveIdentifierCacheForKext(OSKextRef aKext);
+CFDictionaryRef __OSKextCreateIdentifierCacheDict(
+    OSKextRef   aKext,
+    CFStringRef basePath);
+
+static Boolean __OSKextGetFileSystemPath(
+    OSKextRef aKext,
+    CFURLRef  anURL,
+    Boolean   resolveToBase,
+    char    * pathBuffer);
+CFStringRef __OSKextCreateCompositeKey(
+    CFStringRef  baseKey,
+    const char * auxKey);
+static CFTypeRef __CFDictionaryGetValueForCompositeKey(
+    CFDictionaryRef aDict,
+    CFStringRef     baseKey,
+    const char *    auxKey);
+
+static Boolean __OSKextReadExecutable(OSKextRef aKext);
+
+static Boolean __OSKextHasAllDependencies(OSKextRef aKext);
+static Boolean __OSKextResolveDependencies(
+    OSKextRef         aKext,
+    OSKextRef         rootKext,
+    CFMutableSetRef   resolvedSet,
+    CFMutableArrayRef loopStack);
+static Boolean __OSKextAddLinkDependencies(
+    OSKextRef         aKext,
+    CFMutableArrayRef linkDependencies,
+    Boolean           needAllFlag,
+    Boolean           bleedthroughFlag);
+
+static Boolean __OSKextReadSymbolReferences(
+    OSKextRef              aKext,
+    CFMutableDictionaryRef symbols);
+static Boolean __OSKextIsSearchableForSymbols(
+    OSKextRef aKext,
+    Boolean   nonKPIFlag,
+    Boolean   allowUnsupportedFlag);
+static Boolean __OSKextFindSymbols(
+    OSKextRef              aKext,
+    CFMutableDictionaryRef undefSymbols,
+    CFMutableDictionaryRef onedefSymbols,
+    CFMutableDictionaryRef multdefSymbols,
+    CFMutableArrayRef      multdefLibs);
+
+static CFMutableArrayRef __OSKextCopyDependenciesList(
+    OSKextRef aKext,
+    Boolean   needAllFlag,
+    uint32_t  minDepth);
+
+CFMutableDictionaryRef __OSKextCreateKextRequest(
+    CFStringRef              predicateIn,
+    CFTypeRef                bundleIdentifierIn,
+    CFMutableDictionaryRef * argumentsOut);
+OSReturn __OSKextSendKextRequest(
+    OSKextRef       aKext,
+    CFDictionaryRef kextRequest,
+    CFTypeRef     * cfResponseOut,
+    char         ** rawResponseOut,
+    uint32_t      * rawResponseLengthOut);
+static OSReturn __OSKextSimpleKextRequest(
+    OSKextRef     aKext,
+    CFStringRef   predicate,
+    CFTypeRef   * cfResponseOut);
+OSReturn __OSKextProcessKextRequestResults(
+    OSKextRef       aKext,
+    kern_return_t   mig_result,
+    kern_return_t   op_result,
+    char          * logInfoBuffer,
+    uint32_t        logInfoLength);
+
+static OSReturn __OSKextLoadWithArgsDict(
+    OSKextRef       aKext,
+    CFDictionaryRef loadArgsDict);
+#ifndef IOKIT_EMBEDDED
+static Boolean __OSKextGenerateDebugSymbols(
+    OSKextRef                aKext,
+    CFDataRef                kernelImage,
+    uint64_t                 kernelLoadAddress,
+    KXLDContext            * kxldContext,
+    CFMutableDictionaryRef   symbols);
+
+typedef struct __OSKextKXLDCallbackContext {
+    OSKextRef   kext;
+    uint64_t    kernelLoadAddress;
+} __OSKextKXLDCallbackContext;
+static kxld_addr_t __OSKextLinkAddressCallback(
+    u_long              size,
+    KXLDAllocateFlags * flags,
+    void              * user_data);
+static void __OSKextLoggingCallback(
+    KXLDLogSubsystem    subsystem,
+    KXLDLogLevel        level, 
+    const char        * format, 
+    va_list             argList,
+    void              * user_data);
+#endif /* !IOKIT_EMBEDDED */
+
+OSReturn __OSKextRemovePersonalities(
+    OSKextRef   aKext,
+    CFStringRef aBundleID);
+
+static void __OSKextProcessLoadInfo(
+    const void * vKey __unused,
+    const void * vValue,
+          void * vContext __unused);
+static void __OSKextCheckLoaded(OSKextRef aKext);
+
+Boolean __OSKextSetLoadAddress(OSKextRef aKext, uint64_t address);
+static Boolean __OSKextCreateLoadInfo(OSKextRef aKext);
+static Boolean __OSKextCreateMkextInfo(OSKextRef aKext);
+static Boolean __OSKextIsValid(OSKextRef aKext);
+static Boolean __OSKextValidate(OSKextRef aKext, CFMutableArrayRef propPath);
+static Boolean __OSKextValidateExecutable(OSKextRef aKext);
+static Boolean __OSKextAuthenticateURLRecursively(
+    OSKextRef aKext,
+    CFURLRef  anURL,
+    CFURLRef  pluginsURL);
+
+static CFDictionaryRef __OSKextCopyDiagnosticsDict(
+    OSKextRef              aKext,
+    OSKextDiagnosticsFlags type);
+static CFMutableDictionaryRef __OSKextGetDiagnostics(OSKextRef aKext,
+    OSKextDiagnosticsFlags type);
+static void __OSKextSetDiagnostic(OSKextRef aKext,
+    OSKextDiagnosticsFlags type, CFStringRef key);
+static void __OSKextAddDiagnostic(OSKextRef aKext,
+    OSKextDiagnosticsFlags type,
+    CFStringRef            key,
+    CFTypeRef              value,
+    CFTypeRef              note);
+
+static Boolean __OSKextCheckProperty(
+    OSKextRef       aKext,
+    CFDictionaryRef aDict,
+    CFTypeRef       propKey,
+    CFTypeRef       diagnosticValue, /* string or array of strings */
+    CFTypeID        expectedType,
+    CFArrayRef      legalValues,     /* NULL if not relevant */
+    Boolean         required,
+    Boolean         typeRequired,
+    Boolean         nonnilRequired,
+    CFTypeRef     * valueOut,
+    Boolean       * valueIsNonnil);
+
+static Boolean __OSKextReadInfoDictionary(
+    OSKextRef aKext, CFBundleRef kextBundle);
+static Boolean __OSKextProcessInfoDictionary(
+    OSKextRef aKext, CFBundleRef kextBundle);
+
+static Boolean __OSKextAddCompressedFileToMkext(
+    OSKextRef        aKext,
+    CFMutableDataRef mkextData,
+    CFDataRef        fileData,
+    Boolean          plistFlag,
+    Boolean        * compressed);
+static Boolean __OSKextAddToMkext(
+    OSKextRef         aKext,
+    CFMutableDataRef  mkextData,
+    CFMutableArrayRef mkextInfoDictArray,
+    char            * volumePath,
+    Boolean           compressFlag);
+static CFDataRef __OSKextCreateMkext(
+    CFAllocatorRef      allocator,
+    CFArrayRef          kextArray,
+    CFURLRef            volumeRootURL,
+    OSKextRequiredFlags requiredFlags,
+    Boolean             compressFlag,
+    Boolean             skipLoadedFlag,
+    CFDictionaryRef     loadArgsDict);
+static CFDataRef __OSKextUncompressMkext2FileData(
+    CFAllocatorRef   allocator,
+    const UInt8    * buffer,
+    uint32_t        compressedSize,
+    uint32_t        fullSize);
+static CFArrayRef __OSKextCreateKextsFromMkext(
+    CFAllocatorRef allocator,
+    CFDataRef mkextData,
+    CFURLRef  mkextURL);
+static CFDataRef __OSKextExtractMkext2FileEntry(
+    OSKextRef   aKext,
+    CFDataRef   mkextData,
+    CFNumberRef offsetNum,
+    CFStringRef filename);  // null for executable
+
+#ifndef IOKIT_EMBEDDED
+static boolean_t __OSKextSwapHeaders(
+    CFDataRef kernelImage);
+static boolean_t __OSKextUnswapHeaders(
+    CFDataRef kernelImage);
+static boolean_t __OSKextGetLastKernelLoadAddr(
+    CFDataRef kernelImage, 
+    uint64_t *lastLoadAddrOut);
+static boolean_t __OSKextGetSegmentAddressAndOffset(
+    CFDataRef kernelImage, 
+    const char *segname, 
+    uint32_t *fileOffsetOut, 
+    uint64_t *loadAddrOut);
+static boolean_t __OSKextGetSegmentFileAndVMSize(
+    CFDataRef kernelImage, 
+    const char *segname, 
+    uint64_t *fileSizeOut, 
+    uint64_t *VMSizeOut);
+static boolean_t __OSKextSetSegmentAddress(
+    CFDataRef kernelImage, 
+    const char *segname, 
+    uint64_t loadAddr);
+static boolean_t __OSKextSetSegmentVMSize(
+    CFDataRef kernelImage, 
+    const char *segname, 
+    uint64_t vmsize);
+static boolean_t __OSKextSetSegmentOffset(
+    CFDataRef kernelImage, 
+    const char *segname, 
+    uint64_t fileOffset);
+static boolean_t __OSKextSetSegmentFilesize(
+    CFDataRef kernelImage, 
+    const char *segname, 
+    uint64_t filesize);
+static boolean_t __OSKextSetSectionAddress(
+    CFDataRef kernelImage, 
+    const char *segname, 
+    const char *sectname, 
+    uint64_t loadAddr);
+static boolean_t __OSKextSetSectionSize(
+    CFDataRef kernelImage, 
+    const char *segname, 
+    const char *sectname, 
+    uint64_t size);
+static boolean_t __OSKextSetSectionOffset(
+    CFDataRef kernelImage, 
+    const char *segname, 
+    const char *sectname, 
+    uint32_t fileOffset);
+static uint64_t __OSKextGetFakeLoadAddress(CFDataRef kernelImage);
+static Boolean __OSKextCheckForPrelinkedKernel(
+    OSKextRef aKext,
+    Boolean   needAllFlag,
+    Boolean   skipAuthenticationFlag,
+    Boolean   printDiagnosticsFlag);
+static CFArrayRef __OSKextPrelinkKexts(
+    CFArrayRef        kextArray,
+    CFDataRef         kernelImage,
+    uint64_t          loadAddrBase,
+    uint64_t          sourceAddrBase,
+    KXLDContext     * kxldContext,
+    u_long          * loadSizeOut,
+    Boolean           needAllFlag,
+    Boolean           skipAuthenticationFlag,
+    Boolean           printDiagnosticsFlag,
+    Boolean           stripSymbolsFlag);
+static CFDataRef __OSKextCreatePrelinkInfoDictionary(
+    CFArrayRef loadList,
+    CFURLRef   volumeRootURL,
+    Boolean includeAllPersonalities);
+static Boolean __OSKextRequiredAtEarlyBoot(
+    OSKextRef   theKext);
+static u_long __OSKextCopyPrelinkedKexts(
+    CFMutableDataRef prelinkImage,
+    CFArrayRef loadList,
+    u_long fileOffsetBase,
+    uint64_t sourceAddrBase);
+static u_long __OSKextCopyPrelinkInfoDictionary(
+    CFMutableDataRef prelinkImage,
+    CFDataRef prelinkInfoData,
+    u_long fileOffset,
+    uint64_t sourceAddr);
+#endif /* !IOKIT_EMBEDDED */
+
+CFComparisonResult __OSKextCompareIdentifiers(
+    const void * val1,
+    const void * val2,
+    void       * context);
+char * __absPathOnVolume(
+    const char * path,
+    const char * volumePath);
+CFStringRef __OSKextCopyExecutableRelativePath(OSKextRef aKext);
+
+static bool __OSKextShouldLog(
+    OSKextRef        aKext,
+    OSKextLogSpec    msgLogSpec);
+
+#pragma mark Function-Like Macros
+/*********************************************************************
+* Function-Like Macros
+*********************************************************************/
+
+#pragma mark Core Foundation Class Functions
+/*********************************************************************
+* Core Foundation Class Definition Stuff
+*********************************************************************/
+
+/* This gets set by __OSKextInitialize().
+ */
+static CFTypeID __kOSKextTypeID = _kCFRuntimeNotATypeID;
+
+CFTypeID OSKextGetTypeID(void) {
+    return __kOSKextTypeID;
+}
+
+/*********************************************************************
+*********************************************************************/
+static const CFRuntimeClass __OSKextClass = {
+    0,                            // version
+    "OSKext",                     // className
+    NULL,                         // init
+    NULL,                         // copy
+    __OSKextReleaseContents,      // finalize
+    NULL,                         // equal: pointer equality, baby.
+    NULL,                         // hash
+    NULL,                         // copyFormattingDesc
+    __OSKextCopyDebugDescription, // copyDebugDesc
+#if CF_RECLAIM_AVAILABLE
+    NULL,                         // xxx - need to set reclaim field for garbage collection
+#endif
+#if CF_REFCOUNT_AVAILABLE
+    NULL
+#endif
+};
+
+/*********************************************************************
+*********************************************************************/
+static void __OSKextInitialize(void)
+{
+    CFTypeRef packageTypeValues[] = { CFSTR("KEXT") };
+    CFTypeRef bundleRequiredValues[] = {
+        CFSTR(kOSBundleRequiredRoot),
+        CFSTR(kOSBundleRequiredLocalRoot),
+        CFSTR(kOSBundleRequiredNetworkRoot),
+        CFSTR(kOSBundleRequiredSafeBoot),
+        CFSTR(kOSBundleRequiredConsole),
+    };
+    CFTypeRef essentialInfoKeys[] = {
+        kCFBundleIdentifierKey,
+        kCFBundleVersionKey,
+        CFSTR(kOSBundleCompatibleVersionKey),
+        CFSTR(kOSBundleIsInterfaceKey),
+        CFSTR(kOSKernelResourceKey),
+
+        CFSTR(kOSBundleCPUTypeKey),
+        CFSTR(kOSBundleCPUSubtypeKey),
+        CFSTR(kOSBundlePathKey),
+        CFSTR(kOSBundleUUIDKey),
+        CFSTR(kOSBundleStartedKey),
+        CFSTR(kOSBundleLoadTagKey),
+        CFSTR(kOSBundleLoadAddressKey),
+        CFSTR(kOSBundleLoadSizeKey),
+        CFSTR(kOSBundleWiredSizeKey),
+        CFSTR(kOSBundlePrelinkedKey),
+        CFSTR(kOSBundleDependenciesKey),
+        CFSTR(kOSBundleRetainCountKey)
+    };
+    CFAllocatorContext nonrefcountAllocatorContext;
+    CFAllocatorRef     nonrefcountAllocator = NULL;  // must release
+
+    // must release each
+    CFURLRef  extensionsDirs[_kOSKextNumSystemExtensionsFolders] = { 0, 0 };
+
+    int    numValues;
+
+   /* Prevent deadlock when calling other functions that might think they
+    * need to initialize.
+    */
+    __sOSKextInitializing = true;
+
+    __kOSKextTypeID = _CFRuntimeRegisterClass(&__OSKextClass);
+
+    CFAllocatorGetContext(kCFAllocatorDefault, &nonrefcountAllocatorContext);
+    nonrefcountAllocatorContext.retain = NULL;
+    nonrefcountAllocatorContext.release = NULL;
+    nonrefcountAllocator = CFAllocatorCreate(kCFAllocatorDefault,
+        &nonrefcountAllocatorContext);
+    if (!nonrefcountAllocator) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    extensionsDirs[0] = CFURLCreateFromFileSystemRepresentation(
+                nonrefcountAllocator,
+                (const UInt8 *)_kOSKextSystemLibraryExtensionsFolder,
+                strlen(_kOSKextSystemLibraryExtensionsFolder),
+                /* isDir */ true);
+    
+    extensionsDirs[1] = CFURLCreateFromFileSystemRepresentation(
+                nonrefcountAllocator,
+                (const UInt8 *)_kOSKextLibraryExtensionsFolder,
+                strlen(_kOSKextLibraryExtensionsFolder),
+                /* isDir */ true);
+    
+    __sOSKextSystemExtensionsFolderURLs = CFArrayCreate(
+                    nonrefcountAllocator,
+                    (const void **)extensionsDirs,
+                    _kOSKextNumSystemExtensionsFolders,
+                    &kCFTypeArrayCallBacks);
+    
+    if (!extensionsDirs[0] ||
+        !extensionsDirs[1] ||
+        !__sOSKextSystemExtensionsFolderURLs) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+   /* Set up the the static arrays we use internally.
+    */
+    numValues = sizeof(packageTypeValues) / sizeof(void *);
+    __sOSKextPackageTypeValues = CFArrayCreate(kCFAllocatorDefault,
+        packageTypeValues, numValues, &kCFTypeArrayCallBacks);
+    numValues = sizeof(bundleRequiredValues) / sizeof(void *);
+    __sOSKextOSBundleRequiredValues = CFArrayCreate(kCFAllocatorDefault,
+        bundleRequiredValues, numValues, &kCFTypeArrayCallBacks);
+
+    numValues = sizeof(essentialInfoKeys) / sizeof(void *);
+    __sOSKextInfoEssentialKeys = CFArrayCreate(kCFAllocatorDefault,
+        essentialInfoKeys, numValues, &kCFTypeArrayCallBacks);
+
+   /* This module keeps track of all open kexts by both URL and bundle ID,
+    * in dictionaries that do not retain/release so that we do cleanup on
+    * final client release.
+    */
+    if (!__sOSAllKexts) {
+        CFArrayCallBacks nonrefcountValueCallBacks =
+            kCFTypeArrayCallBacks;
+
+        nonrefcountValueCallBacks.retain = NULL;
+        nonrefcountValueCallBacks.release = NULL;
+        __sOSAllKexts = CFArrayCreateMutable(kCFAllocatorDefault,
+            0, &nonrefcountValueCallBacks);
+        if (!__sOSAllKexts) {
+            OSKextLogMemError();
+            // xxx - what can we do? the program *will* crash pretty soon
+            // xxx - CFBundle doesn't even bother to check, it will just crash
+            goto finish;
+        }
+    }
+
+   /* This module keeps track of all open kexts by both URL and bundle ID,
+    * in dictionaries that do not retain/release so that we do cleanup on
+    * final client release.
+    */
+    if (!__sOSKextsByURL) {
+        CFDictionaryValueCallBacks nonrefcountValueCallBacks =
+            kCFTypeDictionaryValueCallBacks;
+
+        nonrefcountValueCallBacks.retain = NULL;
+        nonrefcountValueCallBacks.release = NULL;
+        __sOSKextsByURL = CFDictionaryCreateMutable(
+            kCFAllocatorDefault, 0,
+            &kCFTypeDictionaryKeyCallBacks, &nonrefcountValueCallBacks);
+        __sOSKextsByIdentifier = CFDictionaryCreateMutable(
+            kCFAllocatorDefault, 0,
+            &kCFTypeDictionaryKeyCallBacks, &nonrefcountValueCallBacks);
+        if (!__sOSKextsByURL || !__sOSKextsByIdentifier) {
+
+            OSKextLogMemError();
+            // xxx - what can we do? the program *will* crash pretty soon
+            // xxx - CFBundle doesn't even bother to check, it will just crash
+            goto finish;
+        }
+    }
+
+   /* As of kernel version 6.0, we started stamping the bundle ID & version
+    * into the kmod_info struct rather than relying on them to match the
+    * info dictionary.
+    *
+    * xxx - Need to update that version #? Compare with original KX code.
+    */
+    __sOSNewKmodInfoKernelVersion = OSKextParseVersionString("6.0");
+
+   /* Default to running kernel's arch by setting with NULL.
+    */
+    OSKextSetArchitecture(NULL);
+
+finish:
+    SAFE_RELEASE(nonrefcountAllocator);
+
+    __sOSKextInitializing = false;
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+static OSKextRef __OSKextAlloc(
+    CFAllocatorRef       allocator,
+    CFAllocatorContext * context __unused)
+{
+    OSKextRef   result  = NULL;
+    char      * offset  = NULL;
+    UInt32      size;
+
+    size  = sizeof(__OSKext) - sizeof(CFRuntimeBase);
+    result = (OSKextRef)_CFRuntimeCreateInstance(allocator,
+        __kOSKextTypeID, size, NULL);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    offset = (char *)result;
+    bzero(offset + sizeof(CFRuntimeBase), size);
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static void __OSKextReleaseContents(CFTypeRef cfObject)
+{
+    OSKextRef aKext = (OSKextRef)cfObject;
+
+   /* Remove the kext from bookkeeping tables *before* releasing contents.
+    */
+    __OSKextRemoveKext(aKext);
+
+    OSKextFlushDiagnostics(aKext, kOSKextDiagnosticsFlagAll);
+    OSKextFlushLoadInfo(aKext, /* flushDependencies */ true);
+
+    if (aKext->mkextInfo) {
+        SAFE_RELEASE_NULL(aKext->mkextInfo->mkextURL);
+        SAFE_RELEASE_NULL(aKext->mkextInfo->mkextData);
+        SAFE_RELEASE_NULL(aKext->mkextInfo->executable);
+        SAFE_RELEASE_NULL(aKext->mkextInfo->resources);
+        SAFE_FREE_NULL(aKext->mkextInfo);
+    }
+
+   /* Release these bits last, the URL & identifier especially might get
+    * referenced by functions above.
+    */
+    SAFE_RELEASE_NULL(aKext->bundleURL);
+    SAFE_RELEASE_NULL(aKext->bundleID);
+    SAFE_RELEASE_NULL(aKext->infoDictionary);
+
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+static CFStringRef __OSKextCopyDebugDescription(CFTypeRef cfObject)
+{
+    CFMutableStringRef result;
+    OSKextRef          aKext = (OSKextRef)cfObject;
+    CFAllocatorRef     allocator = CFGetAllocator(cfObject);
+    CFStringRef        bundleID = NULL;   // do not release
+    CFURLRef           mkextURL = NULL;   // do not release
+
+    bundleID = OSKextGetIdentifier(aKext);
+
+    result = CFStringCreateMutable(allocator, 0);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    CFStringAppendFormat(result, NULL, CFSTR("<OSKext %p [%p]> { "),
+        cfObject, allocator);
+
+    if (OSKextIsFromMkext(aKext)) {
+        mkextURL = aKext->mkextInfo->mkextURL;
+        CFStringAppendFormat(result, NULL, CFSTR("mkext URL = \"%@\", "),
+            mkextURL ?(CFTypeRef)mkextURL : (CFTypeRef)CFSTR(__kStringUnknown));
+        if (aKext->bundleURL) {
+            CFStringAppendFormat(result, NULL, CFSTR("original URL = \"%@\", "),
+                aKext->bundleURL);
+        }
+    } else if (aKext->bundleURL) {
+        CFStringAppendFormat(result, NULL, CFSTR("URL = \"%@\", "),
+            aKext->bundleURL);
+    }
+    CFStringAppendFormat(result, NULL, CFSTR("ID = \"%@\""),
+        bundleID ? bundleID : CFSTR(__kStringUnknown));
+    CFStringAppendFormat(result, NULL, CFSTR(" }"));
+
+finish:
+    return result;
+}
+
+#pragma mark Module Configuration
+/*********************************************************************
+* Module Configuration
+*********************************************************************/
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextReadRegistryNumberProperty(
+    io_registry_entry_t   ioObject,
+    CFStringRef           key,
+    CFNumberType          numberType,
+    void                * valuePtr)
+{
+    Boolean      result      = false;
+    CFTypeRef    regObj      = NULL;  // must release
+    CFNumberRef  numberObj   = NULL;  // do not release
+
+    regObj = IORegistryEntryCreateCFProperty(ioObject,
+        key, kCFAllocatorDefault, kNilOptions);
+    if (!regObj || CFGetTypeID(regObj) != CFNumberGetTypeID()) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel |
+            kOSKextLogGeneralFlag | kOSKextLogIPCFlag,
+            "Can't read kernel CPU info from IORegistry (absent or wrong type).");
+        goto finish;
+    }
+    numberObj = (CFNumberRef)regObj;
+    result = CFNumberGetValue(numberObj, numberType, valuePtr);
+
+finish:
+    SAFE_RELEASE(regObj);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+const NXArchInfo * OSKextGetRunningKernelArchitecture(void)
+{
+    static const NXArchInfo * result           = &__sOSKextUnknownArchInfo;
+    io_registry_entry_t       ioRegRoot        = IO_OBJECT_NULL;  // must IOObjectRelease()
+    cpu_type_t                kernelCPUType    = CPU_TYPE_ANY;
+    cpu_subtype_t             kernelCPUSubtype = CPU_SUBTYPE_MULTIPLE;
+
+    if (result != &__sOSKextUnknownArchInfo) {
+        goto finish;
+    }
+
+    /* 
+     * XXX: This needs to be a runtime check and do the right thing based on
+     * XXX: current OS (maybe check registry and fall back to cputype)?
+     */
+#if (MAC_OS_X_VERSION_MIN_REQUIRED >= 1060) || (__IPHONE_OS_VERSION_MIN_REQUIRED >= 50000)
+    ioRegRoot = IORegistryGetRootEntry(kIOMasterPortDefault);
+    if (ioRegRoot == IO_OBJECT_NULL) {
+        goto finish;
+    }
+
+    if (!__OSKextReadRegistryNumberProperty(ioRegRoot,
+        CFSTR(kOSKernelCPUTypeKey),
+        kCFNumberSInt32Type,
+        &kernelCPUType)) {
+
+        goto finish;
+    }
+    if (!__OSKextReadRegistryNumberProperty(ioRegRoot,
+        CFSTR(kOSKernelCPUSubtypeKey),
+        kCFNumberSInt32Type,
+        &kernelCPUSubtype)) {
+
+        goto finish;
+    }
+#else
+#pragma unused(ioRegRoot)
+    size_t size;
+    
+    size = sizeof(kernelCPUType);
+    if (sysctlbyname("hw.cputype", &kernelCPUType, &size, NULL, 0) != 0) {
+        goto finish;
+    }
+    size = sizeof(kernelCPUSubtype);
+    if (sysctlbyname("hw.cpusubtype", &kernelCPUSubtype, &size, NULL, 0) != 0) {
+        goto finish;
+    }
+#endif
+
+    result = NXGetArchInfoFromCpuType(kernelCPUType, kernelCPUSubtype);
+    if (result) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogProgressLevel | kOSKextLogKextBookkeepingFlag,
+            "Running kernel architecture is %s.", result->name);
+    }
+
+finish:
+#if defined(MAC_OS_X_VERSION_10_6) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_6
+    if (ioRegRoot) {
+        IOObjectRelease(ioRegRoot);
+    }
+#endif
+    if (!result) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel |
+            kOSKextLogGeneralFlag | kOSKextLogIPCFlag,
+            "Can't read running kernel architecture.");
+        result = &__sOSKextUnknownArchInfo;
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextSetArchitecture(const NXArchInfo * archInfo)
+{
+    Boolean            result      = true;
+    const NXArchInfo * oldArchInfo = __sOSKextArchInfo;
+
+       /* Prevent deadlock on lib initialization.
+        */
+    if (!__sOSKextInitializing) {
+        pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+    }
+
+    if (oldArchInfo && (oldArchInfo == archInfo)) {
+        goto finish;
+    }
+
+   /* Set internal arch to NULL before we try to figure out the new one.
+    */
+    __sOSKextArchInfo = NULL;
+    if (archInfo) {
+        __sOSKextArchInfo = NXGetArchInfoFromCpuType(archInfo->cputype,
+            archInfo->cpusubtype);
+        if (!__sOSKextArchInfo) {
+            if (archInfo->name && archInfo->name[0]) {
+                OSKextLog(/* kext */ NULL,
+                    kOSKextLogDebugLevel |
+                    kOSKextLogGeneralFlag,
+                    "Architecture %s not found by CPU info (type %d, subtype %d), "
+                    "trying by name.",
+                    archInfo->name, archInfo->cputype, archInfo->cpusubtype);
+
+                __sOSKextArchInfo = NXGetArchInfoFromName(archInfo->name);
+                if (!__sOSKextArchInfo) {
+                    OSKextLog(/* kext */ NULL,
+                        kOSKextLogDebugLevel |
+                        kOSKextLogGeneralFlag,
+                        "Architecture %s not found by name, "
+                        "using running kernel architecture %s.",
+                        archInfo->name,
+                        OSKextGetRunningKernelArchitecture()->name);
+                    result = false;
+                }
+            } else {
+                OSKextLog(/* kext */ NULL,
+                    kOSKextLogDebugLevel,
+                    "Unknown CPU info given (type %d, subtype %d), "
+                    "using running kernel architecture %s.",
+                    archInfo->cputype, archInfo->cpusubtype,
+                    OSKextGetRunningKernelArchitecture()->name);
+                result = false;
+            }
+        }
+    }
+
+   /* If we didn't get one from the arg, get the running kernel's arch.
+    * Failing that, set it back to the unknown record.
+    */
+    if (!__sOSKextArchInfo) {
+        __sOSKextArchInfo = OSKextGetRunningKernelArchitecture();
+    }
+    if (!__sOSKextArchInfo) {
+        __sOSKextArchInfo = &__sOSKextUnknownArchInfo;
+    }
+
+finish:
+
+   /* Dump all load info and reinit kexts based on new arch.
+    */
+    if (oldArchInfo == __sOSKextArchInfo) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogDebugLevel | kOSKextLogGeneralFlag,
+            "Kext library architecture is %s (unchanged).",
+            __sOSKextArchInfo->name ? __sOSKextArchInfo->name : __kStringUnknown);
+    } else {
+        const char * auxMsg = "";
+
+        if (!__sOSKextInitializing && __sOSAllKexts &&
+            CFArrayGetCount(__sOSAllKexts)) {
+
+            auxMsg = "; reinitializing all kexts for new architecture";
+        }
+
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogDetailLevel |
+            kOSKextLogGeneralFlag | kOSKextLogKextBookkeepingFlag,
+            "Kext library architecture set to %s%s.",
+            __sOSKextArchInfo->name ? __sOSKextArchInfo->name : __kStringUnknown,
+            auxMsg);
+
+       /* Prevent deadlock on lib initialization.
+        */
+        if (!__sOSKextInitializing) {
+            __OSKextReinit(NULL);
+            OSKextFlushLoadInfo(NULL, /* flushDependencies */ true);
+        }
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+const NXArchInfo * OSKextGetArchitecture(void)
+{
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    return __sOSKextArchInfo;
+}
+
+/*********************************************************************
+*********************************************************************/
+static Boolean __OSKextIsArchitectureLP64(void)
+{
+    return ((OSKextGetArchitecture()->cputype & CPU_ARCH_ABI64) != 0);
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextSetLogFilter(
+    OSKextLogSpec logFilter,
+    Boolean       kernelFlag)
+{
+    OSKextLogSpec oldLogFilter;
+
+       /* Save the old flags and set the new ones.
+        */
+    if (kernelFlag) {
+        oldLogFilter = __sKernelLogFilter;
+        __sKernelLogFilter = logFilter;
+    } else {
+        oldLogFilter = __sUserLogFilter;
+        __sUserLogFilter = logFilter;
+    }
+
+    if (oldLogFilter != logFilter) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogDebugLevel |
+            kOSKextLogGeneralFlag,
+            "Kext %s-space log filter changed from 0x%x to 0x%x.",
+            kernelFlag ? "kernel" : "user",
+            oldLogFilter, kernelFlag ? __sKernelLogFilter : __sUserLogFilter);
+    }
+
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSKextLogSpec OSKextGetLogFilter(Boolean kernelFlag)
+{
+    return kernelFlag ? __sKernelLogFilter : __sUserLogFilter;
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextSetLogOutputFunction(OSKextLogOutputFunction func)
+{
+   /* Well now, how could we log this?
+    * The log function itself is being changed!
+    */
+    __sOSKextLogOutputFunction = func;
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextSetSimulatedSafeBoot(Boolean flag)
+{
+    Boolean oldSafeBootValue = __sOSKextSimulatedSafeBoot;
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogDetailLevel | kOSKextLogKextBookkeepingFlag,
+        "Kext library setting simulated safe boot mode to %s.",
+        flag ? "true" : "false");
+
+    __sOSKextSimulatedSafeBoot = flag;
+
+    if (oldSafeBootValue != __sOSKextSimulatedSafeBoot) {
+        __OSKextReinit(/* kext */ NULL);
+    }
+
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextGetSimulatedSafeBoot(void)
+{
+    return __sOSKextSimulatedSafeBoot;
+}
+
+/*********************************************************************
+*********************************************************************/
+#define SYSCTL_MIB_LENGTH   (2)
+
+Boolean OSKextGetActualSafeBoot(void)
+{
+    static Boolean result         = false;
+    static Boolean gotIt          = false;
+    int            kern_safe_boot = 0;
+    size_t         length         = 0;
+    int            mib_name[SYSCTL_MIB_LENGTH] = { CTL_KERN, KERN_SAFEBOOT };
+
+    if (gotIt) {
+        goto finish;
+    }
+
+    /* First check the kernel sysctl. */
+    length = sizeof(kern_safe_boot);
+    if (!sysctl(mib_name, SYSCTL_MIB_LENGTH,
+        &kern_safe_boot, &length, NULL, 0)) {
+
+        result = kern_safe_boot ? true : false;
+        gotIt = true;
+    } else {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel |
+            kOSKextLogGeneralFlag | kOSKextLogIPCFlag,
+            "Can't determine actual safe boot mode - "
+            "sysctl() failed for KERN_SAFEBOOT - %s.",
+            strerror(errno));
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextGetSystemExtensionsFolderURLs(void)
+{
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    return __sOSKextSystemExtensionsFolderURLs;
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextSetRecordsDiagnostics(OSKextDiagnosticsFlags flags)
+{
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogDetailLevel |
+        kOSKextLogValidationFlag | kOSKextLogAuthenticationFlag |
+        kOSKextLogDependenciesFlag | kOSKextLogLoadFlag |
+        kOSKextLogLinkFlag | kOSKextLogPatchFlag | kOSKextLogKextBookkeepingFlag,
+        "Kext library recording diagnostics%s%s%s%s%s.",
+        flags == kOSKextDiagnosticsFlagNone          ? " off"            : " for:",
+        flags & kOSKextDiagnosticsFlagValidation     ? " validation"     : "",
+        flags & kOSKextDiagnosticsFlagAuthentication ? " authentication" : "",
+        flags & kOSKextDiagnosticsFlagDependencies   ? " dependencies"   : "",
+        flags & kOSKextDiagnosticsFlagWarnings       ? " warnings"       : "");
+
+    __sOSKextRecordsDiagnositcs = flags;
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSKextDiagnosticsFlags OSKextGetRecordsDiagnostics(void)
+{
+    return __sOSKextRecordsDiagnositcs;
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextSetUsesCaches(Boolean flag)
+{
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogDetailLevel | kOSKextLogKextBookkeepingFlag,
+        "Kext library %s using caches.", flag ? "now" : "not");
+
+    __sOSKextUsesCaches = flag;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextGetUsesCaches(void)
+{
+    return __sOSKextUsesCaches;
+}
+
+/*********************************************************************
+*********************************************************************/
+void _OSKextSetStrictRecordingByLastOpened(Boolean flag)
+{
+    __sOSKextStrictRecordingByLastOpened = flag;
+    return;
+}
+
+
+
+#pragma mark Instance Management
+/*********************************************************************
+* Instance Management
+*********************************************************************/
+
+/*********************************************************************
+*********************************************************************/
+static Boolean __OSKextInitWithURL(
+    OSKextRef aKext,
+    CFURLRef  anURL)
+{
+    Boolean     result     = false;
+    CFBundleRef kextBundle = NULL;  // must release
+    char        urlPath[PATH_MAX];
+
+    __OSKextGetFileSystemPath(/* kext */ NULL, /* otherURL */ anURL,
+        /* resolveToBase */ true, urlPath);
+
+    OSKextLog(aKext,
+        kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+        "Opening CFBundle for %s.", urlPath);
+
+    kextBundle = CFBundleCreate(CFGetAllocator(aKext), anURL);
+    if (!kextBundle) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Can't open CFBundle for %s.", urlPath);
+        goto finish;
+    }
+
+   /* Save the URL only after we've confirmed we can open a bundle there.
+    * See __OSKextRemoveKext().
+    */
+    aKext->bundleURL = CFRetain(anURL);
+
+   /* If we can't get the info dictionary at all, we don't even
+    * have an examinable broken kext.
+    */
+    if (!__OSKextReadInfoDictionary(aKext, kextBundle)) {
+        goto finish;
+    }
+
+   /* Don't worry about the return value of this; we want to be
+    * able to open bad kexts to do further diagnostics. It's up
+    * to the client to close out unusable kexts.
+    */
+    __OSKextProcessInfoDictionary(aKext, kextBundle);
+
+    result = __OSKextRecordKext(aKext);
+
+finish:
+    if (kextBundle) {
+        OSKextLog(aKext,
+            kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+            "Releasing CFBundle for %s",
+            urlPath);
+    }
+    SAFE_RELEASE(kextBundle);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static Boolean __OSKextInitFromMkext(
+    OSKextRef       aKext,
+    CFDictionaryRef infoDict,
+    CFURLRef        mkextURL,
+    CFDataRef       mkextData)
+{
+    Boolean     result     = false;
+    CFStringRef bundlePath = NULL;   // do not release
+
+    aKext->staticFlags.isFromMkext = 1;
+
+    // xxx - we should remove the bundle path from the info dict once
+    // xxx - it's been extracted
+    bundlePath = CFDictionaryGetValue(infoDict, CFSTR(kMKEXTBundlePathKey));
+    if (bundlePath) {
+        aKext->bundleURL = CFURLCreateWithFileSystemPath(CFGetAllocator(aKext),
+            bundlePath, kCFURLPOSIXPathStyle, true);
+        if (!aKext->bundleURL) {
+            OSKextLogMemError();
+        }
+
+        // xxx - must a kext always have a bundle URL?
+        // xxx - if we support mkext1 format, they definitely won't!
+        // xxx - goto finish; // ?
+    }
+    aKext->infoDictionary = CFRetain(infoDict);
+
+    if (!__OSKextCreateMkextInfo(aKext)) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    if (mkextURL) {
+        aKext->mkextInfo->mkextURL = CFRetain(mkextURL);
+    }
+    aKext->mkextInfo->mkextData = CFRetain(mkextData);
+
+    if (!__OSKextProcessInfoDictionary(aKext, NULL)) {
+        goto finish; // skip file extraction
+    }
+
+    result = __OSKextRecordKext(aKext);
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static void __OSKextReinitApplierFunction(
+    const void * vKey __unused,
+    const void * vValue,
+          void * vContext __unused)
+{
+    OSKextRef aKext = (OSKextRef)vValue;
+
+    __OSKextReinit(aKext);
+    return;
+}
+
+void __OSKextReinit(OSKextRef aKext)
+{
+    if (aKext) {
+        if (!aKext->staticFlags.isFromIdentifierCache) {
+            SAFE_RELEASE_NULL(aKext->bundleID);
+            OSKextFlushDiagnostics(aKext, kOSKextDiagnosticsFlagAll);
+            bzero(&aKext->flags, sizeof(aKext->flags));
+            __OSKextProcessInfoDictionary(aKext, /* bundle */ NULL);
+        }
+    } else if (__sOSKextsByURL) {
+        CFDictionaryApplyFunction(__sOSKextsByURL,
+            __OSKextReinitApplierFunction, NULL);
+    }
+    return;
+}
+
+/*********************************************************************
+* The record/remove functions are the few functions we know will only
+* be called after the bookkeeping data structures have been created,
+* so we don't check them here.
+*********************************************************************/
+Boolean __OSKextRecordKext(OSKextRef aKext)
+{
+    Boolean      result        = false;
+    CFStringRef  kextID        = NULL;  // do not release
+    CFURLRef     kextURL       = NULL;  // do not release
+    CFURLRef     canonicalURL  = NULL;  // must release
+    char       * kextIDCString = NULL;  // must free
+    char         versionCString[kOSKextVersionMaxLength];
+    char         urlPath[PATH_MAX];
+
+    kextID = OSKextGetIdentifier(aKext);
+    if (kextID) {
+        kextIDCString = createUTF8CStringForCFString(kextID);
+    }
+
+   /* Kexts are allowed not to have an URL. Specifically, kexts
+    * from an old-format mkext won't have one.
+    */
+    kextURL = OSKextGetURL(aKext);
+    if (kextURL) {
+        canonicalURL = CFURLCopyAbsoluteURL(kextURL);
+        if (!canonicalURL) {
+            OSKextLogMemError();
+            goto finish;
+        }
+    }
+
+    __OSKextGetFileSystemPath(/* kext */ NULL,
+        /* otherURL */ canonicalURL,
+        /* resolveToBase */ true, urlPath);
+
+   /* Record the kext in the main array, the URL dict, then the bundle ID dict.
+    * Kexts created from an mkext do *not* get cached by URL.
+    */
+    if (CFArrayGetFirstIndexOfValue(__sOSAllKexts, RANGE_ALL(__sOSAllKexts),
+        aKext) == kCFNotFound) {
+
+        CFArrayAppendValue(__sOSAllKexts, aKext);
+    }
+
+    // xxx - what if somehow we actually create 2 kexts w/same URL?
+    if (canonicalURL && !OSKextIsFromMkext(aKext)) {
+        CFDictionarySetValue(__sOSKextsByURL, canonicalURL, aKext);
+    }
+
+    result = __OSKextRecordKextInIdentifierDict(aKext, __sOSKextsByIdentifier);
+    if (result) {
+        OSKextVersionGetString(OSKextGetVersion(aKext), versionCString,
+            sizeof(versionCString));
+        OSKextLog(aKext,
+            kOSKextLogStepLevel | kOSKextLogKextBookkeepingFlag,
+            "Recorded %s%s, id %s, version %s.",
+            urlPath,
+            OSKextIsFromMkext(aKext) ? " (from mkext)" : "",
+            kextIDCString ? kextIDCString : __kStringUnknown,
+            versionCString);
+    }
+
+finish:
+    SAFE_RELEASE(canonicalURL);
+    SAFE_FREE(kextIDCString);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+void __OSKextRemoveKext(OSKextRef aKext)
+{
+    CFTypeRef    foundEntry             = NULL;    // do not release
+    CFURLRef     kextURL                = NULL;    // do not release
+    CFURLRef     canonicalURL           = NULL;    // must release
+    CFStringRef  kextIdentifier         = NULL;    // do not release
+    char       * allocatedCString       = NULL;   // must free
+    char       * kextIdentifierCString  = NULL;   // do not free
+
+    char         urlPath[PATH_MAX] = __kStringUnknown;
+    char         versionCString[kOSKextVersionMaxLength];
+    CFIndex      count, i;
+
+   /* Remove from the cache of all kexts. This must absolutely happen
+    * regardless of any other problems with bundle IDs or URLs.
+    */
+    count = CFArrayGetCount(__sOSAllKexts);
+    if (count) {
+        for (i = count - 1; i >= 0; i--) {
+            OSKextRef checkKext = (OSKextRef)CFArrayGetValueAtIndex(
+                __sOSAllKexts, i);
+            if (checkKext == aKext) {
+                CFArrayRemoveValueAtIndex(__sOSAllKexts, i);
+            }
+        }
+    }
+
+    kextIdentifier = OSKextGetIdentifier(aKext);
+    if (kextIdentifier) {
+        allocatedCString = createUTF8CStringForCFString(kextIdentifier);
+        kextIdentifierCString = allocatedCString;
+    } else {
+        kextIdentifierCString = __kOSKextUnknownIdentifier;
+    }
+
+    kextURL = OSKextGetURL(aKext);
+    if (kextURL) {
+        canonicalURL = CFURLCopyAbsoluteURL(kextURL);
+        if (canonicalURL) {
+            __OSKextGetFileSystemPath(/* kext */ NULL,
+                /* otherURL */ canonicalURL,
+                /* resolveToBase */ true, urlPath);
+
+           /* Remove from the URL cache.
+            */
+            if (canonicalURL && !OSKextIsFromMkext(aKext)) {
+                foundEntry = CFDictionaryGetValue(__sOSKextsByURL, canonicalURL);
+
+               /* Remove from URL dictionary.
+                * xxx - There really should only be the one; should we log an error
+                * xxx - if they aren't the same??
+                */
+                if (foundEntry == aKext) {
+                    CFDictionaryRemoveValue(__sOSKextsByURL, canonicalURL);
+                }
+            }
+        }
+    }
+
+   /* Remove from bundle identifier lookup dictionary.
+    */
+    __OSKextRemoveKextFromIdentifierDict(aKext, __sOSKextsByIdentifier);
+
+    OSKextVersionGetString(OSKextGetVersion(aKext), versionCString,
+        sizeof(versionCString));
+    OSKextLog(aKext, kOSKextLogStepLevel | kOSKextLogKextBookkeepingFlag,
+        "Removed %s, id %s%s, version %s.",
+        urlPath,
+        OSKextIsFromMkext(aKext) ? " (from mkext)" : "",
+        kextIdentifierCString,
+        versionCString);
+
+    SAFE_RELEASE(canonicalURL);
+    SAFE_FREE(allocatedCString);
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextRecordKextInIdentifierDict(
+    OSKextRef              aKext,
+    CFMutableDictionaryRef identifierDict)
+{
+    Boolean             result        = true;
+    CFStringRef         kextID        = NULL;  // do not release
+    CFTypeRef           foundEntry    = NULL;  // do not release
+    CFMutableArrayRef   subsKexts     = NULL;  // DO NOT RELEASE
+    char              * kextIDCString = NULL;  // must free
+    int                 lookupIndex   = 0;     // default if no array
+
+    kextID = OSKextGetIdentifier(aKext);
+    if (!kextID) {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Can't record kext in identifier lookup dictionary; no identifier.");
+        result = false;
+        goto finish;
+    }
+
+   /*****
+    * Look up the bundle ID.
+    * If we don't find it, add the kext and we're done.
+    * If we find the kext itself, we're done!
+    * If we find another kext, make an array and put both in it.
+    * If we find an array, add the new kext to it.
+    */
+    foundEntry = CFDictionaryGetValue(identifierDict, kextID);
+    if (!foundEntry) {
+        CFDictionarySetValue(identifierDict, kextID, aKext);
+        kextIDCString = createUTF8CStringForCFString(kextID);
+        goto finish;
+    }
+    if (foundEntry == aKext) {
+        kextIDCString = createUTF8CStringForCFString(kextID);
+        goto finish;
+    }
+
+   /* Replace a single different kext with an array of kexts for this
+    * kextID.
+    */
+    if (OSKextGetTypeID() == CFGetTypeID(foundEntry)) {
+
+        CFArrayCallBacks nonrefcountArrayCallBacks =
+            kCFTypeArrayCallBacks;
+        nonrefcountArrayCallBacks.retain = NULL;
+        nonrefcountArrayCallBacks.release = NULL;
+        subsKexts = CFArrayCreateMutable(kCFAllocatorDefault, 0,
+            &nonrefcountArrayCallBacks);
+        // xxx - CFBundle doesn't even bother to check, it will just crash
+        if (!subsKexts) {
+            OSKextLogMemError();
+            result = false;
+            goto finish;
+            // xxx - what can we do? the program *will* crash pretty soon
+            // xxx - CFBundle doesn't even bother to check, it will just crash
+        }
+
+       /* Put the existing kext into the array, then replace
+        * the kext in the dictionary of kexts by ID with the array.
+        * Do *not* release foundEntry, as it wasn't retained
+        * in the dictionary and isn't retained in the array!
+        */
+        CFArrayAppendValue(subsKexts, foundEntry);
+        CFDictionarySetValue(identifierDict, kextID, subsKexts);
+        foundEntry = subsKexts;
+        
+       /* Note: The identifier dicts do not retain values added,
+        * so DO NOT RELEASE subsKexts at the bottom of this function!
+        */
+    }
+
+   /* FALL THROUGH from the last check into this one, to insert the
+    * new kext into the array of kexts by bundle ID.
+    */
+    if (CFArrayGetTypeID() == CFGetTypeID(foundEntry)) {
+    
+       /* Embedded folks want lookup always by last opened, so just shove
+        * the kext at the beginning of the array for them. Otherwise
+        * insert the kext before the first other instance of a kext with
+        * the same or lower version.
+        */
+        if (__sOSKextStrictRecordingByLastOpened) {
+            CFMutableArrayRef kextsWithSameID = (CFMutableArrayRef)foundEntry;
+            CFIndex           i;
+            
+            /* check to see if we've already added this kext (can happen when
+             * __OSKextProcessInfoDictionary is called before __OSKextRecordKext)
+             * <rdar://problem/11843581>
+             */
+            i = CFArrayGetFirstIndexOfValue(kextsWithSameID,
+                                            RANGE_ALL(kextsWithSameID), aKext);
+            if (i == kCFNotFound) {
+                CFArrayInsertValueAtIndex(kextsWithSameID, 0, aKext);
+            }
+        } else {
+
+            CFMutableArrayRef kextsWithSameID      = (CFMutableArrayRef)foundEntry;
+            OSKextVersion     addedKextVersion     = OSKextGetVersion(aKext);
+            CFIndex           addedKextCreateOrder = kCFNotFound;
+            CFIndex           count, i;
+
+           /* See if we already have the kext in the array, and yank it so we
+            * can reinsert it at a (possibly different) location.
+            */
+            i = CFArrayGetFirstIndexOfValue(kextsWithSameID,
+                RANGE_ALL(kextsWithSameID), aKext);
+            if (i != kCFNotFound) {
+                CFArrayRemoveValueAtIndex(kextsWithSameID, i);
+            }
+
+           /* Find out where in the list of all kexts the one being added is,
+            * in case we are re-adding after a reload from disk. We need to
+            * preserve the ordering amongst kexts with the same version.
+            */
+            addedKextCreateOrder = CFArrayGetFirstIndexOfValue(__sOSAllKexts,
+                RANGE_ALL(__sOSAllKexts), aKext);
+
+            count = CFArrayGetCount(kextsWithSameID);
+            for (i = 0; i < count; i++) {
+                OSKextRef         existingKext = (OSKextRef)CFArrayGetValueAtIndex(
+                                                 kextsWithSameID, i);
+                OSKextVersion     existingKextVersion = OSKextGetVersion(existingKext);
+                CFIndex           existingKextCreateOrder = kCFNotFound;
+
+                existingKextCreateOrder = CFArrayGetFirstIndexOfValue(__sOSAllKexts,
+                    RANGE_ALL(__sOSAllKexts), existingKext);
+
+               /* When recording kexts with the same identifier,
+                * we sort them in DESCENDING version *and* create order, (as when
+                * re-adding a kext because it got re-read from disk).
+                *
+                * So we are scanning through the list, we ignore higher versions
+                * until we see any with the same version. When the versions are the
+                * same, we break as soon as we see an "existing" kext that has a
+                * LOWER create order than the one being added.
+                *
+                * Then, we're past the higher/same versions, so we break as soon
+                * as we see an "existing" kext that has a LOWER version. If we
+                * run through the whole array we'll just add to the end.
+                */
+                if (addedKextVersion == existingKextVersion) {
+                    if (addedKextCreateOrder > existingKextCreateOrder) {
+                        break;
+                    }
+                }
+                if (addedKextVersion > existingKextVersion) {
+                    break;
+                }
+            }
+            
+           /* Insert the kext at the location we found for it.
+            */
+            CFArrayInsertValueAtIndex(kextsWithSameID, i, aKext);
+            kextIDCString = createUTF8CStringForCFString(kextID);
+            lookupIndex = i;
+        }
+    }
+
+finish:
+    if (result && kextIDCString) {
+        char versionString[kOSKextVersionMaxLength];
+        OSKextVersionGetString(OSKextGetVersion(aKext), versionString,
+            sizeof(versionString));
+        if (foundEntry == aKext) {
+            OSKextLog(aKext, kOSKextLogStepLevel | kOSKextLogKextBookkeepingFlag,
+                "%s, version %s is already "
+                "in the identifier lookup dictionary at index %d.",
+                kextIDCString, versionString, lookupIndex);
+        } else {
+            OSKextLog(aKext, kOSKextLogDebugLevel | kOSKextLogKextBookkeepingFlag,
+                "%s, version %s recorded at index %d "
+                "in the identifier lookup dictionary.",
+                kextIDCString, versionString, lookupIndex);
+        }
+    }
+    SAFE_FREE(kextIDCString);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+void __OSKextRemoveKextFromIdentifierDict(
+    OSKextRef              aKext,
+    CFMutableDictionaryRef identifierDict)
+{
+    CFStringRef  kextID        = NULL;   // do not release
+    CFTypeRef    foundEntry    = NULL;   // do not release
+    OSKextRef    foundKext     = NULL;  // do not release
+    char       * kextIDCString = NULL;  // must free
+
+   /* A kext with no identifier is going to cause us a world of hurt,
+    * but there's nothing we can do about it now.
+    */
+    kextID = OSKextGetIdentifier(aKext);
+    if (!kextID) {
+        goto finish;
+    }
+
+    kextIDCString = createUTF8CStringForCFString(kextID);
+    if (!kextIDCString) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    foundEntry = CFDictionaryGetValue(identifierDict, kextID);
+    if (!foundEntry) {
+        goto finish;
+    }
+
+    if (foundEntry == aKext) {
+        foundKext = (OSKextRef)foundEntry;
+        CFDictionaryRemoveValue(identifierDict, kextID);
+    } else if (CFArrayGetTypeID() == CFGetTypeID(foundEntry)) {
+        CFMutableArrayRef kextsWithSameID = (CFMutableArrayRef)foundEntry;
+        CFIndex           count, i;
+
+        count = CFArrayGetCount(kextsWithSameID);
+        for (i = 0; i < count; i++) {
+            OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(
+                kextsWithSameID, i);
+            if (thisKext == aKext) {
+                foundKext = thisKext;
+                CFArrayRemoveValueAtIndex(kextsWithSameID, i);
+                break;
+                // xxx - scan through the whole array?
+            }
+        }
+        
+       /* If we've emptied the array kextsWithSameID, remove it
+        * from the identifier dictionary. Also, because that dictionary
+        * doesn't retain values, release it explicitly.
+        */
+        if (!CFArrayGetCount(kextsWithSameID)) {
+            CFDictionaryRemoveValue(identifierDict, kextID);
+            CFRelease(kextsWithSameID);
+        }
+    }
+
+finish:
+    if (foundKext) {
+        char versionCString[kOSKextVersionMaxLength];
+        OSKextVersionGetString(OSKextGetVersion(aKext),
+            versionCString, sizeof(versionCString));
+        OSKextLog(aKext,
+            kOSKextLogStepLevel | kOSKextLogKextBookkeepingFlag,
+            "%s, version %s removed from identifier lookup dictionary.",
+            kextIDCString, versionCString);
+    } else if (kextIDCString) {
+        char * auxMsg = NULL;
+        
+        if (!strncmp(kextIDCString, __kOSKextUnknownIdentifier,
+            sizeof(__kOSKextUnknownIdentifier) - 1)) {
+
+            auxMsg = " (expected while realizing)";
+        }
+        OSKextLog(aKext,
+            kOSKextLogDebugLevel | kOSKextLogKextBookkeepingFlag,
+            "%s not found in identifier lookup dictionary%s.",
+            kextIDCString, auxMsg);
+    }
+    SAFE_FREE(kextIDCString);
+    return;
+}
+
+/*********************************************************************
+* I really need to have stuff initialized before any instances are
+* created, I hope the constructor attribute is the right approach.
+*********************************************************************/
+OSKextRef OSKextCreate(
+    CFAllocatorRef allocator,
+    CFURLRef       anURL)
+{
+    OSKextRef   result       = NULL;
+    CFStringRef pathExtension = NULL;  // must release
+    char        relPath[PATH_MAX];
+
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    pathExtension = CFURLCopyPathExtension(anURL);
+    if (!pathExtension || !CFEqual(pathExtension, CFSTR(kOSKextBundleExtension))) {
+        goto finish;
+    }
+
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, /* otherURL */ anURL,
+            /* resolveToBase */ false, relPath)) {
+            
+        goto finish;
+    }
+
+    result = OSKextGetKextWithURL(anURL);
+    if (result) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogDebugLevel |
+            kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+            "%s is already open; returning existing object.",
+            relPath);
+        CFRetain(result);
+        goto finish;
+    }
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogDebugLevel |
+        kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+        "Creating %s.",
+        relPath);
+
+    result = __OSKextAlloc(allocator, /* context */ NULL);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    if (!__OSKextInitWithURL(result, anURL)) {
+        SAFE_RELEASE_NULL(result);
+        goto finish;
+    }
+
+finish:
+    SAFE_RELEASE(pathExtension);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFMutableArrayRef __OSKextCreateKextsFromURL(
+    CFAllocatorRef allocator,
+    CFURLRef       anURL,
+    OSKextRef      aKext,  // if called by a kext looking for plugins
+    Boolean        createPluginsFlag)
+{
+    CFMutableArrayRef result          = NULL;
+    CFStringRef       pathExtension   = NULL;  // must release
+    OSKextRef         theKext         = NULL;  // must release
+    CFArrayRef        plugins         = NULL;  // must release
+    CFURLRef          absURL          = NULL;  // must release
+    char              urlPath[PATH_MAX];
+    CFBooleanRef      dirExists       = NULL;  // must release
+    CFArrayRef        urlContents     = NULL;  // must release
+    SInt32            error;
+    CFArrayRef        kexts           = NULL;  // must release
+    CFIndex           count, i;
+
+   /* Check for a single kext, read it and its plugins.
+    */
+    pathExtension = CFURLCopyPathExtension(anURL);
+    if (pathExtension && CFEqual(pathExtension,
+        CFSTR(kOSKextBundleExtension))) {
+
+        result = CFArrayCreateMutable(allocator, 0, &kCFTypeArrayCallBacks);
+        if (!result) {
+            OSKextLogMemError();
+            goto finish;
+        }
+
+        theKext = OSKextCreate(allocator, anURL);
+        if (theKext) {
+            CFArrayAppendValue(result, theKext);
+            if (createPluginsFlag) {
+                plugins = OSKextCopyPlugins(theKext);
+                if (plugins && CFArrayGetCount(plugins)) {
+                    CFArrayAppendArray(result, plugins, RANGE_ALL(plugins));
+                }
+            }
+        }
+        goto finish;
+    }
+
+    absURL = CFURLCopyAbsoluteURL(anURL);
+    if (!absURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    __OSKextGetFileSystemPath(/* kext */ NULL, /* otherURL */ absURL,
+        /* resolveToBase */ true, urlPath);
+
+   /* If we're scanning for plugins, silently skip when there's no plugins
+    * folder. Else complain.
+    */
+    dirExists = CFURLCreatePropertyFromResource(allocator, anURL,
+        kCFURLFileExists, &error);
+    if (!dirExists) {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Failed to check path %s (CF error %ld).",
+            urlPath, (long)error);
+        goto finish;
+    } else if (!CFBooleanGetValue(dirExists)) {
+        if (!aKext) {
+            OSKextLog(aKext,
+                kOSKextLogProgressLevel | kOSKextLogFileAccessFlag,
+                "%s: %s - no such file or directory.",
+                __func__, urlPath);
+        }
+        goto finish;
+    }
+
+   /*****
+    * If anURL is not a kext bundle, then scan it as a directory
+    * for any kexts, with their plugins.
+    * xxx - should we check for a symlink loop? :-O
+    */
+
+   /* If we can read from an identifier cache, we are done!
+    */
+    if (_OSKextReadFromIdentifierCacheForFolder(absURL, &result)) {
+        goto finish;
+    }
+
+    result = CFArrayCreateMutable(allocator, 0, &kCFTypeArrayCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    OSKextLog(aKext,
+        kOSKextLogProgressLevel | kOSKextLogDirectoryScanFlag,
+        "Scanning %s for kexts.", urlPath);
+
+    // do not use absURL here, allow kexts to have relative URLs
+    urlContents = CFURLCreatePropertyFromResource(allocator, anURL,
+        kCFURLFileDirectoryContents, &error);
+    if (!urlContents || error) {
+        if (error && error != kCFURLResourceNotFoundError) {
+            OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Failed to read contents of %s, CFURL error %d.",
+                urlPath, (int)error);
+        }
+        goto finish;
+    }
+    count = CFArrayGetCount(urlContents);
+    for (i = 0; i < count; i++) {
+        CFURLRef thisURL = (CFURLRef)CFArrayGetValueAtIndex(urlContents, i);
+
+        SAFE_RELEASE_NULL(pathExtension);
+        SAFE_RELEASE_NULL(kexts);
+
+        pathExtension = CFURLCopyPathExtension(thisURL);
+        if (pathExtension && CFEqual(pathExtension,
+            CFSTR(kOSKextBundleExtension))) {
+
+            char kextURLPath[PATH_MAX];
+            
+            __OSKextGetFileSystemPath(/* kext */ NULL, thisURL,
+                /* resolveToBase */ FALSE, kextURLPath);
+
+            if (aKext) {
+                OSKextLog(aKext,
+                    kOSKextLogDetailLevel | kOSKextLogDirectoryScanFlag,
+                    "Found plugin %s.",
+                    kextURLPath);
+            } else {
+                OSKextLog(aKext,
+                    kOSKextLogDetailLevel | kOSKextLogDirectoryScanFlag,
+                    "Found %s.",
+                    kextURLPath);
+            }
+
+           /* Create kexts with their immediate plugins from the
+            * current URL.
+            */
+            kexts = OSKextCreateKextsFromURL(allocator, thisURL);
+            if (kexts) {
+                CFArrayAppendArray(result, kexts, RANGE_ALL(kexts));
+            }
+        }
+    }
+
+    (void)_OSKextWriteIdentifierCacheForKextsInDirectory(result, absURL,
+        /* force? */ false);
+
+finish:
+    SAFE_RELEASE(pathExtension);
+    SAFE_RELEASE(theKext);
+    SAFE_RELEASE(plugins);
+    SAFE_RELEASE(dirExists);
+    SAFE_RELEASE(urlContents);
+    SAFE_RELEASE(kexts);
+    SAFE_RELEASE(absURL);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCreateKextsFromURL(
+    CFAllocatorRef allocator,
+    CFURLRef       anURL)
+{
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+   /* Passing NULL for the kext means we'll scan for plugins.
+    */
+    return __OSKextCreateKextsFromURL(allocator, anURL,
+        /* kext */ NULL, true);
+}
+
+/*********************************************************************
+*********************************************************************/
+CFMutableArrayRef __OSKextCreateKextsFromURLs(
+    CFAllocatorRef allocator,
+    CFArrayRef     arrayOfURLs,
+    Boolean        createPluginsFlag)
+{
+    CFMutableArrayRef result = NULL;
+    CFArrayRef        scannedKexts = NULL;  // must release
+    CFIndex           count, i;
+
+    result = CFArrayCreateMutable(allocator, 0, &kCFTypeArrayCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    count = CFArrayGetCount(arrayOfURLs);
+    for (i = 0; i < count; i++) {
+        CFURLRef theURL = (CFURLRef)CFArrayGetValueAtIndex(arrayOfURLs, i);
+
+        SAFE_RELEASE_NULL(scannedKexts);
+
+        scannedKexts = __OSKextCreateKextsFromURL(allocator, theURL,
+            /* kext */ NULL, createPluginsFlag);
+        if (scannedKexts) {
+            CFArrayAppendArray(result, scannedKexts, RANGE_ALL(scannedKexts));
+        }
+    }
+
+finish:
+    SAFE_RELEASE(scannedKexts);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCreateKextsFromURLs(
+    CFAllocatorRef allocator,
+    CFArrayRef arrayOfURLs)
+{
+    CFMutableArrayRef result = NULL;
+    CFIndex           count, i, j;
+
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    result = __OSKextCreateKextsFromURLs(allocator, arrayOfURLs, true);
+    if (!result) {
+        goto finish;
+    }
+    count = CFArrayGetCount(result);
+    if (!count) {
+        goto finish;
+    }
+
+   /* Remove duplicates from the result. Note we don't use cached array
+    * counts here, as the array is changing!
+    */
+    for (i = 0; i < CFArrayGetCount(result); i++) {
+        OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(result, i);
+        for (j = i + 1; j < CFArrayGetCount(result); /* see loop */) {
+            OSKextRef thatKext = (OSKextRef)CFArrayGetValueAtIndex(result, j);
+
+           /* If we have two entries for the same kext, remove the latter.
+            * Otherwise bump the inner index.
+            */
+            if (thisKext == thatKext) {
+                CFArrayRemoveValueAtIndex(result, j);
+            } else {
+                j++;
+            }
+        }
+    }
+
+finish:
+    return result;
+}
+
+#pragma mark (Plist Caches)
+/*********************************************************************
+* Plist Caches
+*********************************************************************/
+
+/*********************************************************************
+*********************************************************************/
+#define GZIP_RATIO    (5)
+#define MAX_REALLOCS (16)
+
+Boolean _OSKextReadFromIdentifierCacheForFolder(
+    CFURLRef            anURL,
+    CFMutableArrayRef * kextsOut)
+{
+    Boolean            result                = false;
+    CFMutableArrayRef  kexts                 = NULL;  // must release
+    CFURLRef           absURL                = NULL;  // must release
+    char               absPath[PATH_MAX]     = "";
+    CFDictionaryRef    cacheDict             = NULL;  // must release
+    CFStringRef        basePath              = NULL;  // do not release
+    CFNumberRef        cacheVersion          = NULL;  // do not release
+    SInt32             cacheVersionValue     = 0;
+    CFArrayRef         kextInfoArray         = NULL;  // do not release
+    OSKextRef          newKext               = NULL;  // must release
+    CFIndex            count, i;
+
+    if (!OSKextGetUsesCaches()) {
+        goto finish;
+    }
+
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, anURL,
+        /* resolveToBase */ true, absPath)) {
+
+        OSKextLogStringError(/* kext */ NULL);
+        goto finish;
+    }
+
+    if (!_OSKextReadCache(anURL, 
+        CFSTR(_kOSKextIdentifierCacheBasename),
+        /* arch */ NULL,
+        _kOSKextCacheFormatCFBinary,
+        /* parseXML? */ true,
+        kextsOut ? (CFPropertyListRef *)&cacheDict : NULL)) {
+
+        goto finish;
+    }
+
+   /* If we aren't asked to actually read out kexts, we were just checking
+    * that the cache is up to date, so return success now.
+    */
+    if (!kextsOut) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogDebugLevel | kOSKextLogKextBookkeepingFlag,
+            "Kext identifier->path cache for %s is up to date.",
+            absPath);
+        result = true;
+        goto finish;
+    }
+
+    if (CFDictionaryGetTypeID() != CFGetTypeID(cacheDict)) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Kext identifier->path cache for %s - not a dictionary.",
+            absPath);
+        goto finish;
+    }
+
+    cacheVersion = CFDictionaryGetValue(cacheDict,
+        CFSTR(__kOSKextIdentifierCacheVersionKey));
+    if (!cacheVersion ||
+        CFNumberGetTypeID() != CFGetTypeID(cacheVersion) ||
+        !CFNumberGetValue(cacheVersion, kCFNumberSInt32Type, &cacheVersionValue)) {
+
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Kext identifier->cache for %s - cache version missing/invalid.",
+            absPath);
+        goto finish;
+    }
+
+    if (cacheVersionValue != __kOSKextIdentifierCacheCurrentVersion) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Kext identifier->path cache for %s - version %d unsupported.",
+            absPath, (int)cacheVersionValue);
+        goto finish;
+    }
+
+    basePath = CFDictionaryGetValue(cacheDict,
+        CFSTR(__kOSKextIdentifierCacheBasePathKey));
+    if (!basePath ||
+        CFStringGetTypeID() != CFGetTypeID(basePath)) {
+
+       OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Kext identifier->path cache for %s - base path missing or invalid.",
+            absPath);
+        goto finish;
+    }
+
+    kextInfoArray = CFDictionaryGetValue(cacheDict,
+        CFSTR(__kOSKextIdentifierCacheKextInfoKey));
+    if (!kextInfoArray ||
+        CFArrayGetTypeID() != CFGetTypeID(kextInfoArray)) {
+
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Kext identifier->path cache - kext info is not an array.");
+        goto finish;
+    }
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogProgressLevel | kOSKextLogKextBookkeepingFlag,
+        "Creating kexts from identifier->path cache for %s.",
+        absPath);
+
+    kexts = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+    if (!kexts) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    // create kexts from cache file
+    count = CFArrayGetCount(kextInfoArray);
+    for (i = 0; i < count; i++) {
+        CFDictionaryRef cacheDict = (CFDictionaryRef)CFArrayGetValueAtIndex(
+            kextInfoArray, i);
+        if (CFDictionaryGetTypeID() != CFGetTypeID(cacheDict)) {
+            OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel,
+                "Kext identifier->path cache for %s - kext entry not a dictionary.",
+                absPath);
+            goto finish;
+        }
+        SAFE_RELEASE_NULL(newKext);
+        newKext = __OSKextCreateFromIdentifierCacheDict(CFGetAllocator(absURL),
+            cacheDict, basePath, i);
+        if (!newKext) {
+           /* The create call will have logged an error.
+            */
+            goto finish;
+        }
+        if (kCFNotFound == CFArrayGetFirstIndexOfValue(kexts, RANGE_ALL(kexts),
+            newKext)) {
+
+            CFArrayAppendValue(kexts, newKext);
+        }
+    }
+
+   /* Now we know we have them all, record them (or drop them if recording
+    * fails, which is why we're going backwards through the array).
+    */
+    count = CFArrayGetCount(kexts);
+    if (count) {
+        for (i = count - 1; i >= 0; i--) {
+            OSKextRef aKext = (OSKextRef)CFArrayGetValueAtIndex(
+                kexts, i);
+            if (!__OSKextRecordKext(aKext)) {
+                CFArrayRemoveValueAtIndex(kexts, i);
+            }
+        }
+    }
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogProgressLevel |
+        kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+        "Finished reading identifier->path cache for %s.",
+        absPath);
+    result = true;
+    if (kextsOut) {
+        *kextsOut = (CFMutableArrayRef)CFRetain(kexts);
+    }
+
+finish:
+
+    SAFE_RELEASE(kexts);
+    SAFE_RELEASE(absURL);
+    SAFE_RELEASE(cacheDict);
+    SAFE_RELEASE(newKext);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSKextRef __OSKextCreateFromIdentifierCacheDict(
+    CFAllocatorRef  allocator,
+    CFDictionaryRef cacheDict,
+    CFStringRef     basePath,
+    CFIndex         entryIndex)
+{
+    OSKextRef     result             = NULL;
+    OSKextRef     newKext            = NULL;  // must release
+    OSKextRef     existingKext       = NULL;  // do not release
+    CFStringRef   bundleID           = NULL;  // do not release
+    CFStringRef   bundlePath         = NULL;  // do not release
+    CFStringRef   bundleVersion      = NULL;  // do not release
+    CFStringRef   fullPath           = NULL;  // must release
+    CFURLRef      bundleURL          = NULL;  // must release
+    OSKextVersion kextVersion        = -1;
+    CFBooleanRef  scratchBool        = NULL;  // do not release
+    char          kextPath[PATH_MAX];
+
+    bundlePath = (CFStringRef)CFDictionaryGetValue(cacheDict,
+        CFSTR("OSBundlePath"));
+    if (!bundlePath || (CFGetTypeID(bundlePath) != CFStringGetTypeID())) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Can't create kext: missing or non-string path "
+            "in identifier cache entry %d.",
+            (int)entryIndex);
+        goto finish;
+    }
+    
+   /* Reject any non-.kext path.
+    */
+    if (!CFStringHasSuffix(bundlePath, CFSTR(kOSKextBundleExtension))) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Can't create kext: path in identifier cache entry %d "
+            "doesn't name a kext.",
+            (int)entryIndex);
+        goto finish;
+    }
+    
+    fullPath = CFStringCreateWithFormat(allocator,
+        /* options */ 0, CFSTR("%@/%@"), basePath, bundlePath);
+     if (!fullPath) {
+        OSKextLogMemError();
+        goto finish;
+     }
+ 
+    bundleURL = CFURLCreateWithFileSystemPath(allocator,
+        fullPath, kCFURLPOSIXPathStyle, /* isDir */ true);
+    if (!bundleURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    __OSKextGetFileSystemPath(/* kext */ NULL, bundleURL,
+        /* resolveToBase */ TRUE, kextPath);
+
+   /* See if we already have an instance.
+    */
+    existingKext = (OSKextRef)CFDictionaryGetValue(__sOSKextsByURL, bundleURL);
+    if (existingKext) {
+        result = existingKext;
+    } else {
+        newKext = __OSKextAlloc(allocator, /* context */ NULL);
+        if (!newKext) {
+            OSKextLogMemError();
+            goto finish;
+        }
+
+        newKext->staticFlags.isFromIdentifierCache = 1;
+        newKext->bundleURL = CFRetain(bundleURL);
+    }
+    
+    bundleID = (CFStringRef)CFDictionaryGetValue(cacheDict,
+        kCFBundleIdentifierKey);
+    if (!bundleID || (CFGetTypeID(bundleID) != CFStringGetTypeID())) {
+        OSKextLog(existingKext,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Can't create kext: missing or non-string CFBundleIdentifier "
+            "in identifier cache entry %d.",
+            (int)entryIndex);
+        goto finish;
+    }
+
+    if (existingKext) {
+        if (!CFEqual(bundleID, OSKextGetIdentifier(existingKext))) {
+            OSKextLog(existingKext,
+                kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+                "Can't create kext from cache: %s is already open and "
+                "has a different CFBundleIdentifier "
+                "from identifier->path cache entry %d.",
+                kextPath, (int)entryIndex);
+            goto finish;
+        }
+    } else {
+        newKext->bundleID = CFRetain(bundleID);
+    }
+
+    bundleVersion = CFDictionaryGetValue(cacheDict, kCFBundleVersionKey);
+    if (!bundleVersion || (CFGetTypeID(bundleVersion) != CFStringGetTypeID())) {
+        OSKextLog(existingKext,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Can't create kext: missing or non-string version "
+            "in identifier cache entry %d.",
+            (int)entryIndex);
+        goto finish;
+    }
+    kextVersion = OSKextParseVersionCFString(bundleVersion);
+    if (kextVersion < 0) {
+        OSKextLog(existingKext,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Can't create kext: invalid CFBundleVersion "
+            "in identifier cache entry entry %d.",
+            (int)entryIndex);
+        goto finish;
+    }
+    if (existingKext) {
+        if (kextVersion != OSKextGetVersion(existingKext)) {
+            OSKextLog(existingKext,
+                kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+                "Can't create kext from cache: %s is already open and "
+                "has a different CFBundleVersion "
+                "from identifier->path cache entry %d.",
+                kextPath, (int)entryIndex);
+            goto finish;
+        }
+    } else {
+        newKext->version = kextVersion;
+    }
+
+   /* Log flags are stored optionally in the cache.
+    * Do not check log spec against cache, as those can be changed any time.
+    */
+    if (newKext) {
+        scratchBool = (CFBooleanRef)CFDictionaryGetValue(cacheDict,
+            CFSTR(kOSBundleEnableKextLoggingKey));
+        if (scratchBool) {
+             if (CFGetTypeID(scratchBool) != CFBooleanGetTypeID()) {
+                OSKextLog(existingKext,
+                kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+                    "Can't create kext from cache: non-boolean "
+                    "OSKextEnableKextLogging in identifier cache entry %d.",
+                    (int)entryIndex);
+                goto finish;
+            }
+            newKext->flags.plistHasEnableLoggingSet = CFBooleanGetValue(scratchBool) ? 1 : 0;
+            newKext->flags.loggingEnabled = CFBooleanGetValue(scratchBool) ? 1 : 0;
+        }
+    }
+
+    if (!existingKext) {
+        result = newKext;
+    }
+
+finish:
+
+    if (result) {
+        CFRetain(result);
+    }
+
+   /* Do not __OSKextRecordKext() in this function; we want to see if any fail
+    * before we record the whole set.
+    */
+    SAFE_RELEASE(newKext);
+    SAFE_RELEASE(fullPath);
+    SAFE_RELEASE(bundleURL);
+    return result;
+}
+
+/*********************************************************************
+* __OSKextRealize() takes a kext from an identifier->URL cache and
+* tries to read its info for real from the bundle. Any time a kext
+* is created or referenced by URL or identifier, it must be realized
+* immediately (for sanity, else we'd be realizing on every property
+* access). Further any time a lookup is done by identifier, ALL kexts
+* with that same identifier are realized, so version/compat./loaded
+* checks all work with the currently open set of kexts.
+*
+* Mixing kexts opened from an identifier cache with those opened from
+* an mkext is not supported at this time.
+*
+* This function's signature matches a CFArrayApplierFunction for
+* convenience in use.
+*********************************************************************/
+void __OSKextRealize(const void * vKext, void * context __unused)
+{
+    OSKextRef     aKext          = (OSKextRef)vKext;
+    CFStringRef   cachedBundleID = NULL;
+    OSKextVersion cachedVersion  = -1;
+    Boolean       removeCache    = false;
+    char          kextPath[PATH_MAX];
+
+    if (!aKext->staticFlags.isFromIdentifierCache) {
+        goto finish;
+    }
+    
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL, 
+        /* resolveToBase */ false, kextPath);
+
+    OSKextLog(aKext,
+        kOSKextLogDetailLevel | kOSKextLogKextBookkeepingFlag,
+        "Realizing %s from identifier cache object.",
+        kextPath);
+
+   /* __OSKextProcessInfoDictionary() calls this, but we'll have wiped
+    * the bundle ID so it won't work! Do it now, for safety.
+    */
+    __OSKextRemoveKextFromIdentifierDict(aKext, __sOSKextsByIdentifier);
+
+   /* Save the current identifier & version, then wipe them from the kext
+    * in case we get nothing from disk. We are basically doing an
+    * __OSKextInitWithURL() from here on out but without the absolute URL
+    * lookup, and with a different return semantic.
+    *
+    * Note that we release cachedBundleID in the finish: block, so no
+    * goto finish from here on!
+    */
+    cachedBundleID = aKext->bundleID;
+    cachedVersion  = aKext->version;
+    aKext->version = -1;
+    aKext->bundleID = CFSTR(__kOSKextUnknownIdentifier);
+
+   /* Read the basic info that we lack from the info dictionary
+    * of the bundle on disk. Ignore the return value, we are
+    * instantiated and may have client refs, nothing we can do,
+    * unless we implement exceptions....
+    *
+    * This call re-files the kext in the kextsByIdentifier dict
+    * and restores bundleID even if one isn't found.
+    */
+    __OSKextProcessInfoDictionary(aKext, /* bundle */ NULL);
+
+
+   /* Oh dear, we have a possibly-referenced instance but no real bundle ID.
+    * __OSKextProcessInfoDictionary() has already set the invalid bit.
+    * It's up to the client to close out
+    * unusable kexts.
+    */
+    if (aKext->bundleID == CFSTR(__kOSKextUnknownIdentifier)) {
+        removeCache = true;
+    }
+
+   /* If the cached version or bundle identifier have changed (one more likely
+    * than the other), then we return false!
+    */
+    if (cachedVersion != aKext->version ||
+        !CFEqual(cachedBundleID, aKext->bundleID)) {
+
+        removeCache = true;
+    }
+
+finish:
+   /* We have to clear the flag even if we fail or we'll always be hitting
+    * this function.
+    */
+    aKext->staticFlags.isFromIdentifierCache = 0;
+    
+    if (removeCache) {
+        __OSKextRemoveIdentifierCacheForKext(aKext);
+    }
+    SAFE_RELEASE(cachedBundleID);  // we got a new one from disk
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+void __OSKextRealizeKextsWithIdentifier(
+    CFStringRef kextIdentifier)
+{
+    CFTypeRef foundEntry = NULL;  // do not release
+    OSKextRef theKext    = NULL;  // do not release
+
+   /* No need to init the library if there's nothing to get!
+    */
+    if (!__sOSKextsByIdentifier) {
+        goto finish;
+    }
+
+    foundEntry = CFDictionaryGetValue(__sOSKextsByIdentifier, kextIdentifier);
+    if (!foundEntry) {
+         goto finish;
+    }
+    CFRetain(foundEntry);
+
+    if (OSKextGetTypeID() == CFGetTypeID(foundEntry)) {
+        theKext = (OSKextRef)foundEntry;
+        
+        __OSKextRealize(theKext, /* context */ NULL);
+    } else if (CFArrayGetTypeID() == CFGetTypeID(foundEntry)) {
+        CFMutableArrayRef kexts = (CFMutableArrayRef)foundEntry;
+
+        if (!CFArrayGetCount(kexts)) {
+            goto finish;
+        }
+        CFArrayApplyFunction(kexts, RANGE_ALL(kexts), 
+            &__OSKextRealize, /* context */ NULL);
+    }
+
+finish:
+    SAFE_RELEASE(foundEntry);
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFURLRef __OSKextCreateCacheFileURL(
+    CFTypeRef            folderURLsOrURL,
+    CFStringRef          cacheName,
+    const NXArchInfo   * arch,
+    _OSKextCacheFormat   format)
+{
+    CFURLRef      result                  = NULL;
+    Boolean       isStartup               = FALSE;
+    CFStringRef   folderAbsPath           = NULL;   // must release
+    CFStringRef   cacheFileString         = NULL;   // must release
+    char        * suffix                  = "";     // do not free
+
+    if (CFGetTypeID(folderURLsOrURL) == CFURLGetTypeID()) {
+        CFURLRef folderURL = (CFURLRef)folderURLsOrURL;
+
+        folderAbsPath = _CFURLCopyAbsolutePath(folderURL);
+        if (!folderAbsPath) {
+            OSKextLogMemError();
+            goto finish;
+        }
+
+       /* We only do caches for system extensions folders. If the URL
+        * given isn't on that list, bail.
+        */
+        if (!__OSKextURLIsSystemFolder(folderURL)) {
+            OSKextLogCFString(/* kext */ NULL,
+                              kOSKextLogProgressLevel | kOSKextLogKextBookkeepingFlag,
+                              CFSTR("%@ is not a system extensions folder; not looking for a cache."),
+                              folderAbsPath);
+            goto finish;
+        }
+    } else if (folderURLsOrURL == OSKextGetSystemExtensionsFolderURLs()) {
+        // ??? - log something here?
+        isStartup = TRUE;
+    } else {
+        // ??? - log something here?
+        goto finish;
+    }
+
+    switch (format) {
+    case _kOSKextCacheFormatRaw:
+        // do nothing
+        break;
+    case _kOSKextCacheFormatCFXML: // fall through
+    case _kOSKextCacheFormatCFBinary:
+        suffix = ".plist.gz";
+        break;
+    case _kOSKextCacheFormatIOXML:
+        suffix = ".ioplist.gz";
+        break;
+    }
+
+   /* Compose the path. Start with the path to the kext system's caches folder.
+    * Then add the Startup or Directories component as appropriate.
+    * Then add a the folder abs path (which begins with a /) if it's for a single folder.
+    * Then add the cache name, the arch if necessary, and the suffix!
+    */
+    cacheFileString = CFStringCreateWithFormat(kCFAllocatorDefault,
+        /* options */ NULL, CFSTR("%s/%s%@/%@%s%s%s"),
+        _kOSKextCachesRootFolder,
+        isStartup ? _kOSKextStartupCachesSubfolder : _kOSKextDirectoryCachesSubfolder,
+        isStartup ? CFSTR("") : folderAbsPath,
+        cacheName,
+        arch ? "_" : "",
+        arch ? arch->name : "",
+        suffix);
+    if (!cacheFileString) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    result = CFURLCreateWithFileSystemPath(kCFAllocatorDefault,
+        cacheFileString, kCFURLPOSIXPathStyle, /* isDir */ false);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+finish:
+    SAFE_RELEASE(folderAbsPath);
+    SAFE_RELEASE(cacheFileString);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextCheckURL(CFURLRef anURL, Boolean writeCreateFlag)
+{
+    Boolean        result   = false;
+    char           path[PATH_MAX] = "";
+    char         * statPath = NULL;  // do not free
+    char         * slashPtr = NULL;  // do not free
+    struct stat    statBuffer;
+
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, anURL,
+        /* resolveToBase */ TRUE, path)) {
+        
+        goto finish;
+    }
+
+    if (path[0] != '/') {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogGeneralFlag,
+            "Internal error, invalid argument to __OSKextCheckURL.");
+        goto finish;
+    }
+
+    slashPtr = &path[0];
+    while (1) {
+        if (slashPtr == path) {
+            statPath = "/";
+        } else {
+            statPath = path;
+            if (slashPtr) {
+                slashPtr[0] = '\0';
+            }
+        }
+        
+       /* If we are checking to write a file and possibly create
+        * the containing directory, but the filesystem is read-only,
+        * bail. But only bail if we know for sure it's read-only.
+        */
+        if (writeCreateFlag) {
+            struct statfs  statfsBuffer;
+            if (0 == statfs(statPath, &statfsBuffer)) {
+                if (statfsBuffer.f_flags & MNT_RDONLY) {
+                    OSKextLogCFString(/* kext */ NULL,
+                        kOSKextLogProgressLevel | kOSKextLogFileAccessFlag,
+                        CFSTR("Not saving %s - read-only filesystem."), path);
+                    goto finish;
+                }
+            }
+        }
+
+        if (0 != stat(statPath, &statBuffer)) {
+            if (errno == ENOENT) {
+                if (writeCreateFlag) {
+                    if (0 != mkdir(path, _kOSKextCacheFolderMode) &&
+                        errno != EEXIST) {
+
+                        OSKextLog(/* kext */ NULL,
+                            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                            "Failed to create directory %s - %s.",
+                            statPath, strerror(errno));
+                        goto finish;
+                    }
+                } else {
+                   /* Don't log anything if the file simply doesn't exist.
+                    */
+                    goto finish;
+                }
+            } else {
+                OSKextLog(/* kext */ NULL,
+                    kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                    "Can't stat path %s - %s.",
+                    statPath, strerror(errno));
+                goto finish;
+            }
+        }
+        if (statBuffer.st_uid != 0) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Can't create kext cache under %s - owner not root.",
+                statPath);
+            goto finish;
+        }
+       
+       /* The root folder, /, is owned by group admin! Now what am I supposed
+        * to do? We should be able to check folder groups as well.
+        */
+        if (!S_ISDIR(statBuffer.st_mode) && statBuffer.st_gid != 0) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Can't create kext cache under %s - group not wheel.",
+                statPath);
+            goto finish;
+        }
+
+        if (!slashPtr) {
+            break;
+        } else if (slashPtr == path) {
+            slashPtr = index(path + 1, '/');
+            statPath = path;
+        } else {
+            slashPtr[0] = '/';
+            slashPtr++;
+            slashPtr = index(slashPtr, '/');
+        }
+    }
+
+    result = true;
+
+finish:
+    if (slashPtr && slashPtr != path) {
+        slashPtr[0] = '/';
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean _OSKextCreateFolderForCacheURL(CFURLRef cacheFileURL)
+{
+    Boolean  result    = false;
+    CFURLRef folderURL = NULL;  // must release
+
+    folderURL = CFURLCreateCopyDeletingLastPathComponent(kCFAllocatorDefault,
+        cacheFileURL);
+    if (!folderURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    result = __OSKextCheckURL(folderURL, /* writeCreate? */ true);
+finish:
+    SAFE_RELEASE(folderURL);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextURLIsSystemFolder(CFURLRef folderURL)
+{
+    Boolean  result       = false;
+    CFURLRef folderAbsURL = NULL;  // must release
+
+    folderAbsURL = CFURLCopyAbsoluteURL(folderURL);
+    if (!folderAbsURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    if (kCFNotFound == CFArrayGetFirstIndexOfValue(
+                            __sOSKextSystemExtensionsFolderURLs,
+                            RANGE_ALL(__sOSKextSystemExtensionsFolderURLs),
+                            folderAbsURL)) {
+
+        goto finish;
+    }
+    result = true;
+finish:
+    SAFE_RELEASE(folderAbsURL);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextStatURL(
+    CFURLRef      anURL,
+    Boolean     * missingOut,
+    struct stat * statOut)
+{
+    Boolean     result = FALSE;
+    char        path[PATH_MAX];
+    struct stat statBuf;
+
+    if (missingOut) {
+        *missingOut = FALSE;
+    }
+
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, anURL,
+        /* resolve */ TRUE, path)) {
+
+            goto finish;
+    }
+
+    if (0 != stat(path, &statBuf)) {
+    
+       /* Mask ENOENT and ENOTDIR if the caller is handling.
+        */
+        if ((errno == ENOENT || errno == ENOTDIR) && missingOut) {
+            *missingOut = TRUE;
+        } else {
+            OSKextLogCFString(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                CFSTR("Can't stat %s - %s."),
+                path, strerror(errno));
+        }
+        goto finish;
+    }
+    
+    result = TRUE;
+
+finish:
+    if (statOut) {
+        *statOut = statBuf;
+    }
+    return result;
+}
+
+/*********************************************************************
+* Get the stat buffer of the URL with the latest mod time of those
+* provided.
+*********************************************************************/
+Boolean __OSKextStatURLsOrURL(
+    CFTypeRef     folderURLsOrURL,
+    Boolean     * missingOut,
+    struct stat * latestStatOut)
+{
+    Boolean     result       = FALSE;
+    Boolean     localMissing = FALSE;
+    struct stat newStatBuf;
+    struct stat latestStatBuf;
+    
+    bzero(&latestStatBuf, sizeof(latestStatBuf));
+    
+    if (CFGetTypeID(folderURLsOrURL) == CFURLGetTypeID()) {
+        result = __OSKextStatURL((CFURLRef)folderURLsOrURL,
+            missingOut, &latestStatBuf);
+    } else if (CFGetTypeID(folderURLsOrURL) == CFArrayGetTypeID()) {
+        CFArrayRef folderURLs = (CFArrayRef)folderURLsOrURL;
+        CFIndex    count, i;
+        CFIndex    successCount = 0;
+        
+        count = CFArrayGetCount(folderURLs);
+        for (i = 0; i < count; i++) {
+            result = __OSKextStatURL((CFURLRef)
+                CFArrayGetValueAtIndex(folderURLs, i),
+                missingOut ? &localMissing : NULL,
+                &newStatBuf);
+            if (!result) {
+                continue;
+            }
+            successCount++;
+            if (i == 0 || (newStatBuf.st_mtime > latestStatBuf.st_mtime)) {
+                latestStatBuf = newStatBuf;
+            }
+        }
+
+        if (successCount > 0) {
+            result = TRUE;
+        }
+        if ((successCount < count) && missingOut) {
+            *missingOut = TRUE;
+        }
+    }
+    
+// finish:
+    if (latestStatOut) {
+        *latestStatOut = latestStatBuf;
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean _OSKextWriteCache(
+    CFTypeRef                 folderURLsOrURL,
+    CFStringRef               cacheName,
+    const NXArchInfo        * arch,
+    _OSKextCacheFormat        format,
+    CFPropertyListRef         plist)
+{
+    Boolean                  result              = false;
+    CFURLRef                 folderAbsURL        = NULL;  // must release
+    CFStringRef              folderAbsPath       = NULL;  // must release
+    CFStringRef              cacheFileString     = NULL;  // must release
+    CFURLRef                 cacheFileURL        = NULL;  // must release
+    char                     tmpPath[PATH_MAX]   = "";
+    char                     cachePath[PATH_MAX] = "";
+    char                   * unlinkPath          = NULL;  // do not free
+    int                      fileDescriptor      = -1;    // close on gz error
+    mode_t                   realUmask           = 0;
+    CFWriteStreamRef         plistStream         = NULL;  // must release
+    CFDataRef                cacheData           = NULL;  // must release
+    const UInt8            * cacheDataPtr        = NULL;  // don't free
+    gzFile                   outputGZFile        = Z_NULL;  // must gzclose
+    CFIndex                  cacheDataLength     = 0;
+    CFIndex                  bytesWritten        = 0;
+    struct stat              latestStat;
+
+    if (CFGetTypeID(folderURLsOrURL) == CFURLGetTypeID()) {
+        folderAbsURL = CFURLCopyAbsoluteURL((CFURLRef)folderURLsOrURL);
+        if (!folderAbsURL) {
+            OSKextLogMemError();
+            goto finish;
+        }
+
+        folderAbsPath = _CFURLCopyAbsolutePath((CFURLRef)folderURLsOrURL);
+        if (!folderAbsPath) {
+            OSKextLogMemError();
+            goto finish;
+        }
+    }
+    
+   /* __OSKextCreateCacheFileURL() checks if the URL is for a system extensions
+    * folder and returns NULL if it isn't.
+    */
+    cacheFileURL = __OSKextCreateCacheFileURL(folderURLsOrURL,
+        cacheName, arch, format);
+    if (!cacheFileURL) {
+        goto finish;
+    }
+
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, cacheFileURL,
+        /* resolveToBase */ true, cachePath)) {
+
+        OSKextLogStringError(/* kext */ NULL);
+        goto finish;
+    }
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogProgressLevel | kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+        "Saving cache file %s.",
+        cachePath);
+
+    if (!_OSKextCreateFolderForCacheURL(cacheFileURL)) {
+        goto finish;
+    }
+
+    strlcpy(tmpPath, cachePath, sizeof(tmpPath));
+    if (strlcat(tmpPath, ".XXXXXX", sizeof(tmpPath)) > sizeof(tmpPath)) {
+
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogGeneralFlag,
+            "Temp cache file name too long: %s.",
+            tmpPath);
+        goto finish;
+    }
+
+    fileDescriptor = mkstemp(tmpPath);
+    if (-1 == fileDescriptor) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Can't create %s - %s.",
+            tmpPath, strerror(errno));
+        goto finish;
+    }
+
+    unlinkPath = tmpPath;
+
+   /* Set the umask to get it, then set it back to iself. Wish there were a
+    * better way to query it.
+    */
+    realUmask = umask(0);
+    umask(realUmask);
+
+    if (-1 == fchmod(fileDescriptor, _kOSKextCacheFileMode & ~realUmask)) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Failed to set permissions for %s - %s.",
+            tmpPath, strerror(errno));
+        goto finish;
+    }
+
+    if (format == _kOSKextCacheFormatCFXML ||
+        format == _kOSKextCacheFormatCFBinary) {
+
+        CFPropertyListFormat cfPlistFormat;
+        
+        if (format == _kOSKextCacheFormatCFXML) {
+            cfPlistFormat = kCFPropertyListBinaryFormat_v1_0;
+        } else {
+            cfPlistFormat = kCFPropertyListXMLFormat_v1_0;
+        }
+
+        plistStream = CFWriteStreamCreateWithAllocatedBuffers(
+            kCFAllocatorDefault, kCFAllocatorDefault);
+        if (!plistStream) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+                "Can't create CFWriteStream to save cache %s.",
+                cachePath);
+            goto finish;
+        }
+        CFWriteStreamOpen(plistStream);
+        CFPropertyListWriteToStream(plist, plistStream,
+            cfPlistFormat, /* errorString */ NULL);
+        CFWriteStreamClose(plistStream);
+
+        cacheData = CFWriteStreamCopyProperty(plistStream,
+            kCFStreamPropertyDataWritten);
+    } else {
+        cacheData = IOCFSerialize(plist, /* options */ 0);
+    }
+    if (!cacheData) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Failed to serialize data for cache %s.",
+            cachePath);
+        goto finish;
+    }
+
+    cacheDataPtr = CFDataGetBytePtr(cacheData);
+    cacheDataLength = CFDataGetLength(cacheData);
+    if (!cacheDataPtr) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogGeneralFlag,
+            "Unable to get data to create cache file %s.",
+            cachePath);
+        goto finish;
+    }
+ 
+    errno = 0;
+    outputGZFile = gzdopen(fileDescriptor, "w");
+    if (!outputGZFile) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Failed to open compression stream for %s - %s.",
+            cachePath, strerror(errno));
+        goto finish;
+    }
+
+   /* outputGZFile owns the file descriptor now.
+    */
+    fileDescriptor = -1;
+
+    bytesWritten = 0;   
+    while (bytesWritten < cacheDataLength) {
+        int bytesJustWritten = 0;
+
+        errno = 0;
+        bytesJustWritten = gzwrite(outputGZFile,
+            cacheDataPtr + bytesWritten, cacheDataLength - bytesWritten);
+        if (bytesJustWritten < 0) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Compressed write error for cache file %s - %s.",
+                cachePath, strerror(errno));
+            goto finish;
+        }
+
+        bytesWritten += bytesJustWritten;
+    }
+
+   /* Need to close it before calling utimes.
+    */
+    errno = 0;
+    if (gzclose(outputGZFile) != Z_OK) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Failed to close compression stream for %s - %s.",
+            tmpPath, strerror(errno));
+    }
+    outputGZFile = Z_NULL;
+
+    if (-1 == rename(tmpPath, cachePath)) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Can't rename temp cache file to %s - %s.",
+            cachePath, strerror(errno));
+        goto finish;
+    }
+    unlinkPath = cachePath;
+
+   /* Give the cache file the mod time of the folder with the latest
+    * mod date, +1 sec.
+    */
+    if (!__OSKextStatURLsOrURL(folderURLsOrURL,
+        /* missingIsError */ FALSE, &latestStat)) {
+        goto finish;
+    } else {
+        struct timeval cacheFileTimes[2];
+        cacheFileTimes[0].tv_sec  = latestStat.st_mtime + 1;
+        cacheFileTimes[0].tv_usec = 0;
+        cacheFileTimes[1].tv_sec  = latestStat.st_mtime + 1;
+        cacheFileTimes[1].tv_usec = 0;
+
+        if (-1 == utimes(cachePath, cacheFileTimes)) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Can't update mod time of cache file %s - %s.",
+                cachePath, strerror(errno));
+            if (errno == ENOENT) {
+                unlinkPath = NULL;
+            }
+            goto finish;
+        }
+    }
+    unlinkPath = NULL;
+
+    result = true;
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogProgressLevel | kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+        "Saved cache file %s.", cachePath);
+
+finish:
+    if (-1 != fileDescriptor) close(fileDescriptor);
+
+    if (Z_NULL != outputGZFile && gzclose(outputGZFile) != Z_OK) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Failed to close compression stream for %s - %s.",
+            tmpPath, strerror(errno));
+    }
+
+    if (unlinkPath) {
+        if (-1 == unlink(unlinkPath)) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Failed to remove temp cache file %s - %s.",
+                unlinkPath, strerror(errno));
+        }
+    }
+
+    SAFE_RELEASE(folderAbsURL);
+    SAFE_RELEASE(folderAbsPath);
+    SAFE_RELEASE(cacheFileString);
+    SAFE_RELEASE(cacheFileURL);
+    SAFE_RELEASE(cacheData);
+    SAFE_RELEASE(plistStream);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextCacheNeedsUpdate(
+    CFURLRef  cacheURL,
+    CFTypeRef folderURLsOrURL)
+{
+    Boolean     result    = TRUE;  // default is to need update
+    Boolean     missing   = FALSE;
+    CFStringRef cachePath = NULL;  // must release
+    struct stat cacheFileStat;
+    struct stat latestFolderStat;
+
+    cachePath = _CFURLCopyAbsolutePath(cacheURL);
+    if (!cachePath) {
+        goto finish;
+    }
+
+    if (!__OSKextStatURL(cacheURL, &missing, &cacheFileStat)) {
+        if (missing) {
+             OSKextLogCFString(/* kext */ NULL,
+                kOSKextLogDebugLevel |
+                kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+                CFSTR("Cache file %@ does not exist."),
+                cachePath);
+        }
+
+        goto finish;
+    }
+
+   /*****
+    * Various stats and checks.
+    */
+   /* Exists but isn't a regular file; we'll never use it.
+    */
+    if (!(cacheFileStat.st_mode & S_IFREG)) {
+        OSKextLogCFString(/* kext */ NULL,
+            kOSKextLogProgressLevel | kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+            CFSTR("Cache file %@ is not a regular file; ignoring."),
+            cachePath);
+        goto finish;
+    }
+
+    if (!__OSKextCheckURL(cacheURL, /* writeCreate? */ false)) {
+        goto finish;
+    }
+
+   /* Check if the cache file is ok to use.
+    */
+    if (cacheFileStat.st_uid != 0) {
+        OSKextLogCFString(/* kext */ NULL,
+            kOSKextLogWarningLevel |
+            kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+            CFSTR("Cache file %@ - owner not root; not using."),
+            cachePath);
+        goto finish;
+    }
+
+    if (cacheFileStat.st_gid != 0) {
+        OSKextLogCFString(/* kext */ NULL,
+            kOSKextLogWarningLevel |
+            kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+            CFSTR("Cache file %@ - group not wheel; not using."), cachePath);
+        goto finish;
+    }
+    
+    if ((cacheFileStat.st_mode & _kOSKextCacheFileModeMask) != _kOSKextCacheFileMode) {
+        OSKextLogCFString(/* kext */ NULL,
+            kOSKextLogWarningLevel |
+            kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+            CFSTR("Cache file %@ - wrong permissions (%#o, should be %#o); not using."),
+            cachePath,
+            cacheFileStat.st_mode, _kOSKextCacheFileMode);
+        goto finish;
+    }
+
+    if (!__OSKextStatURLsOrURL(folderURLsOrURL,
+        /* missing */ &missing, &latestFolderStat)) {
+
+        OSKextLogCFString(/* kext */ NULL,
+            kOSKextLogWarningLevel |
+            kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+            CFSTR("Can't stat source folders for cache file %@."),
+            cachePath);
+        goto finish;
+    }
+
+    if (cacheFileStat.st_mtime != (latestFolderStat.st_mtime + 1)) {
+        OSKextLogCFString(/* kext */ NULL,
+            kOSKextLogWarningLevel |
+            kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+            CFSTR("Cache file %@ is out of date; not using."),
+            cachePath);
+        goto finish;
+    }
+
+    result = FALSE;
+
+finish:
+    SAFE_RELEASE(cachePath);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean _OSKextReadCache(
+    CFTypeRef                 folderURLsOrURL,
+    CFStringRef               cacheName,
+    const NXArchInfo        * arch,
+    _OSKextCacheFormat        format,
+    Boolean                   parseXMLFlag,
+    CFPropertyListRef       * cacheContentsOut)
+{
+    Boolean           result                  = false;
+    CFURLRef          cacheFileURL            = NULL;  // must release
+    char              cachePath[PATH_MAX]     = "";
+    CFDataRef         cacheData               = NULL;  // must release
+    SInt32            error = 0;
+    CFStringRef       errorString             = NULL;  // must release
+    char            * errorCString            = NULL;  // must free
+    CFDataRef         uncompressedCacheData   = NULL;  // must release
+    ssize_t           uncompressedByteSize    = 0;
+    u_char          * uncompressedBytes       = NULL;  // do not free
+    z_stream          zstream;
+    int               zlibResult              = Z_UNKNOWN;
+    int               numReallocs;
+    Boolean           inflateTried            = false;
+    CFPropertyListRef cacheContents           = NULL;  // must release
+
+   /* __OSKextCreateCacheFileURL() checks if the URL is for a system extensions
+    * folder and returns NULL if it isn't.
+    */
+    cacheFileURL = __OSKextCreateCacheFileURL(folderURLsOrURL,
+        cacheName, arch, format);
+    if (!cacheFileURL) {
+        goto finish;
+    }
+
+   /* Get the C string path for the cache.
+    */
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, cacheFileURL,
+        /* resolveToBase */ TRUE, cachePath)) {
+
+        goto finish;
+    }
+
+    if (__OSKextCacheNeedsUpdate(cacheFileURL, folderURLsOrURL)) {
+        goto finish;
+    }
+
+   /* If we weren't given an out param, we're just checking that the cache
+    * is up to date, and if we got this far, we are up to date.
+    */
+    if (!cacheContentsOut) {
+        result = true;
+        goto finish;
+    }
+    
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogProgressLevel | kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+        "Reading cache file %s.",
+        cachePath);
+
+    if (!CFURLCreateDataAndPropertiesFromResource(
+        CFGetAllocator(cacheFileURL), cacheFileURL, &cacheData, /* props */ NULL,
+        /* desiredProps */ NULL, &error)) {
+
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Can't open cache file %s, CF error %d.",
+            cachePath, (int)error);
+        goto finish;
+    }
+
+    zstream.next_in   = (UInt8 *)CFDataGetBytePtr(cacheData);
+    zstream.avail_in  = CFDataGetLength(cacheData);
+    zstream.zalloc    = NULL;
+    zstream.zfree     = NULL;
+    zstream.opaque    = NULL;
+
+    uncompressedByteSize = GZIP_RATIO * zstream.avail_in;
+    uncompressedBytes = (u_char *)malloc(uncompressedByteSize);
+    if (!uncompressedBytes) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    zstream.next_out  = uncompressedBytes;
+    zstream.avail_out = uncompressedByteSize;
+
+   /* In order to read gzip data, we need to specify the default
+    * bit window of 15, and add 32, per the zlib.h comments.
+    */
+    zlibResult = inflateInit2(&zstream, 15 + 32);
+    if (zlibResult != Z_OK) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Error initializing zlib uncompression for %s.",
+            cachePath);
+        goto finish;
+    }
+    inflateTried = true;
+
+    numReallocs = 0;
+    while (numReallocs < MAX_REALLOCS && zlibResult == Z_OK) {
+        zlibResult = inflate(&zstream, Z_NO_FLUSH);
+        if (zlibResult == Z_STREAM_END) {
+            // success! nothing do here, actually
+            break;
+        } else if ((zlibResult == Z_OK) || (zlibResult == Z_BUF_ERROR)) {
+            numReallocs++;
+            uncompressedByteSize *= 2;
+            uncompressedBytes = realloc(uncompressedBytes, uncompressedByteSize);
+            if (!uncompressedBytes) {
+                OSKextLogMemError();
+                goto finish;
+            }
+            zstream.next_out  = uncompressedBytes + zstream.total_out;
+            zstream.avail_out = uncompressedByteSize - zstream.total_out;
+            zlibResult = Z_OK;  // make it ok for the while loop
+        } else {
+            break;
+        }
+    }
+    if (zlibResult != Z_STREAM_END) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Error uncompressing kext cache file %s - zlib returned %d - %s.",
+            cachePath, zlibResult, zstream.msg ? zstream.msg : "(unknown)");
+        goto finish;
+    }
+
+    uncompressedCacheData = CFDataCreateWithBytesNoCopy(kCFAllocatorDefault,
+        (const UInt8 *)uncompressedBytes, zstream.total_out, kCFAllocatorMalloc);
+    if (!uncompressedCacheData) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    if (parseXMLFlag) {
+        if (format == _kOSKextCacheFormatCFXML ||
+            format == _kOSKextCacheFormatCFBinary) {
+
+            cacheContents = CFPropertyListCreateFromXMLData(kCFAllocatorDefault,
+                uncompressedCacheData, kCFPropertyListImmutable, &errorString);
+        } else if (format == _kOSKextCacheFormatIOXML) {
+            cacheContents = IOCFUnserialize((const char *)uncompressedBytes,
+                kCFAllocatorDefault,
+                /* options */ 0, &errorString);
+        } else {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel |
+                kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+                "Invalid cache format %d specified.", format);
+            goto finish;
+        }
+        if (!cacheContents) {
+            errorCString = createUTF8CStringForCFString(errorString);
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel |
+                kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+                "Can't read plist from cache file %s - %s.",
+                cachePath, errorCString ? errorCString : __kStringUnknown);
+            goto finish;
+        }
+    } else {
+        cacheContents = CFRetain(uncompressedCacheData);
+    }
+
+    result = true;
+
+finish:
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogProgressLevel |
+        kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+        "Finished reading cache file %s.",
+        cachePath);
+
+    if (result && cacheContentsOut && cacheContents) {
+        *cacheContentsOut = CFRetain(cacheContents);
+    }
+
+    SAFE_RELEASE(cacheFileURL);
+    SAFE_RELEASE(cacheContents);
+    SAFE_RELEASE(cacheData);
+    SAFE_RELEASE(errorString);
+    SAFE_RELEASE(uncompressedCacheData);
+
+    SAFE_FREE(errorCString);
+
+    if (inflateTried) {
+        inflateEnd(&zstream);
+    }
+
+    return result;
+}
+
+/*********************************************************************
+* xxx - will need to optimize so we only check & remove once
+*********************************************************************/
+void __OSKextRemoveIdentifierCacheForKext(OSKextRef aKext)
+{
+    char         scratchPath[PATH_MAX];
+    const char * delRoot = NULL;   // do not free
+
+   /* We can't do it if we aren't root.
+    */    
+    if (geteuid() != 0) {
+        return;
+    }
+
+    if (!__OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ true, scratchPath)) {
+
+        goto finish;
+    }
+
+   /* I'm sick of CF verbosity so we're going to do this C style.
+    */
+    if (!strncmp(scratchPath,
+        _kOSKextSystemLibraryExtensionsFolder,
+        strlen(_kOSKextSystemLibraryExtensionsFolder))) {
+        
+        delRoot = _kOSKextSystemLibraryExtensionsFolder;
+
+    } else if (!strncmp(scratchPath,
+        _kOSKextLibraryExtensionsFolder,
+        strlen(_kOSKextLibraryExtensionsFolder))){
+
+        delRoot = _kOSKextSystemLibraryExtensionsFolder;
+
+    } else if (!strncmp(scratchPath,
+        _kOSKextAppleInternalLibraryExtensionsFolder,
+        strlen(_kOSKextAppleInternalLibraryExtensionsFolder))){
+
+        delRoot = _kOSKextSystemLibraryExtensionsFolder;
+    }
+    
+    if (!delRoot) {
+        goto finish;
+    }
+    
+    OSKextLog(/* kext */ NULL,
+         kOSKextLogProgressLevel |
+         kOSKextLogKextBookkeepingFlag | kOSKextLogFileAccessFlag,
+        "Removing identifier->path cache %s.",
+        scratchPath);
+
+    scratchPath[0] = '\0';
+    strlcpy(scratchPath, _kOSKextCachesRootFolder, sizeof(scratchPath));
+    strlcat(scratchPath, delRoot, sizeof(scratchPath));
+    strlcat(scratchPath, _kOSKextIdentifierCacheBasename, sizeof(scratchPath));
+    if (unlink(scratchPath)) {
+        if (errno != ENOENT && errno != ENOTDIR) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Failed to remove identifier->path cache %s - %s.",
+                scratchPath, strerror(errno));
+        }
+    }
+
+finish:
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean _OSKextWriteIdentifierCacheForKextsInDirectory(
+    CFArrayRef kextArray,
+    CFURLRef   directoryURL,
+    Boolean    forceFlag)
+{
+    Boolean                  result                = false;
+    CFURLRef                 cacheFileURL          = NULL;  // must release
+    CFStringRef              basePath              = NULL;  // must release
+    CFNumberRef              cacheVersion          = NULL;  // must release
+    SInt32                   cacheVersionValue     = 0;
+    CFMutableDictionaryRef   cacheDict             = NULL;  // must release
+    CFMutableArrayRef        kextInfoArray         = NULL;  // must release
+    CFDictionaryRef          kextDict              = NULL;  // must release
+    OSKextRef                aKext                 = NULL;  // do not release
+    char                     origDirPath[PATH_MAX] = "";
+    CFIndex                  count, i;
+
+    if (!OSKextGetUsesCaches() && !forceFlag) {
+        goto finish;
+    }
+
+   /* We can't do it if we aren't root.
+    */    
+    if (geteuid() != 0) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogProgressLevel | kOSKextLogKextBookkeepingFlag,
+            "Not running as root; skipping save of identifier->path cache.");
+        goto finish;
+    }
+
+   /* __OSKextCreateCacheFileURL() checks if the URL is for a system extensions
+    * folders and returns NULL if it isn't. We don't actually use the URL in
+    * this function; we're just using the convenience of the NULL return value
+    * to avoid all the work of generating data we'll never save.
+    */
+   cacheFileURL = __OSKextCreateCacheFileURL(
+        directoryURL,
+        CFSTR(_kOSKextIdentifierCacheBasename),
+        /* arch */ NULL,
+        _kOSKextCacheFormatCFBinary);
+    if (!cacheFileURL) {
+        goto finish;
+    }
+
+    cacheDict = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (!cacheDict) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, directoryURL,
+        /* resolveToBase */ true, origDirPath)) {
+
+        goto finish;
+    }
+
+   /* Length passed in is w/o terminating nul character.
+    */
+    basePath = CFStringCreateWithBytes(kCFAllocatorDefault,
+        (UInt8 *)origDirPath, strlen(origDirPath), kCFStringEncodingUTF8,
+        /* isExtRep */ false);
+    if (!basePath) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    CFDictionarySetValue(cacheDict, CFSTR(__kOSKextIdentifierCacheBasePathKey),
+        basePath);
+
+    kextInfoArray = CFArrayCreateMutable(kCFAllocatorDefault, 0,
+        &kCFTypeArrayCallBacks);
+    if (!kextInfoArray) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    CFDictionarySetValue(cacheDict, CFSTR(__kOSKextIdentifierCacheKextInfoKey),
+        kextInfoArray);
+        
+    cacheVersionValue = __kOSKextIdentifierCacheCurrentVersion;
+    cacheVersion = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type,
+        &cacheVersionValue);
+    if (!kextInfoArray) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    CFDictionarySetValue(cacheDict, CFSTR(__kOSKextIdentifierCacheVersionKey),
+        cacheVersion);
+
+    count = CFArrayGetCount(kextArray);
+    for (i = 0; i < count; i++) {
+        SAFE_RELEASE(kextDict);
+        aKext = (OSKextRef)CFArrayGetValueAtIndex(kextArray, i);
+        kextDict = __OSKextCreateIdentifierCacheDict(aKext, basePath);
+        if (!kextDict) {
+            continue;
+        }
+        CFArrayAppendValue(kextInfoArray, kextDict);
+    }
+
+    result = _OSKextWriteCache(directoryURL,
+        CFSTR(_kOSKextIdentifierCacheBasename),
+        /* arch */ NULL, _kOSKextCacheFormatCFBinary,
+        cacheDict);
+
+finish:
+    SAFE_RELEASE(cacheFileURL);
+    SAFE_RELEASE(cacheDict);
+    SAFE_RELEASE(kextInfoArray);
+    SAFE_RELEASE(kextDict);
+    SAFE_RELEASE(cacheVersion);
+    SAFE_RELEASE(basePath);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDictionaryRef __OSKextCreateIdentifierCacheDict(
+    OSKextRef   aKext,
+    CFStringRef basePath)
+{
+    CFMutableDictionaryRef result        = NULL;
+    CFMutableDictionaryRef preResult     = NULL;
+    CFURLRef               absURL        = NULL;  // must release
+    CFStringRef            bundlePath    = NULL;  // must release
+    CFStringRef            relativePath  = NULL;  // must release
+    CFStringRef            scratchString = NULL;  // do not release
+    char                   bundlePathCString[PATH_MAX];
+    char                   basePathCString[PATH_MAX];
+    CFIndex                baseLength, fullLength;
+    
+    preResult = CFDictionaryCreateMutable(CFGetAllocator(aKext), 0, 
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (!preResult) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    absURL = CFURLCopyAbsoluteURL(OSKextGetURL(aKext));
+    if (!absURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    bundlePath = CFURLCopyFileSystemPath(absURL, kCFURLPOSIXPathStyle);
+    if (!bundlePath) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    if (!CFStringHasPrefix(bundlePath, basePath)) {
+        CFStringGetCString(bundlePath, bundlePathCString,
+            sizeof(bundlePathCString), kCFStringEncodingUTF8);
+        CFStringGetCString(basePath, basePathCString,
+            sizeof(basePathCString), kCFStringEncodingUTF8);
+            
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "%s not in base path %s for identifier->path cache.",
+            bundlePathCString, basePathCString);
+    }
+
+    fullLength = CFStringGetLength(bundlePath);
+    baseLength = 1 + CFStringGetLength(basePath);  // +1 for the final slash
+    relativePath = CFStringCreateWithSubstring(CFGetAllocator(aKext),
+        bundlePath,
+        CFRangeMake(baseLength, fullLength - baseLength));
+    if (!relativePath) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    CFDictionarySetValue(preResult, CFSTR("OSBundlePath"), relativePath);
+
+    scratchString = OSKextGetIdentifier(aKext);
+    if (!scratchString) {
+        goto finish;
+    }
+    CFDictionarySetValue(preResult, kCFBundleIdentifierKey, scratchString);
+
+    scratchString = OSKextGetValueForInfoDictionaryKey(aKext,
+        kCFBundleVersionKey);
+    if (!scratchString) {
+        goto finish;
+    }
+    CFDictionarySetValue(preResult, kCFBundleVersionKey, scratchString);
+
+   /* Only save nonzero log flags, to save file space.
+    */
+    if (aKext->flags.loggingEnabled) {
+        CFDictionarySetValue(preResult, CFSTR(kOSBundleEnableKextLoggingKey),
+            kCFBooleanTrue);
+    }
+
+    result = preResult;
+    preResult = NULL;
+    
+finish:
+    SAFE_RELEASE(preResult);
+    SAFE_RELEASE(absURL);
+    SAFE_RELEASE(bundlePath);
+    SAFE_RELEASE(relativePath);
+    return result;
+}
+
+#pragma mark Instance Management (Continued)
+/*********************************************************************
+* Instance Management (Continued)
+*********************************************************************/
+
+/*********************************************************************
+*********************************************************************/
+OSKextRef OSKextCreateWithIdentifier(
+    CFAllocatorRef allocator,
+    CFStringRef    kextIdentifier)
+{
+    OSKextRef       result = NULL;
+
+    CFArrayRef      kextIDs           = NULL;  // must release
+    CFDictionaryRef loadedKextsInfo   = NULL;  // must release
+    CFDictionaryRef loadedKextInfo    = NULL;  // do not release
+    CFStringRef     kextPath          = NULL;  // do not release
+    CFURLRef        createdKextURL    = NULL;  // must release
+    OSKextRef       createdKext       = NULL;  // must release
+    CFArrayRef      allSystemKexts    = NULL;  // must release
+    OSKextRef       lookedUpKext      = NULL;  // do not release
+    CFStringRef     kextVersionString = NULL;  // do not release
+    OSKextVersion   kextVersion       = -1;
+    char          * pathCString       = NULL;  // must free
+
+   /* Check with the kernel first to ensure correct info
+    * about a loaded kext is returned.
+    */
+    kextIDs = CFArrayCreate(kCFAllocatorDefault,
+        (const void **)&kextIdentifier, /* numValues */ 1,
+        &kCFTypeArrayCallBacks);
+    if (!kextIDs) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    do {
+        loadedKextsInfo = OSKextCopyLoadedKextInfo(kextIDs, __sOSKextInfoEssentialKeys);
+        if (!loadedKextsInfo || (CFGetTypeID(loadedKextsInfo) != CFDictionaryGetTypeID())) {
+            break;
+        }
+            
+        loadedKextInfo = (CFDictionaryRef)CFDictionaryGetValue(loadedKextsInfo, kextIdentifier);
+        if (!loadedKextInfo) {
+            break;
+        }
+        if (CFGetTypeID(loadedKextInfo) != CFDictionaryGetTypeID()) {
+            break;
+        }
+        kextPath = (CFStringRef)CFDictionaryGetValue(loadedKextInfo,
+            CFSTR(kOSBundlePathKey));
+        if (!kextPath || CFGetTypeID(kextPath) != CFStringGetTypeID()) {
+            kextPath = NULL;
+        }
+        kextVersionString = (CFStringRef)CFDictionaryGetValue(
+            loadedKextInfo, kCFBundleVersionKey);
+        if (!kextVersionString || CFGetTypeID(kextVersionString) != CFStringGetTypeID()) {
+            kextVersionString = NULL;
+        }
+        kextVersion = OSKextParseVersionCFString(kextVersionString);
+
+    } while (0);
+
+   /* If we got a path for the kext from the kernel, confirm that we can
+    * open up the bundle and that its identifier is indeed the one requested.
+    */
+    if (kextPath) {
+        pathCString = createUTF8CStringForCFString(kextPath);
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogDebugLevel | kOSKextLogKextBookkeepingFlag,
+            "Creating kext with path %s.", pathCString);
+        createdKextURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault,
+            kextPath, kCFURLPOSIXPathStyle, /* isDir? */ true);
+        if (!createdKextURL) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        createdKext = OSKextCreate(allocator, createdKextURL);
+        if (result && CFEqual(OSKextGetIdentifier(result), kextIdentifier)) {
+            result = (OSKextRef)CFRetain(createdKext);  // we will be releasing it
+        }
+    }
+
+    if (!result) {
+
+       /* No luck finding the kext from the path in the kernel.
+        * Try with the ID and version from the kernel.
+        * Failing that, just try the ID.
+        *
+        * xxx - the API doesn't really say we need to check the version....
+        */
+        allSystemKexts = OSKextCreateKextsFromURLs(allocator,
+            OSKextGetSystemExtensionsFolderURLs());
+        
+        if (kextVersion != -1) {
+            lookedUpKext = OSKextGetKextWithIdentifierAndVersion(kextIdentifier,
+                kextVersion);
+        }
+        if (!lookedUpKext) {
+            lookedUpKext = OSKextGetKextWithIdentifier(kextIdentifier);
+        }
+        if (lookedUpKext) {
+            result = (OSKextRef)CFRetain(lookedUpKext);
+        }
+    }
+
+   /* xxx - This really shouldn't affect any kexts other than the one we are
+    * returning, but it affects all w/same identifier.
+    */
+    if (result && loadedKextInfo) {
+        __OSKextProcessLoadInfo(kextIdentifier, loadedKextInfo, /* context */ NULL);
+    }
+
+finish:
+    SAFE_FREE(pathCString);
+
+    SAFE_RELEASE(kextIDs);
+    SAFE_RELEASE(loadedKextsInfo);
+    SAFE_RELEASE(createdKextURL);
+    SAFE_RELEASE(createdKext);
+    SAFE_RELEASE(allSystemKexts);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextGetAllKexts(void)
+{
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    if (__sOSAllKexts) {
+        CFArrayApplyFunction(__sOSAllKexts, RANGE_ALL(__sOSAllKexts), 
+            &__OSKextRealize, /* context */ NULL);
+    }
+    return __sOSAllKexts;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSKextRef OSKextGetKextWithURL(
+    CFURLRef anURL)
+{
+    OSKextRef   result        = NULL;
+    CFURLRef    canonicalURL  = NULL;  // must release
+    char        relPath[PATH_MAX];
+    char        absPath[PATH_MAX];
+
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+   /* A bit of paranoia, perhaps.
+    */
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, /* otherURL */ anURL,
+            /* resolveToBase */ false, relPath) ||
+        !__OSKextGetFileSystemPath(/* kext */ NULL, /* otherURL */ anURL,
+            /* resolveToBase */ true, absPath)) {
+
+        goto finish;
+    }
+
+   /* Canonicalize the URL so we can use it for a dictionary lookup.
+    */
+    canonicalURL = CFURLCreateFromFileSystemRepresentation(CFGetAllocator(anURL),
+        (uint8_t *)absPath, strlen(absPath), /* isDir */ true);
+    if (!canonicalURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+   /* Check if we already have this URL.
+    */
+    if (__sOSKextsByURL) {
+        result = (OSKextRef)CFDictionaryGetValue(__sOSKextsByURL, canonicalURL);
+        if (result) {
+
+           /* Realize it from the identifier cache as needed. We don't
+            * care about the result if the realize fails, even if the bundle's
+            * gone missing, because there's already retained instances out
+            * there somewhere.
+            */
+            if (result->staticFlags.isFromIdentifierCache) {
+                __OSKextRealize(result, /* context */ NULL);
+            }
+            goto finish;
+        }
+    }
+finish:
+    SAFE_RELEASE(canonicalURL);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSKextRef OSKextGetKextWithIdentifier(
+    CFStringRef aBundleID)
+{
+    OSKextRef result     = NULL;
+    CFTypeRef foundEntry = NULL;  // do not release
+    OSKextRef theKext    = NULL;  // do not release
+
+   /* No need to init the library if there's nothing to get!
+    */
+    if (!__sOSKextsByIdentifier) {
+        goto finish;
+    }
+
+   /* Make sure the lookup dict only contains realized kexts with the
+    * requested identifier.
+    */
+    __OSKextRealizeKextsWithIdentifier(aBundleID);
+
+    foundEntry = CFDictionaryGetValue(__sOSKextsByIdentifier, aBundleID);
+    if (!foundEntry) {
+         goto finish;
+    }
+
+    if (OSKextGetTypeID() == CFGetTypeID(foundEntry)) {
+        theKext = (OSKextRef)foundEntry;
+        
+        result = theKext;
+
+    } else if (CFArrayGetTypeID() == CFGetTypeID(foundEntry)) {
+        CFMutableArrayRef kexts = (CFMutableArrayRef)foundEntry;
+
+        if (CFArrayGetCount(kexts)) {
+            result = (OSKextRef)CFArrayGetValueAtIndex(kexts, 0);
+        }
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+* XXX - Should this look for a loaded kext amongst duplicates?
+*********************************************************************/
+OSKextRef OSKextGetKextWithIdentifierAndVersion(
+    CFStringRef aBundleID, OSKextVersion aVersion)
+{
+    OSKextRef result     = NULL;
+    CFTypeRef foundEntry = NULL;  // do not release
+    OSKextRef theKext    = NULL;  // do not release
+
+   /* No need to init the library if there's nothing to get!
+    */
+    if (!__sOSKextsByIdentifier) {
+        goto finish;
+    }
+
+   /* Make sure the lookup dict only contains realized kexts with the
+    * requested identifier.
+    */
+    __OSKextRealizeKextsWithIdentifier(aBundleID);
+
+    foundEntry = CFDictionaryGetValue(__sOSKextsByIdentifier, aBundleID);
+    if (!foundEntry) {
+         goto finish;
+    }
+
+    if (OSKextGetTypeID() == CFGetTypeID(foundEntry)) {
+        theKext = (OSKextRef)foundEntry;
+
+        if (theKext->version == aVersion) {
+            result = theKext;
+        }
+
+    } else if (CFArrayGetTypeID() == CFGetTypeID(foundEntry)) {
+        CFMutableArrayRef kexts = (CFMutableArrayRef)foundEntry;
+        CFIndex count, i;
+
+        count = CFArrayGetCount(kexts);
+        for (i = 0; i < count; i++) {
+            theKext = (OSKextRef)CFArrayGetValueAtIndex(kexts, i);
+            if (theKext->version == aVersion) {
+                result = theKext;
+                goto finish;
+            }
+        }
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+* All loaded kexts for a given identifier are theoretically the same
+* (version, UUID), but that's as much verification as we ever do.
+*********************************************************************/
+OSKextRef OSKextGetLoadedKextWithIdentifier(
+    CFStringRef aBundleID)
+{
+    OSKextRef result     = NULL;
+    CFTypeRef foundEntry = NULL;  // do not release
+    OSKextRef theKext    = NULL;  // do not release
+ 
+    if (!__sOSKextsByIdentifier) {
+        goto finish;
+    }
+
+   /* Make sure the lookup dict only contains realized kexts with the
+    * requested identifier.
+    */
+    __OSKextRealizeKextsWithIdentifier(aBundleID);
+
+    foundEntry = CFDictionaryGetValue(__sOSKextsByIdentifier, aBundleID);
+    if (!foundEntry) {
+         goto finish;
+    }
+
+    if (OSKextGetTypeID() == CFGetTypeID(foundEntry)) {
+        theKext = (OSKextRef)foundEntry;
+
+        if (OSKextIsLoaded(theKext)) {
+            result = theKext;
+        }
+    } else if (CFArrayGetTypeID() == CFGetTypeID(foundEntry)) {
+        CFMutableArrayRef kexts = (CFMutableArrayRef)foundEntry;
+        CFIndex           count, i;
+
+        count = CFArrayGetCount(kexts);
+        for (i = 0; i < count; i++) {
+            theKext = (OSKextRef)CFArrayGetValueAtIndex(kexts, i);
+            if (OSKextIsLoaded(theKext)) {
+                result = theKext;
+                goto finish;
+            }
+        }
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+XXX - Should this check valid/authentic flags and skip failed kexts?
+*********************************************************************/
+OSKextRef OSKextGetCompatibleKextWithIdentifier(
+    CFStringRef   aBundleID,
+    OSKextVersion requestedVersion)
+{
+    OSKextRef result     = NULL;
+    CFTypeRef foundEntry = NULL;  // do not release
+
+   /* No need to init the library if there's nothing to get!
+    */
+    if (!__sOSKextsByIdentifier) {
+        goto finish;
+    }
+
+   /* Make sure the lookup dict only contains realized kexts with the
+    * requested identifier.
+    */
+    __OSKextRealizeKextsWithIdentifier(aBundleID);
+
+    foundEntry = CFDictionaryGetValue(__sOSKextsByIdentifier, aBundleID);
+    if (!foundEntry) {
+         goto finish;
+    }
+
+    if (OSKextGetTypeID() == CFGetTypeID(foundEntry)) {
+        OSKextRef theKext = (OSKextRef)foundEntry;
+
+        if (OSKextIsCompatibleWithVersion(theKext, requestedVersion)) {
+            result = theKext;
+        }
+
+    } else if (CFArrayGetTypeID() == CFGetTypeID(foundEntry)) {
+        CFMutableArrayRef kexts = (CFMutableArrayRef)foundEntry;
+        CFIndex count, i;
+
+        count = CFArrayGetCount(kexts);
+        for (i = 0; i < count; i++) {
+            OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(kexts, i);
+            if (OSKextIsCompatibleWithVersion(thisKext, requestedVersion)) {
+                result = thisKext;
+                goto finish;
+            }
+        }
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCopyKextsWithIdentifier(
+    CFStringRef aBundleID)
+{
+    CFArrayRef result       = NULL;
+    CFTypeRef  foundEntry   = NULL;  // do not release
+    CFArrayRef realizeArray = NULL;  // must release
+
+   /* Note that this function always returns an array, even if there
+    * are no kexts, so this test is different from previous retrieval
+    * functions.
+    */
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+   /* Make sure the lookup dict only contains realized kexts with the
+    * requested identifier.
+    */
+    __OSKextRealizeKextsWithIdentifier(aBundleID);
+
+    if (__sOSKextsByIdentifier) {
+        foundEntry = CFDictionaryGetValue(__sOSKextsByIdentifier, aBundleID);
+    }
+
+    if (!foundEntry) {
+        goto finish;
+
+    } else if (OSKextGetTypeID() == CFGetTypeID(foundEntry)) {
+        OSKextRef theKext = (OSKextRef)foundEntry;
+
+        result = CFArrayCreate(kCFAllocatorDefault, (const void **)&theKext, 1,
+            &kCFTypeArrayCallBacks);
+
+    } else if (CFArrayGetTypeID() == CFGetTypeID(foundEntry)) {
+        CFMutableArrayRef kexts = (CFMutableArrayRef)foundEntry;
+
+        result = CFArrayCreateCopy(kCFAllocatorDefault, kexts);
+    }
+
+finish:
+    SAFE_RELEASE(realizeArray);
+    if (!result) {
+        result = CFArrayCreate(kCFAllocatorDefault, NULL, 0,
+            &kCFTypeArrayCallBacks);
+    }
+    return result;
+}
+
+/*********************************************************************
+ *********************************************************************/
+CFComparisonResult __OSKextBundleIDCompare(const void *val1,
+    const void *val2, void *context __unused)
+{ 
+    return CFStringCompare(val1, val2, 0);
+}
+
+/*********************************************************************
+ *********************************************************************/
+CFArrayRef OSKextCopyAllRequestedIdentifiers(void)
+{
+    CFMutableArrayRef      result = NULL;
+    CFRange                resultRange;
+    CFSetRef               requestedIdentifiers = NULL;  // must release
+    OSReturn               op_result            = kOSReturnError;
+    CFMutableDictionaryRef requestDict          = NULL;  // must release
+    const void           ** values              = NULL;  // must free
+    int                    i                    = 0;
+    
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogDebugLevel | kOSKextLogIPCFlag,
+        "Reading list of all kexts requested by kernel since startup.");
+    
+    /* Create the kext request to get the bundle IDs of all load requests */
+    
+    requestDict = __OSKextCreateKextRequest(
+        CFSTR(kKextRequestPredicateGetAllLoadRequests),
+        /* bundleID */ NULL, /* argsOut */ NULL);
+    
+    /* Execute the load request and validate that we got a CFSet back */
+    
+    op_result = __OSKextSendKextRequest(/* kext */ NULL, requestDict,
+        (CFTypeRef *)&requestedIdentifiers, /* rawResponseOut */ NULL, 
+        /* rawResponseLengthOut */ NULL);
+    if (op_result != kOSReturnSuccess) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+            "Failed to read kexts requested by kernel since startup - %s.",
+            safe_mach_error_string(op_result));
+        goto finish;
+    }
+    
+    if (!requestedIdentifiers || 
+        CFSetGetTypeID() != CFGetTypeID(requestedIdentifiers)) 
+    {
+        goto finish;
+    }
+    
+    /* Create a temporary array that we'll use to copy the bundle IDs from
+     * the CFSet to a CFArray.
+     */
+    
+    values = malloc(CFSetGetCount(requestedIdentifiers) * sizeof(*values));
+    if (!values) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    /* Create a new CFArray to return the identifiers in */
+    
+    CFSetGetValues(requestedIdentifiers, values);
+    
+    result = CFArrayCreateMutable(kCFAllocatorDefault,
+        CFSetGetCount(requestedIdentifiers), &kCFTypeArrayCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    for (i = 0; i < CFSetGetCount(requestedIdentifiers); ++i) {
+        CFArrayAppendValue(result, values[i]);
+    }
+
+    /* Sort the array to make the order reproducible */
+
+    resultRange.location = 0;
+    resultRange.length = CFArrayGetCount(result);
+    CFArraySortValues(result, resultRange, &__OSKextBundleIDCompare, NULL);
+
+finish:
+    SAFE_RELEASE(requestDict);
+    SAFE_RELEASE(requestedIdentifiers);
+    SAFE_FREE(values);
+        
+    return result;
+}
+
+/*********************************************************************
+ *********************************************************************/
+CFMutableArrayRef OSKextCopyKextsWithIdentifiers(CFArrayRef kextIdentifiers)
+{
+    CFMutableArrayRef   result                  = NULL;
+    CFMutableArrayRef   kexts                   = NULL;  // must release
+    CFArrayRef          kextsWithIdentifier     = NULL;  // must release
+    char              * kextIdentifierCString   = NULL;  // must free
+    int                 count, i;
+    
+    /* Create an array to hold the kext objects */
+    
+    count = CFArrayGetCount(kextIdentifiers);
+    kexts = CFArrayCreateMutable(kCFAllocatorDefault, 
+        count, &kCFTypeArrayCallBacks);
+    if (!kexts) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    /* Find a kext for each of the bundle identifiers */
+    
+    for (i = 0; i < count; ++i) {
+        CFStringRef kextIdentifier = NULL;
+
+        SAFE_RELEASE_NULL(kextsWithIdentifier);
+        SAFE_FREE_NULL(kextIdentifierCString);
+        kextIdentifier = CFArrayGetValueAtIndex(kextIdentifiers, i);
+
+        kextsWithIdentifier = OSKextCopyKextsWithIdentifier(kextIdentifier);
+        if (kextsWithIdentifier) {
+            CFArrayAppendArray(kexts, kextsWithIdentifier,
+                RANGE_ALL(kextsWithIdentifier));
+        } else {
+            kextIdentifierCString = createUTF8CStringForCFString(kextIdentifier);
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogDebugLevel | kOSKextLogKextBookkeepingFlag,
+                "Note: OSKextCopyKextsWithIdentifiers() - identifier %s not found.",
+                kextIdentifierCString);
+        }
+    }
+    
+    result = kexts;
+    kexts = NULL;
+    
+finish:
+    SAFE_RELEASE(kexts);
+    SAFE_RELEASE(kextsWithIdentifier);
+    SAFE_FREE(kextIdentifierCString);
+    
+    return result;
+}
+
+/*********************************************************************
+ *********************************************************************/
+CFMutableArrayRef OSKextCopyLoadListForKexts(
+    CFArrayRef kexts,
+    Boolean    needAllFlag)
+{
+    CFMutableArrayRef result         = NULL;
+    CFMutableArrayRef globalLoadList = NULL;
+    CFMutableSetRef   resolvedKexts  = NULL;
+    CFArrayRef        loadList       = NULL;
+    CFIndex           kextCount, loadListCount, i, j;
+    
+    /* Create a set to track the kexts whose dependencies have been resolved */
+    
+    resolvedKexts = CFSetCreateMutable(kCFAllocatorDefault, 0,
+        &kCFTypeSetCallBacks);
+    if (!resolvedKexts) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    /* Create the global load list */
+    
+    globalLoadList = CFArrayCreateMutable(kCFAllocatorDefault, 0,
+        &kCFTypeArrayCallBacks);
+    if (!globalLoadList) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    /* Generate the global load list */
+    
+    kextCount = CFArrayGetCount(kexts);
+    for (i = 0; i < kextCount; ++i) {
+        Boolean valid     = false;
+        
+        SAFE_RELEASE_NULL(loadList);
+        
+        OSKextRef theKext = (OSKextRef) CFArrayGetValueAtIndex(kexts, i);
+        
+       /* If we've already determined this kext's load order, skip it.
+        */
+        if (CFSetGetValue(resolvedKexts, theKext)) continue;
+
+       /* Skip kexts that we can't possibly load.
+        */
+        valid = __OSKextIsValid(theKext);
+        
+        if (!valid) {
+            char kextPath[PATH_MAX];
+            OSKextLogSpec logLevel = needAllFlag ? kOSKextLogErrorLevel :
+                kOSKextLogWarningLevel;
+            
+            __OSKextGetFileSystemPath(theKext, /* otherURL */ NULL,
+                /* resolveToBase */ FALSE, kextPath);
+
+            OSKextLog(theKext,
+                logLevel | kOSKextLogGeneralFlag | kOSKextLogArchiveFlag,
+                "%s is not valid.",
+                kextPath);
+
+            if (needAllFlag) {
+                goto finish;
+            } else {
+                continue;
+            }
+        }
+
+       /* Determine the dependency graph for this kext.
+        */
+        loadList = OSKextCopyLoadList(theKext, needAllFlag);
+        if (!loadList) {
+            goto finish;
+        }
+
+        loadListCount = CFArrayGetCount(loadList);
+        for (j = 0; j < loadListCount; ++j) {
+            
+            OSKextRef listKext = (OSKextRef)CFArrayGetValueAtIndex(loadList, j);
+            
+           /* If we've already determined this kext's load order, skip it.
+            */
+            if (CFSetGetValue(resolvedKexts, listKext)) continue;
+            
+           /* Add the kext to the global load list and the set of resolved kexts.
+            */
+            CFArrayAppendValue(globalLoadList, listKext);
+            CFSetSetValue(resolvedKexts, listKext);
+        }
+    }
+    
+    result = globalLoadList;
+    globalLoadList = NULL;
+    
+finish:
+    SAFE_RELEASE(resolvedKexts);
+    SAFE_RELEASE(globalLoadList);
+    SAFE_RELEASE(loadList);
+    
+    return result;
+}
+
+#pragma mark Basic Accessors
+/*********************************************************************
+* Basic Accessors
+*********************************************************************/
+
+/*********************************************************************
+*********************************************************************/
+CFURLRef OSKextGetURL(OSKextRef aKext)
+{
+    return aKext->bundleURL;
+}
+
+/*********************************************************************
+* Get the C string path for a kext's bundleURL, or for an arbitrary
+* URL passed in. Should only ever give one or the other, but if both
+* are given, the URL wins.
+*
+* pathBuffer length assumed to be PATH_MAX
+*********************************************************************/
+Boolean __OSKextGetFileSystemPath(
+    OSKextRef aKext,
+    CFURLRef  anURL,
+    Boolean   resolveToBase,
+    char    * pathBuffer)
+{
+    Boolean  result   = false;
+    CFURLRef urlToUse = NULL;  // do not release
+
+    if (aKext) {
+        if (aKext->bundleURL) {
+            urlToUse = aKext->bundleURL;
+        }
+    } else {
+        urlToUse = anURL;
+    }
+    if (!urlToUse) {
+        goto finish;
+    }
+    result = CFURLGetFileSystemRepresentation(urlToUse,
+        resolveToBase, (UInt8 *)pathBuffer, PATH_MAX);
+
+finish:
+    if (!result) {
+        OSKextLogStringError(aKext);
+        memcpy(pathBuffer, __kStringUnknown, sizeof(__kStringUnknown));
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFStringRef OSKextGetIdentifier(OSKextRef aKext)
+{
+    return aKext->bundleID;
+}
+
+/*********************************************************************
+*********************************************************************/
+#define COMPOSITE_KEY_SEPARATOR  "_"
+
+CFStringRef __OSKextCreateCompositeKey(
+    CFStringRef  baseKey,
+    const char * auxKey)
+{
+    return CFStringCreateWithFormat(kCFAllocatorDefault, NULL,
+        CFSTR("%@%s%s"), baseKey, COMPOSITE_KEY_SEPARATOR, auxKey);
+}
+
+/*********************************************************************
+*********************************************************************/
+CFTypeRef __CFDictionaryGetValueForCompositeKey(
+    CFDictionaryRef aDict,
+    CFStringRef     baseKey,
+    const char *    auxKey)
+{
+    CFTypeRef   result = NULL;
+    CFStringRef compositeKey = NULL;  // must release
+
+    compositeKey = __OSKextCreateCompositeKey(baseKey, auxKey);
+    if (!compositeKey) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    result = CFDictionaryGetValue(aDict, compositeKey);
+    if (!result) {
+        result = CFDictionaryGetValue(aDict, baseKey);
+    }
+
+finish:
+    SAFE_RELEASE(compositeKey);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFTypeRef OSKextGetValueForInfoDictionaryKey(
+    OSKextRef   aKext,
+    CFStringRef key)
+{
+    CFTypeRef result = NULL;
+
+    if (!__OSKextReadInfoDictionary(aKext, NULL)) {
+        goto finish;
+    }
+
+   /* We only do arch-specific properties for keys within the domain
+    * of kexts/OSBundle/IOKit.
+    */
+    if (CFStringHasPrefix(key, CFSTR("OS")) ||
+        CFStringHasPrefix(key, CFSTR("IO"))) {
+
+       /* Only use the generic CPU type, not the subtype, for arch-specific
+        * properties. (Do not free lookupArchInfo.)
+        */
+        const NXArchInfo * lookupArchInfo = NXGetArchInfoFromCpuType(
+            OSKextGetArchitecture()->cputype, CPU_SUBTYPE_MULTIPLE);
+
+        if (lookupArchInfo) {
+            result = __CFDictionaryGetValueForCompositeKey(aKext->infoDictionary,
+                key, lookupArchInfo->name);
+        }
+
+    }
+    
+    if (!result) {
+        result = CFDictionaryGetValue(aKext->infoDictionary, key);
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFMutableDictionaryRef OSKextCopyInfoDictionary(OSKextRef aKext)
+{
+    CFMutableDictionaryRef result = NULL;
+
+    if (!aKext->infoDictionary) {
+        if (!__OSKextReadInfoDictionary(aKext, NULL)) {
+            goto finish;
+        }
+    }
+
+    result = CFDictionaryCreateMutableCopy(CFGetAllocator(aKext), 0,
+        aKext->infoDictionary);
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static void __OSKextFlushInfoDictionaryApplierFunction(
+    const void * vKey __unused,
+    const void * vValue,
+          void * vContext __unused)
+{
+    OSKextRef theKext = (OSKextRef)vValue;
+
+    OSKextFlushInfoDictionary(theKext);
+    return;
+}
+
+void OSKextFlushInfoDictionary(OSKextRef aKext)
+{
+    static Boolean flushingAll = false;
+    char           kextPath[PATH_MAX];
+
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    if (aKext) {
+        if (!flushingAll) {
+            if (OSKextGetURL(aKext)) {
+                __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+                    /* resolveToBase */ false, kextPath);
+            }
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogDetailLevel | kOSKextLogKextBookkeepingFlag,
+                "Flushing info dictionary for %s.",
+                kextPath);
+        }
+        if (!OSKextIsFromMkext(aKext)) {
+            SAFE_RELEASE_NULL(aKext->infoDictionary);
+
+           /* The info dict could change by the time we read it again,
+            * so clear all validation/authentication flags. Leave
+            * diagnostics in place (a bit funky I suppose).
+            */
+            aKext->flags.valid = 0;
+            aKext->flags.invalid = 0;
+            aKext->flags.validated = 0;
+            aKext->flags.authentic = 0;
+            aKext->flags.inauthentic = 0;
+            aKext->flags.authenticated = 0;
+            aKext->flags.isSigned = 0;
+        }
+
+    } else if (__sOSKextsByURL) {
+        flushingAll = true;
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogDetailLevel | kOSKextLogKextBookkeepingFlag,
+            "Flushing info dictionaries for all kexts.");
+        CFDictionaryApplyFunction(__sOSKextsByURL,
+            __OSKextFlushInfoDictionaryApplierFunction, NULL);
+        flushingAll = false;
+    }
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSKextVersion OSKextGetVersion(OSKextRef aKext)
+{
+    return aKext->version;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSKextVersion OSKextGetCompatibleVersion(OSKextRef aKext)
+{
+    return aKext->compatibleVersion;
+}
+
+/*********************************************************************
+*********************************************************************/
+struct _uuid_stuff {
+    unsigned int   uuid_size;
+    char         * uuid;
+};
+
+macho_seek_result __OSKextUUIDCallback(
+    struct load_command * load_command,
+    const void * file_end,
+    uint8_t swap __unused,
+    void * user_data)
+{
+    struct _uuid_stuff * uuid_stuff = (struct _uuid_stuff *)user_data;
+    if (load_command->cmd == LC_UUID) {
+        struct uuid_command * uuid_command = (struct uuid_command *)load_command;
+        if (((void *)load_command + load_command->cmdsize) > file_end) {
+            return macho_seek_result_error;
+        }
+        uuid_stuff->uuid_size = sizeof(uuid_command->uuid);
+        uuid_stuff->uuid = (char *)uuid_command->uuid;
+        return macho_seek_result_found;
+    }
+    return macho_seek_result_not_found;
+}
+
+CFDataRef OSKextCopyUUIDForArchitecture(
+    OSKextRef          aKext,
+    const NXArchInfo * arch)
+{
+    CFDataRef                  result = NULL;
+    CFDataRef                  executable = NULL;  // must release
+    const struct mach_header * mach_header = NULL;
+    const void               * file_end;
+    macho_seek_result          seek_result;
+    struct _uuid_stuff         seek_uuid;
+    int swap = 0;
+
+    // xxx - would we want to cache this, is it going to be accessed a lot?
+
+    if (!arch) {
+        arch = OSKextGetArchitecture();
+    }
+
+    executable = OSKextCopyExecutableForArchitecture(aKext, arch);
+    if (!executable) {
+        goto finish;
+    }
+
+    mach_header = (const struct mach_header *)CFDataGetBytePtr(executable);
+    file_end = (((const char *)mach_header) + CFDataGetLength(executable));
+
+    if (ISSWAPPEDMACHO(MAGIC32(mach_header))) {
+        swap = 1;
+    }
+
+    seek_result = macho_scan_load_commands(
+        mach_header, file_end,
+        __OSKextUUIDCallback, (const void **)&seek_uuid);
+    if (seek_result == macho_seek_result_error) {
+        __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+            kOSKextDiagnosticExecutableBadKey);
+        goto finish;
+    } else if (seek_result != macho_seek_result_found) {
+        // ok for there to not be a uuid
+        goto finish;
+    }
+
+    result = CFDataCreate(CFGetAllocator(aKext), (u_char *)seek_uuid.uuid,
+        CondSwapInt32(swap, seek_uuid.uuid_size));
+
+finish:
+
+   /* Advise the system that we no longer need the mmapped executable.
+    */
+    if (executable) {
+        (void)posix_madvise((void *)CFDataGetBytePtr(executable),
+            CFDataGetLength(executable),
+            POSIX_MADV_DONTNEED);
+    }
+
+    SAFE_RELEASE(executable);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean  OSKextIsKernelComponent(OSKextRef aKext)
+{
+    return aKext->flags.isKernelComponent ? true : false;
+
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean  OSKextIsInterface(OSKextRef aKext)
+{
+    return aKext->flags.isInterface ? true : false;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean  OSKextIsLibrary(OSKextRef aKext)
+{
+    return (aKext->compatibleVersion > 0) ? true : false;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean  OSKextDeclaresExecutable(OSKextRef aKext)
+{
+    return aKext->flags.declaresExecutable ? true : false;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean  OSKextHasLogOrDebugFlags(OSKextRef aKext)
+{
+    return aKext->flags.plistHasEnableLoggingSet ||
+        aKext->flags.plistHasIOKitDebugFlags;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextIsLoggingEnabled(OSKextRef aKext)
+{
+    return aKext->flags.loggingEnabled;
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextSetLoggingEnabled(
+    OSKextRef aKext,
+    Boolean   flag)
+{
+    unsigned int oldValue = aKext->flags.loggingEnabled;
+
+    aKext->flags.loggingEnabled = flag ? 1 : 0;
+
+    if (oldValue != aKext->flags.loggingEnabled) {
+        char kextPath[PATH_MAX];
+        __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+            /* resolveToBase */ false, kextPath);
+        OSKextLog(aKext,
+            kOSKextLogDebugLevel | kOSKextLogKextBookkeepingFlag,
+            "Kext logging %sabled for %s.",
+            aKext->flags.loggingEnabled ? "en" : "dis",
+            kextPath);
+    }
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextIsLoadableInSafeBoot(OSKextRef aKext)
+{
+    return aKext->flags.isLoadableInSafeBoot ? true : false;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextDependenciesAreLoadableInSafeBoot(OSKextRef aKext)
+{
+    Boolean     result = true;
+    CFArrayRef  allDependencies = NULL;  // must release
+    CFIndex     count, i;
+
+    allDependencies = OSKextCopyAllDependencies(aKext,
+        /* needAll */ true);
+    if (!allDependencies) {
+        result = false;
+        goto finish;
+    }
+
+    count = CFArrayGetCount(allDependencies);
+    for (i = 0; i < count; i++) {
+        OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(
+            allDependencies, i);
+
+        if ((OSKextGetActualSafeBoot() || OSKextGetSimulatedSafeBoot()) &&
+            !OSKextIsLoadableInSafeBoot(thisKext)) {
+
+            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagBootLevel,
+                kOSKextDependencyIneligibleInSafeBoot,
+                OSKextGetIdentifier(thisKext), /* note */ NULL);
+            result = false;
+        }
+    }
+
+finish:
+    SAFE_RELEASE(allDependencies);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+const NXArchInfo ** OSKextCopyArchitectures(OSKextRef aKext)
+{
+    const NXArchInfo  ** result        = NULL;
+    const UInt8        * executable    = NULL;  // do not free
+    const UInt8        * executableEnd = NULL;  // do not free
+    fat_iterator         fatIterator   = NULL;  // must fat_iterator_close
+    char                 urlPath[PATH_MAX];
+    int                  numArches     = 0;
+    int                  resultSize    = 0;
+    struct mach_header * machHeader    = NULL;
+    uint32_t             index;
+
+    if (!OSKextDeclaresExecutable(aKext) || !__OSKextReadExecutable(aKext)) {
+        goto finish;
+    }
+
+    executable = CFDataGetBytePtr(aKext->loadInfo->executable);
+    executableEnd = executable + CFDataGetLength(aKext->loadInfo->executable);
+    fatIterator = fat_iterator_for_data(executable, executableEnd,
+        1 /* mach-o only */);
+
+    if (!fatIterator) {
+        __OSKextGetFileSystemPath(aKext,
+        /* otherURL */ _CFBundleCopyExecutableURLInDirectory(OSKextGetURL(aKext)),
+        /* resolveToBase */ false, urlPath);
+
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Can't read mach-o file %s.",
+            urlPath);
+        goto finish;
+    }
+
+    numArches = fat_iterator_num_arches(fatIterator);
+    resultSize = (1 + numArches) * sizeof(NXArchInfo *);
+    result = (const NXArchInfo **)malloc(resultSize);
+    if (!result) {
+        goto finish;
+    }
+    
+    bzero(result, resultSize);
+
+    index = 0;
+    for (index = 0;
+         (machHeader = (struct mach_header *)fat_iterator_next_arch(
+            fatIterator, NULL));
+         index++) {
+
+        int           swap       = ISSWAPPEDMACHO(machHeader->magic);
+        cpu_type_t    cputype    = CondSwapInt32(swap, machHeader->cputype);
+        cpu_subtype_t cpusubtype = CondSwapInt32(swap, machHeader->cpusubtype);
+        result[index] = NXGetArchInfoFromCpuType(cputype, cpusubtype);
+    }
+
+finish:
+   /* Advise the system that we no longer need the mmapped executable.
+    */
+    if (executable) {
+        (void)posix_madvise((void *)executable, executableEnd - executable,
+            POSIX_MADV_DONTNEED);
+    }
+    if (fatIterator) {
+        fat_iterator_close(fatIterator);
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextSupportsArchitecture(OSKextRef aKext,
+    const NXArchInfo * archInfo)
+{
+    Boolean       result = false;
+    CFDataRef     executable     = NULL;  // must release
+    fat_iterator  fatIterator    = NULL;  // must fat_iterator_close()
+    const UInt8 * exec           = NULL;  // do not free
+    void        * thinExec;
+    void        * thinExecEnd;
+
+    if (!OSKextDeclaresExecutable(aKext)) {
+        result = true;
+        goto finish;
+    }
+
+    if (!archInfo) {
+        archInfo = OSKextGetArchitecture();
+    }
+
+    if (!__OSKextReadExecutable(aKext)) {
+        goto finish;
+    }
+
+    if (aKext->staticFlags.isFromMkext) {
+        if (aKext->mkextInfo && aKext->mkextInfo->executable) {
+            executable = CFRetain(aKext->mkextInfo->executable);
+        }
+    } else {
+        if (aKext->loadInfo && aKext->loadInfo->executable) {
+            executable = CFRetain(aKext->loadInfo->executable);
+        }
+    }
+
+    if (!executable) {
+        goto finish;
+    }
+
+    exec = CFDataGetBytePtr(executable);
+    fatIterator = fat_iterator_for_data(exec,
+        exec + CFDataGetLength(executable), 1 /* mach-o only */);
+    if (!fatIterator) {
+        goto finish;
+    }
+    thinExec = fat_iterator_find_arch(fatIterator,
+        archInfo->cputype, archInfo->cpusubtype, &thinExecEnd);
+
+    if (!thinExec || (thinExec == thinExecEnd)) {
+        goto finish;
+    }
+
+    result = true;
+
+finish:
+   /* Advise the system that we no longer need the mmapped executable.
+    */
+    if (executable) {
+        (void)posix_madvise((void *)CFDataGetBytePtr(executable),
+            CFDataGetLength(executable),
+            POSIX_MADV_DONTNEED);
+    }
+
+    SAFE_RELEASE(executable);
+    if (fatIterator) fat_iterator_close(fatIterator);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCopyPlugins(OSKextRef aKext)
+{
+    CFArrayRef  result     = NULL;
+    CFBundleRef kextBundle = NULL;  // must release
+    CFURLRef    pluginsURL = NULL;  // must release
+    CFArrayRef  pluginURLs = NULL;   // must release
+
+   /* If aKext is a plugin, don't scan, and return an empty array.
+    */
+    if (OSKextIsPlugin(aKext)) {
+        result = CFArrayCreate(CFGetAllocator(aKext), NULL, 0,
+            &kCFTypeArrayCallBacks);
+        goto finish;
+    }
+
+    kextBundle = CFBundleCreate(kCFAllocatorDefault, aKext->bundleURL);
+    if (!kextBundle) {
+        goto finish;
+    }
+
+    pluginsURL = CFBundleCopyBuiltInPlugInsURL(kextBundle);
+    if (!pluginsURL) {
+        result = CFArrayCreateMutable(kCFAllocatorDefault, 0,
+            &kCFTypeArrayCallBacks);
+        goto finish;
+    }
+
+    result = __OSKextCreateKextsFromURL(kCFAllocatorDefault, pluginsURL,
+        aKext, /* createPlugins */ false);
+
+finish:
+    SAFE_RELEASE(kextBundle);
+    SAFE_RELEASE(pluginsURL);
+    SAFE_RELEASE(pluginURLs);
+    return result;
+}
+
+/*********************************************************************
+* OSKextIsPlugin uses a pretty naive algorithm: If any part of the
+* path leading to the kext is ".kext/", the kext must be a plugin
+* of some other kext.
+*********************************************************************/
+Boolean OSKextIsPlugin(OSKextRef aKext)
+{
+    Boolean     result     = false;
+    CFURLRef    absURL     = NULL;  // must release
+    CFURLRef    parentURL  = NULL;  // must release
+    CFStringRef parentPath = NULL;  // must release
+    CFRange     findRange;
+
+    if (aKext->staticFlags.isPluginChecked) {
+        result = aKext->staticFlags.isPlugin;
+        goto finish;
+    }
+
+    if (!aKext->bundleURL) {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel |
+            kOSKextLogGeneralFlag | kOSKextLogKextBookkeepingFlag,
+            "Bundle URL unexpectedly NULL!");
+        goto finish;
+    }
+
+    absURL = CFURLCopyAbsoluteURL(aKext->bundleURL);
+    if (!absURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    parentURL = CFURLCreateCopyDeletingLastPathComponent(
+        kCFAllocatorDefault, absURL);
+    if (!parentURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    parentPath = CFURLCopyFileSystemPath(parentURL, kCFURLPOSIXPathStyle);
+    if (!parentPath) {
+        OSKextLogMemError();
+    }
+    findRange = CFStringFind(parentPath, CFSTR(__sOSKextFullBundleExtension),
+        /* compareOptions */ 0);
+
+    aKext->staticFlags.isPlugin = (findRange.location == kCFNotFound) ? 0 : 1;
+    aKext->staticFlags.isPluginChecked = 1;
+
+    result = aKext->staticFlags.isPlugin;
+
+finish:
+    SAFE_RELEASE(absURL);
+    SAFE_RELEASE(parentURL);
+    SAFE_RELEASE(parentPath);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSKextRef OSKextCopyContainerForPluginKext(OSKextRef aKext)
+{
+    OSKextRef   result             = NULL;
+    CFURLRef    absURL             = NULL;  // must release
+    CFURLRef    parentURL          = NULL;  // must release
+    CFStringRef parentPath         = NULL;  // must release
+    CFStringRef containerPath      = NULL;  // must release
+    CFURLRef    containerURL       = NULL;  // must release
+    CFRange     findRange;
+    OSKextRef   potentialContainer = NULL;  // must release
+    CFBundleRef pContainerBundle   = NULL;  // must release
+    CFURLRef    pluginsURL         = NULL;  // must release
+    CFURLRef    checkURL           = NULL;  // must release
+    char        potentialContainerPath[PATH_MAX];
+    char        canonicalPath[PATH_MAX];
+    char        scratchPath[PATH_MAX];
+
+    if (aKext->staticFlags.isPluginChecked && !aKext->staticFlags.isPlugin) {
+        goto finish;
+    }
+
+    absURL = CFURLCopyAbsoluteURL(aKext->bundleURL);
+    if (!absURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    parentURL = CFURLCreateCopyDeletingLastPathComponent(
+        kCFAllocatorDefault, absURL);
+    if (!parentURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    parentPath = CFURLCopyFileSystemPath(parentURL, kCFURLPOSIXPathStyle);
+    if (!parentPath) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    findRange = CFStringFind(parentPath, CFSTR(__sOSKextFullBundleExtension),
+        kCFCompareBackwards);
+
+    aKext->staticFlags.isPlugin = (findRange.location == kCFNotFound) ? 0 : 1;
+    aKext->staticFlags.isPluginChecked = 1;
+
+    if (!aKext->staticFlags.isPlugin) {
+        goto finish;
+    }
+
+    containerPath = CFStringCreateWithSubstring(kCFAllocatorDefault,
+        parentPath, CFRangeMake(0, findRange.location + findRange.length));
+    if (!containerPath) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    if (!CFStringGetCString(containerPath, scratchPath, PATH_MAX,
+         kCFStringEncodingUTF8)) {
+
+        OSKextLogStringError(aKext);
+        goto finish;
+    }
+
+    containerURL = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault,
+        (const UInt8 *)scratchPath, strlen(scratchPath), true);
+    if (!containerURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    potentialContainer = OSKextCreate(kCFAllocatorDefault, containerURL);
+    if (!potentialContainer) {
+        // this may fail, but should we log it?
+        goto finish;
+    }
+    __OSKextGetFileSystemPath(potentialContainer, /* otherURL */ NULL,
+        /* resolveToBase */ false, potentialContainerPath);
+    OSKextLog(aKext, kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+        "Opening CFBundle for %s.", potentialContainerPath);
+    pContainerBundle = CFBundleCreate(kCFAllocatorDefault,
+        potentialContainer->bundleURL);
+    if (!pContainerBundle) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Failed to open CFBundle for %s.", potentialContainerPath);
+        goto finish;
+    }
+    pluginsURL = CFBundleCopyBuiltInPlugInsURL(pContainerBundle);
+    checkURL = CFURLCreateCopyAppendingPathComponent(kCFAllocatorDefault,
+        pluginsURL, CFURLCopyLastPathComponent(aKext->bundleURL), true);
+    if (!checkURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+   /* Sigh. CFURL is stupid with regard to CFEqual. We have to canonicalize
+    * the thing first.
+    * xxx - this might not be enough wrt .. and // and such
+    */
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, checkURL,
+        /* resolveToBase */ true, canonicalPath)) {
+
+        goto finish;
+    }
+    SAFE_RELEASE_NULL(checkURL);
+    checkURL = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault,
+        (uint8_t *)canonicalPath, strlen(canonicalPath), true);
+    if (!checkURL) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    if (CFEqual(absURL, checkURL)) {
+        result = (OSKextRef)CFRetain(potentialContainer);
+    }
+
+finish:
+    SAFE_RELEASE(absURL);
+    SAFE_RELEASE(parentURL);
+    SAFE_RELEASE(parentPath);
+    SAFE_RELEASE(containerPath);
+    SAFE_RELEASE(containerURL);
+    SAFE_RELEASE(potentialContainer);
+    if (pContainerBundle) {
+        OSKextLog(aKext,
+            kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+            "Releasing CFBundle for %s.",
+            potentialContainerPath);
+    }
+    SAFE_RELEASE(pContainerBundle);
+    SAFE_RELEASE(pluginsURL);
+    SAFE_RELEASE(checkURL);
+    return result;
+}
+
+
+/*********************************************************************
+*********************************************************************/
+typedef struct {
+    OSKextRef         kext;
+    CFMutableArrayRef personalities;
+} __OSKextPersonalityBundleIdentifierContext;
+
+static void __OSKextPersonalityBundleIdentifierApplierFunction(
+    const void * vKey,
+    const void * vValue,
+          void * vContext)
+{
+    CFStringRef            personalityName     = (CFStringRef)vKey;
+    CFMutableDictionaryRef personality         = (CFMutableDictionaryRef)vValue;
+    __OSKextPersonalityBundleIdentifierContext  * context =
+        (__OSKextPersonalityBundleIdentifierContext *)vContext;
+    OSKextRef              aKext               = context->kext;
+    CFMutableArrayRef      personalities       = context->personalities;
+    CFStringRef            bundleID            = NULL;  // do not release
+
+    CFMutableDictionaryRef personalityCopy     = NULL;  // must release
+    CFStringRef            personalityBundleID = NULL;  // do not release
+    char                   kextPath[PATH_MAX];
+    char                 * bundleIDCString     = NULL;  // must free
+    char                 * personalityCString  = NULL;  // must free
+
+    bundleID = OSKextGetIdentifier(aKext);
+    if (!bundleID) {
+        goto finish; // xxx - not much we can do, maybe log an error?
+    }
+
+   /* Make a copy of the personality, we may be modifying it and we want
+    * to leave the kext's copy alone.
+    */
+    personalityCopy = CFDictionaryCreateMutableCopy(CFGetAllocator(aKext),
+        0, personality);
+    if (!personalityCopy) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+   /* If the personality has no bundle identifier, insert that of the
+    * containing bundle. If is has one but it's not the same as the
+    * containing bundle's, insert that as the personality publisher.
+    */
+    personalityBundleID = CFDictionaryGetValue(personality,
+        kCFBundleIdentifierKey);
+    if (!personalityBundleID) {
+        CFDictionarySetValue(personalityCopy, kCFBundleIdentifierKey, bundleID);
+    } else if (!CFEqual(bundleID, personalityBundleID)) {
+        CFDictionarySetValue(personalityCopy, CFSTR(kIOPersonalityPublisherKey),
+            bundleID);
+    }
+
+   /* Spare the effort of creating the data when not logging by checking
+    * before the OSKextLog() call.
+    */
+    if (__OSKextShouldLog(aKext, kOSKextLogDetailLevel | kOSKextLogLoadFlag)) {
+        __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+            /* resolveToBase */ false, kextPath);
+        bundleIDCString = createUTF8CStringForCFString(bundleID);
+        personalityCString = createUTF8CStringForCFString(personalityName);
+        if (!personalityBundleID) {
+            OSKextLog(aKext,
+                kOSKextLogDetailLevel | kOSKextLogLoadFlag,
+                "Adding CFBundleIdentifier %s to %s personality %s.",
+                bundleIDCString, kextPath, personalityCString);
+        } else if (!CFEqual(bundleID, personalityBundleID)) {
+            OSKextLog(aKext,
+                kOSKextLogDetailLevel | kOSKextLogLoadFlag,
+                "Adding IOBundlePublisher %s to %s personality %s.",
+                bundleIDCString, kextPath, personalityCString);
+        }
+    }
+
+    CFArrayAppendValue(personalities, personalityCopy);
+
+finish:
+    SAFE_FREE(bundleIDCString);
+    SAFE_FREE(personalityCString);
+    SAFE_RELEASE(personalityCopy);
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCopyPersonalitiesArray(OSKextRef aKext)
+{
+    CFMutableArrayRef        result            = NULL;
+    CFDictionaryRef          personalities     = NULL; // do not release
+    __OSKextPersonalityBundleIdentifierContext context;
+
+    result = CFArrayCreateMutable(CFGetAllocator(aKext), 0,
+        &kCFTypeArrayCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    personalities = OSKextGetValueForInfoDictionaryKey(aKext,
+        CFSTR(kIOKitPersonalitiesKey));
+    if (!personalities || !CFDictionaryGetCount(personalities)) {
+        goto finish;
+    }
+
+    context.kext = aKext;
+    context.personalities = result;
+    CFDictionaryApplyFunction(personalities,
+        __OSKextPersonalityBundleIdentifierApplierFunction,
+        &context);
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCopyPersonalitiesOfKexts(CFArrayRef kextArray)
+{
+    CFMutableArrayRef result              = NULL;
+    CFDictionaryRef   kextPersonalities   = NULL; // do not release
+    __OSKextPersonalityBundleIdentifierContext context;
+    CFIndex           count, i;
+
+    if (!kextArray) {
+        pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+        kextArray = OSKextGetAllKexts();
+    }
+
+    result = CFArrayCreateMutable(CFGetAllocator(kextArray),
+        0, &kCFTypeArrayCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    context.personalities = result;
+
+    count = CFArrayGetCount(kextArray);
+    for (i = 0; i < count; i++) {
+        OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(kextArray, i);
+
+        kextPersonalities = OSKextGetValueForInfoDictionaryKey(thisKext,
+            CFSTR(kIOKitPersonalitiesKey));
+        if (!kextPersonalities || !CFDictionaryGetCount(kextPersonalities)) {
+            continue;
+        }
+        context.kext = thisKext;
+        CFDictionaryApplyFunction(kextPersonalities,
+            __OSKextPersonalityBundleIdentifierApplierFunction,
+            &context);
+    }
+
+finish:
+    return result;
+}
+
+
+/*********************************************************************
+*********************************************************************/
+typedef struct {
+    size_t length;
+} __OSKextMmapBufferInfo;
+
+void __OSKextDeallocateMmapBuffer(void * pointer, void * vInfo)
+{
+    __OSKextMmapBufferInfo * info = (__OSKextMmapBufferInfo *)vInfo;
+    munmap(pointer, info->length);
+    // need to log munmap under kOSKextLogFileAccessFlag w/path of file,
+    // store it in vInfo
+    free(info);
+    return;
+}
+
+/********************************************************************/
+CFDataRef __OSKextMapExecutable(
+    OSKextRef  aKext,
+    off_t      offset,
+    off_t      length);
+CFDataRef __OSKextMapExecutable(
+    OSKextRef  aKext,
+    off_t      offset,
+    off_t      length)
+{
+    CFDataRef                result                     = NULL;
+    int                      localErrno                 = 0;
+    char                     kextPath[PATH_MAX];
+    CFStringRef              executableName             = NULL;  // do not release
+    char                     executablePath[PATH_MAX];
+    struct stat              executableStat;
+    int                      executableFD               = -1;    // must close
+    void                   * executableBuffer           = NULL;  // munmap on error
+    __OSKextMmapBufferInfo * mmapAllocatorInfo          = NULL;  // free on error
+    CFAllocatorContext       mmapAllocatorContext;
+    CFAllocatorRef           mmapAllocator              = NULL;  // must release
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ true, kextPath);
+
+    if (!__OSKextCreateLoadInfo(aKext)) {
+        goto finish;
+    }
+
+    if (!aKext->loadInfo->executableURL) {
+        // xxx - this bit might warrant a kOSKextLogFileAccessFlag message
+        OSKextLog(aKext,
+            kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+            "Checking CFBundle of %s for executable URL.",
+            kextPath);
+        aKext->loadInfo->executableURL =
+            _CFBundleCopyExecutableURLInDirectory(OSKextGetURL(aKext));
+    }
+
+   /* Did we fail to get an executable URL, even though the kext has a
+    * CFBundleExecutable? Tag the kext with a diagnostic.
+    */
+    if (!aKext->loadInfo->executableURL) {
+        executableName = OSKextGetValueForInfoDictionaryKey(aKext,
+            kCFBundleExecutableKey);
+            
+        if (executableName) {
+            __OSKextAddDiagnostic(aKext,
+                kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticExecutableMissingKey,
+                executableName, /* note */ NULL);
+            goto finish;
+        }
+    }
+
+#if SHARED_EXECUTABLE
+   /* No executable URL? Check for a shared executable and nab
+    * a copy direct from the owning kext.
+    */
+    if (!aKext->loadInfo->executableURL) {
+        CFStringRef sharedExecutableIdentifier = NULL;  // do not release
+        sharedExecutableIdentifier = OSKextGetValueForInfoDictionaryKey(
+            aKext, CFSTR(kOSBundleSharedExecutableIdentifierKey));
+        if (sharedExecutableIdentifier) {
+
+            // xxx - does not handle multiple versions/duplicates!
+            OSKextRef sharedExecutableKext =
+                OSKextGetKextWithIdentifier(sharedExecutableIdentifier);
+            if (sharedExecutableKext) {
+                aKext->loadInfo->executableURL =
+                    _CFBundleCopyExecutableURLInDirectory(
+                        OSKextGetURL(sharedExecutableKext));
+            } else {
+                __OSKextAddDiagnostic(aKext,
+                    kOSKextDiagnosticsFlagValidation,
+                    kOSKextDiagnosticSharedExecutableKextMissingKey,
+                    sharedExecutableIdentifier, /* note */ NULL);
+                goto finish;
+            }
+        }
+    }
+#endif
+
+   /* We have no way of distinguishing whether the kext has no
+    * CFBundleExecutable vs. whether the call above failed, so
+    * just process when we do get an URL.
+    */
+    if (aKext->loadInfo->executableURL) {
+        if (!__OSKextGetFileSystemPath(/* kext */ NULL,
+            aKext->loadInfo->executableURL,
+            /* resolveToBase */ true, executablePath)) {
+
+            goto finish;
+        }
+
+        OSKextLog(aKext,
+            kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+            "Statting %s for map.",
+            executablePath);
+
+        if (-1 == stat(executablePath, &executableStat)) {
+            localErrno = errno;
+            if (localErrno == ENOENT) {
+                __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                    kOSKextDiagnosticExecutableMissingKey,
+                    executableName, /* note */ NULL);
+                __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                    kOSKextDiagnosticFileNotFoundKey,
+                    aKext->loadInfo->executableURL, /* note */ NULL);
+
+            } else {
+                __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                    kOSKextDiagnosticStatFailureKey,
+                    aKext->loadInfo->executableURL, /* note */ NULL);
+            }
+            OSKextLog(aKext,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Stat failed for %s - %s.",
+                executablePath, strerror(localErrno));
+            goto finish;
+        }
+
+        if (!length) {
+            length = executableStat.st_size;
+        } else if ((offset + length) > executableStat.st_size) {
+            OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Internal error; overrun mapping executable file %s.",
+                executablePath);
+            goto finish;
+        }
+
+        OSKextLog(aKext,
+            kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+            "Opening %s for map.",
+            executablePath);
+        executableFD = open(executablePath, O_RDONLY);
+        if (executableFD == -1) {
+            localErrno = errno;
+            if (localErrno == ENOENT) {
+                __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                    kOSKextDiagnosticExecutableMissingKey, executableName,
+                    /* note */ NULL);
+                __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                    kOSKextDiagnosticFileNotFoundKey,
+                    aKext->loadInfo->executableURL, /* note */ NULL);
+            } else {
+                __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                    kOSKextDiagnosticFileAccessKey,
+                    aKext->loadInfo->executableURL, /* note */ NULL);
+            }
+            OSKextLog(aKext,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Open failed for %s - %s.",
+                executablePath, strerror(localErrno));
+            goto finish;
+        }
+        
+       /* Must do MAP_PRIVATE here because the linker scribbles in the executable
+        * when doing a link.
+        * xxx - do we want MAP_NOCACHE here?
+        */
+        executableBuffer = mmap(/* addr */ NULL, length,
+            PROT_READ|PROT_WRITE, MAP_FILE|MAP_PRIVATE, executableFD, offset);
+        if (!executableBuffer) {
+            localErrno = errno;
+            
+           /* Only if we are mapping the executable as a whole, flag its
+            * absence as a validation error. It is never a validation failure
+            * for a given arch to not be present (you should check with
+            * OSKextSupportsArchitecture()).
+            */
+            if (length == 0) {
+                __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                    kOSKextDiagnosticFileAccessKey, aKext->loadInfo->executableURL,
+                    /* note */ NULL);
+                __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                    kOSKextDiagnosticExecutableMissingKey, executableName,
+                    /* note */ NULL);
+                aKext->flags.invalid = 1;
+                aKext->flags.valid = 0;
+            }
+
+            OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Failed to map executable file %s (offset %lu, %lu bytes) - %s.",
+                    executablePath, (unsigned long)offset, (unsigned long)length,
+                    strerror(localErrno));
+
+            goto finish;
+        }
+
+        OSKextLog(aKext, kOSKextLogDetailLevel | kOSKextLogFileAccessFlag,
+            "Mapped executable file %s (offset %lu, %lu bytes).",
+            executablePath, (unsigned long)offset, (unsigned long)length);
+
+        CFAllocatorGetContext(kCFAllocatorDefault, &mmapAllocatorContext);
+        mmapAllocatorInfo = (__OSKextMmapBufferInfo *)malloc(
+            sizeof(__OSKextMmapBufferInfo));
+        if (!mmapAllocatorInfo) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        mmapAllocatorInfo->length = length;
+        mmapAllocatorContext.info = mmapAllocatorInfo;
+        mmapAllocatorContext.deallocate = &__OSKextDeallocateMmapBuffer;
+        mmapAllocator = CFAllocatorCreate(kCFAllocatorDefault,
+            &mmapAllocatorContext);
+        if (!mmapAllocator) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        result = CFDataCreateWithBytesNoCopy(
+            CFGetAllocator(aKext), executableBuffer, length,
+            /* bytesDeallocator */ mmapAllocator);
+    }
+
+finish:
+    SAFE_RELEASE(mmapAllocator);
+    if (executableFD != -1) {
+        close(executableFD);
+    }
+
+    if (!result) {
+        SAFE_FREE(mmapAllocatorInfo);
+        if (executableBuffer) {
+            OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Error encountered, unmapping executable file %s (offset %lu, %lu bytes).",
+                executablePath, (unsigned long)offset, (unsigned long)length);
+            munmap(executableBuffer, length);
+        }
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextReadExecutable(OSKextRef aKext)
+{
+    Boolean                  result                     = false;
+
+    if (!OSKextDeclaresExecutable(aKext)) {
+        result = false;  // nothing to read
+        goto finish;
+    } else if (aKext->staticFlags.isFromMkext) {
+        if (aKext->mkextInfo && aKext->mkextInfo->executable) {
+            result = true;
+            goto finish;
+        } else {
+            CFNumberRef executableOffsetNum = NULL;  // do not release
+
+            if (!__OSKextCreateMkextInfo(aKext)) {
+                goto finish;
+            }
+
+// xxx - log a msg on kOSKextLogArchiveFlag ?
+
+           /* Do not use OSKextGetValueForInfoDictionaryKey() here,
+            * this isn't an arch-spefic prop.
+            */
+            executableOffsetNum = CFDictionaryGetValue(aKext->infoDictionary,
+                CFSTR(kMKEXTExecutableKey));
+            if (executableOffsetNum) {
+                aKext->mkextInfo->executable = __OSKextExtractMkext2FileEntry(
+                    aKext,
+                    aKext->mkextInfo->mkextData,
+                    executableOffsetNum,
+                    /* filename */ NULL);
+                if (!aKext->mkextInfo->executable) {
+                    __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                        kOSKextDiagnosticExecutableMissingKey,
+                        CFSTR("(executable from mkext)"), /* note */ NULL);
+                    aKext->flags.invalid = 1;
+                    aKext->flags.valid = 0;
+                    goto finish;
+                }
+            }
+
+            result = true;
+            goto finish;
+        }
+    } else {
+        if (aKext->loadInfo && aKext->loadInfo->executable) {
+            result = true;
+            goto finish;
+        } else {
+            if (!__OSKextCreateLoadInfo(aKext)) {
+                goto finish;
+            }
+
+            aKext->loadInfo->executable = __OSKextMapExecutable(aKext,
+                /* offset */ 0, /* length (0 => whole file) */ 0);
+            if (!aKext->loadInfo->executable) {
+                goto finish;
+            }
+        }
+    }
+
+    result = true;
+
+finish:
+   /* Most access to a Mach-O executable is going to be random, so advise
+    * the system about that.
+    */
+    if (aKext->loadInfo && aKext->loadInfo->executable) {
+        (void)posix_madvise(
+            (void *)CFDataGetBytePtr(aKext->loadInfo->executable),
+            CFDataGetLength(aKext->loadInfo->executable),
+            POSIX_MADV_RANDOM);
+    }
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDataRef OSKextCopyExecutableForArchitecture(
+    OSKextRef          aKext,
+    const NXArchInfo * archInfo)
+{
+    CFDataRef    result          = NULL;
+    CFBundleRef  kextBundle      = NULL;  // must release
+    CFURLRef     execURL         = NULL;  // must release
+    CFDataRef    executable      = NULL;  // must release
+    CFDataRef    thinExecutable  = NULL;  // must release
+    CFStringRef  archName        = NULL;  // must release
+    fat_iterator fatIterator     = NULL;  // must fat_iterator_close()
+    char         kextPath[PATH_MAX];
+
+    if (!__OSKextReadExecutable(aKext)) {
+        goto finish;
+    }
+
+    if (aKext->staticFlags.isFromMkext) {
+        if (aKext->mkextInfo && aKext->mkextInfo->executable) {
+            executable = CFRetain(aKext->mkextInfo->executable);
+        }
+    } else {
+        if (aKext->loadInfo && aKext->loadInfo->executable) {
+            executable = CFRetain(aKext->loadInfo->executable);
+        }
+    }
+
+    if (!executable) {
+        goto finish;
+    }
+
+    if (!archInfo) {
+
+        if (aKext->staticFlags.isFromMkext) {
+
+           /* Do not use CFDataCreateCopy(), it might just retain the
+            * data object. We need a distinct buffer. Because the linker
+            * might scribble in it.
+            */
+            result = CFDataCreate(CFGetAllocator(executable),
+                CFDataGetBytePtr(executable), CFDataGetLength(executable));
+        } else {
+           /* Map the executable separately from the main one in the kext.
+            * Again, we need to guarantee the copy semantic for real.
+            */
+            result = __OSKextMapExecutable(aKext,
+                /* offset */ 0,
+                /* length (0 => whole file) */ 0);
+        }
+    } else {
+        const UInt8 * exec        = CFDataGetBytePtr(executable);
+            void    * thinExec    = NULL;  // do not free
+            void    * thinExecEnd = NULL;  // do not free
+
+        fatIterator = fat_iterator_for_data(exec,
+            exec + CFDataGetLength(executable), 1 /* mach-o only */);
+        if (!fatIterator) {
+            __OSKextSetDiagnostic(aKext,
+                kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticExecutableBadKey);
+            goto finish;
+        }
+
+       /* If not from an mkext, we are going to mmap the thin executable
+        * if possible directly from the on-disk file, separately from
+        * the main executable held by the kext. If we can't mmap it because
+        * the alignment isn't at PAGE_SIZE, we'll FALL THROUGH to do it
+        * by copying a CFDataRef just like for an mkext.
+        */
+        if (!aKext->staticFlags.isFromMkext) {
+            struct fat_arch fatArchInfo;
+            
+            if (!fat_iterator_find_fat_arch(fatIterator,
+                archInfo->cputype, archInfo->cpusubtype, &fatArchInfo)) {
+
+                goto finish;
+            }
+            
+            if ((1 << fatArchInfo.align) == PAGE_SIZE) {
+                result = __OSKextMapExecutable(aKext,
+                    /* offset */ fatArchInfo.offset,
+                    /* length (0 => whole file) */ fatArchInfo.size);
+                goto finish;
+            }
+            // otherwise we FALL THROUGH here
+        }
+    
+        thinExec = fat_iterator_find_arch(fatIterator,
+            archInfo->cputype, archInfo->cpusubtype, &thinExecEnd);
+        if (thinExec) {
+            result = CFDataCreate(CFGetAllocator(aKext), thinExec,
+                thinExecEnd - thinExec);
+        }
+    }
+
+    if (!result) {
+        goto finish;
+    }
+    
+finish:
+    if (!result && archInfo && fatIterator) {
+
+        __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+            /* resolveToBase */ false, kextPath);
+
+        archName = CFStringCreateWithCString(
+            CFGetAllocator(aKext), archInfo->name,
+            kCFStringEncodingUTF8);
+        if (archName) {
+            __OSKextAddDiagnostic(aKext,
+                kOSKextDiagnosticsFlagWarnings,
+                kOSKextDiagnosticExecutableArchNotFoundKey,
+                archName, /* note */ NULL);
+        }
+    }
+
+    SAFE_RELEASE(archName);
+    SAFE_RELEASE(execURL);
+    SAFE_RELEASE(kextBundle);
+    SAFE_RELEASE(executable);
+    SAFE_RELEASE(thinExecutable);
+    if (fatIterator) fat_iterator_close(fatIterator);
+    return result;
+}
+
+/*********************************************************************
+* xxx - note that for mkext kexts, this won't get a non-boot resource
+* xxx - we don't want to go rooting around the system for it, do we?
+*********************************************************************/
+CFDataRef OSKextCopyResource(
+    OSKextRef   aKext,
+    CFStringRef resourceName,
+    CFStringRef resourceType)
+{
+    CFDataRef       result               = NULL;
+    CFDataRef       resource             = NULL;  // do not release
+    CFStringRef     resourceNamePlusType = NULL;  // must release
+    CFBundleRef     kextBundle           = NULL;  // must release
+    CFURLRef        resourceURL          = NULL;  // must release
+    SInt32          error;
+    char          * resourceCString      = NULL;  // must free
+    char            kextPath[PATH_MAX];
+    char            resourcePath[PATH_MAX];
+
+    if (!aKext->staticFlags.isFromMkext) {
+        __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+            /* resolveToBase */ false, kextPath);
+        OSKextLog(aKext, kOSKextLogDetailLevel | kOSKextLogFileAccessFlag,
+            "Opening CFBundle for %s.", kextPath);
+
+        kextBundle = CFBundleCreate(CFGetAllocator(aKext),
+            aKext->bundleURL);
+        if (!kextBundle) {
+            OSKextLog(aKext, kOSKextLogProgressLevel | kOSKextLogFileAccessFlag,
+                "Couldn't open CFBundle for %s.", kextPath);
+            goto finish;
+        }
+        resourceURL = CFBundleCopyResourceURL(kextBundle,
+            resourceName, resourceType, /* subdirName */ NULL);
+
+        if (!resourceURL) {
+            resourceCString = createUTF8CStringForCFString(resourceName);
+            OSKextLog(aKext, kOSKextLogProgressLevel | kOSKextLogFileAccessFlag,
+                "Couldn't read resource URL in %s for resource %s.",
+                kextPath, resourceCString);
+            goto finish;
+        }
+
+        __OSKextGetFileSystemPath(/* kext */ NULL, resourceURL,
+            /* resolveToBase */ false, resourcePath);
+        OSKextLog(aKext, kOSKextLogDetailLevel | kOSKextLogFileAccessFlag,
+            "Reading resource %s.", resourcePath);
+
+        if (!CFURLCreateDataAndPropertiesFromResource(CFGetAllocator(aKext),
+            resourceURL, &resource, NULL, NULL, &error)) {
+            // xxx - get error string from error
+            OSKextLog(aKext, kOSKextLogProgressLevel | kOSKextLogFileAccessFlag,
+                "Couldn't read resource file %s.",
+                resourcePath);
+            goto finish;
+        }
+    }
+
+    result = resource;
+
+finish:
+    if (resourceURL) {
+        OSKextLogSpec logLevel = kOSKextLogDebugLevel;
+        if (!result) {
+            logLevel = kOSKextLogProgressLevel;
+        }
+        OSKextLog(aKext, logLevel | kOSKextLogFileAccessFlag,
+            "Reading resource file %s%s.",
+            resourcePath,
+            result ? "" : " failed");
+    }
+
+    SAFE_RELEASE(resourceNamePlusType);
+    SAFE_RELEASE(resourceURL);
+    SAFE_FREE(resourceCString);
+
+    if (kextBundle) {
+        OSKextLog(aKext,
+            kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+            "Releasing CFBundle for %s.",
+            kextPath);
+    }
+    SAFE_RELEASE(kextBundle);
+    return result;
+}
+
+#ifndef IOKIT_EMBEDDED
+
+#define GET_CSTRING_PTR(the_cfstring, the_ptr, the_buffer, the_size) \
+do { \
+    the_ptr = CFStringGetCStringPtr(the_cfstring, kCFStringEncodingUTF8); \
+    if (the_ptr == NULL) { \
+        the_buffer[0] = 0x00; \
+        the_ptr = the_buffer;  \
+        CFStringGetCString(the_cfstring, the_buffer, the_size, kCFStringEncodingUTF8); \
+    } \
+} while(0)
+
+#define isWhiteSpace(c)	((c) == ' ' || (c) == '\t' || (c) == '\r' || (c) == '\n')
+
+/*********************************************************************
+ * OSKextIsInExcludeList checks to see if the given kext is in the 
+ * kext exclude list (com.apple.driver.KextExcludeList).  If useCache
+ * is TRUE, we will use the cached copy of the exclude list.
+ * If useCache is FALSE, we will refresh the cache from disk.  The 
+ * kext exclude list rarely changes but to insure you have the most 
+ * recent copy in the cache pass FALSE for the first call and TRUE for
+ * subsequent calls (when dealing with a large list of kexts).
+ * theKext can be NULL if you just want the invalidate the cache.
+ *********************************************************************/
+Boolean OSKextIsInExcludeList(OSKextRef theKext, Boolean useCache)
+{
+    Boolean             result              = false;
+    CFStringRef         kextID              = NULL;  // must release
+    OSKextRef           excludelistKext     = NULL;  // must release
+    CFDictionaryRef     excludelistDict     = NULL;  // do NOT release
+    static CFDictionaryRef myDictionary     = NULL;  // do NOT release
+ 
+    /* invalidate the cache or create it if not present */
+    if (useCache == false || myDictionary == NULL) {
+        if (myDictionary != NULL) {
+            SAFE_RELEASE_NULL(myDictionary);
+        }
+        kextID = CFStringCreateWithCString(kCFAllocatorDefault,
+                                           "com.apple.driver.KextExcludeList",
+                                           kCFStringEncodingUTF8);
+        if (!kextID) {
+            OSKextLogStringError(/* kext */ NULL);
+            goto finish;
+        }
+        
+        excludelistKext = OSKextCreateWithIdentifier(kCFAllocatorDefault,
+                                                     kextID);
+        if (!excludelistKext) {
+            OSKextLog(/* kext */ NULL,
+                      kOSKextLogWarningLevel | kOSKextLogGeneralFlag,
+                      "Warning: %s could not find com.apple.driver.KextExcludeList",
+                      __FUNCTION__);
+            goto finish;
+        }
+        
+        excludelistDict = OSKextGetValueForInfoDictionaryKey(
+                                                excludelistKext,
+                                                CFSTR("OSKextExcludeList"));
+        if (!excludelistDict) {
+            OSKextLog(/* kext */ NULL,
+                      kOSKextLogErrorLevel | kOSKextLogGeneralFlag,
+                      "%s could not get excludelistDict",
+                      __FUNCTION__);
+            goto finish;
+        }
+        
+        if ((unsigned int)CFDictionaryGetCount(excludelistDict) > 0) {
+            myDictionary = CFDictionaryCreateCopy(NULL, excludelistDict);
+        }
+        if (myDictionary == NULL) {
+            OSKextLogMemError();
+            goto finish;
+       }
+    }
+    
+    /*********************************************************************
+     * myDictionary is a dictionary with keys / values of:
+     *  key = bundleID string of kext we will not allow to load
+     *  value = version string(s) of kexts to not load.
+     *      The version strings can be comma delimited.  For example if kext
+     *      com.foocompany.fookext has two versions that we want to deny
+     *      adding to kernel cache then the version strings might look like:
+     *      1.0.0, 1.0.1
+     *      If the current fookext has a version of 1.0.0 OR 1.0.1 we will
+     *      not add the kext to the kernel cache.
+     *
+     *      Value may also be in the form of "LE 2.0.0" (version numbers
+     *      less than or equal to 2.0.0 will not load) or "LT 2.0.0" (version
+     *      number less than 2.0.0 will not load).
+     *      NOTE - we cannot use the characters "<=" or "<" because code in the
+     *      kernel that serializes plists treats '<' as a special character.
+     *********************************************************************/
+    if (theKext != NULL) {
+        CFStringRef     bundleID                = NULL;  // do NOT release
+        CFStringRef     excludedKextVersString  = NULL;  // do NOT release
+        OSKextVersion   kextVers                = -1;
+        const char *    versCString             = NULL;  // do not free
+        size_t          i, j;
+        Boolean         wantLessThan            = FALSE;
+        Boolean         wantLessThanEqualTo     = FALSE;
+        char            versBuffer[256];
+        
+        bundleID = OSKextGetIdentifier(theKext);
+        if (!bundleID) {
+            OSKextLog(/* kext */ NULL,
+                      kOSKextLogErrorLevel | kOSKextLogGeneralFlag,
+                      "%s could not get bundleID",
+                      __FUNCTION__);
+            goto finish;
+        }
+        
+        kextVers = OSKextGetVersion(theKext);
+        if (!kextVers) {
+            OSKextLog(/* kext */ NULL,
+                      kOSKextLogErrorLevel | kOSKextLogGeneralFlag,
+                      "%s could not get kextVers",
+                      __FUNCTION__);
+            goto finish;
+        }
+        
+        excludedKextVersString = CFDictionaryGetValue(myDictionary, bundleID);
+        if (!excludedKextVersString) {
+            goto finish;
+        }
+        
+        /* parse version strings */
+        GET_CSTRING_PTR(excludedKextVersString,
+                        versCString,
+                        versBuffer,
+                        sizeof(versBuffer));
+        if (strlen(versCString) < 1) {
+            goto finish;
+        }
+        /* look for "LT" or "LE" form of version string, must be in first two
+         * positions.
+         */
+        if (strlen(versCString) > 1) {
+            if (*versCString == 'L' && *(versCString + 1) == 'T') {
+                wantLessThan = true;
+                versCString +=2;
+            }
+            else if (*versCString == 'L' && *(versCString + 1) == 'E') {
+                wantLessThanEqualTo = true;
+                versCString +=2;
+            }
+        }
+        
+        for (i = 0, j = 0; i < strlen(versCString) + 1; i++) {
+            Boolean         excludeIt = FALSE;
+            char            myBuffer[32];
+            
+            /* skip whitespace */
+            if ( isWhiteSpace(*(versCString + i)) ) {
+                continue;
+            }
+            
+            /* look for version string separator or null terminator */
+            if (*(versCString + i) == ',' ||
+                *(versCString + i) == 0x00) {
+                
+                /* OK, we have a version string */
+                myBuffer[j] = 0x00;
+ 
+                OSKextVersion excludedKextVers;
+                excludedKextVers = OSKextParseVersionString(myBuffer);
+                
+                if (wantLessThanEqualTo) {
+                    if (kextVers <= excludedKextVers) {
+                        excludeIt = TRUE;
+                    }
+                }
+                else if (wantLessThan) {
+                    if (kextVers < excludedKextVers) {
+                        excludeIt = TRUE;
+                    }
+                }
+                else if (kextVers == excludedKextVers)  {
+                    excludeIt = TRUE;
+                }
+                
+                if (excludeIt) {
+#if 0
+                    const char *    cp;
+                    char            tempBuffer[256];
+                    
+                    GET_CSTRING_PTR(bundleID, cp, tempBuffer, sizeof(tempBuffer));
+                    OSKextLog(/* kext */ NULL,
+                              kOSKextLogErrorLevel | kOSKextLogArchiveFlag |
+                              kOSKextLogValidationFlag | kOSKextLogGeneralFlag,
+                              "bundleID \"%s\" %lld is in exclude list %lld",
+                              cp, kextVers, excludedKextVers);
+#endif
+                    
+                    result = true;
+                    goto finish;
+                }
+                
+                /* now move to the next (if any) version string */
+                j = 0;
+                wantLessThan = FALSE;
+                wantLessThanEqualTo = FALSE;
+            }
+            else {
+                /* save valid version character */
+                myBuffer[j++] = *(versCString + i);
+                
+                /* make sure bogus version string doesn't overrun local buffer */
+                if ( j >= sizeof(myBuffer) ) {
+                    break; /* bogus form of version string */
+                }
+            }
+        }
+    }
+    
+finish:
+    SAFE_RELEASE(kextID);
+    SAFE_RELEASE(excludelistKext);
+    return result;
+}
+#endif /* !IOKIT_EMBEDDED */
+
+#pragma mark Dependency Resolution
+/*********************************************************************
+* Dependency Resolution
+*********************************************************************/
+Boolean __OSKextHasAllDependencies(OSKextRef aKext)
+{
+    if (aKext->flags.isKernelComponent ||
+        (aKext->loadInfo && aKext->loadInfo->flags.hasAllDependencies)) {
+
+        return true;
+    }
+    return false;
+}
+
+/*********************************************************************
+*********************************************************************/
+// return should be OSReturn
+Boolean __OSKextResolveDependencies(
+    OSKextRef         aKext,
+    OSKextRef         rootKext,
+    CFMutableSetRef   resolvedSet,
+    CFMutableArrayRef loopStack)
+{
+    Boolean         result               = false;
+    Boolean         error                = false;
+    Boolean         addedToLoopStack     = false;
+    CFDictionaryRef declaredDependencies = NULL;  // do not release
+    CFStringRef   * libIDs               = NULL;  // must free
+    CFStringRef   * libVersions          = NULL;  // must free
+    char          * libIDCString         = NULL;  // must free
+    char            kextPath[PATH_MAX];
+    char            dependencyPath[PATH_MAX];
+    CFIndex         count = 0, i = 0;
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+
+    if (!__OSKextReadInfoDictionary(aKext, /* bundle */ NULL) ||
+        !aKext->infoDictionary) {
+
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+            "%s has no info dictionary; can't resolve dependencies.",
+            kextPath);
+        goto finish;
+    }
+    
+   /* If the kext is invalid, it's best not to try to resolve personalities.
+    * I suppose we could add a flag bit specifically covering whether the
+    * CFBundleVersion, OSBundleCompatibleVersion, and OSBundleLibraries
+    * properties are kosher, but really the developer should just fix the
+    * validation problems before doing more.
+    */
+    if (!__OSKextIsValid(aKext)) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+            "%s is invalid; can't resolve dependencies.",
+            kextPath);
+        goto finish;
+    }
+
+   /* If we've already done resolution for aKext on this run
+    * through the graph, we shouldn't repeat the work.
+    */
+    if (CFSetContainsValue(resolvedSet, aKext)) {
+        OSKextLog(aKext, kOSKextLogDebugLevel | kOSKextLogDependenciesFlag,
+            "%s already has dependencies resolved.", kextPath);
+        result = true;
+        goto finish;
+    }
+
+    // xxx - this looks silly being printed for kernel components
+    if (!OSKextIsKernelComponent(aKext)) {
+        OSKextLog(aKext, kOSKextLogStepLevel | kOSKextLogDependenciesFlag,
+            "Resolving dependencies for %s.", kextPath);
+    }
+
+    if (CFArrayGetCountOfValue(loopStack, RANGE_ALL(loopStack), aKext)) {
+        __OSKextAddDiagnostic(rootKext, kOSKextDiagnosticsFlagDependencies,
+            kOSKextDependencyCircularReference, aKext->bundleID, /* note */ NULL);
+        __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagDependencies,
+            kOSKextDependencyCircularReference, aKext->bundleID, /* note */ NULL);
+        goto finish;
+    }
+
+    CFArrayAppendValue(loopStack, aKext);
+    addedToLoopStack = true;
+
+    OSKextFlushDependencies(aKext);
+    if (!__OSKextCreateLoadInfo(aKext)) {
+        goto finish;
+    }
+
+   /* Other code expects the array to exist, even for a kernel component.
+    */
+    aKext->loadInfo->dependencies = CFArrayCreateMutable(
+        CFGetAllocator(aKext), 0, &kCFTypeArrayCallBacks);
+    if (!aKext->loadInfo->dependencies) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+   /* If we got this far we've confirmed it's a dictionary.
+    */
+    declaredDependencies = (CFDictionaryRef)OSKextGetValueForInfoDictionaryKey(
+        aKext, CFSTR(kOSBundleLibrariesKey));
+
+    // xxx - I think we need to allow for no dependencies, and link direct
+    // xxx - on the kernel?
+
+   /* No more work to do for a kernel component!
+    */
+    if (OSKextIsKernelComponent(aKext)) {
+        if (aKext == rootKext) {
+            OSKextLog(aKext, kOSKextLogDependenciesFlag,
+                "%s is a kernel component with no dependencies.", kextPath);
+        }
+        result = true;
+        goto finish;
+    }
+
+    if (declaredDependencies) {
+        count = CFDictionaryGetCount(declaredDependencies);
+        if (count) {
+            libIDs = (CFStringRef *)malloc(count * sizeof(CFStringRef));
+            libVersions = (CFStringRef *)malloc(count * sizeof(CFStringRef));
+            if (!libIDs || !libVersions) {
+                OSKextLogMemError();
+                goto finish;
+            }
+            CFDictionaryGetKeysAndValues(declaredDependencies,
+                (const void **)libIDs, (const void **)libVersions);
+        }
+    }
+
+    for (i = 0; i < count; i++) {
+        CFStringRef   libID                        = libIDs[i];
+        CFStringRef   libVersion                   = libVersions[i];
+        OSKextVersion requestedVersion             = OSKextParseVersionCFString(libVersion);
+        OSKextRef     dependency                   = NULL;
+        Boolean       loaded                       = false;
+        Boolean       compatible                   = false;
+
+        // xxx - need to check types of libID & libVersion, log error, add diagnostic
+
+        SAFE_FREE_NULL(libIDCString);
+        libIDCString = createUTF8CStringForCFString(libID);
+
+       /* Look first for a dependency that's loaded and see if it's compatible.
+        * If we don't do that look up or don't find one, search in all kexts.
+        *
+        * If the client doesn't want to require resoution against loaded
+        * kexts, they should not call OSKextReadLoadedKextInfo() before calling
+        * in here, or they should call OSKextFlushLoadInfo(NULL) before calling
+        * in here.
+        */
+        dependency = OSKextGetLoadedKextWithIdentifier(libID);
+        if (dependency) {
+            loaded = true;
+            compatible = OSKextIsCompatibleWithVersion(dependency,
+                requestedVersion);
+
+            if (!compatible) {
+                char requestedVersionCString[kOSKextVersionMaxLength];
+                char actualVersionCString[kOSKextVersionMaxLength];
+                
+                OSKextVersionGetString(requestedVersion,
+                    requestedVersionCString, sizeof(requestedVersionCString));
+                OSKextVersionGetString(OSKextGetVersion(dependency),
+                    actualVersionCString, sizeof(actualVersionCString));
+
+                if (OSKextGetCompatibleVersion(dependency) > 0) {
+                    OSKextLog(aKext,
+                        kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+                        "%s - loaded dependency %s, v%s is "
+                        "not compatible with requested version %s.",
+                        kextPath, libIDCString,
+                        actualVersionCString, requestedVersionCString);
+                    __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagDependencies,
+                        kOSKextDependencyLoadedIsIncompatible, libID, /* note */ NULL);
+                } else {
+                    OSKextLog(aKext,
+                        kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+                        "%s - loaded dependency %s lacks valid OSBundleCompatibleVersion.",
+                        kextPath, libIDCString);
+                    __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagDependencies,
+                        kOSKextDependencyLoadedCompatibleVersionUndeclared, libID, /* note */ NULL);
+                }
+                error = true;
+                continue;
+            }
+        } else {
+            dependency = OSKextGetCompatibleKextWithIdentifier(libID,
+                requestedVersion);
+            if (dependency) {
+                compatible = true;
+            }
+        }
+
+        if (CFEqual(libID, __kOSKextKernelLibBundleID)) {
+            aKext->loadInfo->flags.hasRawKernelDependency = 1;
+        } else if (CFStringHasPrefix(libID, __kOSKextKernelLibPrefix)) {
+            aKext->loadInfo->flags.hasKernelDependency = 1;
+        } else if (CFStringHasPrefix(libID, __kOSKextKPIPrefix)) {
+            aKext->loadInfo->flags.hasKPIDependency = 1;
+            if (CFEqual(libID, __kOSKextPrivateKPI)) {
+                aKext->loadInfo->flags.hasPrivateKPIDependency = 1;
+            }
+        }
+
+       /* If we got a usable dependency, add it to the list. Otherwise
+        * dig a little more for a proper diagnostic.
+        */
+        if (dependency) {
+            Boolean kernelComponent = OSKextIsKernelComponent(dependency);
+
+            __OSKextGetFileSystemPath(dependency, /* otherURL */ NULL,
+                /* resolveToBase */ false, dependencyPath);
+            OSKextLog(aKext, kOSKextLogDetailLevel | kOSKextLogDependenciesFlag,
+                "%s found %s%sdependency %s for %s%s.",
+                kextPath,
+                compatible ? "compatible " : "incompatible ",
+                loaded ? "loaded " : "",
+                dependencyPath, libIDCString,
+                kernelComponent ? " (kernel component)" : "");
+
+           CFArrayAppendValue(aKext->loadInfo->dependencies, dependency);
+        } else {
+
+            dependency = OSKextGetKextWithIdentifier(libID);
+            if (dependency) {
+                if (OSKextGetCompatibleVersion(dependency) > 0) {
+                    OSKextLog(aKext,
+                        kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+                        "%s - no compatible dependency found for %s.",
+                        kextPath, libIDCString);
+                    __OSKextAddDiagnostic(aKext,
+                        kOSKextDiagnosticsFlagDependencies,
+                        kOSKextDependencyNoCompatibleVersion, libID, /* note */ NULL);
+                } else {
+                    OSKextLog(aKext,
+                        kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+                        "%s - dependency for %s lacks valid OSBundleCompatibleVersion.",
+                        kextPath, libIDCString);
+                    __OSKextAddDiagnostic(aKext,
+                        kOSKextDiagnosticsFlagDependencies,
+                        kOSKextDependencyCompatibleVersionUndeclared, libID, /* note */ NULL);
+                }
+            } else {
+                OSKextLog(aKext,
+                    kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+                    "%s - no dependency found for %s.",
+                    kextPath, libIDCString);
+                __OSKextAddDiagnostic(aKext,
+                    kOSKextDiagnosticsFlagDependencies,
+                    kOSKextDependencyUnavailable, libID, /* note */ NULL);
+            }
+            error = true;
+            continue;
+        }
+    }
+
+    if (aKext->loadInfo->flags.hasRawKernelDependency) {
+        __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagDependencies,
+            kOSKextDiagnosticRawKernelDependency);
+        error = true;
+    }
+
+   /* Interface kexts must have exactly one dependency.
+    */
+    if (OSKextIsInterface(aKext) && 
+        CFArrayGetCount(aKext->loadInfo->dependencies) != 1) 
+    {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+            "%s - Interface kext must have exactly one dependency.",
+            kextPath);
+        __OSKextSetDiagnostic(aKext,
+            kOSKextDiagnosticsFlagDependencies,
+            kOSKextDiagnosticsInterfaceDependencyCount);
+        error = true;
+    }
+
+   /* Now that we've resolved aKext's dependencies, go through and
+    * resolve the dependencies of the dependencies recursively.
+    * Keep this in post-order for sanity with the logging.
+    */
+    count = CFArrayGetCount(aKext->loadInfo->dependencies);
+    for (i = 0; i < count; i++) {
+        OSKextRef dependency = (OSKextRef)CFArrayGetValueAtIndex(
+            aKext->loadInfo->dependencies, i);
+        CFStringRef libID = OSKextGetIdentifier(dependency);
+
+        if (!__OSKextResolveDependencies(dependency, rootKext, resolvedSet,
+            loopStack)) {
+
+            CFIndex stackCount, stackIndex;
+
+            stackCount = CFArrayGetCount(loopStack);
+            for (stackIndex = 0; stackIndex < stackCount; stackIndex++) {
+                OSKextRef stackKext = (OSKextRef)CFArrayGetValueAtIndex(
+                    loopStack, stackIndex);
+                __OSKextAddDiagnostic(stackKext,
+                    kOSKextDiagnosticsFlagDependencies,
+                    kOSKextDependencyIndirectDependencyUnresolvable,
+                    libID, /* note */ NULL);
+            }
+            error = true;
+        }
+    }
+
+    /* On 64-bit, we require that a kext explicitly list its dependencies
+     * through KPIs only. This means that while it is not an error not to link
+     * against any kernel components, we also won't implicitly link the kext
+     * against the kernel.
+     *
+     * On 32-bit, a kext (with an executable) that doesn't declare any kernel
+     * dependencies is linked against the full kernel.
+     */
+    if (__OSKextIsArchitectureLP64()) {
+        if (OSKextDeclaresExecutable(aKext) && OSKextSupportsArchitecture(aKext, OSKextGetArchitecture())) {
+            if (aKext->loadInfo->flags.hasKernelDependency) {
+
+                __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagDependencies,
+                    kOSKextDiagnosticDeclaresNonKPIDependenciesKey);
+
+                goto finish;
+            }
+
+            if (!aKext->loadInfo->flags.hasKPIDependency) {
+                __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+                    kOSKextDiagnosticDeclaresNoKPIsWarningKey);
+            }
+        }
+    } else {
+        if (OSKextDeclaresExecutable(aKext) &&
+            !aKext->loadInfo->flags.hasKernelDependency &&
+            !aKext->loadInfo->flags.hasKPIDependency) {
+
+            OSKextLog(aKext,
+                kOSKextLogWarningLevel | kOSKextLogDependenciesFlag,
+                "%s does not declare a kernel dependency; using %s.",
+                kextPath, __kOSKextCompatibilityBundleID);
+
+            OSKextRef kernel6 = OSKextGetKextWithIdentifier(
+                CFSTR(__kOSKextCompatibilityBundleID));
+
+            if (!kernel6) {
+                OSKextLog(aKext,
+                    kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+                    "%s - no dependency found for %s.",
+                    kextPath, __kOSKextCompatibilityBundleID);
+                goto finish;
+            }
+
+            CFArrayAppendValue(aKext->loadInfo->dependencies, kernel6);
+
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+                kOSKextDiagnosticNoExplicitKernelDependencyKey);
+        }
+
+        if (aKext->loadInfo->flags.hasKPIDependency &&
+            aKext->loadInfo->flags.hasKernelDependency) {
+
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+                kOSKextDiagnosticDeclaresBothKernelAndKPIDependenciesKey);
+        }
+    }
+
+#ifndef IOKIT_EMBEDDED
+    /* If the kext links against the private KPI, we want to make an effort
+     * to ensure they are Apple-internal kexts.  We do this by verifying that
+     * the kext's bundle identifier begins with "com.apple.", and by making
+     * sure the kext's info dictionary contains an Apple copyright string
+     * in either CFBundleGetInfoString (obsolete) or NSHumanReadableCopyright.
+     */
+
+    if (aKext->loadInfo->flags.hasPrivateKPIDependency)
+    {
+        CFStringRef     infoString                  = NULL;  // do not release
+        CFStringRef     readableString              = NULL;  // do not release
+        Boolean         hasApplePrefix              = false;
+        Boolean         infoCopyrightIsValid        = false;
+        Boolean         readableCopyrightIsValid    = false;
+
+        hasApplePrefix = CFStringHasPrefix(aKext->bundleID, __kOSKextApplePrefix);
+
+        infoString = (CFStringRef) OSKextGetValueForInfoDictionaryKey(aKext,
+            CFSTR("CFBundleGetInfoString"));
+        if (infoString) {
+            char *infoCString = createUTF8CStringForCFString(infoString);
+            infoCopyrightIsValid = kxld_validate_copyright_string(infoCString);
+            SAFE_FREE(infoCString);
+        }
+
+        readableString = (CFStringRef) OSKextGetValueForInfoDictionaryKey(aKext,
+            CFSTR("NSHumanReadableCopyright"));
+        if (readableString) {
+            char *readableCString = createUTF8CStringForCFString(readableString);
+            readableCopyrightIsValid = 
+                kxld_validate_copyright_string(readableCString);
+            SAFE_FREE(readableCString);
+        }
+
+        if (!hasApplePrefix || (!infoCopyrightIsValid && !readableCopyrightIsValid)) {
+
+            OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+                "%s has an Apple prefix but no copyright.", kextPath);
+
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagDependencies,
+                kOSKextDiagnosticNonAppleKextDeclaresPrivateKPIDependencyKey);
+            result = false;
+            goto finish;
+        }
+    }
+#endif /* !IOKIT_EMBEDDED */
+
+    if (!error) {
+        result = true;
+    }
+    
+finish:
+    SAFE_FREE(libIDCString);
+    SAFE_FREE(libIDs);
+    SAFE_FREE(libVersions);
+
+    if (result && aKext->loadInfo) {
+        aKext->loadInfo->flags.hasAllDependencies = 1;
+    }
+
+   /* Whether successful or not, we've done resolution.
+    */
+    CFSetAddValue(resolvedSet, aKext);
+
+    if (addedToLoopStack) {
+        CFArrayRemoveValueAtIndex(loopStack, CFArrayGetCount(loopStack) - 1);
+    }
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+typedef struct {
+    Boolean result;
+} __OSKextResolveDependenciesContext;
+
+static void __OSKextResolveDependenciesApplierFunction(
+    const void * vKey __unused,
+    const void * vValue,
+          void * vContext)
+{
+    OSKextRef aKext    = (OSKextRef)vValue;
+    Boolean   resolved = false;
+    __OSKextResolveDependenciesContext * context =
+        (__OSKextResolveDependenciesContext *)vContext;
+
+    resolved = OSKextResolveDependencies(aKext);
+    if (!resolved) {
+       context->result = false;
+    }
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextResolveDependencies(OSKextRef aKext)
+{
+    Boolean           result       = false;
+    CFMutableSetRef   resolvedSet  = NULL;  // must release
+    CFMutableArrayRef loopStack    = NULL;  // must release
+    CFArrayRef        loadList     = NULL;  // must release
+    CFStringRef       kextID       = NULL;  // do not release
+    CFIndex           count, i, j;
+    char              kextPath[PATH_MAX];
+
+    resolvedSet = CFSetCreateMutable(
+        CFGetAllocator(aKext), 0, &kCFTypeSetCallBacks);
+    loopStack = CFArrayCreateMutable(
+        CFGetAllocator(aKext), 0, &kCFTypeArrayCallBacks);
+    if (!resolvedSet || !loopStack) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    if (aKext) {
+        if (__OSKextHasAllDependencies(aKext)) {
+            __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+                /* resolveToBase */ false, kextPath);
+            OSKextLog(aKext,
+                kOSKextLogDebugLevel | kOSKextLogDependenciesFlag,
+                "%s - dependencies already resolved.", kextPath);
+
+            result = true;
+            goto finish;
+        }
+        result = __OSKextResolveDependencies(aKext, aKext, resolvedSet,
+            loopStack);
+
+       /* If we got a full dependency graph, check it for multiple instances
+        * of kexts with the same ID. No need to check version or UUID, if
+        * it's two separate objects, that's bad. Note we only do this for the
+        * root kext being resolved, it's probably too expensive to do for all.
+        */
+        if (result) {
+            CFStringRef required                   = NULL;  // do not release
+            Boolean     checkRootOrConsoleRequired = FALSE;
+            Boolean     checkLocalRequired         = FALSE;
+            Boolean     checkNetworkRequired       = FALSE;
+
+            loadList = OSKextCopyLoadList(aKext, /* needAll */ true);
+            if (!loadList) {
+                result = false;
+                goto finish;
+            }
+
+           /* If the kext we are resolving has OSBundleRequired set,
+            * we are going to check all its dependencies to see
+            * if they will be available during early boot.
+            */
+            required = OSKextGetValueForInfoDictionaryKey(aKext, CFSTR(kOSBundleRequiredKey));
+            if (required) {
+                if (CFEqual(required, CFSTR(kOSBundleRequiredRoot)) ||
+                    CFEqual(required, CFSTR(kOSBundleRequiredConsole))) {
+                    
+                    checkRootOrConsoleRequired = TRUE;
+                } else if (CFEqual(required, CFSTR(kOSBundleRequiredLocalRoot))) {
+                    checkLocalRequired = TRUE;
+                } else if (CFEqual(required, CFSTR(kOSBundleRequiredNetworkRoot))) {
+                    checkNetworkRequired = TRUE;
+                }
+            }
+
+            count = CFArrayGetCount(loadList);
+            for (i = 0; i < count; i++) {
+                OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(
+                    loadList, i);
+                CFStringRef thisRequired = OSKextGetValueForInfoDictionaryKey(thisKext,
+                    CFSTR(kOSBundleRequiredKey));
+
+                kextID = OSKextGetIdentifier(thisKext);
+
+               /* Root and Console are good to go for any OSBundleRequired except
+                * Safe Boot. We can assume the kext is valid here and therefore
+                * that its OSBundleRequired is a required value.
+                */
+                if (checkRootOrConsoleRequired) {
+                    if (!thisRequired ||
+                        CFEqual(CFSTR(kOSBundleRequiredSafeBoot), thisRequired)) {
+                        
+                            __OSKextAddDiagnostic(aKext,
+                                kOSKextDiagnosticsFlagWarnings,
+                                kOSKextDiagnosticsDependencyNotOSBundleRequired,
+                                kextID,
+                                /* note */ thisRequired ? thisRequired : CFSTR("OSBundleRequired not set"));
+                        }
+                }
+
+                if (checkLocalRequired) {
+                    if (!thisRequired ||
+                        !(CFEqual(CFSTR(kOSBundleRequiredRoot), thisRequired) ||
+                          CFEqual(CFSTR(kOSBundleRequiredLocalRoot), thisRequired) ||
+                          CFEqual(CFSTR(kOSBundleRequiredConsole), thisRequired))) {
+                        
+                            __OSKextAddDiagnostic(aKext,
+                                kOSKextDiagnosticsFlagWarnings,
+                                kOSKextDiagnosticsDependencyNotOSBundleRequired,
+                                kextID,
+                                /* note */ thisRequired ? thisRequired : CFSTR("OSBundleRequired not set"));
+                        }
+                }
+
+                if (checkNetworkRequired) {
+                    if (!thisRequired ||
+                        !(CFEqual(CFSTR(kOSBundleRequiredRoot), thisRequired) ||
+                         CFEqual(CFSTR(kOSBundleRequiredNetworkRoot), thisRequired) ||
+                         CFEqual(CFSTR(kOSBundleRequiredConsole), thisRequired))) {
+                        
+                            __OSKextAddDiagnostic(aKext,
+                                kOSKextDiagnosticsFlagWarnings,
+                                kOSKextDiagnosticsDependencyNotOSBundleRequired,
+                                kextID,
+                                /* note */ thisRequired ? thisRequired : CFSTR("OSBundleRequired not set"));
+                        }
+                }
+
+                for (j = i+1; j < count; j++) {
+                    OSKextRef thatKext = (OSKextRef)CFArrayGetValueAtIndex(
+                        loadList, j);
+                    if (CFEqual(kextID, OSKextGetIdentifier(thatKext))) {
+
+                        __OSKextAddDiagnostic(aKext,
+                            kOSKextDiagnosticsFlagDependencies,
+                            kOSKextDependencyMultipleVersionsDetected,
+                            kextID, /* note */ NULL);
+                        result = false;
+                       /* But keep going, get all diagnostics. */
+                    }
+                }
+            }
+        }
+    } else if (__sOSKextsByURL) {
+        __OSKextResolveDependenciesContext context;
+        context.result = true;  // failed resolve sets to false
+        CFDictionaryApplyFunction(__sOSKextsByURL,
+            __OSKextResolveDependenciesApplierFunction, &context);
+    }
+finish:
+    SAFE_RELEASE(resolvedSet);
+    SAFE_RELEASE(loopStack);
+    SAFE_RELEASE(loadList);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static void __OSKextFlushDependenciesApplierFunction(
+    const void * vKey __unused,
+    const void * vValue,
+          void * vContext __unused)
+{
+    OSKextRef theKext = (OSKextRef)vValue;
+
+    OSKextFlushDependencies(theKext);
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+void __OSKextClearHasAllDependenciesOnKext(OSKextRef aKext)
+{
+    char      kextPath[PATH_MAX];
+    CFIndex   count, i;
+
+    count = CFArrayGetCount(__sOSAllKexts);
+    for (i = 0; i < count; i++) {
+        OSKextRef checkKext = (OSKextRef)CFArrayGetValueAtIndex(__sOSAllKexts, i);
+        if (!checkKext->loadInfo || !checkKext->loadInfo->dependencies ||
+            !__OSKextHasAllDependencies(checkKext)) {
+            continue;
+        }
+        if (CFArrayContainsValue(checkKext->loadInfo->dependencies,
+            RANGE_ALL(checkKext->loadInfo->dependencies), aKext)) {
+
+            __OSKextGetFileSystemPath(checkKext, /* otherURL */ NULL,
+                /* resolveToBase */ false, kextPath);
+            OSKextLog(aKext,
+                kOSKextLogDebugLevel | kOSKextLogKextBookkeepingFlag,
+                "Clearing \"has all dependencies\" for %s.", kextPath);
+
+            checkKext->loadInfo->flags.hasAllDependencies = 0;
+            __OSKextClearHasAllDependenciesOnKext(checkKext);
+        }
+    }
+    
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextFlushDependencies(OSKextRef aKext)
+{
+    static Boolean flushingAll = false;
+    char           kextPath[PATH_MAX];
+
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    if (aKext) {
+        if (!flushingAll) {
+            if (OSKextGetURL(aKext)) {
+                __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+                    /* resolveToBase */ false, kextPath);
+            }
+            OSKextLog(aKext,
+                kOSKextLogDetailLevel | kOSKextLogKextBookkeepingFlag,
+                "Flushing dependencies for %s.", kextPath);
+        }
+
+        if (aKext->loadInfo) {
+            aKext->loadInfo->flags.hasRawKernelDependency = 0;
+            aKext->loadInfo->flags.hasKernelDependency = 0;
+            aKext->loadInfo->flags.hasKPIDependency = 0;
+
+            if (aKext->loadInfo->dependencies) {
+                SAFE_RELEASE_NULL(aKext->loadInfo->dependencies);
+                aKext->loadInfo->flags.hasAllDependencies = 0;
+                aKext->loadInfo->flags.dependenciesValid = 0;
+                aKext->loadInfo->flags.dependenciesAuthentic = 0;
+
+               /* If we've cleared any dependency info, we need to go up
+                * all dependency graphs and clear the "has all dependencies"
+                * bits on any dependents of this kext, direct or indirect.
+                */
+                __OSKextClearHasAllDependenciesOnKext(aKext);
+            }
+
+            OSKextFlushDiagnostics(aKext, kOSKextDiagnosticsFlagDependencies);
+        }
+    } else if (__sOSKextsByURL) {
+        flushingAll = true;
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogDetailLevel | kOSKextLogKextBookkeepingFlag,
+            "Flushing dependencies for all kexts.");
+        CFDictionaryApplyFunction(__sOSKextsByURL,
+            __OSKextFlushDependenciesApplierFunction, NULL);
+        flushingAll = false;
+    }
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextValidateDependencies(OSKextRef aKext)
+{
+    Boolean     result = true;
+    CFArrayRef  allDependencies = NULL;  // must release
+    CFIndex     count, i;
+
+    if (aKext->loadInfo && aKext->loadInfo->flags.dependenciesValid) {
+        goto finish;
+    }
+    allDependencies = OSKextCopyAllDependencies(aKext,
+        /* needAll */ true);
+    if (!allDependencies) {
+        result = false;
+        goto finish;
+    }
+
+    count = CFArrayGetCount(allDependencies);
+    for (i = 0; i < count; i++) {
+        OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(
+            allDependencies, i);
+
+        if (!__OSKextIsValid(thisKext)) {
+            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagDependencies,
+                kOSKextDependencyInvalid, OSKextGetIdentifier(thisKext),
+                /* note */ NULL);
+            result = false;
+            // run through them all, do not continue or goto finish
+        }
+    }
+
+    if (result) {
+       /* We might not have loadInfo yet!
+        */
+        if (!__OSKextCreateLoadInfo(aKext)) {
+            result = false;
+            goto finish;
+        }
+        aKext->loadInfo->flags.dependenciesValid = 1;
+    }
+
+finish:
+    SAFE_RELEASE(allDependencies);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextAuthenticateDependencies(OSKextRef aKext)
+{
+    Boolean     result          = true;
+    CFArrayRef  allDependencies = NULL;  // must release
+    CFIndex     count, i;
+
+    if (aKext->loadInfo && aKext->loadInfo->flags.dependenciesAuthentic) {
+        goto finish;
+    }
+
+    allDependencies = OSKextCopyAllDependencies(aKext,
+        /* needAll */ true);
+    if (!allDependencies) {
+        result = false;
+        goto finish;
+    }
+
+    count = CFArrayGetCount(allDependencies);
+    for (i = 0; i < count; i++) {
+        OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(
+            allDependencies, i);
+        if (!OSKextIsAuthentic(thisKext)) {
+            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagDependencies,
+                kOSKextDependencyInauthentic,
+                OSKextGetIdentifier(thisKext), /* note */ NULL);
+            result = false;
+            // run through them all, do not continue or goto finish
+        }
+    }
+
+    if (result) {
+        if (!__OSKextCreateLoadInfo(aKext)) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        aKext->loadInfo->flags.dependenciesAuthentic = 1;
+    }
+
+finish:
+    SAFE_RELEASE(allDependencies);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCopyDeclaredDependencies(
+    OSKextRef aKext,
+    Boolean   needAllFlag)
+{
+    CFArrayRef result = NULL;
+    Boolean resolved = false;
+
+    resolved = OSKextResolveDependencies(aKext);
+
+    if (needAllFlag && !resolved) {
+        goto finish;
+    }
+
+    if (aKext->loadInfo && aKext->loadInfo->dependencies) {
+        result = CFArrayCreateCopy(CFGetAllocator(aKext),
+            aKext->loadInfo->dependencies);
+    } else {
+        result = CFArrayCreate(CFGetAllocator(aKext), NULL, 0,
+            &kCFTypeArrayCallBacks);
+    }
+finish:
+    return result;
+}
+
+/*********************************************************************
+* If a kext *doesn't* depend on com.apple.kernel or any com.apple.kpi.*
+* component, it's a pretty old kext that might need the old linear linkage
+* model, so we pull all indirect dependencies into the link list for the kext. 
+*********************************************************************/
+Boolean
+__OSKextGetBleedthroughFlag(OSKextRef aKext)
+{
+    Boolean result = false;
+
+    /* Bleedthrough is ignored on 64-bit.
+     */
+    if (__OSKextIsArchitectureLP64()) {
+        result = false;
+    } else {
+        result = !aKext->loadInfo->flags.hasKPIDependency;
+    }
+
+    return result;
+}
+
+
+/*********************************************************************
+* List must be built in postorder (link order)
+* xxx - de we want any kind of kOSKextLogDependenciesFlag
+* xxx - messages for these?
+*********************************************************************/
+Boolean
+__OSKextAddLinkDependencies(
+    OSKextRef         aKext,
+    CFMutableArrayRef linkDependencies,
+    Boolean           needAllFlag,
+    Boolean           bleedthroughFlag)
+{
+    Boolean result = false;
+    CFIndex count, i;
+
+   /* A kernel component has no dependencies other than an implicit
+    * one on the kernel, and such a kext never has an array of
+    * dependencies.
+    */
+    if (OSKextIsKernelComponent(aKext)) {
+        result = true;
+        goto finish;
+    }
+
+   /* If the kext doesn't have loadInfo or dependencies, we've hit
+    * an internal error.
+    */
+    if (!aKext->loadInfo || !aKext->loadInfo->dependencies) {
+        result = !needAllFlag;
+        goto finish;
+    }
+
+   /* See if the bleedthroughFlag bit flips with this kext.  This flag then
+    * propagates down the recursive call stack.
+    */
+    bleedthroughFlag = bleedthroughFlag || __OSKextGetBleedthroughFlag(aKext);
+
+    count = CFArrayGetCount(aKext->loadInfo->dependencies);
+    for (i = 0; i < count; i++) {
+        OSKextRef dependency = (OSKextRef)CFArrayGetValueAtIndex(
+            aKext->loadInfo->dependencies, i);
+
+       /* If bleeding through for old kexts, or for a redirect kext that
+        * has no executable, call recursively.
+        */
+        if (bleedthroughFlag || !OSKextDeclaresExecutable(dependency)) {
+            if (!__OSKextAddLinkDependencies(dependency,
+                linkDependencies,
+                needAllFlag,
+                bleedthroughFlag)) 
+            {
+                goto finish;
+            }
+        }
+
+       /* The easy part: a kext with an executable goes on the list if it isn't
+        * already on!
+        */
+        if (OSKextDeclaresExecutable(dependency)) {
+            if (kCFNotFound == CFArrayGetFirstIndexOfValue(linkDependencies,
+                RANGE_ALL(linkDependencies), dependency)) {
+
+                CFArrayAppendValue(linkDependencies, dependency);
+            }
+        }
+    }
+
+    result = true;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCopyLinkDependencies(
+    OSKextRef aKext,
+    Boolean   needAllFlag)
+{
+    CFMutableArrayRef result = NULL;
+    Boolean resolved = OSKextResolveDependencies(aKext);
+    if (needAllFlag && !resolved) {
+        goto finish;
+    }
+
+    result = CFArrayCreateMutable(CFGetAllocator(aKext), 0,
+        &kCFTypeArrayCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    if (!__OSKextAddLinkDependencies(aKext, result,
+        needAllFlag, /* bleedthrough */ false)) {
+
+        SAFE_RELEASE_NULL(result);
+    }
+
+finish:
+    return result;
+
+}
+
+/*******************************************************************************
+* Suck from a kext's executable all of its undefined symbol names and build
+* an array of empty arrays keyed  by symbol. The arrays will be filled with
+* lib kexts that export that symbol. Also note the cpu arch of the kext to
+* match on that for the libs.
+*
+* xxx - do we want to log stuff for this?
+*******************************************************************************/
+Boolean __OSKextReadSymbolReferences(
+    OSKextRef              aKext,
+    CFMutableDictionaryRef symbols)
+{
+    Boolean                    result        = false;
+    char                       kextPath[PATH_MAX];
+
+    CFDataRef                  executable    = NULL;  // must release
+    const struct mach_header * mach_header   = NULL;
+    const void               * file_end      = NULL;
+
+    Boolean                    sixtyfourbit  = false;
+    uint8_t                    swap          = 0;
+
+    macho_seek_result          symtab_result = macho_seek_result_not_found;
+    struct symtab_command    * symtab        = NULL;
+    char                     * syms_address  = NULL;
+    const void               * string_list   = NULL;
+    unsigned int               sym_offset    = 0;
+    unsigned int               str_offset    = 0;
+    unsigned int               num_syms      = 0;
+    unsigned int               syms_bytes    = 0;
+    unsigned int               sym_index     = 0;
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+
+   /* A kernel component has no symbol references outside the kernel,
+    * and a kext with no executable also plainly has none.
+    */
+    if (OSKextIsKernelComponent(aKext) || !OSKextDeclaresExecutable(aKext)) {
+        result = true;
+        goto finish;
+    }
+
+   /* Get the executable for the current arch, return false if it doesn't
+    * have one.
+    */
+    executable = OSKextCopyExecutableForArchitecture(aKext, OSKextGetArchitecture());
+    if (!executable) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+            "%s has no executable for architecture %s.",
+            kextPath, OSKextGetArchitecture()->name);
+        goto finish;
+    }
+
+    mach_header = (const struct mach_header *)CFDataGetBytePtr(executable);
+    file_end = (((const char *)mach_header) + CFDataGetLength(executable));
+
+    if (ISMACHO64(MAGIC32(mach_header))) {
+        sixtyfourbit = true;
+    }
+    if (ISSWAPPEDMACHO(MAGIC32(mach_header))) {
+        swap = 1;
+    }
+
+    symtab_result = macho_find_symtab(mach_header, file_end, &symtab);
+    if (symtab_result != macho_seek_result_found) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+            "%s has no symtab in its executable (%s)",
+                kextPath, OSKextGetArchitecture()->name);
+        goto finish;
+    }
+
+    sym_offset = CondSwapInt32(swap, symtab->symoff);
+    str_offset = CondSwapInt32(swap, symtab->stroff);
+    num_syms   = CondSwapInt32(swap, symtab->nsyms);
+
+    syms_address = (char *)mach_header + sym_offset;
+    string_list = (char *)mach_header + str_offset;
+    syms_bytes = num_syms * sizeof(struct nlist);
+
+    if (syms_address + syms_bytes > (char *)file_end) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+            "%s: internal overrun in executable file (%s).",
+            kextPath, OSKextGetArchitecture()->name);
+        goto finish;
+    }
+
+    for (sym_index = 0; sym_index < num_syms; sym_index++) {
+        struct nlist    * seekptr;
+        struct nlist_64 * seekptr_64;
+        uint32_t          string_index;
+        uint8_t           n_type;
+
+        if (sixtyfourbit) {
+            seekptr_64 = &((struct nlist_64 *)syms_address)[sym_index];
+            string_index = CondSwapInt32(swap, seekptr_64->n_un.n_strx);
+            n_type = seekptr_64->n_type;
+        } else {
+            seekptr = &((struct nlist *)syms_address)[sym_index];
+            string_index = CondSwapInt32(swap, seekptr->n_un.n_strx);
+            n_type = seekptr->n_type;
+        }
+
+        // no need to swap n_type (one-byte value)
+        if (string_index == 0 || n_type & N_STAB) {
+            continue;
+        }
+
+        if ((n_type & N_TYPE) == N_UNDF) {
+            char * symbol_name;
+            CFStringRef cfSymbolName; // must release
+
+            symbol_name = (char *)(string_list + string_index);
+            cfSymbolName = CFStringCreateWithCString(kCFAllocatorDefault,
+                symbol_name, kCFStringEncodingASCII);
+            if (!cfSymbolName) {
+                OSKextLogMemError();
+                goto finish;
+            }
+            CFDictionarySetValue(symbols, cfSymbolName, kCFBooleanTrue);
+            CFRelease(cfSymbolName);
+        }
+    }
+
+    result = true;
+finish:
+
+   /* Advise the system that we no longer need the mmapped executable.
+    */
+    if (executable) {
+        (void)posix_madvise((void *)CFDataGetBytePtr(executable),
+            CFDataGetLength(executable),
+            POSIX_MADV_DONTNEED);
+    }
+
+    SAFE_RELEASE(executable);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextIsSearchableForSymbols(
+    OSKextRef aKext,
+    Boolean   nonKPIFlag,
+    Boolean   allowUnsupportedFlag)
+{
+    CFStringRef kextID = NULL;  // do not release
+
+    if (!OSKextIsLibrary(aKext)) {
+        return false;
+    }
+    if (!OSKextDeclaresExecutable(aKext)) {
+        return false;
+    }
+
+    kextID = OSKextGetIdentifier(aKext);
+
+   /* Check as appropriate for unsupported/private KPIs and disallow them.
+    * Truly private KPIs will fail at link time.
+    */
+    if (!allowUnsupportedFlag) {
+        if (CFEqual(kextID, CFSTR("com.apple.kernel.unsupported")) ||
+            CFEqual(kextID, CFSTR("com.apple.kpi.unsupported")) ||
+            CFEqual(kextID, CFSTR("com.apple.kpi.private")) ||
+            CFEqual(kextID, CFSTR("com.apple.kpi.dsep"))) {
+
+            return false;
+        }
+    }
+
+    if (nonKPIFlag) {
+        if (CFStringHasPrefix(kextID, __kOSKextKPIPrefix)) {
+            return false;
+        }
+    } else {
+        if (CFStringHasPrefix(kextID, __kOSKextKernelLibPrefix)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/*******************************************************************************
+* Given a library kext, check all of its exported symbols against the running
+* lists of undef (not yet found) symbols, symbols found once, and symbols
+* found already in other library kexts. Adjust tallies appropriately.
+*
+* xxx - do we want to log stuff for this?
+*******************************************************************************/
+Boolean __OSKextFindSymbols(
+    OSKextRef              aKext,
+    CFMutableDictionaryRef undefSymbols,
+    CFMutableDictionaryRef onedefSymbols,
+    CFMutableDictionaryRef multdefSymbols,
+    CFMutableArrayRef      multdefLibs)
+{
+    Boolean                    result        = false;
+    char                       kextPath[PATH_MAX];
+
+    CFDataRef                  executable    = NULL;  // must release
+    const struct mach_header * mach_header   = NULL;
+    const void               * file_end      = NULL;
+
+    Boolean                    sixtyfourbit  = false;
+    uint8_t                    swap          = 0;
+
+    macho_seek_result          symtab_result = macho_seek_result_not_found;
+    struct symtab_command    * symtab        = NULL;
+    char                     * syms_address  = NULL;
+    const void               * string_list   = NULL;
+    unsigned int               sym_offset    = 0;
+    unsigned int               str_offset    = 0;
+    unsigned int               num_syms      = 0;
+    unsigned int               syms_bytes    = 0;
+    unsigned int               sym_index     = 0;
+    CFMutableArrayRef          libsArray     = NULL;  // release if created
+    OSKextRef                  libKext       = NULL;  // do not release
+    char                     * symbol_name   = NULL;  // do not free
+    Boolean                    eligible      = false;
+    Boolean                    notedMultdef  = false;
+
+    CFStringRef                cfSymbolName  = NULL;  // must release
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+
+   /* Get the executable for the current arch, return false if it doesn't
+    * have one.
+    */
+    executable = OSKextCopyExecutableForArchitecture(aKext, OSKextGetArchitecture());
+    if (!executable) {
+        goto finish;
+    }
+
+    mach_header = (const struct mach_header *)CFDataGetBytePtr(executable);
+    file_end = (((const char *)mach_header) + CFDataGetLength(executable));
+
+    if (ISMACHO64(MAGIC32(mach_header))) {
+        sixtyfourbit = true;
+    }
+    if (ISSWAPPEDMACHO(MAGIC32(mach_header))) {
+        swap = 1;
+    }
+
+    symtab_result = macho_find_symtab(mach_header, file_end, &symtab);
+    if (symtab_result != macho_seek_result_found) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+            "%s has no symtab in its executable (%s)",
+                kextPath, OSKextGetArchitecture()->name);
+        goto finish;
+    }
+
+    sym_offset = CondSwapInt32(swap, symtab->symoff);
+    str_offset = CondSwapInt32(swap, symtab->stroff);
+    num_syms   = CondSwapInt32(swap, symtab->nsyms);
+
+    syms_address = (char *)mach_header + sym_offset;
+    string_list = (char *)mach_header + str_offset;
+    syms_bytes = num_syms * sizeof(struct nlist);
+
+    if (syms_address + syms_bytes > (char *)file_end) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+            "%s - internal overrun in executable file (%s).",
+            kextPath, OSKextGetArchitecture()->name);
+        goto finish;
+    }
+
+    for (sym_index = 0; sym_index < num_syms; sym_index++) {
+        struct nlist    * seekptr;
+        struct nlist_64 * seekptr_64;
+        uint32_t          string_index;
+        uint8_t           n_type;
+
+        if (sixtyfourbit) {
+            seekptr_64 = &((struct nlist_64 *)syms_address)[sym_index];
+            string_index = CondSwapInt32(swap, seekptr_64->n_un.n_strx);
+            n_type = seekptr_64->n_type;
+        } else {
+            seekptr = &((struct nlist *)syms_address)[sym_index];
+            string_index = CondSwapInt32(swap, seekptr->n_un.n_strx);
+            n_type = seekptr->n_type;
+        }
+
+        if (string_index == 0 || (n_type & N_STAB)) {
+            continue;
+        }
+
+       /* Kernel component kexts are weird; they are just lists of indirect
+        * and undefined symtab entries for the real data in the kernel.
+        */
+
+        // no need to swap n_type (one-byte value)
+        switch (n_type & N_TYPE) {
+          case N_UNDF:
+            /* Fall through, only support indirects for KPI for now. */
+          case N_INDR:
+            eligible = OSKextIsKernelComponent(aKext) ? true : false;
+            break;
+          case N_SECT:
+            eligible = OSKextIsKernelComponent(aKext) ? false : true;
+            break;
+          default:
+            eligible = false;
+            break;
+        }
+
+        if (eligible) {
+
+            SAFE_RELEASE_NULL(cfSymbolName);
+
+            symbol_name = (char *)(string_list + string_index);
+
+            cfSymbolName = CFStringCreateWithCString(kCFAllocatorDefault,
+                symbol_name, kCFStringEncodingASCII);
+            if (!cfSymbolName) {
+                OSKextLogMemError();
+                result = false;
+                goto finish;
+            }
+
+           /* Bubble library tallies from undef->onedef->multdef as symbols
+            * are found. Also note any lib that has a duplicate match.
+            */
+            libsArray = (CFMutableArrayRef)CFDictionaryGetValue(
+                multdefSymbols, cfSymbolName);
+            if (libsArray) {
+
+               /* The symbol is already multiply-defined, so just add this
+                * kext to the list.
+                */
+                result = true;
+
+                CFArrayAppendValue(libsArray, aKext);
+
+            } else {
+                libKext = (OSKextRef)CFDictionaryGetValue(
+                    onedefSymbols, cfSymbolName);
+                if (libKext) {
+
+                   /* The symbol was found in one kext so far; now we have two.
+                    * Create an array of those two kexts for the multdef dict,
+                    * and remove the symbol from the onedef dict.
+                    */
+                    result = true;
+
+                    libsArray = CFArrayCreateMutable(kCFAllocatorDefault,
+                        /* capacity */ 0, &kCFTypeArrayCallBacks);
+                    if (!libsArray) {
+                        OSKextLogMemError();
+                        goto finish;
+                    }
+                    CFArrayAppendValue(libsArray, libKext);
+                    CFArrayAppendValue(libsArray, aKext);
+                    CFDictionarySetValue(multdefSymbols, cfSymbolName, libsArray);
+                    SAFE_RELEASE_NULL(libsArray);
+
+                    if (!notedMultdef) {
+                        if (kCFNotFound == CFArrayGetFirstIndexOfValue(
+                            multdefLibs, RANGE_ALL(multdefLibs), aKext)) {
+                        
+                            CFArrayAppendValue(multdefLibs, aKext);
+                        }
+                        notedMultdef = true;
+                    }
+                    
+                    CFDictionaryRemoveValue(onedefSymbols, cfSymbolName);
+
+                } else {
+                    if (CFDictionaryGetValue(undefSymbols, cfSymbolName)) {
+
+                       /* The symbol just got found for the first time. Set
+                        * this kext in the onedef dict, and remove the entry
+                        * from the undef dict.
+                        */
+                        result = true;
+
+                        CFDictionarySetValue(onedefSymbols, cfSymbolName, aKext);
+                        CFDictionaryRemoveValue(undefSymbols, cfSymbolName);
+                    }
+                }
+            }
+
+        } /* if (eligible) */
+    } /* for (...) */
+
+finish:
+
+   /* Advise the system that we no longer need the mmapped executable.
+    */
+    if (executable) {
+        (void)posix_madvise((void *)CFDataGetBytePtr(executable),
+            CFDataGetLength(executable),
+            POSIX_MADV_DONTNEED);
+    }
+    SAFE_RELEASE(cfSymbolName);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextFindLinkDependencies(
+    OSKextRef         aKext,
+    Boolean           nonKPIFlag,
+    Boolean           allowUnsupportedFlag,
+    CFDictionaryRef * undefinedSymbolsOut,
+    CFDictionaryRef * onedefSymbolsOut,
+    CFDictionaryRef * multiplyDefinedSymbolsOut,
+    CFArrayRef      * multipleDefinitionLibraries)
+{
+    CFArrayRef             result         = NULL;
+    CFArrayRef             allKexts       = NULL;  // do not release
+    CFMutableArrayRef      libKexts       = NULL;  // must release
+    CFMutableDictionaryRef undefSymbols   = NULL;  // must release
+    CFMutableDictionaryRef onedefSymbols  = NULL;  // must release
+    CFMutableDictionaryRef multdefSymbols = NULL;  // must release
+    CFMutableArrayRef      multdefLibs    = NULL;  // must release
+    char                   kextPath[PATH_MAX];
+    char                   dependencyPath[PATH_MAX];
+    CFIndex                kextCount, kextIndex;
+
+   /* If this doesn't exist there's nothing we can do. No point
+    * initializing it either, it'll be empty.
+    */
+    allKexts = OSKextGetAllKexts();
+    if (!allKexts) {
+        // xxx - log internal error?
+        goto finish;
+    }
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+    OSKextLog(aKext,
+        kOSKextLogStepLevel |
+        kOSKextLogDependenciesFlag | kOSKextLogLinkFlag,
+        "Searching for link dependencies of %s.",
+        kextPath);
+
+    libKexts = CFArrayCreateMutable(CFGetAllocator(aKext),
+        0, &kCFTypeArrayCallBacks);
+    undefSymbols = CFDictionaryCreateMutable(CFGetAllocator(aKext),
+        0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    onedefSymbols = CFDictionaryCreateMutable(CFGetAllocator(aKext),
+        0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    multdefSymbols = CFDictionaryCreateMutable(CFGetAllocator(aKext),
+        0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    multdefLibs = CFArrayCreateMutable(CFGetAllocator(aKext),
+        0, &kCFTypeArrayCallBacks);
+    if (!libKexts || !undefSymbols || !onedefSymbols ||
+        !multdefSymbols || !multdefLibs) {
+
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    if (!__OSKextReadSymbolReferences(aKext, undefSymbols)) {
+        goto finish;
+    }
+
+    kextCount = CFArrayGetCount(allKexts);
+    for (kextIndex = 0; kextIndex < kextCount; kextIndex++) {
+        OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(
+            allKexts, kextIndex);
+
+        if (thisKext != aKext &&
+            __OSKextIsSearchableForSymbols(thisKext, nonKPIFlag,
+                allowUnsupportedFlag)) {
+
+            if (__OSKextFindSymbols(thisKext, undefSymbols, onedefSymbols,
+                multdefSymbols, multdefLibs)) {
+
+                __OSKextGetFileSystemPath(thisKext, /* otherURL */ NULL,
+                    /* resolveToBase */ false, dependencyPath);
+                OSKextLog(aKext,
+                    kOSKextLogDetailLevel | kOSKextLogDependenciesFlag | kOSKextLogLinkFlag,
+                    "%s found link dependency %s.",
+                    kextPath, dependencyPath);
+
+                if (kCFNotFound == CFArrayGetFirstIndexOfValue(libKexts,
+                    RANGE_ALL(libKexts), thisKext)) {
+
+                    CFArrayAppendValue(libKexts, thisKext);
+                }
+            }
+        }
+    }
+
+    CFArraySortValues(libKexts, RANGE_ALL(libKexts),
+        &__OSKextCompareIdentifiers, /* context */ NULL);
+    CFArraySortValues(multdefLibs, RANGE_ALL(multdefLibs),
+        &__OSKextCompareIdentifiers, /* context */ NULL);
+    result = CFRetain(libKexts);
+
+finish:
+    if (result) {
+        CFIndex count;
+
+        count = CFDictionaryGetCount(undefSymbols);
+        if (count) {
+            OSKextLog(aKext, kOSKextLogDetailLevel |
+                kOSKextLogDependenciesFlag | kOSKextLogLinkFlag,
+                "%s has %d remaining undefined symbol%s",
+                kextPath, (int)count, count > 1 ? "s" : "");
+        }
+
+        count = CFDictionaryGetCount(multdefSymbols);
+        if (count) {
+            OSKextLog(aKext, kOSKextLogDetailLevel |
+                kOSKextLogDependenciesFlag | kOSKextLogLinkFlag,
+                "%s has multiply defined %ld symbol%s",
+                kextPath, count, count > 1 ? "s" : "");
+        }
+
+        if (undefinedSymbolsOut) {
+            *undefinedSymbolsOut = CFRetain(undefSymbols);
+        }
+        if (onedefSymbolsOut) {
+            *onedefSymbolsOut = CFRetain(onedefSymbols);
+        }
+        if (multiplyDefinedSymbolsOut) {
+            *multiplyDefinedSymbolsOut = CFRetain(multdefSymbols);
+        }
+        if (multipleDefinitionLibraries) {
+            *multipleDefinitionLibraries = CFRetain(multdefLibs);
+        }
+    }
+
+    SAFE_RELEASE(libKexts);
+    SAFE_RELEASE(undefSymbols);
+    SAFE_RELEASE(onedefSymbols);
+    SAFE_RELEASE(multdefSymbols);
+    SAFE_RELEASE(multdefLibs);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+typedef struct {
+    CFMutableArrayRef array;
+    uint32_t          minDepth;
+    uint32_t          depth;
+    Boolean           error;
+} __OSKextAddDependenciesContext;
+
+static void __OSKextAddDependenciesApplierFunction(
+    const void * vKext,
+          void * vContext)
+{
+    char kextPath[PATH_MAX];
+
+    OSKextRef aKext = (OSKextRef)vKext;
+    __OSKextAddDependenciesContext * context =
+        (__OSKextAddDependenciesContext *)vContext;
+
+   /* A kernel component has no dependencies other than an implicit
+    * one on the kernel, and such a kext never has an array of
+    * dependencies.
+    */
+    if (OSKextIsKernelComponent(aKext)) {
+        goto finish;
+    }
+
+    if (!aKext->loadInfo || !aKext->loadInfo->dependencies) {
+        __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL, /* resolve */ true,
+            kextPath);
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogDependenciesFlag,
+            "%s - missing load info or dependencies array in applier function.",
+            kextPath);
+        context->error = true;
+        goto finish;
+    }
+
+    context->depth++;
+    CFArrayApplyFunction(aKext->loadInfo->dependencies,
+        RANGE_ALL(aKext->loadInfo->dependencies),
+        &__OSKextAddDependenciesApplierFunction, context);
+    context->depth--;
+
+finish:
+    if (!context->error) {
+        if (context->depth >= context->minDepth) {
+            if (CFArrayGetFirstIndexOfValue(context->array,
+                RANGE_ALL(context->array),
+                aKext) == -1) {
+
+                CFArrayAppendValue(context->array, aKext);
+            }
+        }
+    }
+
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFMutableArrayRef __OSKextCopyDependenciesList(
+    OSKextRef aKext,
+    Boolean   needAllFlag,
+    uint32_t  minDepth)
+{
+    CFMutableArrayRef result = NULL;
+    Boolean resolved = false;
+    __OSKextAddDependenciesContext context;
+
+    resolved = OSKextResolveDependencies(aKext);
+    if (needAllFlag && !resolved) {
+        goto finish;
+    }
+
+    result = CFArrayCreateMutable(CFGetAllocator(aKext), 0,
+        &kCFTypeArrayCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    context.array = result;
+    context.minDepth = minDepth;
+    context.depth = 0;
+    context.error = false;
+
+    __OSKextAddDependenciesApplierFunction(aKext, &context);
+    if (context.error) {
+        SAFE_RELEASE_NULL(result);
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFMutableArrayRef OSKextCopyLoadList(
+    OSKextRef aKext,
+    Boolean   needAllFlag)
+{
+   /* minDepth: 0 means include self
+    */
+    return __OSKextCopyDependenciesList(aKext, needAllFlag,
+        /* minDepth */ 0);
+}
+
+/*********************************************************************
+*********************************************************************/
+CFMutableArrayRef OSKextCopyAllDependencies(
+    OSKextRef aKext,
+    Boolean needAllFlag)
+{
+   /* minDepth: 1 means skip self
+    */
+    return __OSKextCopyDependenciesList(aKext, needAllFlag,
+        /* minDepth */ 1);
+}
+
+/*********************************************************************
+*********************************************************************/
+CFMutableArrayRef OSKextCopyIndirectDependencies(
+    OSKextRef aKext,
+    Boolean needAllFlag)
+{
+   /* minDepth: 2 means skip self & direct dependencies
+    */
+    return __OSKextCopyDependenciesList(aKext, needAllFlag,
+        /* minDepth */ 2);
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextDependsOnKext(OSKextRef aKext,
+    OSKextRef libraryKext,
+    Boolean directFlag)
+{
+    Boolean result = false;
+    CFIndex count, i;
+
+    OSKextResolveDependencies(aKext);
+    if (!aKext->loadInfo || !aKext->loadInfo->dependencies) {
+        goto finish;
+    }
+
+    count = CFArrayGetCount(aKext->loadInfo->dependencies);
+    for (i = 0; i < count; i++) {
+        OSKextRef dependency = (OSKextRef)CFArrayGetValueAtIndex(
+            aKext->loadInfo->dependencies, i);
+
+        if ((dependency == libraryKext) ||
+            (!directFlag && OSKextDependsOnKext(dependency, libraryKext,
+                directFlag))) {
+
+            result = true;
+            goto finish;
+        }
+    }
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFMutableArrayRef OSKextCopyDependents(OSKextRef aKext,
+    Boolean directFlag)
+{
+    CFMutableArrayRef result = NULL;
+    CFArrayRef        allKexts = NULL;   // do not release
+    CFIndex           count, i;
+
+   /* If this doesn't exist there's nothing we can do. No point
+    * initializing it either, it'll be empty.
+    */
+    allKexts = OSKextGetAllKexts();
+    if (!allKexts) {
+        // xxx - log internal error?
+        goto finish;
+    }
+
+    OSKextResolveDependencies(NULL);
+
+    result = CFArrayCreateMutable(CFGetAllocator(aKext), 0,
+        &kCFTypeArrayCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    count = CFArrayGetCount(allKexts);
+    for (i = 0; i < count; i++) {
+        OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(allKexts, i);
+        if (OSKextDependsOnKext(thisKext, aKext, /* direct */ directFlag)) {
+            CFArrayAppendValue(result, thisKext);
+        }
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextIsCompatibleWithVersion(
+    OSKextRef aKext,
+    OSKextVersion aVersion)
+{
+    Boolean result = false;
+
+   /* Be sure to check that the kext *has* a valid compatibleVersion
+    * (parsed > 0) as well as checking the range.
+    */
+    if (aKext->compatibleVersion > 0 &&
+        aKext->compatibleVersion <= aVersion &&
+        aKext->version >= aVersion) {
+
+        result = true;
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+typedef struct __OSKextPrintDependenciesContext {
+    UInt32  depth;
+    Boolean bundleIDFlag;
+    Boolean linkFlag;
+} __OSKextPrintDependenciesContext;
+
+#define _DEPENDENCY_DEPTH_INCREMENT  (4)
+
+void __OSKextLogDependencyGraphApplierFunction(
+    const void * vKext,
+          void * vContext)
+{
+    OSKextRef aKext = (OSKextRef)vKext;
+    __OSKextPrintDependenciesContext dContext =
+        *(__OSKextPrintDependenciesContext *)vContext;
+
+    char        * pad = NULL;  // must free
+    CFStringRef   kextLabel = NULL;  // must release
+    char        * kextName = NULL; // must free
+    char          kextVersion[kOSKextVersionMaxLength];
+    char        * note = ""; // do not free
+    CFArrayRef    linkDependencies = NULL;  // must release
+    CFArrayRef    dependencies = NULL;      // do not release
+
+    if (!OSKextResolveDependencies(aKext)) {
+        // xxx - log it?
+        goto finish;
+    }
+
+    if (dContext.depth) {
+        pad = (char *)malloc((1 + dContext.depth) * sizeof(char));
+        if (!pad) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        memset(pad, ' ', dContext.depth);
+        pad[dContext.depth] = '\0';
+    }
+
+    if (dContext.bundleIDFlag) {
+        kextLabel = OSKextGetIdentifier(aKext);
+        CFRetain(kextLabel);
+    } else {
+        // xxx - relative or absolute?
+        kextLabel = CFURLCopyLastPathComponent(aKext->bundleURL);
+    }
+    kextName = createUTF8CStringForCFString(kextLabel);
+    if (!kextName) {
+        goto finish;
+    }
+
+    OSKextVersionGetString(aKext->version, kextVersion, kOSKextVersionMaxLength);
+
+   /* Mark kexts with final or missing dependencies.
+    */
+    if (!aKext->loadInfo || !aKext->loadInfo->dependencies) {
+        if (__OSKextHasAllDependencies(aKext)) {
+            note = ".";  // stops here (at the kernel, really)
+        } else {
+            note = " (dependencies not resolved).";
+        }
+    } else {
+        if (__OSKextHasAllDependencies(aKext)) {
+            note = " ->";
+        } else {
+            note = " (dependencies not fully resolved) ->";
+        }
+    }
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogExplicitLevel | kOSKextLogDependenciesFlag,
+        "%s%s (%s)%s", pad ? pad : "", kextName, kextVersion, note);
+
+    dContext.depth += _DEPENDENCY_DEPTH_INCREMENT;
+    if (dContext.linkFlag) {
+        linkDependencies = OSKextCopyLinkDependencies(aKext,
+            /* needAll */ false);
+        dependencies = linkDependencies;
+    } else if (aKext->loadInfo && aKext->loadInfo->dependencies) {
+        dependencies = aKext->loadInfo->dependencies;
+    }
+
+    if (dependencies) {
+        CFArrayApplyFunction(dependencies, RANGE_ALL(dependencies),
+            __OSKextLogDependencyGraphApplierFunction, &dContext);
+    }
+
+finish:
+    SAFE_FREE(pad);
+    SAFE_FREE(kextName);
+    SAFE_RELEASE(kextLabel);
+    SAFE_RELEASE(linkDependencies);
+    return;
+}
+
+void OSKextLogDependencyGraph(OSKextRef aKext,
+    Boolean bundleIDFlag,
+    Boolean linkFlag)
+{
+    __OSKextPrintDependenciesContext context;
+
+    context.depth = 0;
+    context.bundleIDFlag = bundleIDFlag;
+    context.linkFlag = linkFlag;
+
+    OSKextResolveDependencies(aKext);
+    __OSKextLogDependencyGraphApplierFunction(aKext, &context);
+}
+
+#pragma mark Core Kernel IPC
+
+/*********************************************************************
+*********************************************************************/
+CFMutableDictionaryRef __OSKextCreateKextRequest(
+    CFStringRef              predicateIn,
+    CFTypeRef                bundleIdentifierIn,
+    CFMutableDictionaryRef * argumentsOut)
+{
+    CFMutableDictionaryRef result    = NULL;
+    CFMutableDictionaryRef arguments = NULL;  // must release
+    Boolean                error     = false;
+
+    result = CFDictionaryCreateMutable(kCFAllocatorDefault,
+        0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    CFDictionarySetValue(result, CFSTR(kKextRequestPredicateKey), predicateIn);
+    if (bundleIdentifierIn || argumentsOut) {
+        arguments = CFDictionaryCreateMutable(kCFAllocatorDefault,
+            0, &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+        if (!arguments) {
+            OSKextLogMemError();
+            error = true;
+            goto finish;
+        }
+
+        CFDictionarySetValue(result, CFSTR(kKextRequestArgumentsKey),
+            arguments);
+
+        if (argumentsOut) {
+            *argumentsOut = arguments;
+        }
+
+        if (bundleIdentifierIn) {
+            CFDictionarySetValue(arguments,
+                CFSTR(kKextRequestArgumentBundleIdentifierKey),
+                bundleIdentifierIn);
+        }
+    }
+finish:
+    if (error) {
+        SAFE_RELEASE_NULL(result);
+    }
+    SAFE_RELEASE(arguments);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn __OSKextSendKextRequest(
+    OSKextRef       aKext,
+    CFDictionaryRef kextRequest,
+    CFTypeRef     * cfResponseOut,
+    char         ** rawResponseOut,
+    uint32_t      * rawResponseLengthOut)
+{
+    OSReturn       result            = kOSReturnError;
+    kern_return_t  mig_result        = KERN_FAILURE;
+    OSReturn       op_result         = kOSReturnError;
+    CFDataRef      requestData       = NULL;  // must release
+    Boolean        deallocResponse   = true; 
+    char         * responseBuffer    = NULL;  // must vm_dealloc per deallocResponse
+    uint32_t       responseLength    = 0;
+    char         * logInfoBuffer     = NULL;  // must vm_dealloc
+    uint32_t       logInfoLength     = 0;
+    host_priv_t    hostPriv          = HOST_PRIV_NULL; // xxx - need to clean up?
+    CFStringRef    errorString       = NULL;  // must release
+    char         * errorCString      = NULL;  // must free
+
+   /* Technically not necessary since we are just getting info.
+    */
+    hostPriv = mach_host_self();
+
+    requestData = IOCFSerialize(kextRequest, kNilOptions);
+    if (!requestData) {
+        result = kOSKextReturnSerialization;
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+            "Failed to serialize kext request.");
+        goto finish;
+    }
+
+   /* If we don't have a log function to process the messages,
+    * don't bother sending any log flags to the kernel.
+    */
+    mig_result = kext_request(
+        hostPriv,
+        __sOSKextLogOutputFunction ? __sKernelLogFilter : kOSKextLogSilentFilter,
+        (vm_offset_t)CFDataGetBytePtr(requestData),
+        CFDataGetLength(requestData),
+        (vm_offset_t *)&responseBuffer,
+        &responseLength,
+        (vm_offset_t *)&logInfoBuffer,
+        &logInfoLength,
+        &op_result);
+
+    result = __OSKextProcessKextRequestResults(aKext,
+        mig_result, op_result, 
+        (char *)logInfoBuffer, logInfoLength);
+    if (result != kOSReturnSuccess) {
+        goto finish;
+    }
+
+    if (responseBuffer && responseLength) {
+        if (cfResponseOut) {
+
+            *cfResponseOut = IOCFUnserialize(responseBuffer, kCFAllocatorDefault,
+                /* options */ 0, &errorString);
+            if (!*cfResponseOut) {
+                result = kOSKextReturnSerialization;
+                if (errorString) {
+                    errorCString = createUTF8CStringForCFString(errorString);
+                }
+                OSKextLog(aKext,
+                    kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+                    "Can't unserialize kext request response: %s",
+                    errorCString ? errorCString : "unknown error");
+                SAFE_FREE_NULL(errorCString);
+                SAFE_RELEASE_NULL(errorString);
+                goto finish;
+            }
+        } else if (rawResponseOut && rawResponseLengthOut) {
+            *rawResponseOut = responseBuffer;
+            *rawResponseLengthOut = responseLength;
+            deallocResponse = false;
+        }
+    }
+
+    result = kOSReturnSuccess;
+
+finish:
+    SAFE_RELEASE(requestData);
+    SAFE_RELEASE(errorString);
+    SAFE_FREE(errorCString);
+
+    if (deallocResponse && responseBuffer && responseLength) {
+        vm_deallocate(mach_task_self(), (vm_address_t)responseBuffer,
+            responseLength);
+    }
+    if (logInfoBuffer) {
+        vm_deallocate(mach_task_self(), (vm_address_t)logInfoBuffer,
+            logInfoLength);
+    }
+
+    if (hostPriv != HOST_PRIV_NULL) {
+        mach_port_deallocate(mach_task_self(), hostPriv);
+    }
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn __OSKextSimpleKextRequest(
+    OSKextRef     aKext,
+    CFStringRef   predicate,
+    CFTypeRef   * cfResponseOut)
+{
+    kern_return_t   result        = kOSKextReturnInternalError;
+    CFDictionaryRef kextRequest   = NULL;  // must release
+
+    kextRequest = __OSKextCreateKextRequest(predicate,
+        aKext ? OSKextGetIdentifier(aKext) : NULL, /* argsOut */ NULL);
+    if (!kextRequest) {
+        goto finish;
+    }
+
+    result = __OSKextSendKextRequest(aKext, kextRequest,
+        cfResponseOut,
+        /* rawResponseOut */ NULL, /* rawResponseLengthOut */ NULL);
+
+finish:
+    SAFE_RELEASE(kextRequest);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn __OSKextProcessKextRequestResults(
+    OSKextRef       aKext,
+    kern_return_t   mig_result,
+    kern_return_t   op_result,
+    char          * logInfoBuffer,
+    uint32_t        logInfoLength)
+{
+    OSReturn    result             = kOSReturnError;
+    CFTypeRef   kernelLogMessages  = NULL;  // must release
+    CFStringRef errorString        = NULL;  // must release
+    char      * errorCString       = NULL;  // must free
+
+    if (mig_result != KERN_SUCCESS) {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+             "Error communicating with kernel - %s.",
+             safe_mach_error_string(mig_result));
+        result = mig_result;
+        goto finish;
+    }
+
+   /* Errors here are not to be considered problems with the request
+    * itself. Log about the problem but continue as if things worked.
+    */
+    if (logInfoBuffer && logInfoLength) {
+        kernelLogMessages = IOCFUnserialize((char *)logInfoBuffer,
+            kCFAllocatorDefault,
+            /* options */ 0, &errorString);
+        if (kernelLogMessages) {
+            __OSKextLogKernelMessages(aKext, kernelLogMessages);
+        } else {
+            errorCString = createUTF8CStringForCFString(errorString);
+            OSKextLog(aKext,
+                kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+                "Failed to parse kernel log messages: %s.",
+                errorCString ? errorCString : "(unknown)");
+        }
+    }
+    
+   /* It's really the job of the caller to provide a specific error message.
+    * We'll use this one for debugging.
+    */
+    if (op_result != KERN_SUCCESS) {
+        OSKextLog(aKext, kOSKextLogDebugLevel | kOSKextLogIPCFlag,
+            "Kernel error handling kext request - %s.",
+            safe_mach_error_string(op_result));
+        result = op_result;
+        goto finish;
+    }
+    
+    result = kOSReturnSuccess;
+    
+finish:
+
+    SAFE_RELEASE(kernelLogMessages);
+    SAFE_RELEASE(errorString);
+    SAFE_FREE(errorCString);
+
+    return result;
+}
+
+#pragma mark Linking and Loading; Other Kernel Operations
+
+/*********************************************************************
+*********************************************************************/
+OSReturn __OSKextLoadWithArgsDict(
+    OSKextRef       aKext,
+    CFDictionaryRef loadArgsDict)
+{
+    OSReturn           result          = kOSReturnError;
+    CFArrayRef         loadList        = NULL;           // must release
+    CFMutableArrayRef  kextIdentifiers = NULL;           // must release
+    kern_return_t      mig_result      = KERN_FAILURE;
+    OSReturn           op_result       = kOSReturnError;
+    host_priv_t        hostPriv        = HOST_PRIV_NULL; // xxx - need to clean up?
+    CFDataRef          mkext           = NULL;           // must release
+    const UInt8      * requestBuffer   = NULL;
+    CFIndex            requestLength   = 0;
+    vm_address_t       responseBuffer  = 0;              // must vm_deallocate
+    uint32_t           responseLength  = 0;
+    vm_address_t       logInfoBuffer   = 0;              // must vm_deallocate
+    uint32_t           logInfoLength   = 0;
+    CFStringRef        errorString     = NULL;           // must release
+    char               kextPath[PATH_MAX];
+    CFIndex            count = 0, i = 0;
+
+   /* If we are privileged this will work.
+    */
+    hostPriv = mach_host_self();
+    if (hostPriv == HOST_PRIV_NULL) {
+        result = kOSKextReturnNotPrivileged;
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+             "Process must be running as root to load kexts.");
+        goto finish;
+    }
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+
+   /*****
+    * Do all the checks we can before sending the kext down to the kernel.
+    *****/
+
+    if (!__OSKextIsValid(aKext)) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Can't load %s - validation problems.", kextPath);
+        result = kOSKextReturnValidation;
+        goto finish;
+    }
+
+    if (!OSKextSupportsArchitecture(aKext, OSKextGetArchitecture())) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Can't load %s - no code for running kernel's architecture.",
+            kextPath);
+        result = kOSKextReturnArchNotFound;
+        goto finish;
+    }
+
+    if ((OSKextGetActualSafeBoot() || OSKextGetSimulatedSafeBoot()) &&
+        !OSKextIsLoadableInSafeBoot(aKext)) {
+
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Can't load %s - ineligible during safe boot.", kextPath);
+        result = kOSKextReturnBootLevel;
+        goto finish;
+    }
+
+    if (!OSKextIsAuthentic(aKext)) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Can't load %s - authentication problems.", kextPath);
+        result = kOSKextReturnAuthentication;
+        goto finish;
+    }
+
+   /* First resolve dependencies without loaded kext info to build
+    * a list of identifiers, so we don't read any more bundles off
+    * disk than necessary when we do check loaded. If we have different
+    * versions of libraries that have wildly different dependencies
+    * amongst themselves, things may fail in the next resolve step,
+    * but it's really unlikely innit.
+    */
+    OSKextFlushLoadInfo(/* kext */ NULL, /* flushDependencies? */ true);
+    loadList = OSKextCopyLoadList(aKext, /* needAll? */ true);
+    if (!loadList) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Can't load %s - failed to resolve dependencies.", kextPath);
+        result = kOSKextReturnDependencies;
+        goto finish;
+    }
+
+    if (!OSKextAuthenticateDependencies(aKext)) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Can't load %s - dependency authentication problems.", kextPath);
+        result = kOSKextReturnAuthentication;
+        goto finish;
+    }
+
+    if (!OSKextDependenciesAreLoadableInSafeBoot(aKext)) {
+        CFDictionaryRef bootLevelDiagnostics         = NULL;  // do not release
+        CFArrayRef      ineligibleDependencies       = NULL;  // must release
+        CFStringRef     ineligibleDependenciesString = NULL;  // must release
+
+        bootLevelDiagnostics = __OSKextGetDiagnostics(aKext,
+            kOSKextDiagnosticsFlagBootLevel);
+        if (bootLevelDiagnostics) {
+            ineligibleDependencies = CFDictionaryGetValue(bootLevelDiagnostics,
+                kOSKextDependencyIneligibleInSafeBoot);
+        }
+        if (ineligibleDependencies && CFArrayGetCount(ineligibleDependencies)) {
+            ineligibleDependenciesString = createCFStringForPlist_new(
+                ineligibleDependencies, kPListStyleDiagnostics);
+        }
+
+        if (ineligibleDependenciesString) {
+            OSKextLogCFString(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+                CFSTR("Can't load %s - dependencies not elibible during safe boot:\n%@"),
+                kextPath, ineligibleDependenciesString);
+        } else {
+            OSKextLogCFString(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+                CFSTR("Can't load %s - dependencies not elibible during safe boot."),
+                kextPath);
+        }
+        
+        SAFE_RELEASE_NULL(ineligibleDependencies);
+        SAFE_RELEASE_NULL(ineligibleDependenciesString);
+
+        result = kOSKextReturnBootLevel;
+        goto finish;
+    }
+
+    count = CFArrayGetCount(loadList);
+    kextIdentifiers = CFArrayCreateMutable(CFGetAllocator(aKext),
+        count, &kCFTypeArrayCallBacks);
+    if (!kextIdentifiers) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    for (i = 0; i < count; i++) {
+        OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(loadList, i);
+        CFArrayAppendValue(kextIdentifiers, OSKextGetIdentifier(thisKext));
+    }
+    SAFE_RELEASE_NULL(loadList);
+
+   /* Now find out who's really loaded in the kernel, and flush dependency
+    * graphs again so we can build them based on who's loaded.
+    */
+    result = OSKextReadLoadedKextInfo(kextIdentifiers,
+        /* flushDependencies? */ true);
+    if (result != kOSReturnSuccess) {
+        // called function logs well enough
+        goto finish;
+    }
+
+   /* Check before bothering further whether another version/UUID of
+    * the kexts being loaded is already loaded, and bail if so.
+    */
+    if (!OSKextIsLoaded(aKext)) {
+        Boolean      otherVersionLoaded = false;
+        Boolean      otherUUIDLoaded    = false;
+        const char * difference = NULL;
+        
+        otherVersionLoaded = OSKextOtherVersionIsLoaded(aKext, &otherUUIDLoaded);
+        if (otherUUIDLoaded) {
+            difference = "UUID";
+        } else if (otherVersionLoaded) {
+            difference = "version";
+        }
+        if (difference) {
+            OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+                "Can't load %s - a different %s is already loaded.",
+                kextPath, difference);
+            result = kOSKextReturnLoadedVersionDiffers;
+            goto finish;
+        }
+    }
+    
+   /* Ok, now resolve dependencies based on kexts having their load info.
+    * Hopefully it'll still work.
+    */
+    loadList = OSKextCopyLoadList(aKext, /* needAll? */ true);
+    if (!loadList) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Can't load %s - failed to resolve dependencies based on loaded kexts.",
+            kextPath);
+        result = kOSKextReturnDependencies;
+        goto finish;
+    }
+
+    if (!OSKextAuthenticateDependencies(aKext)) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Can't load %s - dependency authentication problems.", kextPath);
+        result = kOSKextReturnAuthentication;
+        goto finish;
+    }
+
+    // construct mkext w/o compression & w/o loaded kexts in it
+    mkext = __OSKextCreateMkext(CFGetAllocator(aKext), loadList,
+        /* volumeRootURL */ NULL,
+        /* requiredFlags */ 0,
+        /* compress */ false,
+        /* skipLoaded */ true,
+        loadArgsDict);
+    if (!mkext) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+             "Can't create kernel load request for %s.", kextPath);
+        goto finish;
+    }
+
+    requestBuffer = CFDataGetBytePtr(mkext);
+    requestLength = CFDataGetLength(mkext);
+
+    OSKextLog(aKext, kOSKextLogProgressLevel | kOSKextLogLoadFlag,
+         "Loading %s.", kextPath);
+
+   /* We don't actually expect a response, but try to tell MIG that
+    * by passing a NULL pointer and it throws a hissy fit and crashes
+    * your program. Fine, MIG; you has a bukkit for the response that
+    * ain't coming. Are you happy now?
+    *
+    * Also, if we don't have a log function to process the messages,
+    * don't bother sending any log flags to the kernel.
+    */
+    mig_result = kext_request(
+        hostPriv,
+        __sOSKextLogOutputFunction ? __sKernelLogFilter : kOSKextLogSilentFilter,
+        (vm_offset_t)requestBuffer,
+        (mach_msg_type_number_t)requestLength,
+        &responseBuffer,
+        &responseLength,
+        (vm_offset_t *)&logInfoBuffer,
+        &logInfoLength,
+        &op_result);
+
+    result = __OSKextProcessKextRequestResults(aKext,
+        mig_result, op_result,
+        (char *)logInfoBuffer, logInfoLength);
+    if (result != kOSReturnSuccess) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Failed to load %s - %s.",
+            kextPath, safe_mach_error_string(result));
+        goto finish;
+    }
+
+finish:
+    SAFE_RELEASE(kextIdentifiers);
+    SAFE_RELEASE(loadList);
+    SAFE_RELEASE(mkext);
+    SAFE_RELEASE(errorString);
+    if (responseBuffer) {
+        vm_deallocate(mach_task_self(), responseBuffer, responseLength);
+    }
+    if (logInfoBuffer) {
+        vm_deallocate(mach_task_self(), logInfoBuffer, logInfoLength);
+    }
+
+    if (result == kOSReturnSuccess) {
+        OSKextLog(aKext, kOSKextLogProgressLevel | kOSKextLogLoadFlag,
+            "Successfully loaded %s.", kextPath);
+    } else {
+        // error points have logged specific reason for failure
+        OSKextRemoveKextPersonalitiesFromKernel(aKext);
+    }
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn OSKextLoad(OSKextRef aKext)
+{
+    return OSKextLoadWithOptions(aKext,
+        /* startExclusion */ kOSKextExcludeNone,
+        /* addPersonalitiesExclusion */ kOSKextExcludeAll,
+        /* personalityNames */ NULL,
+        /* delayAutounload */ false);
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn OSKextLoadWithOptions(
+    OSKextRef           aKext,
+    OSKextExcludeLevel  startExclusion,
+    OSKextExcludeLevel  addPersonalitiesExclusion,
+    CFArrayRef          personalityNames,
+    Boolean             delayAutounloadFlag)
+{
+    OSReturn               result                       = kOSReturnError;
+    CFMutableDictionaryRef loadArgs                     = NULL;  // must release
+    CFNumberRef            startExclusionNum            = NULL;  // must release
+    CFNumberRef            addPersonalitiesExclusionNum = NULL;  // must release
+
+   /* loadArgs will be set in the mkext under the "arguments" key, containing:
+    *     "bundle ID" = <bundle ID>
+    *     "startKext" = bool
+    *     "startMatching" = bool
+    *     "disableAutounload" = bool
+    */
+    // construct load request dict (wow this is verbose)
+    loadArgs = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (!loadArgs) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    CFDictionarySetValue(loadArgs,
+        CFSTR(kKextRequestArgumentBundleIdentifierKey),
+        OSKextGetIdentifier(aKext));
+
+    startExclusionNum = CFNumberCreate(CFGetAllocator(aKext),
+        kCFNumberSInt8Type,
+        &startExclusion);
+    if (!startExclusionNum) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    CFDictionarySetValue(loadArgs, CFSTR(kKextRequestArgumentStartExcludeKey),
+        startExclusionNum);
+
+    addPersonalitiesExclusionNum = CFNumberCreate(CFGetAllocator(aKext),
+        kCFNumberSInt8Type,
+        &addPersonalitiesExclusion);
+    if (!addPersonalitiesExclusionNum) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    CFDictionarySetValue(loadArgs, CFSTR(kKextRequestArgumentStartMatchingExcludeKey),
+        addPersonalitiesExclusionNum);
+
+    if (personalityNames) {
+        CFDictionarySetValue(loadArgs,
+            CFSTR(kKextRequestArgumentPersonalityNamesKey),
+            personalityNames);
+    }
+
+    if (delayAutounloadFlag) {
+        CFDictionarySetValue(loadArgs, CFSTR(kKextRequestArgumentDelayAutounloadKey),
+            kCFBooleanTrue);
+    }
+
+    result = __OSKextLoadWithArgsDict(aKext, loadArgs);
+
+finish:
+    SAFE_RELEASE(loadArgs);
+    SAFE_RELEASE(startExclusionNum);
+    SAFE_RELEASE(addPersonalitiesExclusionNum);
+    return result;
+}
+
+#ifndef IOKIT_EMBEDDED
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextInitKXLDDependency(
+    KXLDDependency * dependency,
+    OSKextRef        aKext,
+    CFDataRef        kernelImage,
+    Boolean          isDirect)
+{
+    Boolean result = FALSE;
+    char    kextPath[PATH_MAX];
+
+    if (!aKext->loadInfo->linkedExecutable) {
+        __OSKextGetFileSystemPath(aKext,
+            /* otherURL */ NULL,
+            /* resolveToBase */ false, kextPath);
+        OSKextLog(aKext, kOSKextLogErrorLevel,
+            "Can't use %s - not linked.", kextPath);
+        goto finish;
+    }
+
+    if (OSKextIsInterface(aKext)) {
+        CFDataRef   interfaceTarget     = NULL;
+        CFStringRef interfaceTargetName = NULL;
+
+        if (OSKextIsKernelComponent(aKext)) {
+            interfaceTarget = kernelImage;
+            interfaceTargetName = __kOSKextKernelIdentifier;
+        } else {
+            OSKextRef interfaceTargetKext = (OSKextRef) 
+                CFArrayGetValueAtIndex(aKext->loadInfo->dependencies, 0);
+
+            if (!interfaceTargetKext->loadInfo->linkedExecutable) {
+                __OSKextGetFileSystemPath(interfaceTargetKext,
+                    /* otherURL */ NULL,
+                    /* resolveToBase */ false, kextPath);
+
+                OSKextLog(aKext, kOSKextLogErrorLevel,
+                    "Can't use %s - not linked.", kextPath);
+                goto finish;
+            }
+            interfaceTarget = 
+                interfaceTargetKext->loadInfo->linkedExecutable;
+            interfaceTargetName = interfaceTargetKext->bundleID;
+        }
+
+        dependency->kext = (u_char *) 
+            CFDataGetBytePtr(interfaceTarget);
+        dependency->kext_size = CFDataGetLength(interfaceTarget);
+        dependency->kext_name = 
+            createUTF8CStringForCFString(interfaceTargetName);
+
+        dependency->interface = (u_char *) 
+            CFDataGetBytePtr(aKext->loadInfo->linkedExecutable);
+        dependency->interface_size =
+            CFDataGetLength(aKext->loadInfo->linkedExecutable);
+        dependency->interface_name = createUTF8CStringForCFString(
+            OSKextGetIdentifier(aKext));
+    } else {
+        dependency->kext = (u_char *)
+            CFDataGetBytePtr(aKext->loadInfo->linkedExecutable);
+        dependency->kext_size = 
+            CFDataGetLength(aKext->loadInfo->linkedExecutable);
+        dependency->kext_name = createUTF8CStringForCFString(
+            OSKextGetIdentifier(aKext));
+
+        dependency->interface = NULL;
+        dependency->interface_size = 0;
+        dependency->interface_name = NULL;
+    }
+
+    dependency->is_direct_dependency = isDirect;
+    result = TRUE;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDataRef __OSKextCopyStrippedExecutable(OSKextRef aKext)
+{
+    CFDataRef result = NULL;
+    CFMutableDataRef strippedExecutable = NULL;
+    u_char *file;
+    u_long fileSize;
+    u_long linkeditSize;
+
+    if (!aKext->loadInfo->linkedExecutable) goto finish;
+
+    fileSize = CFDataGetLength(aKext->loadInfo->linkedExecutable);
+    strippedExecutable = CFDataCreateMutableCopy(kCFAllocatorDefault,
+        fileSize, aKext->loadInfo->linkedExecutable);
+    if (!strippedExecutable) goto finish;
+
+    file = (u_char *) CFDataGetMutableBytePtr(strippedExecutable);
+    if (!file) goto finish;
+
+    /* Find the linkedit segment.  If it's not the last segment, then freeing
+     * it will fragment the kext into multiple VM regions, so we'll have to skip it.
+     */
+    if (__OSKextIsArchitectureLP64()) {
+        struct segment_command_64 * linkedit =
+            macho_get_segment_by_name_64((struct mach_header_64 *)file, SEG_LINKEDIT);
+        if (!linkedit) goto finish;
+
+        if ((round_page(aKext->loadInfo->loadAddress) + round_page(aKext->loadInfo->loadSize)) !=
+             round_page(linkedit->vmaddr) + round_page(linkedit->vmsize))
+        {
+            goto finish;
+        }
+    } else {
+        struct segment_command * linkedit =
+            macho_get_segment_by_name((struct mach_header *)file, SEG_LINKEDIT);
+        if (!linkedit) goto finish;
+
+        if ((round_page(aKext->loadInfo->loadAddress) + round_page(aKext->loadInfo->loadSize)) !=
+             round_page(linkedit->vmaddr) + round_page(linkedit->vmsize))
+        {
+            goto finish;
+        }
+    }
+
+    /* Remove the headers and truncate the data object */
+    if (!macho_trim_linkedit(file, &linkeditSize)) {
+        goto finish;
+    }
+    fileSize -= linkeditSize;
+    CFDataSetLength(strippedExecutable, fileSize);
+
+    result = CFRetain(strippedExecutable);
+finish:
+    SAFE_RELEASE_NULL(strippedExecutable);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static Boolean __OSKextPerformLink(
+    OSKextRef               aKext,
+    CFDataRef               kernelImage,
+    uint64_t                kernelLoadAddress,
+    Boolean                 stripSymbolsFlag,
+    KXLDContext           * kxldContext)
+{
+    Boolean                    result              = false;
+    char                     * bundleIDCString     = NULL;      // must free
+    CFArrayRef                 dependencies        = NULL;      // must release
+    CFMutableArrayRef          indirectDependencies = NULL;     // must release
+    CFDataRef                  kextExecutable      = NULL;      // must release
+
+    kern_return_t              kxldResult          = KERN_FAILURE;
+    KXLDDependency           * kxldDependencies    = NULL;      // must free
+    CFIndex                    numKxldDependencies = 0;
+    kxld_addr_t                kmodInfoKern        = 0;
+
+    CFIndex                    numDirectDependencies    = 0;
+    CFIndex                    numIndirectDependencies  = 0;
+
+    __OSKextKXLDCallbackContext linkAddressContext;
+
+    u_char                   * relocBytes          = NULL;    // do not free
+    u_char                  ** relocBytesPtr       = NULL;    // do not free
+
+    CFDataRef                  relocData           = NULL;    // must release
+    char                       kextPath[PATH_MAX];
+    CFIndex                    i;
+
+    if (!OSKextDeclaresExecutable(aKext)) {
+        result = true;
+        goto finish;
+    }
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+
+    kextExecutable = OSKextCopyExecutableForArchitecture(aKext,
+        OSKextGetArchitecture());
+    if (!kextExecutable) {
+        OSKextLog(aKext, kOSKextLogErrorLevel,
+            "Can't link %s - architecture %s not found", kextPath,
+            OSKextGetArchitecture()->name);
+
+        goto finish;
+    }
+
+    if (OSKextIsInterface(aKext)) {
+        aKext->loadInfo->linkedExecutable = CFRetain(kextExecutable);
+        aKext->loadInfo->prelinkedExecutable = CFRetain(kextExecutable);
+        aKext->loadInfo->loadSize = CFDataGetLength(kextExecutable);
+        result = true;
+        goto finish;
+    }
+
+    dependencies = OSKextCopyLinkDependencies(aKext, /* needAll */ true);
+    if (!dependencies) {
+        goto finish;
+    }
+
+    OSKextLog(aKext, kOSKextLogProgressLevel | kOSKextLogLinkFlag,
+        "Linking %s.", kextPath);
+
+    bundleIDCString = createUTF8CStringForCFString(
+        OSKextGetIdentifier(aKext));
+
+
+    numDirectDependencies = CFArrayGetCount(dependencies);
+    if (!numDirectDependencies) {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+            "Internal error: attempting to link a kext without its dependencies.");
+        goto finish;
+    }
+
+    if (__OSKextGetBleedthroughFlag(aKext)) {
+        numIndirectDependencies = 0;
+    } else {
+        indirectDependencies = OSKextCopyIndirectDependencies(aKext,
+            /* needAllFlag */ TRUE);
+        if (!indirectDependencies) {
+            goto finish;
+        }
+
+        for (i = 0; i < CFArrayGetCount(indirectDependencies); ++i) {
+            OSKextRef indirectDependency = 
+                (OSKextRef) CFArrayGetValueAtIndex(indirectDependencies, i);
+
+           /* Filter out duplicates and codeless kexts.
+            */
+            if (!OSKextDeclaresExecutable(indirectDependency) ||
+                CFArrayContainsValue(dependencies, RANGE_ALL(dependencies),
+                    indirectDependency)) 
+            {
+                CFArrayRemoveValueAtIndex(indirectDependencies, i);
+                i--;
+                continue;
+            }
+        }
+
+        numIndirectDependencies = CFArrayGetCount(indirectDependencies);
+    }
+
+    numKxldDependencies = numDirectDependencies + numIndirectDependencies;
+    kxldDependencies = (KXLDDependency *) 
+        calloc(numKxldDependencies, sizeof(*kxldDependencies));
+    if (!kxldDependencies) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    for (i = 0; i < numDirectDependencies; i++) {
+        OSKextRef dependency = 
+            (OSKextRef) CFArrayGetValueAtIndex(dependencies, i);
+
+        if (!__OSKextInitKXLDDependency(&kxldDependencies[i],
+            dependency, kernelImage, TRUE)) {
+            
+            goto finish;
+        }
+    }
+
+    for (i = 0; i < numIndirectDependencies; i++) {
+        OSKextRef dependency = 
+            (OSKextRef) CFArrayGetValueAtIndex(indirectDependencies, i);
+
+        if (!__OSKextInitKXLDDependency(
+            &kxldDependencies[i + numDirectDependencies], 
+            dependency, kernelImage, FALSE)) {
+            
+            goto finish;
+        }
+    }
+
+    relocBytesPtr = &relocBytes;
+
+   /* Advise the system that we need all the mmapped bytes right away.
+    */
+    (void)posix_madvise((void *)CFDataGetBytePtr(kextExecutable),
+        CFDataGetLength(kextExecutable),
+        POSIX_MADV_WILLNEED);
+
+    linkAddressContext.kernelLoadAddress = kernelLoadAddress;
+    linkAddressContext.kext = aKext;
+
+    kxldResult = kxld_link_file(kxldContext,
+        (void *)CFDataGetBytePtr(kextExecutable),
+        CFDataGetLength(kextExecutable),
+        bundleIDCString,
+        /* callbackData */ (void *)&linkAddressContext,
+        kxldDependencies, numKxldDependencies,
+        relocBytesPtr, /* kmod_info */ &kmodInfoKern);
+
+    for (i = 0; i < numKxldDependencies; i++) {
+        SAFE_FREE(kxldDependencies[i].kext_name);
+        SAFE_FREE(kxldDependencies[i].interface_name);
+    }
+
+    if (kxldResult != KERN_SUCCESS) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+            "Link failed (error code %d).", kxldResult);
+        goto finish;
+    }
+
+    if (relocBytes && aKext->loadInfo->loadSize) {
+        relocData = CFDataCreateWithBytesNoCopy(CFGetAllocator(aKext),
+            relocBytes, aKext->loadInfo->loadSize, kCFAllocatorDefault);
+        if (!relocData) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        aKext->loadInfo->linkedExecutable = CFRetain(relocData);
+        aKext->loadInfo->kmodInfoAddress = kmodInfoKern;
+
+        if (stripSymbolsFlag) {
+#define KMOD_INFO_DEBUG 0
+#if KMOD_INFO_DEBUG
+            u_int64_t   originalLoadSize = aKext->loadInfo->loadSize;
+#endif  // KMOD_INFO_DEBUG
+
+            aKext->loadInfo->prelinkedExecutable = __OSKextCopyStrippedExecutable(aKext);
+            aKext->loadInfo->loadSize = CFDataGetLength(aKext->loadInfo->prelinkedExecutable);
+
+            // 03/16/12 - <rdar://problem/10980607>
+            // must update the kmod_info.size field embedded within the kext image
+            {
+                u_char      *file = (u_char *) CFDataGetMutableBytePtr((CFMutableDataRef) aKext->loadInfo->prelinkedExecutable);
+                Boolean     is_32bit_kext = ((struct mach_header *) file)->magic == MH_MAGIC;
+                u_int64_t   kmodInfo_offset = kmodInfoKern - aKext->loadInfo->loadAddress;
+                vm_size_t   *size_field = (vm_size_t *) (is_32bit_kext ? 
+                                (file + kmodInfo_offset + offsetof(kmod_info_32_v1_t, size)) : 
+                                (file + kmodInfo_offset + offsetof(kmod_info_64_v1_t, size)));
+
+#if KMOD_INFO_DEBUG
+                vm_size_t   original_kmodInfo_size = *size_field;
+                OSKextLog(aKext, kOSKextLogDebugLevel | kOSKextLogLinkFlag | kOSKextLogLoadFlag,
+                          "--original load size: 0x%.8llx, original kmod_info.size: 0x%.8x",
+                          originalLoadSize, (unsigned int) original_kmodInfo_size);
+#endif  // KMOD_INFO_DEBUG
+
+                *size_field = aKext->loadInfo->loadSize;
+
+#if KMOD_INFO_DEBUG
+                OSKextLog(aKext, kOSKextLogDebugLevel | kOSKextLogLinkFlag | kOSKextLogLoadFlag,
+                          "--     new load size: 0x%.8zx,      new kmod_info.size: 0x%.8x",
+                          aKext->loadInfo->loadSize, (unsigned int) *size_field);
+#endif  // KMOD_INFO_DEBUG
+
+            }
+        }
+
+        if (!aKext->loadInfo->prelinkedExecutable) {
+            aKext->loadInfo->prelinkedExecutable = CFRetain(relocData);
+        }
+    }
+
+    result = true;
+
+finish:
+
+   /* Advise the system that we no longer need the mmapped executable.
+    */
+    if (kextExecutable) {
+        (void)posix_madvise((void *)CFDataGetBytePtr(kextExecutable),
+            CFDataGetLength(kextExecutable),
+            POSIX_MADV_DONTNEED);
+    }
+
+    SAFE_RELEASE(kextExecutable);
+    SAFE_RELEASE(dependencies);
+    SAFE_RELEASE(indirectDependencies);
+
+    SAFE_RELEASE(relocData);
+
+    SAFE_FREE(kxldDependencies);
+    SAFE_FREE(bundleIDCString);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextExtractDebugSymbols(
+    OSKextRef                   aKext,
+    CFMutableDictionaryRef      symbols)
+{
+    Boolean       result              = false;
+    CFStringRef   relocName           = NULL;       // must release
+
+    if (!OSKextDeclaresExecutable(aKext) || OSKextIsInterface(aKext)) {
+        result = true;
+        goto finish;
+    }
+
+    if (aKext->loadInfo->linkedExecutable) {
+        relocName = CFStringCreateWithFormat(CFGetAllocator(aKext), NULL,
+            CFSTR("%@.%s"),
+            OSKextGetIdentifier(aKext),
+            __kOSKextSymbolFileSuffix);
+        if (!relocName) {
+            OSKextLogMemError();
+            goto finish;
+        }
+
+        CFDictionarySetValue(symbols, relocName, aKext->loadInfo->linkedExecutable);
+    }
+
+    result = true;
+
+finish:
+    SAFE_RELEASE(relocName);
+    
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextGenerateDebugSymbols(
+    OSKextRef                aKext,
+    CFDataRef                kernelImage,
+    uint64_t                 kernelLoadAddress,
+    KXLDContext            * kxldContext,
+    CFMutableDictionaryRef   symbols)
+{
+    Boolean       result              = false;
+    CFArrayRef    dependencies        = NULL;       // must release
+    CFIndex       count, i;
+
+
+    if (!__OSKextCreateLoadInfo(aKext)) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+   /* Check if we already linked this one. If so, we've also already done
+    * its dependencies.
+    */
+    if (aKext->loadInfo->linkedExecutable) {
+        result = true;
+        goto finish;
+    }
+
+    dependencies = OSKextCopyLinkDependencies(aKext, /* needAll */ true);
+    if (!dependencies) {
+        result = false;
+        goto finish;
+    }
+
+    count = CFArrayGetCount(dependencies);
+    for (i = 0; i < count; i++) {
+        OSKextRef dependency = (OSKextRef)CFArrayGetValueAtIndex(
+            dependencies, i);
+
+        result = __OSKextGenerateDebugSymbols(dependency, kernelImage,
+             kernelLoadAddress, kxldContext, symbols);
+        if (!result) {
+            goto finish;
+        }
+    }
+
+    result = __OSKextPerformLink(aKext, kernelImage, kernelLoadAddress,
+        false /* stripSymbolsFlag */, kxldContext);
+    if (!result) {
+        goto finish;
+    }
+
+    result = __OSKextExtractDebugSymbols(aKext, symbols);
+    if (!result) {
+        goto finish;
+    }
+
+    result = true;
+finish:
+    SAFE_RELEASE(dependencies);
+
+    return result;
+}
+
+/*********************************************************************
+* Link address callback for kxld, for symbol generation only. If a
+* kext has no address set, we won't be saving its symbols, so we
+* return a fake nonzero address by default.
+*********************************************************************/
+kxld_addr_t __OSKextLinkAddressCallback(
+    u_long              size,
+    KXLDAllocateFlags * flags __unused,
+    void              * user_data)
+{
+    kxld_addr_t result      = 0;
+    kxld_addr_t kextAddress = 0;
+    static kxld_addr_t loadAddressOffset = 0;
+    __OSKextKXLDCallbackContext * context =
+        (__OSKextKXLDCallbackContext *)user_data;
+
+    context->kext->loadInfo->loadSize = size;
+
+    kextAddress = (kxld_addr_t)OSKextGetLoadAddress(context->kext);
+    if (kextAddress) {
+        result = kextAddress;
+    } else {
+        result = context->kernelLoadAddress + loadAddressOffset;
+        loadAddressOffset += size;
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+void __OSKextLoggingCallback(
+    KXLDLogSubsystem    subsystem, 
+    KXLDLogLevel        level, 
+    const char        * format, 
+    va_list             argList,
+    void              * user_data)
+{
+    __OSKextKXLDCallbackContext * context = 
+        (__OSKextKXLDCallbackContext *)user_data;
+    OSKextRef aKext = (context) ? context->kext : NULL;
+    OSKextLogSpec logSpec = 0;
+
+    switch (subsystem) {
+    case kKxldLogLinking:
+        logSpec |= kOSKextLogLinkFlag;
+        break;
+    case kKxldLogPatching:
+        logSpec |= kOSKextLogPatchFlag;
+        break;
+    }
+
+    switch (level) {
+    case kKxldLogExplicit:
+        logSpec |= kOSKextLogExplicitLevel;
+        break;
+    case kKxldLogErr:
+        logSpec |= kOSKextLogErrorLevel;
+        break;
+    case kKxldLogWarn:
+        logSpec |= kOSKextLogWarningLevel;
+        break;
+    case kKxldLogBasic:
+        logSpec |= kOSKextLogProgressLevel;
+        break;
+    case kKxldLogDetail:
+        logSpec |= kOSKextLogDetailLevel;
+        break;
+    case kKxldLogDebug:
+        logSpec |= kOSKextLogDebugLevel;
+        break;
+    }
+
+    OSKextVLog(aKext, logSpec, format, argList);
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDictionaryRef OSKextGenerateDebugSymbols(
+    OSKextRef aKext,
+    CFDataRef kernelImage)
+{
+    CFMutableDictionaryRef   result             = NULL;
+    CFDataRef                kernelImageCopy    = NULL;
+    KXLDContext            * kxldContext        = NULL;
+    KXLDFlags                kxldFlags          = 0;
+    kern_return_t            kxldResult         = 0;
+    uint64_t                 kernelLoadAddress  = 0;
+    macho_seek_result        machoResult;
+    const UInt8 *            kernelStart;
+    const UInt8 *            kernelEnd;
+    fat_iterator             fatIterator        = NULL; // must fat_iterator_close()
+    struct mach_header_64 *  machHeader         = NULL; // do not free
+
+   /* If the kernelImage is not given, then the current architecture must match
+    * that of the running kernel.
+    */
+    if (!kernelImage) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+                  "Can't generate debug symbols; no kernel file provided ");
+        goto finish;
+    }
+
+    if (!OSKextResolveDependencies(aKext)) {
+        goto finish;
+    }
+
+    result = CFDictionaryCreateMutable(CFGetAllocator(aKext), 0,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    kernelStart = CFDataGetBytePtr(kernelImage);
+    kernelEnd = kernelStart + CFDataGetLength(kernelImage) - 1;
+    fatIterator = fat_iterator_for_data(kernelStart, kernelEnd,
+                                        1 /* mach-o only */);
+    if (!fatIterator) {
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                  "Can't read kernel file.");
+        goto finish;
+    }
+    machHeader = (struct mach_header_64 *)
+        fat_iterator_find_arch(fatIterator,
+                               OSKextGetArchitecture()->cputype, 
+                               OSKextGetArchitecture()->cpusubtype,
+                               NULL);
+    if (!machHeader) {
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                  "Can't find architecture %s in kernel file.",
+                  OSKextGetArchitecture()->name);
+        goto finish;
+    }
+    
+    /* this kernel supports KASLR if there is a LC_DYSYMTAB load command */
+    machoResult = macho_find_dysymtab(machHeader, kernelEnd, NULL);
+    if (machoResult == macho_seek_result_found) {
+        kxldFlags |= kKXLDFlagIncludeRelocs;
+    }
+    else {
+        OSKextLog(NULL, 
+                  kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                  "kernel does NOT support KASLR");
+    }
+
+    kxldResult = kxld_create_context(&kxldContext, __OSKextLinkAddressCallback,
+        __OSKextLoggingCallback, kxldFlags, OSKextGetArchitecture()->cputype, 
+        OSKextGetArchitecture()->cpusubtype);
+    if (kxldResult != KERN_SUCCESS) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+             "Can't create link context.");
+        goto finish;
+    }
+
+    kernelLoadAddress = __OSKextGetFakeLoadAddress(kernelImage);
+    if (!kernelLoadAddress) {
+        goto finish;
+    }
+
+    if (!__OSKextGenerateDebugSymbols(aKext, kernelImage,
+        kernelLoadAddress, kxldContext, result)) 
+    {
+        SAFE_RELEASE_NULL(result);
+        goto finish;
+    }
+
+finish:
+    SAFE_RELEASE(kernelImageCopy);
+
+    if (kxldContext) kxld_destroy_context(kxldContext);
+    if (fatIterator) fat_iterator_close(fatIterator);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextNeedsLoadAddressForDebugSymbols(OSKextRef aKext)
+{
+    Boolean result = false;
+
+    if (!OSKextIsKernelComponent(aKext) &&
+        !OSKextIsInterface(aKext)       &&
+        !OSKextGetLoadAddress(aKext)    &&
+        OSKextDeclaresExecutable(aKext)) {
+
+        result = true;
+    }
+    return result;
+}
+#endif /* !IOKIT_EMBEDDED */
+
+/*********************************************************************
+*********************************************************************/
+OSReturn __OSKextUnload(
+    OSKextRef   aKext,
+    CFStringRef kextIdentifier,
+    Boolean     terminateServiceAndRemovePersonalities)
+{
+    OSReturn               result        = kOSReturnError;
+    char                 * kextIDCString = NULL;  // must free
+    CFDictionaryRef        kextRequest   = NULL;  // must release
+    CFMutableDictionaryRef requestArgs   = NULL;  // do not release
+    char                 * termMessage   =
+                           " (with termnation of IOServices)";
+    char                   kextPath[PATH_MAX];
+
+    if (aKext) {
+        kextIdentifier = OSKextGetIdentifier(aKext);
+        __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+            /* resolveToBase */ false, kextPath);
+    } else {
+        kextIDCString = createUTF8CStringForCFString(kextIdentifier);
+    }
+
+    OSKextLog(aKext,
+        kOSKextLogProgressLevel |
+        kOSKextLogIPCFlag | kOSKextLogLoadFlag,
+        "Requesting unload of %s%s.",
+        aKext ? kextPath : kextIDCString,
+        terminateServiceAndRemovePersonalities ? termMessage : "");
+
+    kextRequest = __OSKextCreateKextRequest(
+        CFSTR(kKextRequestPredicateUnload),
+        kextIdentifier, /* argsOut */ &requestArgs);
+    if (!kextRequest || !requestArgs) {
+        goto finish;
+    }
+
+    if (terminateServiceAndRemovePersonalities) {
+        CFDictionarySetValue(requestArgs,
+            CFSTR(kKextRequestArgumentTerminateIOServicesKey),
+            kCFBooleanTrue);
+    }
+
+    result = __OSKextSendKextRequest(aKext, kextRequest,
+        /* cfResponseOut */ NULL,
+        /* rawResponseOut */ NULL, /* rawResponseLengthOut */ NULL);
+    if (result != kOSReturnSuccess) {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+            "Failed to unload %s - %s.",
+            aKext ? kextPath : kextIDCString,
+            safe_mach_error_string(result));
+        goto finish;
+    } else {
+        OSKextLog(aKext,
+            kOSKextLogProgressLevel |
+            kOSKextLogIPCFlag | kOSKextLogLoadFlag,
+            "Successfully unloaded %s.",
+            aKext ? kextPath : kextIDCString);
+    }
+
+finish:
+    SAFE_FREE(kextIDCString);
+    SAFE_RELEASE(kextRequest);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn OSKextUnload(
+    OSKextRef aKext,
+    Boolean   terminateServiceAndRemovePersonalities)
+{
+    return __OSKextUnload(aKext, /* kextIdentifier */ NULL,
+        terminateServiceAndRemovePersonalities);
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn OSKextUnloadKextWithIdentifier(
+    CFStringRef kextIdentifier,
+    Boolean     terminateServiceAndRemovePersonalities)
+{
+    return __OSKextUnload(/* kext */ NULL, kextIdentifier,
+        terminateServiceAndRemovePersonalities);
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextIsStarted(OSKextRef aKext)
+{
+    Boolean result = false;
+    
+    if (!aKext->loadInfo) {
+        goto finish;
+    }
+    if (aKext->loadInfo->kernelLoadInfo) {
+        __OSKextCheckLoaded(aKext);
+    }
+    if (aKext->loadInfo->flags.isStarted) {
+        result = true;
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+kern_return_t OSKextStart(OSKextRef aKext)
+{
+    OSReturn result = kOSReturnError;
+    char kextPath[PATH_MAX];
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+    // xxx - check level
+    OSKextLog(aKext,
+        kOSKextLogProgressLevel |
+        kOSKextLogIPCFlag | kOSKextLogLoadFlag,
+        "Requesting start of %s.", kextPath);
+
+    result = __OSKextSimpleKextRequest(aKext,
+        CFSTR(kKextRequestPredicateStart), /* responseOut */ NULL);
+
+    if (result == kOSReturnSuccess) {
+        OSKextLog(aKext, kOSKextLogProgressLevel |
+            kOSKextLogIPCFlag | kOSKextLogLoadFlag,
+            "Started %s.", kextPath);
+    } else {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Failed to start %s - %s.", kextPath,
+            safe_mach_error_string(result));
+    }
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+kern_return_t OSKextStop(OSKextRef aKext)
+{
+    OSReturn result = kOSReturnError;
+    char kextPath[PATH_MAX];
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+
+    OSKextLog(aKext,
+        kOSKextLogProgressLevel |
+        kOSKextLogIPCFlag | kOSKextLogLoadFlag,
+        "Requesting stop of %s.", kextPath);
+
+    result = __OSKextSimpleKextRequest(aKext, CFSTR(kKextRequestPredicateStop),
+        /* responseOut */ NULL);
+
+    if (result == kOSReturnSuccess) {
+        OSKextLog(aKext,
+            kOSKextLogProgressLevel |
+            kOSKextLogIPCFlag | kOSKextLogLoadFlag,
+            "Successfully stopped %s.", kextPath);
+    } else {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Failed to stop %s - %s.", kextPath,
+            safe_mach_error_string(result));
+    }
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn
+OSKextSendPersonalitiesToKernel(CFArrayRef personalities,
+    Boolean resetFlag)
+{
+    OSReturn      result = kOSReturnError;
+    CFDataRef     serializedPersonalities = NULL;  // must release
+    void        * dataPtr;
+    CFIndex       dataLength = 0;
+    uint32_t      sendDataFlag = resetFlag ? kIOCatalogResetDrivers : kIOCatalogAddDrivers;
+
+    if (!personalities) {
+        result = kOSKextReturnInvalidArgument;
+        goto finish;
+    }
+
+    if (!CFArrayGetCount(personalities)) {
+        result = kOSReturnSuccess;
+        goto finish;
+    }
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogStepLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+        "Sending %d personalit%s to the kernel.",
+        (int)CFArrayGetCount(personalities),
+        (CFArrayGetCount(personalities) != 1) ? "ies" : "y");
+
+    serializedPersonalities = IOCFSerialize(personalities, kNilOptions);
+    if (!serializedPersonalities) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Can't serialize personalities.");
+        result = kOSKextReturnSerialization;
+        goto finish;
+    }
+
+    dataPtr = (void *)CFDataGetBytePtr(serializedPersonalities);
+    dataLength = CFDataGetLength(serializedPersonalities);
+
+    result = IOCatalogueSendData(kIOMasterPortDefault,
+        sendDataFlag, dataPtr, dataLength);
+
+    if (result != KERN_SUCCESS) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel |
+            kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+           "Failed to send personalities to the kernel.");
+       goto finish;
+    }
+
+finish:
+    SAFE_RELEASE(serializedPersonalities);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn OSKextSendKextPersonalitiesToKernel(
+    OSKextRef  aKext,
+    CFArrayRef personalityNames)
+{
+    OSReturn          result               = kOSReturnSuccess;
+    CFArrayRef        personalities        = NULL;  // must release
+    CFMutableArrayRef mutablePersonalities = NULL;  // do not release; alias
+    char              kextPath[PATH_MAX];
+    char            * nameCString          = NULL;  // must free
+    CFIndex           count, i;
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+
+    count = 0;
+    if (personalityNames) {
+        count = CFArrayGetCount(personalityNames);
+    }
+    if (!count) {
+        personalities = OSKextCopyPersonalitiesArray(aKext);
+        if (personalities && CFArrayGetCount(personalities)) {
+            OSKextLog(aKext, kOSKextLogStepLevel | kOSKextLogLoadFlag,
+                "Sending all personalties for %s to the kernel.",
+                kextPath);
+        } else {
+            OSKextLog(aKext, kOSKextLogStepLevel | kOSKextLogLoadFlag,
+                "%s has no personalities to send to kernel.",
+                kextPath);
+        }
+    } else {
+        CFDictionaryRef allPersonalities = OSKextGetValueForInfoDictionaryKey(
+            aKext, CFSTR(kIOKitPersonalitiesKey));
+
+        if (!allPersonalities && !CFDictionaryGetCount(allPersonalities)) {
+            OSKextLog(aKext, kOSKextLogStepLevel | kOSKextLogLoadFlag,
+                "%s has no personalities to send to kernel.",
+                kextPath);
+            goto finish;
+        }
+        mutablePersonalities = CFArrayCreateMutable(CFGetAllocator(aKext),
+            0, &kCFTypeArrayCallBacks);
+        if (!mutablePersonalities) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        personalities = mutablePersonalities;
+
+        OSKextLog(aKext,
+            kOSKextLogDetailLevel |
+            kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+            "Sending named personalities of %s to the kernel:",
+            kextPath);
+
+        for (i = 0; i < count; i++) {
+            CFStringRef     name = CFArrayGetValueAtIndex(personalityNames, i);
+            CFDictionaryRef personality = CFDictionaryGetValue(allPersonalities,
+                name);
+
+            SAFE_FREE_NULL(nameCString);
+            nameCString = createUTF8CStringForCFString(name);
+            if (!nameCString) {
+                OSKextLogMemError();
+                goto finish;
+            }
+
+            if (!personality) {
+                OSKextLog(aKext,
+                    kOSKextLogErrorLevel | kOSKextLogGeneralFlag,
+                    "Personality %s not found in %s.",
+                    nameCString, kextPath);
+                result = kOSKextReturnInvalidArgument;
+                goto finish;
+            }
+
+            OSKextLog(aKext,
+                kOSKextLogDetailLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+                "    %s", nameCString);
+            CFArrayAppendValue(mutablePersonalities, personality);
+        }
+    }
+
+    if (personalities && CFArrayGetCount(personalities)) {
+        OSReturn sendResult = OSKextSendPersonalitiesToKernel(personalities,
+            /* reset? */ FALSE);
+        if (sendResult != kOSReturnSuccess) {
+            result = sendResult;
+        }
+    }
+finish:
+    SAFE_FREE(nameCString);
+    SAFE_RELEASE(personalities);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn OSKextSendPersonalitiesOfKextsToKernel(CFArrayRef kextArray,
+    Boolean resetFlag)
+{
+    OSReturn      result            = kOSReturnSuccess;
+    CFArrayRef    personalities     = NULL;  // must release
+    CFIndex       count;
+
+    count = CFArrayGetCount(kextArray);
+    if (!count) {
+        goto finish;
+    }
+    personalities = OSKextCopyPersonalitiesOfKexts(kextArray);
+    if (!personalities || !CFArrayGetCount(personalities)) {
+        // xxx - there could be an error buried in that call above...
+        goto finish;
+    }
+
+    result = OSKextSendPersonalitiesToKernel(personalities, resetFlag);
+
+finish:
+    SAFE_RELEASE(personalities);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn __OSKextRemovePersonalities(
+    OSKextRef   aKext,
+    CFStringRef aBundleID)
+{
+    OSReturn        result            = kOSReturnError;
+    kern_return_t   iocatalogueResult = KERN_SUCCESS;
+    CFDictionaryRef personality       = NULL;  // must release
+    CFDataRef       data              = NULL;  // must release
+    void          * dataPointer       = NULL;  // do not free
+    CFIndex         dataLength        = 0;
+    char            kextPath[PATH_MAX];
+
+    personality = CFDictionaryCreate(CFGetAllocator(aKext),
+        (const void **)&kCFBundleIdentifierKey,
+        (const void **)&aBundleID, 1,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (!personality) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ FALSE, kextPath);
+
+    data = IOCFSerialize(personality, kNilOptions);
+    if (!data) {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+            "Can't serialize personalities for %s.",
+            kextPath);
+        goto finish;
+    }
+
+    dataPointer = (void *)CFDataGetBytePtr(data);
+    dataLength = CFDataGetLength(data);
+    iocatalogueResult = IOCatalogueSendData(kIOMasterPortDefault,
+        kIOCatalogRemoveDrivers,
+        dataPointer, dataLength);
+
+    if (iocatalogueResult != KERN_SUCCESS) {
+       OSKextLog(aKext,
+           kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+           "Failed to remove personalities of %s from IOCatalogue - %s.",
+           kextPath,
+           safe_mach_error_string(iocatalogueResult));
+       goto finish;
+    }
+    result = kOSReturnSuccess;
+finish:
+    SAFE_RELEASE(data);
+    SAFE_RELEASE(personality);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn OSKextRemoveKextPersonalitiesFromKernel(OSKextRef aKext)
+{
+    return __OSKextRemovePersonalities(aKext, OSKextGetIdentifier(aKext));
+}
+
+
+/*********************************************************************
+*********************************************************************/
+OSReturn OSKextRemovePersonalitiesForIdentifierFromKernel(
+    CFStringRef aBundleID)
+{
+    return __OSKextRemovePersonalities(/* kext */ NULL, aBundleID);
+}
+
+/*********************************************************************
+*********************************************************************/
+void __OSKextProcessLoadInfo(
+    const void * vKey __unused,
+    const void * vValue,
+          void * vContext __unused)
+{
+    CFDictionaryRef loadInfoDict  = (CFDictionaryRef)vValue;
+    CFStringRef     bundleID        = NULL;  // do not release
+    char          * bundleIDCString = NULL;  // must free
+    CFArrayRef      matchingKexts   = NULL;  // must release
+    OSKextRef       aKext           = NULL;  // do not release
+    Boolean         foundOne        = FALSE;
+    OSKextVersion   loadedVersion   = -1;
+    CFStringRef     scratchString   = NULL;  // do not release
+
+    char            kextPath[PATH_MAX];
+    char            kextVersBuffer[kOSKextVersionMaxLength];
+    char            loadedVersBuffer[kOSKextVersionMaxLength] = __kStringUnknown;
+    CFIndex         count, i;
+
+   /* See if we have any kexts for the bundle identifier.
+    */
+    bundleID = CFDictionaryGetValue(loadInfoDict, kCFBundleIdentifierKey);
+    if (!bundleID) {
+        goto finish;
+    }
+    matchingKexts = OSKextCopyKextsWithIdentifier(bundleID);
+    if (!matchingKexts) {
+        goto finish;
+    }
+
+    bundleIDCString = createUTF8CStringForCFString(bundleID);
+
+    scratchString = CFDictionaryGetValue(loadInfoDict, kCFBundleVersionKey);
+    if (scratchString) {
+        loadedVersion = OSKextParseVersionCFString(scratchString);
+        OSKextVersionGetString(loadedVersion,
+            loadedVersBuffer, sizeof(loadedVersBuffer));
+    } else {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+            "Kernel load info for %s lacks a CFBundleVersion.",
+            bundleIDCString);
+        goto finish;
+    }
+
+
+    count = CFArrayGetCount(matchingKexts);
+    for (i = 0; i < count; i++) {
+        aKext = (OSKextRef)CFArrayGetValueAtIndex(matchingKexts, i);
+
+        if (!__OSKextCreateLoadInfo(aKext)) {
+            OSKextLogMemError();
+            goto finish;
+        }
+
+        __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+            /* resolveToBase */ false, kextPath);
+        OSKextVersionGetString(OSKextGetVersion(aKext),
+            kextVersBuffer, sizeof(kextVersBuffer));
+
+       /* If the versions don't match, there's nothing more to check!
+        */
+        if (loadedVersion != aKext->version) {
+            aKext->loadInfo->flags.otherCFBundleVersionIsLoaded = 1;
+            continue;
+        }
+
+       /* We only retain loadInfoDict if we have to lazily figure out
+        * whether this kext is loaded. If we know another version is loaded
+        * there's no more to do. Note that we need to release the existing one!
+        */
+        SAFE_RELEASE_NULL(aKext->loadInfo->kernelLoadInfo);
+        aKext->loadInfo->kernelLoadInfo = CFRetain(loadInfoDict);
+        foundOne = TRUE;
+
+        // xxx - do we want to do anything with:
+        // xxx - prelinked, path, metaclasses, dependencies?
+    }
+
+finish:
+    if (!foundOne && !CFEqual(bundleID, CFSTR(kOSKextKernelIdentifier))) {
+        OSKextLog(aKext,
+            kOSKextLogDetailLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+            "For loaded kext %s, v%s: no opened kext matches.",
+            bundleIDCString, loadedVersBuffer);
+    }
+
+    SAFE_FREE(bundleIDCString);
+    SAFE_RELEASE(matchingKexts);
+    return;
+}
+
+/*********************************************************************
+// xxx - don't want to log with lazy eval any more
+*********************************************************************/
+static void __OSKextCheckLoaded(OSKextRef aKext)
+{
+    CFDataRef     kextUUID           = NULL;  // must release
+    CFDataRef     loadedUUID         = NULL;  // do not release
+    uuid_string_t kextUUIDCString    = "";
+    uuid_string_t loadedUUIDCString  = "";
+    CFNumberRef   scratchNumber      = NULL;  // do not release
+    CFBooleanRef  scratchBool        = NULL;  // do not release
+    char          kextPath[PATH_MAX];
+    char          kextVersBuffer[kOSKextVersionMaxLength];
+
+    if (!aKext->loadInfo || !aKext->loadInfo->kernelLoadInfo) {
+        goto finish;
+    }
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase? */ false, kextPath);
+
+    /*******
+    * UUID *
+    ********/
+    loadedUUID = CFDictionaryGetValue(aKext->loadInfo->kernelLoadInfo,
+        CFSTR(kOSBundleUUIDKey));
+    kextUUID = OSKextCopyUUIDForArchitecture(aKext,
+        OSKextGetRunningKernelArchitecture());
+
+    if (loadedUUID) {
+        uuid_unparse(CFDataGetBytePtr(loadedUUID), loadedUUIDCString);
+    }
+    if (kextUUID) {
+        uuid_unparse(CFDataGetBytePtr(kextUUID), kextUUIDCString);
+    }
+    OSKextVersionGetString(OSKextGetVersion(aKext), kextVersBuffer,
+        sizeof(kextVersBuffer));
+
+    if ( (loadedUUID && kextUUID && CFEqual(loadedUUID, kextUUID)) ||
+         (!loadedUUID && !kextUUID) ) {
+
+        aKext->loadInfo->flags.isLoaded = 1;
+        
+        /* Will need to find a decent way to log this & following
+         * when we do the logging cleanup after the seed.
+         */
+        OSKextLog(aKext,
+            // xxx - check level
+            kOSKextLogDebugLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+            "%s (version %s%s%s) is loaded.",
+            kextPath, // xxx - better to use bundle ID?
+            kextVersBuffer,
+            kextUUIDCString[0] ? ", UUID " : ", no UUID",
+            kextUUIDCString);
+    } else {
+        aKext->loadInfo->flags.otherUUIDIsLoaded = 1;
+
+        OSKextLog(aKext,
+            kOSKextLogDebugLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+            "%s (version %s%s%s): same version, different UUID (%s) is loaded.",
+            kextPath, // xxx - better to use bundle ID?
+            kextVersBuffer,
+            kextUUIDCString[0] ? ", UUID " : ", no UUID",
+            kextUUIDCString,
+            loadedUUIDCString[0] ? loadedUUIDCString : "none");
+
+        goto finish;
+    }
+
+    /**********
+    * Started *
+    ***********/
+    scratchBool = CFDictionaryGetValue(aKext->loadInfo->kernelLoadInfo,
+        CFSTR(kOSBundleStartedKey));
+    if (scratchBool && CFBooleanGetValue(scratchBool)) {
+        aKext->loadInfo->flags.isStarted = 1;
+
+        OSKextLog(aKext,
+            kOSKextLogDebugLevel | kOSKextLogLoadFlag  | kOSKextLogIPCFlag,
+            "%s (version %s): is%s started.",
+            kextPath, // xxx - better to use bundle ID?
+            kextVersBuffer,
+            aKext->loadInfo->flags.isStarted ? "" : " not");
+
+    }
+
+    /***********
+    * load tag *
+    ************/
+    scratchNumber = CFDictionaryGetValue(aKext->loadInfo->kernelLoadInfo,
+        CFSTR(kOSBundleLoadTagKey));
+    if (scratchNumber) {
+        uint32_t loadTag;
+        if (CFNumberGetValue(scratchNumber, kCFNumberSInt32Type, &loadTag)) {
+            aKext->loadInfo->loadTag = loadTag;
+        } else {
+            // xxx - log an error?
+        }
+    }
+
+    /***************
+    * load address *
+    ****************/
+    scratchNumber = CFDictionaryGetValue(aKext->loadInfo->kernelLoadInfo,
+        CFSTR(kOSBundleLoadAddressKey));
+    if (scratchNumber) {
+        uint64_t loadAddress;
+        if (CFNumberGetValue(scratchNumber, kCFNumberSInt64Type,
+            &loadAddress)) {
+
+           /* Call the internal SetLoadAddress function so we don't call
+            * right back into this function making an infinite recursion.
+            */
+            __OSKextSetLoadAddress(aKext, loadAddress);
+        } else {
+            // xxx - log an error?
+        }
+    }
+
+    /**************
+    * header size *
+    ***************/
+    scratchNumber = CFDictionaryGetValue(aKext->loadInfo->kernelLoadInfo,
+        CFSTR(kOSBundleLoadSizeKey));
+    if (scratchNumber) {
+        uint32_t loadSize;
+        if (CFNumberGetValue(scratchNumber, kCFNumberSInt32Type,
+            &loadSize)) {
+
+            aKext->loadInfo->loadSize = loadSize;
+        } else {
+            // xxx - log an error?
+        }
+    }
+    
+finish:
+
+    if (aKext->loadInfo) {
+        SAFE_RELEASE_NULL(aKext->loadInfo->kernelLoadInfo);
+    }
+    SAFE_RELEASE(kextUUID);
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn OSKextReadLoadedKextInfo(
+    CFArrayRef kextIdentifiers,
+    Boolean    flushDependenciesFlag)
+{
+    OSReturn           result      = kOSReturnError;
+    CFArrayRef         kexts       = NULL;  // must release
+    CFDictionaryRef    allLoadInfo = NULL;  // must release
+    const NXArchInfo * currentArch = NULL;  // do not free
+    const NXArchInfo * kernelArch  = NULL;  // do not free
+    CFIndex            count, i;
+
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    currentArch = OSKextGetArchitecture();
+    kernelArch = OSKextGetRunningKernelArchitecture();
+
+    if (currentArch != kernelArch) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+            "Can't read loaded kext info - current architecture %s != kernel's architecture %s.",
+            currentArch->name, kernelArch->name);
+        result = kOSKextReturnArchNotFound;
+        goto finish;
+    }
+
+   /* Dump all load info, including resolved dependencies as requested.
+    */
+    if (!kextIdentifiers) {
+        OSKextFlushLoadInfo(/* kext */ NULL, flushDependenciesFlag);
+    } else {
+        kexts = OSKextCopyKextsWithIdentifiers(kextIdentifiers);
+        if (!kexts) {
+            // none to update.
+            goto finish;
+        }
+        count = CFArrayGetCount(kexts);
+        for (i = 0; i < count; i++) {
+            OSKextRef thisKext = (OSKextRef) CFArrayGetValueAtIndex(kexts, i);
+            OSKextFlushLoadInfo(thisKext, flushDependenciesFlag);
+        }
+    }
+
+    if (kextIdentifiers && CFArrayGetCount(kextIdentifiers)) {
+        CFIndex numIdentifiers = CFArrayGetCount(kextIdentifiers);
+        OSKextLog(/* kext */ NULL,
+            // xxx - check level
+            kOSKextLogProgressLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+            "Reading load info for %u kext%s.",
+            (uint32_t)numIdentifiers,
+            numIdentifiers == 1 ? "" : "s");
+    } else {
+        OSKextLog(/* kext */ NULL,
+            // xxx - check level
+            kOSKextLogProgressLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+            "Reading load info for all kexts.");
+    }
+
+    // xxx - need to specify just the props OSKext objects actually use
+    allLoadInfo = OSKextCopyLoadedKextInfo(kextIdentifiers, __sOSKextInfoEssentialKeys);
+    if (!allLoadInfo) {
+        // xxx - this is usually an error, though not always!
+        // xxx - we really lack a way to propagate it
+        goto finish;
+    }
+    
+    CFDictionaryApplyFunction(allLoadInfo, __OSKextProcessLoadInfo,
+        /* context */ NULL);
+
+    result = kOSReturnSuccess;
+
+finish:
+    SAFE_RELEASE(kexts);
+    SAFE_RELEASE(allLoadInfo);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextIsLoaded(OSKextRef aKext)
+{
+    Boolean result = false;
+
+    if (!aKext->loadInfo) {
+        goto finish;
+    }
+    if (aKext->loadInfo->kernelLoadInfo) {
+        __OSKextCheckLoaded(aKext);
+    }
+    if (aKext->loadInfo->flags.isLoaded) {
+        result = true;
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+uint64_t OSKextGetLoadAddress(OSKextRef aKext)
+{
+    uint64_t result = 0x0;
+
+    if (!aKext->loadInfo) {
+        goto finish;
+    }
+    if (aKext->loadInfo->kernelLoadInfo) {
+        __OSKextCheckLoaded(aKext);
+    }
+    result = aKext->loadInfo->loadAddress;
+    
+finish:
+    return result;
+}
+
+/*******************************************************************************
+* Internal set-load-address function to avoid infinite recursion from processing
+* load info.
+*******************************************************************************/
+Boolean __OSKextSetLoadAddress(OSKextRef aKext, uint64_t address)
+{
+    Boolean result = false;
+    char    kextPath[PATH_MAX];
+
+    if (!__OSKextCreateLoadInfo(aKext)) {
+        goto finish;
+    }
+    
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+
+    if (!__OSKextIsArchitectureLP64() && address > UINT32_MAX) {
+
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogLoadFlag,
+            "Attempt to set 64-bit load address - %s.",
+            kextPath);
+        goto finish;
+    }
+
+    if (__OSKextIsArchitectureLP64()) {
+        OSKextLog(aKext, kOSKextLogDebugLevel | kOSKextLogLinkFlag | kOSKextLogLoadFlag,
+            "setting load address of %s to 0x%0llx",
+            kextPath, (unsigned long long)address);
+    } else {
+        OSKextLog(aKext, kOSKextLogDebugLevel | kOSKextLogLinkFlag | kOSKextLogLoadFlag,
+            "setting load address of %s to 0x%0x",
+            kextPath, (int)address);
+    }
+
+    aKext->loadInfo->loadAddress = address;
+    result = true;
+finish:
+    return result;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+Boolean OSKextSetLoadAddress(OSKextRef aKext, uint64_t address)
+{
+    Boolean result = false;
+
+    if (!__OSKextCreateLoadInfo(aKext)) {
+        goto finish;
+    }
+    
+   /* Process any pending load info for the kext before overwriting
+    * the load address.
+    */
+    if (aKext->loadInfo->kernelLoadInfo) {
+        __OSKextCheckLoaded(aKext);
+    }
+
+    result = __OSKextSetLoadAddress(aKext, address);
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextOtherVersionIsLoaded(OSKextRef aKext, Boolean * uuidFlag)
+{
+    Boolean result = false;
+    
+    if (!aKext->loadInfo) {
+        goto finish;
+    }
+    if (aKext->loadInfo->kernelLoadInfo) {
+        __OSKextCheckLoaded(aKext);
+    }
+    if (aKext->loadInfo->flags.otherCFBundleVersionIsLoaded ||
+        aKext->loadInfo->flags.otherUUIDIsLoaded) {
+
+        result = true;
+    }
+    if (uuidFlag) {
+        *uuidFlag = aKext->loadInfo->flags.otherUUIDIsLoaded ? true : false;
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+uint32_t OSKextGetLoadTag(OSKextRef aKext)
+{
+    uint32_t result = 0;
+
+    if (!aKext->loadInfo) {
+        goto finish;
+    }
+    if (aKext->loadInfo->kernelLoadInfo) {
+        __OSKextCheckLoaded(aKext);
+    }
+    result = aKext->loadInfo->loadTag;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static void __OSKextFlushLoadInfoApplierFunction(
+    const void * vKey __unused,
+    const void * vValue,
+          void * vContext)
+{
+    OSKextRef aKext = (OSKextRef)vValue;
+    Boolean   flushDependenciesFlag = *(Boolean *)vContext;
+
+    OSKextFlushLoadInfo(aKext, flushDependenciesFlag);
+    return;
+}
+
+void OSKextFlushLoadInfo(
+    OSKextRef aKext,
+    Boolean   flushDependenciesFlag)
+{
+    static Boolean flushingAll = false;
+    char           kextPath[PATH_MAX];
+
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    if (aKext) {
+        if (OSKextGetURL(aKext)) {
+            __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+                /* resolveToBase */ false, kextPath);
+        }
+        if (aKext->loadInfo) {
+
+            if (!flushingAll) {
+                OSKextLog(aKext,
+                    kOSKextLogStepLevel | kOSKextLogKextBookkeepingFlag,
+                    "Flushing load info for %s (%s dependencies)",
+                    kextPath,
+                    flushDependenciesFlag ? "with" : "keeping");
+            }
+
+            SAFE_RELEASE_NULL(aKext->loadInfo->kernelLoadInfo);
+            SAFE_RELEASE_NULL(aKext->loadInfo->executableURL);
+            SAFE_RELEASE_NULL(aKext->loadInfo->executable);
+            SAFE_RELEASE_NULL(aKext->loadInfo->linkedExecutable);
+            SAFE_RELEASE_NULL(aKext->loadInfo->prelinkedExecutable);
+            if (flushDependenciesFlag) {
+                OSKextFlushDependencies(aKext);
+            }
+            SAFE_FREE_NULL(aKext->loadInfo);
+
+           /* The executable could change by the time we read it again,
+            * so clear all validation/authentication flags. Leave
+            * diagnostics in place (a bit funky I suppose).
+            */
+            aKext->flags.valid = 0;
+            aKext->flags.invalid = 0;
+            aKext->flags.validated = 0;
+            aKext->flags.authentic = 0;
+            aKext->flags.inauthentic = 0;
+            aKext->flags.authenticated = 0;
+            aKext->flags.isSigned = 0;
+       }
+    } else if (__sOSKextsByURL) {
+        flushingAll = true;
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogStepLevel | kOSKextLogKextBookkeepingFlag,
+            "Flushing load info for all kexts (%s dependencies)",
+            flushDependenciesFlag ? "with" : "keeping");
+
+        CFDictionaryApplyFunction(__sOSKextsByURL,
+            __OSKextFlushLoadInfoApplierFunction,
+            /* context */ &flushDependenciesFlag);
+        flushingAll = false;
+    }
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef _OSKextCopyKernelRequests(void)
+{
+    CFArrayRef             result        = NULL;
+    OSReturn               op_result     = kOSReturnError;
+    CFMutableDictionaryRef requestDict   = NULL;  // must release
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogDebugLevel | kOSKextLogIPCFlag,
+        "Reading requests from kernel.");
+
+    requestDict = __OSKextCreateKextRequest(
+        CFSTR(kKextRequestPredicateGetKernelRequests),
+        /* bundleID */ NULL, /* argsOut */ NULL);
+
+    op_result = __OSKextSendKextRequest(/* kext */ NULL, requestDict,
+        (CFTypeRef *)&result,
+        /* rawResponseOut */ NULL, /* rawResponseLengthOut */ NULL);
+    if (op_result != kOSReturnSuccess) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+            "Failed to read requests from kernel - %s.",
+            safe_mach_error_string(op_result));
+        SAFE_RELEASE_NULL(result);
+        goto finish;
+    }
+
+    if (!result || CFArrayGetTypeID() != CFGetTypeID(result)) {
+        SAFE_RELEASE_NULL(result);
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+            "Requests from kernel missing or of wrong type.");
+        goto finish;
+    }
+
+finish:
+    SAFE_RELEASE(requestDict);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSReturn _OSKextSendResource(
+    CFDictionaryRef request,
+    OSReturn        requestResult,
+    CFDataRef       resource)
+{
+    OSReturn               result           = kOSReturnError;
+    CFDictionaryRef        requestArgs      = NULL;  // do not release
+    CFMutableDictionaryRef response         = NULL;  // must release
+    CFMutableDictionaryRef responseArgs     = NULL;  // must release
+    CFNumberRef            requestResultNum = NULL;  // must release
+    
+    requestArgs = CFDictionaryGetValue(request,
+        CFSTR(kKextRequestArgumentsKey));
+    if (!requestArgs) {
+        result = kOSKextReturnInvalidArgument;
+        goto finish;
+    }
+    
+    response = CFDictionaryCreateMutableCopy(kCFAllocatorDefault,
+        0, request);
+    if (!response) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    responseArgs = CFDictionaryCreateMutableCopy(kCFAllocatorDefault,
+        0, requestArgs);
+    if (!responseArgs) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    
+    CFDictionarySetValue(response, CFSTR(kKextRequestPredicateKey),
+        CFSTR(kKextRequestPredicateSendResource));
+    CFDictionarySetValue(response, CFSTR(kKextRequestArgumentsKey),
+        responseArgs);
+        
+    if (resource) {
+        CFDictionarySetValue(responseArgs, CFSTR(kKextRequestArgumentValueKey),
+            resource);
+    }
+    
+    requestResultNum = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type,
+        (SInt32 *)&requestResult);
+
+   /* Let's not treat this as fatal, we'd like to get the waiting callback
+    * cleared in the kernel and it can just send an error.
+    */
+    if (requestResultNum) {
+        CFDictionarySetValue(responseArgs, CFSTR(kKextRequestArgumentResultKey),
+            requestResultNum);
+    }
+
+    result = __OSKextSendKextRequest(/* kext */ NULL, response,
+        /* cfResponseOut */ NULL,
+        /* rawResponseOut */ NULL, /* rawResponseLengthOut */ NULL);
+
+finish:
+    SAFE_RELEASE(requestResultNum);
+    SAFE_RELEASE(responseArgs);
+    SAFE_RELEASE(response);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCreateLoadedKextInfo(
+    CFArrayRef kextIdentifiers)
+{
+    CFArrayRef        result          = NULL;
+    CFDictionaryRef   allLoadInfoDict = NULL;  // must release
+    CFDictionaryRef * loadInfoItems   = NULL;  // must free
+    CFIndex           count;
+    
+    allLoadInfoDict = OSKextCopyLoadedKextInfo(kextIdentifiers, NULL /* all info */);
+    if (!allLoadInfoDict || CFDictionaryGetTypeID() != CFGetTypeID(allLoadInfoDict)) {
+        goto finish;
+    }
+
+    count = CFDictionaryGetCount(allLoadInfoDict);
+    loadInfoItems = malloc(count * sizeof(CFDictionaryRef));;
+    if (!loadInfoItems) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    CFDictionaryGetKeysAndValues(allLoadInfoDict, /* keys */ NULL,
+        (const void **)loadInfoItems);
+    
+    result = CFArrayCreate(kCFAllocatorDefault,
+        (const void **)loadInfoItems, count, &kCFTypeArrayCallBacks);
+
+finish:
+    SAFE_RELEASE(allLoadInfoDict);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDictionaryRef OSKextCopyLoadedKextInfo(
+    CFArrayRef kextIdentifiers,
+    CFArrayRef infoKeys)
+{
+    CFDictionaryRef        result        = NULL;
+    OSReturn               op_result     = kOSReturnError;
+    CFMutableDictionaryRef requestDict   = NULL;  // must release
+    CFMutableDictionaryRef requestArgs   = NULL;  // do not release
+    CFStringRef            infoString    = NULL;  // must release
+    char                 * infoCString   = NULL;  // must free
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogStepLevel | kOSKextLogIPCFlag,
+        "Reading loaded kext info from kernel.");
+
+    requestDict = __OSKextCreateKextRequest(CFSTR(kKextRequestPredicateGetLoaded),
+        kextIdentifiers, &requestArgs);
+        
+    if (infoKeys && CFArrayGetCount(infoKeys)) {
+        CFDictionarySetValue(requestArgs,
+            CFSTR(kKextRequestArgumentInfoKeysKey),
+            infoKeys);
+    }
+
+    op_result = __OSKextSendKextRequest(/* kext */ NULL, requestDict,
+        (CFTypeRef *)&result,
+        /* rawResponseOut */ NULL, /* rawResponseLengthOut */ NULL);
+    if (op_result != kOSReturnSuccess) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+            "Failed to read loaded kext info from kernel - %s.",
+            safe_mach_error_string(op_result));
+        SAFE_RELEASE_NULL(result);
+        goto finish;
+    }
+
+    if (!result) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+            "Kernel request call returned no data.");
+        goto finish;
+    }
+    if (CFDictionaryGetTypeID() != CFGetTypeID(result)) {
+        SAFE_RELEASE_NULL(result);
+        // xxx - these flags don't seem quite right
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+            "Loaded kext info from kernel is wrong type.");
+        goto finish;
+    }
+
+    if (__OSKextShouldLog(/* kext */ NULL,
+        kOSKextLogDebugLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag)) {
+
+        infoString = createCFStringForPlist_new(result,
+            kPListStyleClassic);
+        infoCString = createUTF8CStringForCFString(infoString);
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogDebugLevel | kOSKextLogLoadFlag | kOSKextLogIPCFlag,
+            "Loaded kext info:\n%s", infoCString);
+    }
+
+finish:
+    SAFE_RELEASE(requestDict);
+    SAFE_RELEASE(infoString);
+    SAFE_FREE(infoCString);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextCreateLoadInfo(OSKextRef aKext)
+{
+    Boolean result = false;
+
+// xxx - log under kOSKextLogDetailLevel | kOSKextLogKextBookkeepingFlag ?
+
+    if (!aKext->loadInfo) {
+        aKext->loadInfo = (__OSKextLoadInfo *)
+            malloc(sizeof(*(aKext->loadInfo)));
+        if (!aKext->loadInfo) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        memset(aKext->loadInfo, 0, sizeof(*(aKext->loadInfo)));
+    }
+    result = true;
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextCreateMkextInfo(OSKextRef aKext)
+{
+    Boolean result = false;
+
+    if (!aKext->mkextInfo) {
+        aKext->mkextInfo = (__OSKextMkextInfo *)
+            malloc(sizeof(*(aKext->mkextInfo)));
+        if (!aKext->mkextInfo) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        memset(aKext->mkextInfo, 0, sizeof(*(aKext->mkextInfo)));
+    }
+    result = true;
+finish:
+    return result;
+}
+
+#pragma mark Sanity Checking and Diagnostics
+/*********************************************************************
+* Sanity Checking and Diagnostics
+*********************************************************************/
+
+/*********************************************************************
+*********************************************************************/
+typedef struct {
+    OSKextRef          kext;
+    CFDictionaryRef    libraries;
+    CFMutableArrayRef  propPath;
+    Boolean            valid;
+    Boolean            hasKernelStyleDependency;
+    Boolean            hasKPIStyleDependency;
+} __OSKextValidateOSBundleLibraryContext;
+
+
+static void __OSKextValidateOSBundleLibraryApplierFunction(
+    const void * vKey,
+    const void * vValue,
+          void * vContext)
+{
+    CFStringRef libID = (CFStringRef)vKey;
+    CFStringRef libVersion = (CFStringRef)vValue;
+    __OSKextValidateOSBundleLibraryContext * context =
+        (__OSKextValidateOSBundleLibraryContext *)vContext;
+
+    OSKextVersion version = -1;
+
+    CFArrayAppendValue(context->propPath, libID);
+
+    if (!__OSKextCheckProperty(context->kext,
+        context->libraries,
+        /* propKey */ libID,
+        /* diagnosticValue */ context->propPath,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ true,
+        /* valueOut */ NULL,
+        /* valueIsNonnil */ NULL)) {
+
+        context->valid = false;
+        goto finish;
+    } else {
+        version = OSKextParseVersionCFString(libVersion);
+        if (version == -1) {
+            __OSKextAddDiagnostic(context->kext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticPropertyIsIllegalValueKey, context->propPath,
+                /* note */ NULL);
+            context->valid = false;
+        }
+    }
+
+   /* If the library is any com.apple.kernel* (note inclusion of kernel itself),
+    * and the version is too old, we make a note to check for mismatched
+    * kmod_info fields when we check the executable.
+    */
+
+    // xxx - 64bit kexts won't even have this, but we can fail in dependency
+    // xxx - resolution I guess!
+
+    if (CFStringHasPrefix(libID, __kOSKextKernelLibBundleID)) {
+        context->hasKernelStyleDependency = true;
+        if (version < __sOSNewKmodInfoKernelVersion) {
+            context->kext->flags.warnForMismatchedKmodInfo = 1;
+        }
+    } else if (CFStringHasPrefix(libID, __kOSKextKPIPrefix)) {
+        context->hasKPIStyleDependency = true;
+        if (version < __sOSNewKmodInfoKernelVersion) {
+            context->kext->flags.warnForMismatchedKmodInfo = 1;
+        }
+    }
+
+
+finish:
+    CFArrayRemoveValueAtIndex(context->propPath,
+        CFArrayGetCount(context->propPath) - 1);
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+typedef struct {
+    OSKextRef         kext;
+    CFDictionaryRef   personalities;
+    CFMutableArrayRef propPath;
+    Boolean           valid;
+    Boolean           justCheckingIOKitDebug;
+} __OSKextValidateIOKitPersonalityContext;
+
+static void __OSKextValidateIOKitPersonalityApplierFunction(
+    const void * vKey,
+    const void * vValue,
+          void * vContext)
+{
+    CFStringRef     personalityName      = (CFStringRef)vKey;
+    CFDictionaryRef personality          = (CFDictionaryRef)vValue;
+    __OSKextValidateIOKitPersonalityContext * context =
+        (__OSKextValidateIOKitPersonalityContext *)vContext;
+    Boolean         checkResult          = false;
+    CFStringRef     propKey              = NULL;  // do not release
+    Boolean         valueIsNonnil;
+    CFStringRef     ioclassProp          = NULL;  // do not release
+    CFStringRef     stringValue          = NULL;  // do not release
+    Boolean         checkIOMatchCategory = false;
+    OSKextRef       personalityKext      = NULL;  // do not release
+    CFStringRef     diagnosticString     = NULL;  // must release
+
+    CFArrayAppendValue(context->propPath, personalityName);
+
+    if (!__OSKextCheckProperty(context->kext,
+        context->personalities,
+        /* propKey */ personalityName,
+        /* diagnosticValue */ context->propPath,
+        /* expectedType */ CFDictionaryGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,
+        /* valueOut */ NULL,
+        /* valueIsNonnil */ NULL)) {
+
+        context->valid = false;
+        goto finish;
+    }
+
+   /**********************
+    * IOKitDebug: number *
+    **********************/
+
+    // xxx - used to disable safe boot loadbility, not worth doing for now
+    propKey = CFSTR(kIOKitDebugKey);
+    CFArrayAppendValue(context->propPath, propKey);
+
+    checkResult = __OSKextCheckProperty(context->kext,
+        personality,
+        /* propKey */ propKey,
+        /* diagnosticValue */ context->propPath,
+        /* expectedType */ CFNumberGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,
+        /* valueOut */ NULL,
+        /* valueIsNonnil */ &valueIsNonnil);
+    context->valid = context->valid && checkResult;
+    if (checkResult && valueIsNonnil) {
+        context->kext->flags.plistHasIOKitDebugFlags = 1;
+    }
+
+    CFArrayRemoveValueAtIndex(context->propPath,
+        CFArrayGetCount(context->propPath) - 1);
+
+   /* A bit of a hack, but why duplicate that code for one check?
+    */
+    if (context->justCheckingIOKitDebug) {
+        goto finish;
+    }
+
+   /******************************
+    * CFBundleIdentifier: string *
+    ******************************/
+
+    propKey = kCFBundleIdentifierKey;
+    CFArrayAppendValue(context->propPath, propKey);
+
+    checkResult = __OSKextCheckProperty(context->kext,
+        personality,
+        /* propKey */ propKey,
+        /* diagnosticValue */ context->propPath,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ true,   // xxx - allow empty string here?
+        /* valueOut */ (CFTypeRef *)&stringValue,
+        /* valueIsNonnil */ &valueIsNonnil);
+    context->valid = context->valid && checkResult;
+    if (!stringValue) {
+        // xxx - this is really more of a notice than a warning
+        __OSKextAddDiagnostic(context->kext, kOSKextDiagnosticsFlagWarnings,
+            kOSKextDiagnosticPersonalityHasNoBundleIdentifierKey,
+            personalityName, /* note */ NULL);
+    } else if (!CFEqual(stringValue, OSKextGetIdentifier(context->kext))) {
+        // xxx - this is really more of a notice than a warning
+        diagnosticString = CFStringCreateWithFormat(kCFAllocatorDefault,
+            /* formatOptions */ NULL, CFSTR("%@ -> %@ (kext is %@)"),
+            personalityName, stringValue, context->kext);
+        __OSKextAddDiagnostic(context->kext, kOSKextDiagnosticsFlagWarnings,
+            kOSKextDiagnosticPersonalityHasDifferentBundleIdentifierKey,
+            personalityName, /* note */ NULL);
+        SAFE_RELEASE_NULL(diagnosticString);
+    }
+
+   /* Check for this condition independent of the other warnings above.
+    */
+    if (stringValue) {
+        personalityKext = OSKextGetKextWithIdentifier(stringValue);
+        if (!personalityKext) {
+            diagnosticString = CFStringCreateWithFormat(kCFAllocatorDefault,
+                /* formatOptions */ NULL, CFSTR("'%@' -> '%@'"),
+                personalityName, stringValue);
+            __OSKextAddDiagnostic(context->kext, kOSKextDiagnosticsFlagWarnings,
+                kOSKextDiagnosticPersonalityNamesUnknownKextKey,
+                diagnosticString, /* note */ NULL);
+            SAFE_RELEASE_NULL(diagnosticString);
+        } else {
+            if (!OSKextDeclaresExecutable(personalityKext)) {
+                diagnosticString = CFStringCreateWithFormat(kCFAllocatorDefault,
+                    /* formatOptions */ NULL, CFSTR("'%@' -> '%@'"),
+                    personalityName, stringValue);
+                __OSKextAddDiagnostic(context->kext, kOSKextDiagnosticsFlagWarnings,
+                    kOSKextDiagnosticPersonalityNamesKextWithNoExecutableKey,
+                    diagnosticString, /* note */ NULL);
+                SAFE_RELEASE_NULL(diagnosticString);
+            }
+            // xxx - moving check for personality target loadable
+        }
+    }
+
+    CFArrayRemoveValueAtIndex(context->propPath,
+        CFArrayGetCount(context->propPath) - 1);
+
+   /*******************
+    * IOClass: string *
+    *******************/
+
+    // xxx - would like to check that class is defined in executable named
+    // xxx - by bundle ID of personality
+
+    propKey = CFSTR(kIOClassKey);
+    CFArrayAppendValue(context->propPath, propKey);
+
+    checkResult = __OSKextCheckProperty(context->kext,
+        personality,
+        /* propKey */ propKey,
+        /* diagnosticValue */ context->propPath,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ true,
+        /* typeRequired */ true,
+        /* nonnilRequired */ true,
+        /* valueOut */ (CFTypeRef *)&ioclassProp,  // we use this later!
+        /* valueIsNonnil */ NULL);
+    context->valid = context->valid && checkResult;
+
+    CFArrayRemoveValueAtIndex(context->propPath,
+        CFArrayGetCount(context->propPath) - 1);
+
+   /****************************************************************
+    * IOProviderClass: string                                      *
+    * We can't do anything to confirm existence of provider class, *
+    * since it could come from the kernel or any other kext.       *
+    ****************************************************************/
+
+    propKey = CFSTR(kIOProviderClassKey);
+    CFArrayAppendValue(context->propPath, propKey);
+
+    checkResult = __OSKextCheckProperty(context->kext,
+        personality,
+        /* propKey */ propKey,
+        /* diagnosticValue */ context->propPath,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ true,
+        /* typeRequired */ true,
+        /* nonnilRequired */ true,
+        /* valueOut */ (CFTypeRef *)&stringValue,
+        /* valueIsNonnil */ NULL);
+    context->valid = context->valid && checkResult;
+    if (checkResult && CFEqual(stringValue, CFSTR(kIOResourcesClass))) {
+        checkIOMatchCategory = true;
+    }
+
+    CFArrayRemoveValueAtIndex(context->propPath,
+        CFArrayGetCount(context->propPath) - 1);
+
+   /***************************
+    * IOMatchCategory: string *
+    ***************************/
+
+    // xxx - is this used for other than with IOResources match?
+
+    if (checkIOMatchCategory) {
+
+        propKey = CFSTR(kIOMatchCategoryKey);
+        CFArrayAppendValue(context->propPath, propKey);
+
+        checkResult = __OSKextCheckProperty(context->kext,
+            personality,
+            /* propKey */ propKey,
+            /* diagnosticValue */ context->propPath,
+            /* expectedType */ CFStringGetTypeID(),
+            /* legalValues */ NULL,
+            /* required */ false,
+            /* typeRequired */ true,
+            /* nonnilRequired */ false,  // xxx - hm...
+            /* valueOut */ (CFTypeRef *)&stringValue,
+            /* valueIsNonnil */ NULL);
+        context->valid = context->valid && checkResult;
+        if (checkResult && stringValue) {
+            if (ioclassProp && !CFEqual(ioclassProp, stringValue)) {
+                __OSKextAddDiagnostic(context->kext,
+                    kOSKextDiagnosticsFlagWarnings,
+                    kOSKextDiagnosticNonuniqueIOResourcesMatchKey,
+                    personalityName, /* note */ NULL);
+            }
+        }
+
+        CFArrayRemoveValueAtIndex(context->propPath,
+            CFArrayGetCount(context->propPath) - 1);
+    }
+
+   /**************************************************************************
+    * IOProbeScore: number (warning only)                                    *
+    * We can't make this a hard error because it might break shipping kexts. *
+    **************************************************************************/
+
+    propKey = CFSTR(kIOProbeScoreKey);
+    CFArrayAppendValue(context->propPath, propKey);
+
+    checkResult = __OSKextCheckProperty(context->kext,
+        personality,
+        /* propKey */ propKey,
+        /* diagnosticValue */ context->propPath,
+        /* expectedType */ CFNumberGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ false,
+        /* nonnilRequired */ false,
+        /* valueOut */ NULL,
+        /* valueIsNonnil */ NULL);
+
+    // __OSKextCheckProperty() sets a warning; we don't care about checkResult
+
+    CFArrayRemoveValueAtIndex(context->propPath,
+        CFArrayGetCount(context->propPath) - 1);
+
+   /*********************
+    * end of properties *
+    *********************/
+finish:
+
+   /* Remove the personality name from the prop path.
+    */
+    CFArrayRemoveValueAtIndex(context->propPath,
+        CFArrayGetCount(context->propPath) - 1);
+
+    SAFE_RELEASE(diagnosticString);
+
+    return;
+}
+
+static void __OSKextValidateIOKitPersonalityTargetApplierFunction(
+    const void * vKey,
+    const void * vValue,
+          void * vContext)
+{
+    CFStringRef     personalityName      = (CFStringRef)vKey;
+    CFDictionaryRef personality            = (CFDictionaryRef)vValue;
+    __OSKextValidateIOKitPersonalityContext * context =
+        (__OSKextValidateIOKitPersonalityContext *)vContext;
+    Boolean         checkResult            = false;
+    CFStringRef     propKey                = NULL;  // do not release
+    Boolean         valueIsNonnil;
+    CFStringRef     stringValue            = NULL;  // do not release
+    OSKextRef       personalityKext        = NULL;  // do not release
+    CFStringRef     diagnosticString       = NULL;  // must release
+
+    CFArrayAppendValue(context->propPath, personalityName);
+
+    if (!__OSKextCheckProperty(context->kext,
+        context->personalities,
+        /* propKey */ personalityName,
+        /* diagnosticValue */ context->propPath,
+        /* expectedType */ CFDictionaryGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,
+        /* valueOut */ NULL,
+        /* valueIsNonnil */ NULL)) {
+
+        context->valid = false;
+        goto finish;
+    }
+
+   /******************************
+    * CFBundleIdentifier: string *
+    ******************************/
+
+    propKey = kCFBundleIdentifierKey;
+    CFArrayAppendValue(context->propPath, propKey);
+
+    checkResult = __OSKextCheckProperty(context->kext,
+        personality,
+        /* propKey */ propKey,
+        /* diagnosticValue */ context->propPath,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ true,   // xxx - allow empty string here?
+        /* valueOut */ (CFTypeRef *)&stringValue,
+        /* valueIsNonnil */ &valueIsNonnil);
+    context->valid = context->valid && checkResult;
+
+    if (stringValue) {
+        personalityKext = OSKextGetKextWithIdentifier(stringValue);
+        if (personalityKext &&
+            personalityKext != context->kext &&
+            !OSKextIsLoadable(personalityKext)) {
+
+                // xxx - should we keep format of diagnostic the same and
+                // xxx - leave it as a stupid CFURL?
+                
+                // XXX - THIS IS NOT AN ABSOLUTE PATH
+    
+                diagnosticString = CFStringCreateWithFormat(kCFAllocatorDefault,
+                    /* formatOptions */ NULL, CFSTR("'%@' -> '%@'"),
+                    stringValue, OSKextGetURL(personalityKext));
+                __OSKextAddDiagnostic(context->kext, kOSKextDiagnosticsFlagWarnings,
+                    kOSKextDiagnosticPersonalityNamesNonloadableKextKey,
+                    diagnosticString, /* note */ NULL);
+                SAFE_RELEASE_NULL(diagnosticString);
+        }
+    }
+
+    CFArrayRemoveValueAtIndex(context->propPath,
+        CFArrayGetCount(context->propPath) - 1);
+
+   /*********************
+    * end of properties *
+    *********************/
+finish:
+
+   /* Remove the personality name from the prop path.
+    */
+    CFArrayRemoveValueAtIndex(context->propPath,
+        CFArrayGetCount(context->propPath) - 1);
+
+    SAFE_RELEASE(diagnosticString);
+
+    return;
+}
+
+/*********************************************************************
+* validates only for current default arch
+*********************************************************************/
+Boolean __OSKextValidate(OSKextRef aKext, CFMutableArrayRef propPath)
+{
+    Boolean           result        = true;  // cleared when we hit a failure
+    CFStringRef       propKey       = NULL;  // do not release
+    CFMutableArrayRef allocPropPath = NULL;  // must release
+    Boolean           checkResult;
+
+    CFDictionaryRef   dictValue = NULL;  // do not release
+    Boolean           valueIsNonnil;
+    
+    char              kextPathCString[PATH_MAX];
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase? */ false, kextPathCString);
+
+    OSKextLog(aKext, kOSKextLogStepLevel | kOSKextLogValidationFlag,
+        "Validating %s.", kextPathCString);
+
+   /* Even if we already determined the kext had problems (for this arch)
+    * without doing a full validation (for this arch), there may be more
+    * to find, so clear all the validationflags, start from scratch,
+    * and check *everything*.
+    */
+    aKext->flags.invalid = 0;
+    aKext->flags.valid = 0;
+    aKext->flags.validated = 0;
+
+    if (!propPath) {
+        allocPropPath = propPath = CFArrayCreateMutable(kCFAllocatorDefault, 0,
+            &kCFTypeArrayCallBacks);
+        if (!propPath) {
+            OSKextLogMemError();
+            goto finish;
+        }
+    }
+
+   /* Redo the basic processing. If that fails, set the result to false,
+    * but don't go to finish unless we didn't get an infoDictionary to validate.
+    */
+    if (!__OSKextProcessInfoDictionary(aKext, /* kextBundle */ NULL)) {
+        result = false;
+    }
+    if (!aKext->infoDictionary) {
+        goto finish;
+    }
+
+   /*****************************************************
+    * OSBundleAllowUserLoad: boolean
+    *****************************************************/
+
+    propKey = CFSTR(kOSBundleAllowUserLoadKey);
+    CFArrayAppendValue(propPath, propKey);
+
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propPath,
+        /* expectedType */ CFBooleanGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ FALSE,
+        /* typeRequired */ true,
+        /* nonnilRequired */ FALSE,
+        /* valueOut */ NULL,
+        /* valueIsNonnil */ NULL);
+    result = result && checkResult;
+
+    CFArrayRemoveValueAtIndex(propPath, CFArrayGetCount(propPath) - 1);
+
+   /*****************************************************
+    * OSBundleLibraries: dict, values parsable versions *
+    *****************************************************/
+
+    propKey = CFSTR(kOSBundleLibrariesKey);
+    CFArrayAppendValue(propPath, propKey);
+
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propPath,
+        /* expectedType */ CFDictionaryGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ (OSKextDeclaresExecutable(aKext) &&
+                       !OSKextIsKernelComponent(aKext)),
+        /* typeRequired */ true,
+        /* nonnilRequired */ (OSKextDeclaresExecutable(aKext) &&
+                       !OSKextIsKernelComponent(aKext)),
+        /* valueOut */ (CFTypeRef *)&dictValue,
+        /* valueIsNonnil */ NULL);
+    result = result && checkResult;
+    
+   /* First check is for no OSBundleLibraries.
+    * All following "else if" mean the kext has at least one.
+    */
+    if (!dictValue || !CFDictionaryGetCount(dictValue)) {
+        if (OSKextDeclaresExecutable(aKext) &&
+            !OSKextIsKernelComponent(aKext)) {
+
+            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticMissingPropertyKey,
+                propPath, /* note */ NULL);
+        }
+    } else if (OSKextIsKernelComponent(aKext)) {
+        // xxx - should I catch kernel components that declare dependencies
+        // xxx - in case somebody screws up the System.kexts? :-P
+
+        __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+            kOSKextDiagnosticBadSystemPropertyKey, CFSTR(kOSBundleLibrariesKey),
+            /* note */ NULL);
+
+        result = false;
+    } else if (!OSKextDeclaresExecutable(aKext) && !OSKextIsLibrary(aKext)) {
+        __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+            kOSKextDiagnosticCodelessWithLibrariesKey);
+    }
+
+    if (checkResult && dictValue) {
+        __OSKextValidateOSBundleLibraryContext validateLibrariesContext;
+        validateLibrariesContext.kext = aKext;
+        validateLibrariesContext.libraries = dictValue;
+        validateLibrariesContext.propPath = propPath;
+        validateLibrariesContext.valid = true;  // starts true!
+        validateLibrariesContext.hasKernelStyleDependency = false;  // starts false!
+        validateLibrariesContext.hasKPIStyleDependency = false;  // starts false!
+        CFDictionaryApplyFunction(dictValue,
+            __OSKextValidateOSBundleLibraryApplierFunction,
+            &validateLibrariesContext);
+        result = result && validateLibrariesContext.valid;
+
+        if (validateLibrariesContext.hasKernelStyleDependency &&
+            validateLibrariesContext.hasKPIStyleDependency) {
+
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+                kOSKextDiagnosticDeclaresBothKernelAndKPIDependenciesKey);
+        }
+    }
+
+    dictValue = NULL;
+    CFArrayRemoveValueAtIndex(propPath, CFArrayGetCount(propPath) - 1);
+
+   /****************************************
+    * OSBundleStartupResources: dictionary *
+    ****************************************/
+    // xxx - verify they exist
+    // kOSKextOSBundleStartupResourceNamesKey
+
+   /**********************************
+    * IOKitPersonalities: dictionary *
+    **********************************/
+
+   /* xxx - Disabling for safe boot if IOKitDebug left out for now */
+
+    propKey = CFSTR(kIOKitPersonalitiesKey);
+    CFArrayAppendValue(propPath, propKey);
+
+    // xxx - need to check that each personality is also a dict
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propPath,
+        /* expectedType */ CFDictionaryGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,                 // can't really say it's required!
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,           // can't really say it's required!
+        /* valueOut */ (CFTypeRef *)&dictValue,
+        &valueIsNonnil);
+    result = result && checkResult;
+    if (checkResult && dictValue) {
+        __OSKextValidateIOKitPersonalityContext validatePersonalitiesContext;
+
+        validatePersonalitiesContext.kext = aKext;
+        validatePersonalitiesContext.personalities = dictValue;
+        validatePersonalitiesContext.propPath = propPath;
+        validatePersonalitiesContext.valid = true;  // starts true!
+        validatePersonalitiesContext.justCheckingIOKitDebug = false;
+        CFDictionaryApplyFunction(dictValue,
+            __OSKextValidateIOKitPersonalityApplierFunction,
+            &validatePersonalitiesContext);
+        result = result && validatePersonalitiesContext.valid;
+    }
+
+    CFArrayRemoveValueAtIndex(propPath, CFArrayGetCount(propPath) - 1);
+
+   /***********************************************
+    * Validate the current arch in the executable *
+    ***********************************************/
+   // xxx - probably want to validate all arches, and not fail VALIDATION
+   // xxx - if a kext doesn't support the current arch
+
+    result = __OSKextValidateExecutable(aKext) && result;
+
+finish:
+    SAFE_RELEASE(allocPropPath);
+
+    if (result) {
+        aKext->flags.validated = true;
+        aKext->flags.valid = true;
+    } else {
+        aKext->flags.invalid = 1;
+    }
+
+    return result;
+}
+
+/*********************************************************************
+* This public entry point for validation does all the real validation
+* via __OSKextValidate() and then adds a check that targets of any
+* IOKitPersonalities are in fact loadable themselves. We have to do
+* this check outside of the internal check--that is, only on request--
+* to avoid an infinite loop if two kexts have personalities that name
+* each other, or if a kext has a personality naming another that in
+* turn has a link dependency (direct or indirect) on the first kext.
+*********************************************************************/
+Boolean OSKextValidate(OSKextRef aKext)
+{
+    Boolean           result    = TRUE;
+    CFMutableArrayRef propPath  = NULL;  // must release
+    CFStringRef       propKey   = NULL;  // do not release
+    Boolean           checkResult;
+    CFDictionaryRef   dictValue = NULL;  // do not release
+
+    propPath = CFArrayCreateMutable(kCFAllocatorDefault, 0,
+        &kCFTypeArrayCallBacks);
+    if (!propPath) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    result = __OSKextValidate(aKext, propPath);
+
+    propKey = CFSTR(kIOKitPersonalitiesKey);
+    CFArrayAppendValue(propPath, propKey);
+
+    // xxx - need to check that each personality is also a dict
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propPath,
+        /* expectedType */ CFDictionaryGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,                 // can't really say it's required!
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,           // can't really say it's required!
+        /* valueOut */ (CFTypeRef *)&dictValue,
+        /* valueIsNonnil */ NULL);
+    result = result && checkResult;
+    if (checkResult && dictValue) {
+        __OSKextValidateIOKitPersonalityContext validatePersonalitiesContext;
+
+        validatePersonalitiesContext.kext = aKext;
+        validatePersonalitiesContext.personalities = dictValue;
+        validatePersonalitiesContext.propPath = propPath;
+        validatePersonalitiesContext.valid = true;  // starts true!
+        validatePersonalitiesContext.justCheckingIOKitDebug = false;
+        CFDictionaryApplyFunction(dictValue,
+            __OSKextValidateIOKitPersonalityTargetApplierFunction,
+            &validatePersonalitiesContext);
+        result = result && validatePersonalitiesContext.valid;
+    }
+
+    CFArrayRemoveValueAtIndex(propPath, CFArrayGetCount(propPath) - 1);
+
+finish:
+
+    SAFE_RELEASE(propPath);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextValidateExecutable(OSKextRef aKext)
+{
+    Boolean                    result             = false;
+    CFDataRef                  executable         = NULL;
+    const struct mach_header * mach_header        = NULL;  // do not free
+    const void               * file_end           = NULL;  // do not free
+
+    macho_seek_result          seek_result;
+    uint8_t                    nlist_type;
+    const void               * symbol_address     = NULL;  // do not free
+
+    const kmod_info_32_v1_t  * kmod_info_32       = NULL;  // do not free
+    const kmod_info_64_v1_t  * kmod_info_64       = NULL;  // do not free
+    CFStringRef                bundleIdentifier   = NULL;  // do not release
+    const u_char             * kmodNameCString    = NULL;  // do not free
+    const u_char             * kmodVersionCString = NULL;  // do not free
+    CFStringRef                kmodName           = NULL;  // must release
+    OSKextVersion              version            = -1;
+
+   /* A kext that doesn't declare an executable is automatically ok,
+    * as is an interface kext since it won't have a kmod_info struct.
+    */
+    if (!OSKextDeclaresExecutable(aKext) ||
+        OSKextIsInterface(aKext)) {
+
+        result = true;
+        goto finish;
+    }
+
+   /* If we got here but can't read the executable at all,
+    * that is a validation problem.
+    */
+    if (!__OSKextReadExecutable(aKext)) {
+        goto finish;
+    }
+
+   /* However, if the kext doesn't support the current arch, that is not a
+    * validation problem (see OSKextSupportsArchitecture()) so return true.
+    */
+    executable = OSKextCopyExecutableForArchitecture(aKext, OSKextGetArchitecture());
+    if (!executable) {
+        result = true;
+        goto finish;
+    }
+
+    mach_header = (const struct mach_header *)CFDataGetBytePtr(executable);
+    file_end = (((const char *)mach_header) + CFDataGetLength(executable));
+
+    seek_result = macho_find_symbol(
+            mach_header, file_end, __kOSKextKmodInfoSymbol, &nlist_type,
+            &symbol_address);
+
+    if ((macho_seek_result_found != seek_result) ||
+        ((nlist_type & N_TYPE) != N_SECT) ||
+        (symbol_address == NULL)) {
+
+        __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+            kOSKextDiagnosticExecutableBadKey);
+        goto finish;
+    }
+
+   /*****
+    * If the kext requires Jaguar or later, we don't have to inspect
+    * the MODULE_NAME and MODULE_VERSION fields of the kmod_info struct.
+    * FIXME: change version reference
+    */
+    if (!aKext->flags.warnForMismatchedKmodInfo) {
+        result = true;
+        goto finish;
+    }
+
+    if (__OSKextIsArchitectureLP64()) {
+        kmod_info_64 = (kmod_info_64_v1_t *)symbol_address;
+        kmodNameCString = kmod_info_64->name;
+        kmodVersionCString = kmod_info_64->version;
+    } else {
+        kmod_info_32 = (kmod_info_32_v1_t *)symbol_address;
+        kmodNameCString = kmod_info_32->name;
+        kmodVersionCString = kmod_info_32->version;
+    }
+
+    bundleIdentifier = OSKextGetIdentifier(aKext);
+    kmodName = CFStringCreateWithCString(kCFAllocatorDefault,
+        (const char *)kmodNameCString, kCFStringEncodingUTF8);
+    if (!kmodName) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    if (!CFEqual(bundleIdentifier, kmodName)) {
+        __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+            kOSKextDiagnosticBundleIdentifierMismatchKey);
+    }
+
+    version = OSKextParseVersionString((const char *)kmodVersionCString);
+    if (version < 0 || aKext->version != version) {
+        __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+            kOSKextDiagnosticBundleVersionMismatchKey);
+    }
+
+    result = true;
+
+finish:
+   /* Advise the system that we no longer need the mmapped executable.
+    */
+    if (executable) {
+        (void)posix_madvise((void *)CFDataGetBytePtr(executable),
+            CFDataGetLength(executable),
+            POSIX_MADV_DONTNEED);
+    }
+
+    // xxx - how do we handle cleanup of load info?
+    SAFE_RELEASE(executable);
+    SAFE_RELEASE(kmodName);
+    return result;
+}
+
+/*********************************************************************
+* Internal-use function that avoids doing cross-kext validation,
+* which can result in an infinite loop. See OSKextValidate() for the
+* additional checks.
+*********************************************************************/
+Boolean __OSKextIsValid(OSKextRef aKext)
+{
+   /* If we know it's not valid, don't do any expensive checks
+    * and just return false right away.
+    */
+    if (aKext->flags.invalid) {
+        return false;
+    }
+    if (!aKext->flags.validated) {
+        __OSKextValidate(aKext, /* propPath */ NULL);
+    }
+
+    return aKext->flags.valid ? true : false;
+}
+
+/*********************************************************************
+* Extern-use function that does cross-kext validation.
+* See OSKextValidate() for the additional checks.
+*********************************************************************/
+Boolean OSKextIsValid(OSKextRef aKext)
+{
+   /* If we know it's not valid, don't do any expensive checks
+    * and just return false right away.
+    */
+    if (aKext->flags.invalid) {
+        return false;
+    }
+    if (!aKext->flags.validated) {
+        OSKextValidate(aKext);
+    }
+
+    return aKext->flags.valid ? true : false;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextAuthenticateURLRecursively(
+    OSKextRef aKext,
+    CFURLRef  anURL,
+    CFURLRef  pluginsURL)
+{
+    Boolean      result   = true;  // until we hit a bad one
+    CFStringRef  filename = NULL;   // must release
+    CFURLRef     absURL   = NULL;   // must release
+    char         kextPath[PATH_MAX];
+    char         urlPath[PATH_MAX];
+    struct stat  stat_buf;
+    struct stat  lstat_buf;
+    CFArrayRef   urlContents = NULL; // must release
+    SInt32       error;
+    CFIndex      count, i;
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ FALSE, kextPath);
+
+   /* Ignore all .DS_Store turdfiles created by Finder.
+    */
+    filename = CFURLCopyLastPathComponent(anURL);
+    if (filename && CFEqual(filename, __kDSStoreFilename)) {
+        goto finish;
+    }
+
+    absURL = CFURLCopyAbsoluteURL(anURL);
+    if (!absURL) {
+        result = false;
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, anURL,
+        /* resolveToBase */ true, urlPath)) {
+
+        __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+            kOSKextDiagnosticURLConversionKey, anURL, /* note */ NULL);
+        result = false;
+        goto finish;
+    }
+
+    OSKextLog(aKext,
+        kOSKextLogStepLevel |
+        kOSKextLogAuthenticationFlag | kOSKextLogFileAccessFlag,
+        "Authenticating %s file/directory %s.",
+        kextPath, urlPath);
+
+    if (0 != stat(urlPath, &stat_buf) || 0 != lstat(urlPath, &lstat_buf)) {
+        if (errno == ENOENT) {
+            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagAuthentication,
+                kOSKextDiagnosticFileNotFoundKey, anURL, /* note */ NULL);
+            result = false;
+            // can't continue so goto finish
+            goto finish;
+        } else {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Can't stat %s - %s.",
+                urlPath, strerror(errno));
+            result = false;
+            // can't continue so goto finish
+            goto finish;
+        }
+    }
+
+   /* File/dir must be owned by root and not writable by others,
+    * and if not owned by gid 0 then not group-writable.
+    */
+    if ( (stat_buf.st_uid != 0) || (stat_buf.st_gid != 0 ) ||
+         (stat_buf.st_mode & S_IWOTH) || (stat_buf.st_mode & S_IWGRP) ) {
+
+        // xxx - log it
+        __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagAuthentication,
+            kOSKextDiagnosticOwnerPermissionKey, anURL, /* note */ NULL);
+        result = false;
+        // keep going to get all child URLs
+    }
+
+    if ((lstat_buf.st_mode & S_IFMT) == S_IFLNK) {
+        __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+            kOSKextDiagnosticSymlinkKey, anURL, /* note */ NULL);
+        /* We don't consider this a hard failure. */
+    }
+
+    if (!CFURLHasDirectoryPath(anURL)) {
+        goto finish;
+    }
+
+   /* Plugins are considered not to be part of the kext, since they are
+    * whole bundles in their own right and aren't necessarily kexts.
+    */
+    if (pluginsURL && CFEqual(absURL, pluginsURL)) {
+        // result is true in this case
+        goto finish;
+    }
+
+   /* Check all the child URLs.
+    * xxx - should we check for a symlink loop? :-O
+    */
+    urlContents = CFURLCreatePropertyFromResource(CFGetAllocator(aKext),
+        anURL,
+        kCFURLFileDirectoryContents, &error);
+    if (!urlContents || error) {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag |
+            kOSKextLogAuthenticationFlag,
+            "Can't read file %s.", urlPath);
+        goto finish;
+    }
+    count = CFArrayGetCount(urlContents);
+    for (i = 0; i < count; i++) {
+        CFURLRef thisURL = (CFURLRef)CFArrayGetValueAtIndex(urlContents, i);
+        result = __OSKextAuthenticateURLRecursively(aKext, thisURL, pluginsURL) && result;
+    }
+
+finish:
+    SAFE_RELEASE(filename);
+    SAFE_RELEASE(absURL);
+    SAFE_RELEASE(urlContents);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextAuthenticate(OSKextRef aKext)
+{
+    Boolean     result        = true;  // cleared when we hit an error
+    CFBundleRef kextBundle    = NULL;  // must release
+    CFURLRef    pluginsURL    = NULL;  // must release
+    CFURLRef    pluginsAbsURL = NULL;  // must release
+
+    aKext->flags.inauthentic = 0;
+    aKext->flags.authentic = 0;
+    aKext->flags.authenticated = 0;
+
+    if (OSKextIsFromMkext(aKext)) {
+        if (aKext->mkextInfo->mkextURL) {
+            result = __OSKextAuthenticateURLRecursively(aKext,
+                aKext->mkextInfo->mkextURL, /* pluginsURL */ NULL);
+            // xxx - need to look up all kexts from the mkext and mark them authenticated
+        } else {
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagAuthentication,
+                kOSKextDiagnosticNoFileKey);
+            result = false;
+        }
+    } else {
+        kextBundle = CFBundleCreate(kCFAllocatorDefault, aKext->bundleURL);
+        // xxx should log bundle creation/error/release
+        if (!kextBundle) {
+            result = false;
+            goto finish;
+        }
+
+        pluginsURL = CFBundleCopyBuiltInPlugInsURL(kextBundle);
+        if (pluginsURL) {
+            pluginsAbsURL = CFURLCopyAbsoluteURL(pluginsURL);
+            if (!pluginsAbsURL) {
+                OSKextLogMemError();
+                result = false;
+                goto finish;
+            }
+        }
+
+        result = __OSKextAuthenticateURLRecursively(aKext, aKext->bundleURL,
+            pluginsAbsURL);
+    }
+
+finish:
+
+   /*****
+    * All tests passed, yay.
+    */
+    if (result) {
+        aKext->flags.authentic = 1;
+        aKext->flags.authenticated = 1;
+    }
+
+    SAFE_RELEASE(kextBundle);
+    SAFE_RELEASE(pluginsURL);
+    SAFE_RELEASE(pluginsAbsURL);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextIsAuthentic(OSKextRef aKext)
+{
+   /* If we know it's not authentic, don't do any expensive checks
+    * and just return false right away.
+    */
+    if (aKext->flags.inauthentic) {
+        return false;
+    }
+    if (!aKext->flags.authenticated) {
+        // xxx - maybe we should do an abort-on first error if coming via this func
+        OSKextAuthenticate(aKext);
+    }
+
+    return aKext->flags.authentic ? true : false;
+}
+
+#ifndef IOKIT_EMBEDDED
+/*********************************************************************
+ * we can't actually link with security signing framework until issues
+ * with the iOS simulator are resolved (see 12826218)
+ *********************************************************************/
+Boolean OSKextIsSigned(OSKextRef aKext)
+{
+    CFURLRef    checkURL           = NULL;  // must release
+    
+    if (aKext->flags.isSigned) {
+        return(true);
+    }
+    
+    checkURL = CFURLCreateCopyAppendingPathComponent(
+                                                     kCFAllocatorDefault,
+                                                     aKext->bundleURL,
+                                                     CFSTR("Contents/_CodeSignature"),
+                                                     true);
+    if (checkURL) {
+        if (CFURLResourceIsReachable(checkURL, NULL)) {
+            aKext->flags.isSigned = 1;
+        }
+        else {
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+                                  kOSKextDiagnosticNotSignedKey);
+        }
+    }
+    SAFE_RELEASE(checkURL);
+    
+    return aKext->flags.isSigned ? true : false;
+}
+#endif /* !IOKIT_EMBEDDED */
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextIsLoadable(OSKextRef aKext)
+{
+    Boolean result = false;
+
+    // xxx - should also do a trial link, now
+    // xxx - says nothing about whether other vers. is loaded
+    // xxx - should we take a safe boot param?
+    // xxx - should we just check against actual safe boot?
+
+    if (__OSKextIsValid(aKext) &&
+        OSKextIsAuthentic(aKext) &&
+        OSKextResolveDependencies(aKext) &&
+        OSKextValidateDependencies(aKext) &&
+        OSKextAuthenticateDependencies(aKext)) {
+
+        result = true;
+    }
+
+// xxx? -    OSKextFlushLoadInfo(aKext);
+    return result;
+}
+
+/*********************************************************************
+* XXX - This will create a bunch of empty subdictionaries, which I
+* XXX - don't particularly like.
+*********************************************************************/
+CFDictionaryRef
+OSKextCopyDiagnostics(OSKextRef aKext,
+    OSKextDiagnosticsFlags typeFlags)
+{
+    CFDictionaryRef result = NULL;
+    CFMutableDictionaryRef mResult = NULL;
+
+    if (aKext->diagnostics) {
+        CFDictionaryRef diagnosticsDict;
+
+        mResult = CFDictionaryCreateMutable(CFGetAllocator(aKext), 0,
+            &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        if (!mResult) {
+            OSKextLogMemError();
+            goto finish;
+        }
+
+        if ((typeFlags & kOSKextDiagnosticsFlagValidation)) {
+
+            diagnosticsDict = __OSKextCopyDiagnosticsDict(aKext,
+                kOSKextDiagnosticsFlagValidation);
+            if (diagnosticsDict && CFDictionaryGetCount(diagnosticsDict)) {
+                CFDictionarySetValue(mResult, kOSKextDiagnosticsValidationKey,
+                    diagnosticsDict);
+            }
+            SAFE_RELEASE_NULL(diagnosticsDict);
+        }
+        if ((typeFlags & kOSKextDiagnosticsFlagAuthentication)) {
+
+            diagnosticsDict = __OSKextCopyDiagnosticsDict(aKext,
+                kOSKextDiagnosticsFlagAuthentication);
+            if (diagnosticsDict && CFDictionaryGetCount(diagnosticsDict)) {
+                CFDictionarySetValue(mResult, kOSKextDiagnosticsAuthenticationKey,
+                    diagnosticsDict);
+            }
+            SAFE_RELEASE_NULL(diagnosticsDict);
+        }
+        if ((typeFlags & kOSKextDiagnosticsFlagDependencies)) {
+
+            diagnosticsDict = __OSKextCopyDiagnosticsDict(aKext,
+                kOSKextDiagnosticsFlagDependencies);
+            if (diagnosticsDict && CFDictionaryGetCount(diagnosticsDict)) {
+                CFDictionarySetValue(mResult, kOSKextDiagnosticsDependenciesKey,
+                    diagnosticsDict);
+            }
+            SAFE_RELEASE_NULL(diagnosticsDict);
+        }
+        if ((typeFlags & kOSKextDiagnosticsFlagWarnings)) {
+
+            diagnosticsDict = __OSKextCopyDiagnosticsDict(aKext,
+                kOSKextDiagnosticsFlagWarnings);
+            if (diagnosticsDict && CFDictionaryGetCount(diagnosticsDict)) {
+                CFDictionarySetValue(mResult, kOSKextDiagnosticsWarningsKey,
+                    diagnosticsDict);
+            }
+            SAFE_RELEASE_NULL(diagnosticsDict);
+        }
+
+        if ((typeFlags & kOSKextDiagnosticsFlagBootLevel)) {
+            diagnosticsDict = __OSKextCopyDiagnosticsDict(aKext,
+                kOSKextDiagnosticsFlagBootLevel);
+            if (diagnosticsDict && CFDictionaryGetCount(diagnosticsDict)) {
+                CFDictionarySetValue(mResult, kOSKextDiagnosticsBootLevelKey,
+                    diagnosticsDict);
+            }
+            SAFE_RELEASE_NULL(diagnosticsDict);
+        }
+
+        result = (CFDictionaryRef)mResult;
+    } else {
+        result = CFDictionaryCreate(CFGetAllocator(aKext),
+            NULL, NULL, 0,
+            &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    }
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDictionaryRef __OSKextCopyDiagnosticsDict(
+    OSKextRef              aKext,
+    OSKextDiagnosticsFlags type)
+{
+    CFDictionaryRef result = NULL;
+    CFDictionaryRef dictToCopy = NULL;  // do not release
+
+    if (!aKext->diagnostics) {
+        goto finish;
+    }
+    switch (type) {
+        case kOSKextDiagnosticsFlagValidation:
+            dictToCopy = aKext->diagnostics->validationFailures;
+            break;
+        case kOSKextDiagnosticsFlagAuthentication:
+            dictToCopy = aKext->diagnostics->authenticationFailures;
+            break;
+        case kOSKextDiagnosticsFlagDependencies:
+            dictToCopy = aKext->diagnostics->dependencyFailures;
+            break;
+        case kOSKextDiagnosticsFlagWarnings:
+            dictToCopy = aKext->diagnostics->warnings;
+            break;
+        case kOSKextDiagnosticsFlagBootLevel:
+            dictToCopy = aKext->diagnostics->bootLevel;
+            break;
+        default:
+            break;
+    }
+
+    if (dictToCopy) {
+        result = CFDictionaryCreateCopy(CFGetAllocator(aKext), dictToCopy);
+    }
+
+finish:
+    if (!result) {
+        result = CFDictionaryCreate(CFGetAllocator(aKext),
+            NULL, NULL, 0,
+            &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+/*********************************************************************
+*********************************************************************/
+void OSKextLogDiagnostics(OSKextRef aKext,
+    OSKextDiagnosticsFlags typeFlags)
+{
+    CFDictionaryRef   diagnosticsDict = NULL;  // must release
+    CFStringRef       plistString     = NULL;  // must release
+    char            * cString         = NULL;  // must free
+
+    diagnosticsDict = OSKextCopyDiagnostics(aKext, typeFlags);
+    if (!diagnosticsDict || !CFDictionaryGetCount(diagnosticsDict)) {
+        goto finish;
+    }
+    plistString = createCFStringForPlist_new(diagnosticsDict,
+        kPListStyleDiagnostics);
+    if (!plistString) {
+        goto finish;
+    }
+    cString = createUTF8CStringForCFString(plistString);
+    if (!cString) {
+        goto finish;
+    }
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogExplicitLevel | kOSKextLogGeneralFlag,
+        "%s", cString);
+
+finish:
+    SAFE_RELEASE(diagnosticsDict);
+    SAFE_RELEASE(plistString);
+    SAFE_FREE(cString);
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+typedef struct {
+    OSKextDiagnosticsFlags typeFlags;
+} __OSKextFlushDiagnosticsContext;
+
+static void __OSKextFlushDiagnosticsApplierFunction(
+    const void * vKey __unused,
+    const void * vValue,
+          void * vContext)
+{
+    OSKextRef aKext = (OSKextRef)vValue;
+    __OSKextFlushDiagnosticsContext * context =
+        (__OSKextFlushDiagnosticsContext *)vContext;
+
+    OSKextFlushDiagnostics(aKext, context->typeFlags);
+    return;
+}
+
+const UInt32 __kOSKextDiagnosticsFlagAllImplemented =
+    kOSKextDiagnosticsFlagValidation     |
+    kOSKextDiagnosticsFlagAuthentication |
+    kOSKextDiagnosticsFlagDependencies   |
+    kOSKextDiagnosticsFlagWarnings       |
+    kOSKextDiagnosticsFlagBootLevel;
+
+void OSKextFlushDiagnostics(OSKextRef aKext, OSKextDiagnosticsFlags typeFlags)
+{
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    if (aKext) {
+        if (aKext->diagnostics) {
+            if (typeFlags & kOSKextDiagnosticsFlagValidation) {
+                SAFE_RELEASE_NULL(aKext->diagnostics->validationFailures);
+            }
+            if (typeFlags & kOSKextDiagnosticsFlagAuthentication) {
+                SAFE_RELEASE_NULL(aKext->diagnostics->authenticationFailures);
+            }
+            if (typeFlags & kOSKextDiagnosticsFlagDependencies) {
+                SAFE_RELEASE_NULL(aKext->diagnostics->dependencyFailures);
+            }
+            if (typeFlags & kOSKextDiagnosticsFlagWarnings) {
+                SAFE_RELEASE_NULL(aKext->diagnostics->warnings);
+            }
+            if (typeFlags & kOSKextDiagnosticsFlagBootLevel) {
+                SAFE_RELEASE_NULL(aKext->diagnostics->bootLevel);
+            }
+            if ((typeFlags & __kOSKextDiagnosticsFlagAllImplemented) ==
+                 __kOSKextDiagnosticsFlagAllImplemented) {
+
+                SAFE_FREE_NULL(aKext->diagnostics);
+            }
+        }
+    } else if (__sOSKextsByURL) {
+        __OSKextFlushDiagnosticsContext context;
+        context.typeFlags = typeFlags;
+        CFDictionaryApplyFunction(__sOSKextsByURL,
+            __OSKextFlushDiagnosticsApplierFunction, &context);
+
+    }
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFMutableDictionaryRef __OSKextGetDiagnostics(OSKextRef aKext,
+    OSKextDiagnosticsFlags type)
+{
+    CFMutableDictionaryRef result = NULL;
+
+    if (!aKext->diagnostics) {
+        aKext->diagnostics = (__OSKextDiagnostics *)malloc(
+            sizeof(*(aKext->diagnostics)));
+        if (!aKext->diagnostics) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        memset(aKext->diagnostics, 0, sizeof(*(aKext->diagnostics)));
+    }
+
+    switch (type) {
+        case kOSKextDiagnosticsFlagValidation:
+            if (!aKext->diagnostics->validationFailures) {
+                aKext->diagnostics->validationFailures =
+                    CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+                    &kCFTypeDictionaryKeyCallBacks,
+                    &kCFTypeDictionaryValueCallBacks);
+                if (!aKext->diagnostics->validationFailures) {
+                    OSKextLogMemError();
+                    goto finish;
+                }
+            }
+            result = aKext->diagnostics->validationFailures;
+            break;
+        case kOSKextDiagnosticsFlagAuthentication:
+            if (!aKext->diagnostics->authenticationFailures) {
+                aKext->diagnostics->authenticationFailures =
+                    CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+                    &kCFTypeDictionaryKeyCallBacks,
+                    &kCFTypeDictionaryValueCallBacks);
+                if (!aKext->diagnostics->authenticationFailures) {
+                    OSKextLogMemError();
+                    goto finish;
+                }
+            }
+            result = aKext->diagnostics->authenticationFailures;
+            break;
+        case kOSKextDiagnosticsFlagDependencies:
+            if (!aKext->diagnostics->dependencyFailures) {
+                aKext->diagnostics->dependencyFailures =
+                    CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+                    &kCFTypeDictionaryKeyCallBacks,
+                    &kCFTypeDictionaryValueCallBacks);
+                if (!aKext->diagnostics->dependencyFailures) {
+                    OSKextLogMemError();
+                    goto finish;
+                }
+            }
+            result = aKext->diagnostics->dependencyFailures;
+            break;
+        case kOSKextDiagnosticsFlagWarnings:
+            if (!aKext->diagnostics->warnings) {
+                aKext->diagnostics->warnings =
+                    CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+                    &kCFTypeDictionaryKeyCallBacks,
+                    &kCFTypeDictionaryValueCallBacks);
+                if (!aKext->diagnostics->warnings) {
+                    OSKextLogMemError();
+                    goto finish;
+                }
+            }
+            result = aKext->diagnostics->warnings;
+            break;
+        case kOSKextDiagnosticsFlagBootLevel:
+            if (!aKext->diagnostics->bootLevel) {
+                aKext->diagnostics->bootLevel =
+                    CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+                    &kCFTypeDictionaryKeyCallBacks,
+                    &kCFTypeDictionaryValueCallBacks);
+                if (!aKext->diagnostics->bootLevel) {
+                    OSKextLogMemError();
+                    goto finish;
+                }
+            }
+            result = aKext->diagnostics->bootLevel;
+            break;
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+void __OSKextSetDiagnostic(
+    OSKextRef              aKext,
+    OSKextDiagnosticsFlags type,
+    CFStringRef            key)
+{
+    CFMutableDictionaryRef diagnosticDict;
+
+    if (!(type & __sOSKextRecordsDiagnositcs)) {
+        goto finish;
+    }
+
+    diagnosticDict = __OSKextGetDiagnostics(aKext, type);
+    if (!diagnosticDict) {
+        goto finish;
+    }
+    CFDictionarySetValue(diagnosticDict, key, kCFBooleanTrue);
+
+finish:
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+void __OSKextAddDiagnostic(
+    OSKextRef              aKext,
+    OSKextDiagnosticsFlags type,
+    CFStringRef            key,
+    CFTypeRef              value,
+    CFTypeRef              note)
+{
+    CFMutableDictionaryRef diagnosticDict;
+    CFMutableArrayRef      valueArray;
+    CFMutableArrayRef      createdArray   = NULL;  // must release
+    CFStringRef            combinedValue  = NULL;  // must release
+    CFStringRef            valueWithNote  = NULL;  // must release
+    CFStringRef            valueToSet     = NULL;  // do not release
+
+    if (!(type & __sOSKextRecordsDiagnositcs)) {
+        goto finish;
+    }
+
+    diagnosticDict = __OSKextGetDiagnostics(aKext, type);
+    if (!diagnosticDict) {
+        goto finish;
+    }
+
+    valueToSet = value;
+    if (CFGetTypeID(value) == CFArrayGetTypeID()) {
+        combinedValue = CFStringCreateByCombiningStrings(kCFAllocatorDefault,
+            (CFArrayRef)value, CFSTR("."));
+        if (!combinedValue) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        valueToSet = combinedValue;
+    }
+    
+    if (note) {
+        valueWithNote = CFStringCreateWithFormat(kCFAllocatorDefault,
+            /* options */ NULL, CFSTR("%@ - %@"), valueToSet, note);
+        if (!valueWithNote) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        valueToSet = valueWithNote;
+    }
+
+    valueArray = (CFMutableArrayRef)CFDictionaryGetValue(diagnosticDict, key);
+    if (!valueArray) {
+        valueArray = createdArray = CFArrayCreateMutable(kCFAllocatorDefault,
+            0, &kCFTypeArrayCallBacks);
+        if (!valueArray) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        CFDictionarySetValue(diagnosticDict, key, valueArray);
+
+   /* Don't allow what should have been a call to __OSKextSetDiagnostic(),
+    * which adds a single Boolean true for a given key.
+    */
+    } else if (CFArrayGetTypeID() != CFGetTypeID(valueArray)) {
+        OSKextLog(aKext,
+            kOSKextLogErrorLevel | kOSKextLogKextBookkeepingFlag,
+            "Internal error in diagnositcs recording");
+        goto finish;
+    }
+    if (!CFArrayGetCountOfValue(valueArray, RANGE_ALL(valueArray), valueToSet)) {
+        CFArrayAppendValue(valueArray, valueToSet);
+    }
+
+finish:
+    SAFE_RELEASE(createdArray);
+    SAFE_RELEASE(combinedValue);
+    SAFE_RELEASE(valueWithNote);
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextCheckProperty(
+    OSKextRef       aKext,
+    CFDictionaryRef aDict,
+    CFTypeRef       propKey,
+    CFTypeRef       diagnosticValue, /* string or array of strings */
+    CFTypeID        expectedType,
+    CFArrayRef      legalValues,  /* NULL if not relevant */
+    Boolean         required,
+    Boolean         typeRequired,
+    Boolean         nonnilRequired,
+    CFTypeRef     * valueOut,
+    Boolean       * valueIsNonnil)
+{
+    Boolean     result              = false;
+    CFTypeRef   value               = NULL;  // do not release
+    Boolean     isFloat             = false;
+    CFStringRef diagnosticString    = NULL;  // must release
+    CFStringRef noteString          = NULL;  // must release
+    CFNumberRef zeroValue           = NULL;  // must release
+    Boolean     valueIsNonnil_local = false;
+    CFIndex     count, i;
+
+    if (valueIsNonnil) {
+        *valueIsNonnil = false;
+    }
+    if (valueOut) {
+        *valueOut = NULL;
+    }
+
+   /* For the top-level dictionary, use OSKextGetValueForInfoDictionaryKey()
+    * so we get arch-specfic variants. For nested dicts, use
+    * CFDictionaryGetValue().
+    */
+    if (aDict == aKext->infoDictionary) {
+        value = OSKextGetValueForInfoDictionaryKey(aKext, propKey);
+    } else {
+        value = CFDictionaryGetValue(aDict, propKey);
+    }
+    if (!value) {
+        if (!required) {
+            result = true;
+        } else {
+            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticMissingPropertyKey, diagnosticValue,
+                /* note */ NULL);
+        }
+        goto finish;
+    } else if (valueOut) {
+        *valueOut = value;
+    }
+
+   /* IOCFUnserialize() actually doesn't recognize <real>
+    * so we'll never see this, bit of a shame.
+    */
+    isFloat = CFNumberGetTypeID() == CFGetTypeID(value) &&
+        CFNumberIsFloatType((CFNumberRef)value);
+
+    if (expectedType != CFGetTypeID(value) || isFloat) {
+        const char * expectedTag = NULL;
+
+        if (expectedType == CFStringGetTypeID()) {
+            expectedTag = "<string>";
+        } else if (expectedType == CFNumberGetTypeID() && isFloat) {
+            expectedTag = "<integer> (kexts may not use <real>)";
+        } else if (expectedType == CFNumberGetTypeID()) {
+            expectedTag = "<integer>";
+        } else if (expectedType == CFDataGetTypeID()) {
+            expectedTag = "<data>";
+        } else if (expectedType == CFBooleanGetTypeID()) {
+            expectedTag = "boolean, <true/> or <false/>";
+        } else if (expectedType == CFArrayGetTypeID()) {
+            expectedTag = "<array>";
+        } else if (expectedType == CFDictionaryGetTypeID()) {
+            expectedTag = "<dict>";
+        }
+        
+        if (expectedType) {
+            noteString = CFStringCreateWithFormat(kCFAllocatorDefault,
+                /* formatOptions */ NULL, CFSTR("should be %s"),
+                expectedTag);
+        }
+        __OSKextAddDiagnostic(aKext,
+            typeRequired ? kOSKextDiagnosticsFlagValidation : kOSKextDiagnosticsFlagWarnings,
+            typeRequired ? kOSKextDiagnosticPropertyIsIllegalTypeKey : kOSKextDiagnosticTypeWarningKey,
+            diagnosticString ? diagnosticString : diagnosticValue, noteString);
+        goto finish;
+    }
+
+    if (legalValues) {
+        Boolean valueIsLegal = false;
+        count = CFArrayGetCount(legalValues);
+        for (i = 0; i < count; i++) {
+            CFTypeRef thisValue = CFArrayGetValueAtIndex(legalValues, i);
+            if (CFEqual(thisValue, value)) {
+                valueIsLegal = true;
+                break;
+            }
+        }
+        if (!valueIsLegal) {
+            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticPropertyIsIllegalValueKey, diagnosticValue,
+                /* note */ NULL);
+        }
+    }
+
+    if (expectedType == CFBooleanGetTypeID()) {
+        CFBooleanRef boolValue = (CFBooleanRef)value;
+        valueIsNonnil_local = CFBooleanGetValue(boolValue);
+    } else if (expectedType == CFStringGetTypeID()) {
+        CFStringRef stringValue = (CFStringRef)value;
+        valueIsNonnil_local = CFStringGetLength(stringValue) ? true : false;
+    } else if (expectedType == CFDataGetTypeID()) {
+        CFDataRef dataValue = (CFDataRef)value;
+        valueIsNonnil_local = CFDataGetLength(dataValue) ? true : false;
+    } else if (expectedType == CFArrayGetTypeID()) {
+        CFArrayRef arrayValue = (CFArrayRef)value;
+        valueIsNonnil_local = CFArrayGetCount(arrayValue) ? true : false;
+    } else if (expectedType == CFDictionaryGetTypeID()) {
+        CFDictionaryRef dictValue = (CFDictionaryRef)value;
+        valueIsNonnil_local = CFDictionaryGetCount(dictValue) ? true : false;
+    } else if (expectedType == CFNumberGetTypeID()) {
+        CFNumberRef numberValue = (CFNumberRef)value;
+        int zero = 0;
+        zeroValue = CFNumberCreate(kCFAllocatorDefault,
+            kCFNumberIntType, &zero);
+        if (!zeroValue) {
+            OSKextLogMemError();
+        }
+        if (kCFCompareEqualTo !=
+            CFNumberCompare(numberValue, zeroValue, NULL)) {
+
+            valueIsNonnil_local = true;
+        }
+    }
+
+    if (valueIsNonnil) {
+         *valueIsNonnil = valueIsNonnil_local;
+     }
+
+    if (nonnilRequired && !valueIsNonnil_local) {
+        __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+            kOSKextDiagnosticPropertyIsIllegalValueKey, diagnosticValue,
+            /* note */ NULL);
+
+        goto finish;
+    }
+
+    result = true;
+
+finish:
+    SAFE_RELEASE(diagnosticString);
+    SAFE_RELEASE(noteString);
+    SAFE_RELEASE(zeroValue);
+    return result;
+}
+
+#pragma mark Misc Private Functions
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextReadInfoDictionary(
+    OSKextRef   aKext,
+    CFBundleRef kextBundle)
+{
+    Boolean        result        = false;
+    CFBundleRef    createdBundle = NULL;  // must release
+    CFURLRef       infoDictURL   = NULL;  // must release
+    struct stat    statbuf;
+    CFDataRef      infoDictData  = NULL;  // must release
+    char         * infoDictXML   = NULL;  // must free
+    int            fd = -1;               // must close
+    ssize_t        totalBytesRead;
+    CFStringRef    errorString   = NULL;  // must release
+    char        *  errorCString  = NULL;  // must free
+    char           kextPath[PATH_MAX];
+    char           mkextPath[PATH_MAX] = __kStringUnknown;
+    char           infoDictPath[PATH_MAX];
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ false, kextPath);
+
+    if (aKext->infoDictionary) {
+        result = true;
+        goto finish;
+    }
+
+   /* Big error if we have no info dict and we came from an mkext.
+    */
+    if (aKext->staticFlags.isFromMkext) {
+        __OSKextGetFileSystemPath(/* kext */ NULL,
+            aKext->mkextInfo->mkextURL,
+            /* resolveToBase */ false, mkextPath);
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+            "%s created from m%s is missing its info dictionary.",
+            kextPath, mkextPath);
+        result = false;
+        goto finish;
+    }
+
+    if (!kextBundle) {
+        OSKextLog(aKext, kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+            "Opening CFBundle for %s.", kextPath);
+        kextBundle = createdBundle = CFBundleCreate(kCFAllocatorDefault,
+            aKext->bundleURL);
+        if (!createdBundle) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+                "Can't open CFBundle for %s.", kextPath);
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticNotABundleKey);
+            goto finish;
+        }
+    }
+    infoDictURL = _CFBundleCopyInfoPlistURL(kextBundle);
+
+    if (!infoDictURL) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "%s has no Info.plist file.", kextPath);
+        __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+            kOSKextDiagnosticNotABundleKey);
+        goto finish;
+    }
+
+    if (!__OSKextGetFileSystemPath(/* kext */ NULL, infoDictURL,
+        /* resolveToBase */ true, infoDictPath)) {
+
+        __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+            kOSKextDiagnosticURLConversionKey, infoDictURL, /* note */ NULL);
+        goto finish;
+    }
+    if (0 != stat(infoDictPath, &statbuf)) {
+        if (errno == ENOENT) {
+            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticFileNotFoundKey, infoDictURL, /* note */ NULL);
+        } else {
+            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticStatFailureKey, infoDictURL, /* note */ NULL);
+        }
+        goto finish;
+    }
+    fd = open(infoDictPath, O_RDONLY);
+    if (fd < 0) {
+        __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+            kOSKextDiagnosticFileAccessKey, infoDictURL, /* note */ NULL);
+        goto finish;
+    }
+
+    infoDictXML = (char *)malloc((1 + statbuf.st_size) * sizeof(char));
+    if (!infoDictXML) {
+       /* XXX - Basically hosed if this happens. */
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    for (totalBytesRead = 0; totalBytesRead < statbuf.st_size; /* nothing */) {
+        ssize_t bytesRead = read(fd, infoDictXML + totalBytesRead,
+            statbuf.st_size - totalBytesRead);
+        if (bytesRead < 0) {
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticFileAccessKey);
+            goto finish;
+        }
+        totalBytesRead += bytesRead;
+    }
+
+    infoDictXML[totalBytesRead] = '\0';
+
+    aKext->infoDictionary = (CFDictionaryRef)IOCFUnserialize(
+        (const char *)infoDictXML, kCFAllocatorDefault, 0, &errorString);
+    if (!aKext->infoDictionary ||
+        CFDictionaryGetTypeID() != CFGetTypeID(aKext->infoDictionary)) {
+
+       /* We're going to fail init for a new kext object, so in addition
+        * to logging we need to print an error message immediately.
+        */
+        __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+            kOSKextDiagnosticBadPropertyListXMLKey,
+            errorString, /* note */ NULL);
+
+        if (errorString) {
+            errorCString = createUTF8CStringForCFString(errorString);
+        }
+        OSKextLog(aKext, kOSKextLogErrorLevel,
+            "Can't read info dictionary for %s: %s.",
+            kextPath, errorCString ? errorCString : "(unknown error)");
+
+        goto finish;
+    }
+
+    result = true;
+
+finish:
+    if (createdBundle) {
+        OSKextLog(aKext, kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+            "Releasing CFBundle for %s.",
+            kextPath);
+    }
+    SAFE_RELEASE(createdBundle);
+    SAFE_RELEASE(infoDictURL);
+    SAFE_RELEASE(infoDictData);
+    SAFE_FREE(infoDictXML);
+    SAFE_RELEASE(errorString);
+    SAFE_FREE(errorCString);
+
+    if (fd >= 0) {
+        close(fd);
+    }
+
+    if (!result) {
+        aKext->flags.invalid = 1;
+        aKext->flags.valid = 0;
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextProcessInfoDictionary(
+    OSKextRef   aKext,
+    CFBundleRef kextBundle)
+{
+    Boolean           result = false;
+    Boolean           valueIsNonnil;
+    Boolean           checkResult;
+    CFMutableArrayRef propPath            = NULL;   // must release
+    CFStringRef       propKey             = NULL;   // do not release
+    CFBooleanRef      boolValue           = NULL;   // do not release
+    CFStringRef       stringValue         = NULL;   // do not release
+    CFDictionaryRef   dictValue           = NULL;   // do not release
+    CFTypeRef         debugLevel          = NULL;   // do not release
+    Boolean           isInterfaceSetFalse = false;
+    OSKextVersion     bundleVersion      = -1;
+    OSKextVersion     compatibleVersion  = -1;
+
+   /* Remove the kext from the lookup dictionary (if there). Its identifier or
+    * version may change if we read the info dictionary from disk. This happens
+    * if we're realizing from the identifier cache or have flushed the info
+    * dictionary.
+    */
+    __OSKextRemoveKextFromIdentifierDict(aKext, __sOSKextsByIdentifier);
+
+    if (!__OSKextReadInfoDictionary(aKext, kextBundle)) {
+        goto finish;
+    }
+
+   /* Set to true so any failed property check clears.
+    */
+    result = true;
+
+   /*********************************
+    * CFBundlePackageType == "KEXT" *
+    *********************************/
+
+   /* This check is somewhat pedantic, but it pretty much means
+    * the rest of the checks aren't worth doing.
+    */
+    propKey = _kCFBundlePackageTypeKey;
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ __sOSKextPackageTypeValues,
+        /* required */ true,
+        /* typeRequired */ true,
+        /* nonnilRequired */ true,
+        /* valueOut */ NULL,
+        /* valueIsNonnil */ NULL);
+    result = result && checkResult;
+    if (!checkResult) {
+        goto finish;
+    }
+
+   /*****
+    * For all remaining checks, fall through so we do them all even on failure.
+    * It's cheap enough to do and means the dev. won't have to do multiple
+    * passes to find every error.
+    *****/
+
+   /*******************************************
+    * CFBundleIdentifier: string, length < 64 *
+    *******************************************/
+
+    propKey = kCFBundleIdentifierKey;
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ true,
+        /* typeRequired */ true,
+        /* nonnilRequired */ true,
+        /* valueOut */ (CFTypeRef *)&stringValue,
+        /* valueIsNonnil */ NULL);
+    result = result && checkResult;
+    if (checkResult && stringValue) {
+        SAFE_RELEASE_NULL(aKext->bundleID);
+        if (stringValue) {
+            aKext->bundleID = CFRetain(stringValue);
+        }
+        if (CFStringGetLength(stringValue) > KMOD_MAX_NAME - 1) {
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticIdentifierOrVersionTooLongKey);
+            result = false;
+        }
+    } else {
+        aKext->bundleID = CFSTR(__kOSKextUnknownIdentifier);
+    }
+
+   /*************************************
+    * CFBundleVersion: string, parsable *
+    *************************************/
+
+    propKey = kCFBundleVersionKey;
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ true,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,   // we catch it on the parse
+        /* valueOut */ (CFTypeRef *)&stringValue,
+        /* valueIsNonnil */ NULL);
+    result = result && checkResult;
+    if (checkResult && stringValue) {
+        if (CFStringGetLength(stringValue) > KMOD_MAX_NAME - 1) {
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticIdentifierOrVersionTooLongKey);
+            result = false;
+        } else {
+            bundleVersion = OSKextParseVersionCFString(stringValue);
+            if (bundleVersion == -1) {
+            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticPropertyIsIllegalValueKey, kCFBundleVersionKey,
+                /* note */ NULL);
+                result = false;
+            }
+            aKext->version = bundleVersion;
+        }
+    }
+
+   /*******************************************************************
+    * OSBundleCompatibleVersion: string, parsable, <= CFBundleVersion *
+    *******************************************************************/
+
+    propKey = CFSTR(kOSBundleCompatibleVersionKey);
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,  // we catch it on the parse
+        /* valueOut */ (CFTypeRef *)&stringValue,
+        /* valueIsNonnil */ NULL);
+    result = result && checkResult;
+    if (checkResult && stringValue) {
+        compatibleVersion = OSKextParseVersionCFString(stringValue);
+        if (compatibleVersion == -1) {
+            result = false;
+        }
+        aKext->compatibleVersion = compatibleVersion;
+
+        if (compatibleVersion > bundleVersion) {
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticCompatibleVersionLaterThanVersionKey);
+            result = false;
+        }
+    }
+
+   /********************************
+    * OSBundleIsInterface: Boolean *
+    ********************************/
+
+   /* Check whether the kext is an interface before checking whether it's
+    * a kernel component. If the kext is a kernel component, it's implicitly
+    * an interface too, so we're not going to require OSBundleIsInterface
+    * be set for them.
+    */
+    propKey = CFSTR(kOSBundleIsInterfaceKey);
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedTypes */ CFBooleanGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,
+        /* valueOut */ (CFTypeRef *)&boolValue,
+        &valueIsNonnil);
+    result = result && checkResult;
+    if (valueIsNonnil) {
+        aKext->flags.isInterface = 1;
+    }
+
+   /* However, if it is set, and set to false, that's a big no-no for a
+    * kernel component.
+    */
+    if (boolValue) {
+        isInterfaceSetFalse = !CFBooleanGetValue(boolValue);
+    }
+
+   /**************************************
+    * OSBundleIsKernelComponent: Boolean *
+    **************************************/
+
+    propKey = CFSTR(kOSKernelResourceKey);
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedType */ CFBooleanGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,
+        /* valueOut */ NULL,
+        &valueIsNonnil);
+    result = result && checkResult;
+    if (valueIsNonnil) {
+        aKext->flags.isKernelComponent = 1;
+    }
+
+    if (aKext->flags.isKernelComponent) {
+        if (isInterfaceSetFalse) {
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+                kOSKextDiagnosticKernelComponentNotInterfaceKey);
+        }
+        aKext->flags.isInterface = 1;
+    }
+
+   /******************************
+    * CFBundleExecutable: string *
+    ******************************/
+
+    propKey = kCFBundleExecutableKey;
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ true,  // xxx - ok for empty prop here?
+        /* valueOut */ NULL,
+        &valueIsNonnil);
+    result = result && checkResult;
+    if (valueIsNonnil) {
+        aKext->flags.declaresExecutable = 1;
+    }
+
+#if SHARED_EXECUTABLE
+    propKey = CFSTR(kOSBundleSharedExecutableIdentifierKey);
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,  // xxx - ok for empty prop here?
+        /* valueOut */ NULL,
+        &valueIsNonnil);
+    result = result && checkResult;
+   /* Can't have both executable and shared! */
+    if (aKext->flags.declaresExecutable) {
+        if (valueIsNonnil) {
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
+                kOSKextDiagnosticSharedExecutableAndExecutableKey);
+        }
+    } else if (valueIsNonnil) {
+        aKext->flags.declaresExecutable = 1;
+    }
+#endif /* SHARED_EXECUBTABLE */
+
+   /**************************************
+    * OSBundleEnableKextLogging: boolean *
+    *************************************/
+
+    propKey = CFSTR(kOSBundleEnableKextLoggingKey);
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedType */ CFBooleanGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,
+        /* propKey */ (CFTypeRef *)&boolValue,
+        &valueIsNonnil);
+    result = result && checkResult;
+
+    if (valueIsNonnil) {
+        aKext->flags.loggingEnabled = CFBooleanGetValue(boolValue) ? 1 : 0;
+        aKext->flags.plistHasEnableLoggingSet = CFBooleanGetValue(boolValue) ? 1 : 0;
+    }
+
+   /*****************************************
+    * OSBundleDebugLevelKey: DEPRECATED (?) *
+    *****************************************/
+
+    propKey = CFSTR(kOSBundleDebugLevelKey);
+    debugLevel = OSKextGetValueForInfoDictionaryKey(aKext, propKey);
+    if (debugLevel) {
+        __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagWarnings,
+            kOSKextDiagnosticDeprecatedPropertyKey, CFSTR(kOSBundleDebugLevelKey),
+            /* note */ NULL);
+    }
+
+   /*****************************************
+    * OSBundleRequired: string, legal value *
+    *****************************************/
+
+   /* Any legal value for OSBundleRequired means kext is safe-boot
+    * loadable.
+    */
+    propKey = CFSTR(kOSBundleRequiredKey);
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedType */ CFStringGetTypeID(),
+        /* legalValues */ __sOSKextOSBundleRequiredValues,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,  // required values given
+        /* valueOut */ NULL,
+        &valueIsNonnil);
+    result = result && checkResult;
+    if (valueIsNonnil) {
+        aKext->flags.isLoadableInSafeBoot = 1;
+    } else {
+        if (OSKextGetActualSafeBoot() || OSKextGetSimulatedSafeBoot()) {
+            __OSKextSetDiagnostic(aKext, kOSKextDiagnosticsFlagBootLevel,
+                kOSKextDiagnosticIneligibleInSafeBoot);
+        }
+    }
+
+   /***********************************************
+    * IOKitPersonalities: dictionary              *
+    * Further validation done in OSKextValidate() *
+    ***********************************************/
+
+    propKey = CFSTR(kIOKitPersonalitiesKey);
+    checkResult = __OSKextCheckProperty(aKext,
+        aKext->infoDictionary,
+        /* propKey */ propKey,
+        /* diagnosticValue */ propKey,
+        /* expectedType */ CFDictionaryGetTypeID(),
+        /* legalValues */ NULL,
+        /* required */ false,
+        /* typeRequired */ true,
+        /* nonnilRequired */ false,  // ok to have empty dict fr. template
+        /* valueOut */ (CFTypeRef *)&dictValue,
+        &valueIsNonnil);
+    result = result && checkResult;
+    if (dictValue) {
+        __OSKextValidateIOKitPersonalityContext validatePersonalitiesContext;
+
+       /* We also need to check for an IOKitDebug property in any personality.
+        * propPath is needed for the applier function call.
+        */
+        propPath = CFArrayCreateMutable(CFGetAllocator(aKext), 0,
+            &kCFTypeArrayCallBacks);
+        if (!propPath) {
+            OSKextLogMemError();
+            result = false;
+            goto finish;
+        }
+        CFArrayAppendValue(propPath, propKey);
+
+        validatePersonalitiesContext.kext = aKext;
+        validatePersonalitiesContext.personalities = dictValue;
+        validatePersonalitiesContext.propPath = propPath;
+        validatePersonalitiesContext.valid = true;  // starts true!
+        validatePersonalitiesContext.justCheckingIOKitDebug = true;
+        CFDictionaryApplyFunction(dictValue,
+            __OSKextValidateIOKitPersonalityApplierFunction,
+            &validatePersonalitiesContext);
+        result = result && validatePersonalitiesContext.valid;
+
+        CFArrayRemoveValueAtIndex(propPath, CFArrayGetCount(propPath) - 1);
+    }
+
+finish:
+   /* If we know the kext is invalid now, mark it. We can't say it's
+    * valid yet without doing other, more expensive checks.
+    */
+    if (!result) {
+        aKext->flags.invalid = 1;
+        aKext->flags.valid = 0;
+    }
+
+   /* Add the kext (back) to the lookup dictionary. Its identifier or
+    * version may have changed.
+    * xxx - we should catch a failure to insert in identifier dict
+    * xxx - but ultimately there isn't much we can do.
+    */
+    (void)__OSKextRecordKextInIdentifierDict(aKext, __sOSKextsByIdentifier);
+
+    SAFE_RELEASE(propPath);
+
+    return result;
+}
+
+#pragma mark Mkext and Prelinked Kernel Files
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextIsFromMkext(OSKextRef aKext)
+{
+    return aKext->staticFlags.isFromMkext ? true : false;
+}
+
+/*********************************************************************
+*********************************************************************/
+#define REQUIRED_MATCH(flags, string, type)  \
+    (((flags) & kOSKextOSBundleRequired ## type ## Flag) && \
+    string && CFEqual(string, CFSTR(kOSBundleRequired ## type)))
+
+Boolean OSKextMatchesRequiredFlags(OSKextRef aKext,
+    OSKextRequiredFlags requiredFlags)
+{
+    Boolean     result         = false;
+    CFStringRef requiredString = NULL;  // do not release
+
+    requiredString = OSKextGetValueForInfoDictionaryKey(aKext,
+        CFSTR(kOSBundleRequiredKey));
+
+    if (REQUIRED_MATCH(requiredFlags, requiredString, Root) ||
+        REQUIRED_MATCH(requiredFlags, requiredString, LocalRoot) ||
+        REQUIRED_MATCH(requiredFlags, requiredString, NetworkRoot) ||
+        REQUIRED_MATCH(requiredFlags, requiredString, Console) ||
+        REQUIRED_MATCH(requiredFlags, requiredString, SafeBoot)) {
+
+        result = true;
+    } else if (!requiredFlags) {
+        result = true;
+    }
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextFilterRequiredKexts(
+    CFArrayRef          kextArray,
+    OSKextRequiredFlags requiredFlags)
+{
+    CFMutableArrayRef result = NULL;
+    CFIndex count, i;
+
+    result = CFArrayCreateMutable(CFGetAllocator(kextArray), 0,
+        &kCFTypeArrayCallBacks);
+    if (!result) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    if (!kextArray) {
+        kextArray = OSKextGetAllKexts();
+    }
+
+    count = CFArrayGetCount(kextArray);
+    for (i = 0; i < count; i++) {
+        OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(kextArray, i);
+        if (OSKextMatchesRequiredFlags(thisKext, requiredFlags)) {
+            CFArrayAppendValue(result, thisKext);
+        }
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+#define GZIP_WINDOW_OFFSET (16)
+
+Boolean __OSKextAddCompressedFileToMkext(
+    OSKextRef        aKext,
+    CFMutableDataRef mkextData,
+    CFDataRef        fileData,
+    Boolean          plistFlag,
+    Boolean        * compressed)
+{
+    Boolean             result           = false;
+    const UInt8       * fileBuffer       = CFDataGetBytePtr(fileData);
+    UInt8             * mkextBuffer;
+    mkext2_header     * mkextHeader;
+    CFIndex             mkextStartLength = CFDataGetLength(mkextData);
+    uint32_t            fullSize         = CFDataGetLength(fileData);
+    unsigned long       compressedSize;
+    uint32_t            compressedSize32;
+    mkext2_file_entry * entryPtr         = NULL;
+    int                 zlib_result;
+    uint32_t            entrySize;
+    UInt8  *            compressDest;
+    z_stream            zstream;
+    Boolean             zstream_inited   = false;
+
+    *compressed = false;
+
+   /* zlib doc says compression buffer must be source len + 0.1% + 12 bytes,
+    * so start with that much.
+    */
+    compressedSize = fullSize + ((fullSize+1000)/1000) + 12;
+
+    if (plistFlag) {
+        entrySize = 0;
+    } else {
+        entrySize = sizeof(mkext2_file_entry);
+    }
+
+    CFDataSetLength(mkextData,
+        mkextStartLength + entrySize + compressedSize);
+    mkextBuffer = CFDataGetMutableBytePtr(mkextData);
+
+    if (plistFlag) {
+        compressDest = mkextBuffer + mkextStartLength;
+    } else {
+        entryPtr = (mkext2_file_entry *)(mkextBuffer + mkextStartLength);
+        entryPtr->full_size = OSSwapHostToBigInt32(fullSize);
+        compressDest = entryPtr->data;
+    }
+
+    zstream.next_in   = (UInt8 *)fileBuffer;
+    zstream.next_out  = compressDest;
+    zstream.avail_in  = fullSize;
+    zstream.avail_out = compressedSize;
+    zstream.zalloc    = Z_NULL;
+    zstream.zfree     = Z_NULL;
+    zstream.opaque    = Z_NULL;
+
+    
+    zlib_result = deflateInit2(&zstream, Z_DEFAULT_COMPRESSION,  Z_DEFLATED,
+        15, 8 /* memLevel */, Z_DEFAULT_STRATEGY);
+    if (Z_OK != zlib_result) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "zlib deflateInit failed.");
+        goto finish;
+    } else {
+        zstream_inited = true;
+    }
+
+    zlib_result = deflate(&zstream, Z_FINISH);
+    if (zlib_result == Z_STREAM_END) {
+        compressedSize = zstream.total_out;
+    } else if (zlib_result == Z_OK) {
+       /* deflate filled output buffer, meaning the data doesn't compress.
+        */
+        compressedSize = zstream.total_out;
+    } else {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "zlib deflate failed.");
+        goto finish;
+    }
+
+    zlib_result = Z_OK;
+
+    // xxx - check for truncation?
+    compressedSize32 = (uint32_t)compressedSize;
+
+   /* Only accept the compression if it actually shrinks the file.
+    */
+    if (Z_OK == zlib_result) {
+        result = true;
+        if (compressedSize32 >= fullSize) {
+            *compressed = false;
+        } else {
+            *compressed = true;
+            if (plistFlag) {
+                mkextHeader = (mkext2_header *)mkextBuffer;
+                mkextHeader->plist_offset =
+                    OSSwapHostToBigInt32(mkextStartLength);
+                mkextHeader->plist_full_size =
+                    OSSwapHostToBigInt32(CFDataGetLength(fileData));
+                mkextHeader->plist_compressed_size =
+                    OSSwapHostToBigInt32(compressedSize32);
+                OSKextLog(aKext, kOSKextLogDetailLevel | kOSKextLogArchiveFlag,
+                    "Compressed info dict from %u to %u bytes (%.2f%%).",
+                    fullSize, compressedSize32,
+                    (100.0 * (float)compressedSize32/(float)fullSize));
+            } else {
+                entryPtr->compressed_size = OSSwapHostToBigInt32(compressedSize32);
+                OSKextLog(aKext, kOSKextLogDetailLevel | kOSKextLogArchiveFlag,
+                    "Compressed executable from %u to %u bytes (%.2f%%).",
+                    fullSize, compressedSize32,
+                    (100.0 * (float)compressedSize32/(float)fullSize));
+            }
+           /* Trim off the extra room left for the compress() call.
+            */
+            CFDataSetLength(mkextData,
+                mkextStartLength + entrySize + compressedSize32);
+        }
+    }
+
+finish:
+   /* Don't bother checking return, nothing we can do on fail.
+    */
+    if (zstream_inited) deflateEnd(&zstream);
+
+   /* If error, revert the mkext data to its original length
+    * so we don't have dead space in it.
+    */
+    if (result != true) {
+        CFDataSetLength(mkextData, mkextStartLength);
+    }
+    return result;
+}
+
+/*********************************************************************
+* Need to distinguish if we're generating mkext for a kernel load or
+* just to make an mkext!
+*********************************************************************/
+Boolean __OSKextAddToMkext(
+    OSKextRef         aKext,
+    CFMutableDataRef  mkextData,
+    CFMutableArrayRef mkextInfoDictArray,
+    char            * volumePath,
+    Boolean           compressFlag)
+{
+    Boolean                result                 = false;
+    CFMutableDictionaryRef infoDictionary         = NULL;   // must release
+    CFStringRef            bundlePath             = NULL;   // must release
+    CFStringRef            executableRelPath       = NULL;  // must release
+    char                   kextPath[PATH_MAX];
+    char                 * kextVolPath = kextPath;
+    CFDataRef              executable             = NULL;   // must release
+    CFIndex                mkextDataStartLength   = CFDataGetLength(mkextData);
+    uint32_t               mkextEntryOffset;
+    CFNumberRef            mkextEntryOffsetNum    = NULL;   // must release
+    mkext2_file_entry      entryScratch;
+    void                 * mkextEntryFile         = NULL;   // need to free if compressed
+    Boolean                compressed             = false;  // true if successfully compressed
+
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ true, kextPath);
+
+    OSKextLog(aKext, kOSKextLogStepLevel | kOSKextLogArchiveFlag,
+        "Adding %s to mkext.", kextPath);
+
+    infoDictionary = OSKextCopyInfoDictionary(aKext);
+    if (!infoDictionary) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+            "Can't get info dictionary for %s.", kextPath);
+        goto finish;
+    }
+
+   /* If the kext has logging enabled, whether originally in the plist
+    * or via run-time setting, set the plist property.
+    */
+    if (aKext->flags.loggingEnabled) {
+        CFDictionarySetValue(infoDictionary, CFSTR(kOSBundleEnableKextLoggingKey),
+            kCFBooleanTrue);
+    }
+
+    // xxx - need to validate
+
+    // xxx - this duplicates shared executables in the mkext
+    executable = OSKextCopyExecutableForArchitecture(aKext, OSKextGetArchitecture());
+    if (!executable && OSKextDeclaresExecutable(aKext)) {
+        OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+            "Can't get executable for %s (architecture %s).", kextPath,
+            OSKextGetArchitecture()->name);
+        goto finish;
+    }
+
+    if (executable) {
+        uint32_t entryFileSize;
+
+       /* Advise the system that we're reading the executable sequentially.
+        */
+        (void)posix_madvise((void *)CFDataGetBytePtr(executable),
+            CFDataGetLength(executable),
+            POSIX_MADV_SEQUENTIAL);
+
+        mkextEntryOffset = mkextDataStartLength;
+        mkextEntryOffsetNum = CFNumberCreate(CFGetAllocator(aKext),
+            kCFNumberSInt32Type, &mkextEntryOffset);
+        if (!mkextEntryOffsetNum) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        CFDictionarySetValue(infoDictionary, CFSTR(kMKEXTExecutableKey),
+            mkextEntryOffsetNum);
+
+        entryFileSize = CFDataGetLength(executable);
+        entryScratch.full_size = OSSwapHostToBigInt32(entryFileSize);
+
+        if (compressFlag && (!__OSKextAddCompressedFileToMkext(aKext,
+                mkextData, executable, /* plist */ false, &compressed))) {
+
+            OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+                "%s failed to compress executable.", kextPath);
+            goto finish;
+        }
+        if (!compressed) {
+            mkextEntryFile = (void *)CFDataGetBytePtr(executable);
+            entryScratch.compressed_size = OSSwapHostToBigInt32(0);
+            CFDataAppendBytes(mkextData, (const UInt8 *)&entryScratch,
+                sizeof(entryScratch));
+            CFDataAppendBytes(mkextData, (const UInt8 *)mkextEntryFile,
+                entryFileSize);
+        }
+        // xxx - name file in log msg
+        OSKextLog(aKext, kOSKextLogDetailLevel | kOSKextLogArchiveFlag,
+            "%s added %u-byte %scompressed executable to mkext.",
+            kextPath, entryFileSize, compressFlag ? "" : "non");
+    }
+
+    if (!__OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ true, kextPath)) {
+     
+        OSKextLogStringError(aKext);
+        goto finish;
+    }
+
+    kextVolPath = __absPathOnVolume(kextPath, volumePath);
+
+    bundlePath = CFStringCreateWithBytes(CFGetAllocator(aKext),
+        (UInt8 *)kextVolPath, strlen(kextVolPath),
+        kCFStringEncodingUTF8, false);
+    if (!bundlePath) {
+        OSKextLogMemError();
+        goto finish;
+    }
+    CFDictionarySetValue(infoDictionary, CFSTR(kMKEXTBundlePathKey),
+        bundlePath);
+
+    executableRelPath = __OSKextCopyExecutableRelativePath(aKext);
+    if (executableRelPath) {
+        CFDictionarySetValue(infoDictionary, CFSTR(kMKEXTExecutableRelativePathKey),
+            executableRelPath);
+    }
+
+    CFArrayAppendValue(mkextInfoDictArray, infoDictionary);
+
+    result = true;
+
+finish:
+    if (!result) {
+        CFDataSetLength(mkextData, mkextDataStartLength);
+    }
+
+   /* Advise the system that we no longer need the mmapped executable.
+    */
+    if (executable) {
+        (void)posix_madvise((void *)CFDataGetBytePtr(executable),
+            CFDataGetLength(executable),
+            POSIX_MADV_DONTNEED);
+    }
+
+    SAFE_RELEASE(infoDictionary);
+    SAFE_RELEASE(bundlePath);
+    SAFE_RELEASE(executableRelPath);
+    SAFE_RELEASE(executable);
+    SAFE_RELEASE(mkextEntryOffsetNum);
+    if (compressed) {
+        SAFE_FREE(mkextEntryFile);
+    }
+    return result;
+}
+
+// xxx - need to move this to mkext.c file
+__private_extern__ u_int32_t
+mkext_adler32(u_int8_t *buffer, int32_t length)
+{
+    int32_t cnt;
+    u_int32_t  result, lowHalf, highHalf;
+
+    lowHalf = 1;
+    highHalf = 0;
+
+    for (cnt = 0; cnt < length; cnt++) {
+        if ((cnt % 5000) == 0) {
+            lowHalf  %= 65521L;
+            highHalf %= 65521L;
+        }
+
+        lowHalf += buffer[cnt];
+        highHalf += lowHalf;
+    }
+
+    lowHalf  %= 65521L;
+    highHalf %= 65521L;
+
+    result = (highHalf << 16) | lowHalf;
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDataRef __OSKextCreateMkext(
+    CFAllocatorRef      allocator,
+    CFArrayRef          kextArray,
+    CFURLRef            volumeRootURL,
+    OSKextRequiredFlags requiredFlags,
+    Boolean             compressFlag,
+    Boolean             skipLoadedFlag,
+    CFDictionaryRef     loadArgsDict)
+{
+    CFMutableDataRef         result             = NULL;
+    CFMutableDataRef         mkextData          = NULL;  // must release
+    mkext2_header            mkextHeaderScratch;
+    mkext2_header          * mkextHeader;
+    void                   * mkextEnd;
+    CFMutableDictionaryRef   mkextPlist         = NULL;  // must release
+    CFMutableArrayRef        mkextInfoDictArray = NULL;  // must release
+    CFDataRef                mkextPlistData     = NULL;  // must release
+    Boolean                  compressed         = false; // true if successfully compressed
+    uint32_t                 adlerChecksum;
+    char                     kextPath[PATH_MAX];
+    char                     volumePath[PATH_MAX] = "";
+    CFIndex                  count, i, numKexts;
+
+    if (!kextArray) {
+        kextArray = OSKextGetAllKexts();
+    }
+    count = CFArrayGetCount(kextArray);
+    if (!count) {
+        goto finish;
+    }
+
+    mkextData = CFDataCreateMutable(allocator, 0);
+    if (!mkextData) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    mkextPlist = CFDictionaryCreateMutable(allocator, 0,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (!mkextPlist) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    mkextInfoDictArray = CFArrayCreateMutable(allocator, 0,
+        &kCFTypeArrayCallBacks);
+    if (!mkextInfoDictArray) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    if (volumeRootURL) {
+        if (!CFURLGetFileSystemRepresentation(volumeRootURL,
+            /* resolveToBase */ TRUE, (UInt8 *)volumePath, sizeof(volumePath))) {
+
+            OSKextLogStringError(/* kext */ NULL);
+            goto finish;
+        }
+    }
+
+    CFDictionarySetValue(mkextPlist, CFSTR(kMKEXTInfoDictionariesKey),
+        mkextInfoDictArray);
+    if (loadArgsDict) {
+        CFDictionarySetValue(mkextPlist, CFSTR(kKextRequestPredicateKey),
+            CFSTR(kKextRequestPredicateLoad));
+        CFDictionarySetValue(mkextPlist, CFSTR(kKextRequestArgumentsKey),
+            loadArgsDict);
+    }
+
+//printPList_new(stderr, mkextPlist, kPListStyleClassic);
+
+    CFDataAppendBytes(mkextData, (const UInt8 *)&mkextHeaderScratch,
+        sizeof(mkextHeaderScratch));
+
+    for (i = 0, numKexts = 0; i < count; i++) {
+        OSKextRef thisKext = (OSKextRef)CFArrayGetValueAtIndex(kextArray, i);
+
+        __OSKextGetFileSystemPath(thisKext, /* otherURL */ NULL,
+            /* resolveToBase */ false, kextPath);
+
+        if (!__OSKextIsValid(thisKext)) {
+            OSKextLog(thisKext,
+                kOSKextLogStepLevel | kOSKextLogArchiveFlag,
+                 "%s is not valid; omitting from mkext.",
+                 kextPath);
+            continue;
+        }
+
+        if (skipLoadedFlag && OSKextIsLoaded(thisKext)) {
+            OSKextLog(thisKext, kOSKextLogDebugLevel | kOSKextLogArchiveFlag,
+                 "Omitting loaded kext %s from mkext for kernel load.",
+                 kextPath);
+            continue;
+        }
+
+        if (OSKextMatchesRequiredFlags(thisKext, requiredFlags)) {
+            if (OSKextSupportsArchitecture(thisKext, NULL)) {
+                if (!__OSKextAddToMkext(thisKext, mkextData,
+                    mkextInfoDictArray, volumePath, compressFlag)) {
+
+                    goto finish;
+                }
+                numKexts++;
+            } else {
+                OSKextLog(thisKext, kOSKextLogStepLevel | kOSKextLogArchiveFlag,
+                     "%s does not contain code for architecture %s.",
+                     kextPath, OSKextGetArchitecture()->name);
+            }
+        }
+    }
+
+   /* The mkext v2 format requires all XML buffers to be nul-terminated.
+    * Fortunately IOCFSerialize does just that.
+    */
+    mkextPlistData = IOCFSerialize(mkextPlist, kNilOptions);
+    if (!mkextPlistData) {
+        goto finish;
+    }
+
+    compressed = false;
+    if (compressFlag && !__OSKextAddCompressedFileToMkext(/* kext */ NULL,
+            mkextData, mkextPlistData, /* plist */ true, &compressed)) {
+
+        goto finish;
+    }
+    if (!compressed) {
+        mkextHeader = (mkext2_header *)CFDataGetMutableBytePtr(mkextData);
+        mkextHeader->plist_offset =
+            OSSwapHostToBigInt32(CFDataGetLength(mkextData));
+        mkextHeader->plist_compressed_size =
+            OSSwapHostToBigInt32(0);
+        mkextHeader->plist_full_size =
+            OSSwapHostToBigInt32(CFDataGetLength(mkextPlistData));
+        CFDataAppendBytes(mkextData, CFDataGetBytePtr(mkextPlistData),
+            CFDataGetLength(mkextPlistData));
+    }
+
+    mkextHeader = (mkext2_header *)CFDataGetMutableBytePtr(mkextData);
+    mkextHeader->magic = OSSwapHostToBigInt32(MKEXT_MAGIC);
+    mkextHeader->signature = OSSwapHostToBigInt32(MKEXT_SIGN);
+    mkextHeader->length = OSSwapHostToBigInt32(CFDataGetLength(mkextData));
+
+    mkextHeader->version = OSSwapHostToBigInt32(MKEXT_VERS_2);
+    mkextHeader->numkexts = OSSwapHostToBigInt32(numKexts);
+    mkextHeader->cputype = OSSwapHostToBigInt32(OSKextGetArchitecture()->cputype);
+    mkextHeader->cpusubtype = OSSwapHostToBigInt32(OSKextGetArchitecture()->cpusubtype);
+
+    mkextEnd = ((void *)mkextHeader + CFDataGetLength(mkextData));
+    adlerChecksum = mkext_adler32((uint8_t *)&(mkextHeader->version),
+        mkextEnd - (void *)&(mkextHeader->version));
+    mkextHeader->adler32 = OSSwapHostToBigInt32(adlerChecksum);
+
+    result = mkextData;
+    CFRetain(result);
+
+    OSKextLog(/* kext */ NULL, kOSKextLogProgressLevel | kOSKextLogArchiveFlag,
+        "Created mkext for architecture %s containing %u kexts.",
+        __sOSKextArchInfo->name, (int)numKexts);
+
+finish:
+    SAFE_RELEASE(mkextInfoDictArray);
+    SAFE_RELEASE(mkextPlist);
+    SAFE_RELEASE(mkextData);
+    SAFE_RELEASE(mkextPlistData);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDataRef OSKextCreateMkext(
+    CFAllocatorRef      allocator,
+    CFArrayRef          kextArray,
+    CFURLRef            volumeRootURL,
+    OSKextRequiredFlags requiredFlags,
+    Boolean             compressFlag)
+{
+    return __OSKextCreateMkext(allocator,
+        kextArray, volumeRootURL, requiredFlags,
+        compressFlag, /* skipLoaded */ false, /* loadArgsDict */ NULL);
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDataRef __OSKextUncompressMkext2FileData(
+    CFAllocatorRef   allocator,
+    const UInt8    * buffer,
+    uint32_t        compressedSize,
+    uint32_t        fullSize)
+{
+    CFDataRef  result            = NULL;
+    CFDataRef  createdData       = NULL; // release on error
+    uint32_t   uncompressedSize;
+    uint8_t  * uncompressedData  = NULL;   // free on error
+    int        zlib_result;
+    z_stream   zstream;
+    Boolean    zstream_inited    = false;
+
+    if (!compressedSize) {
+        createdData = CFDataCreate(allocator, buffer, fullSize);
+        if (createdData) {
+            UInt8 * dataBuffer = (UInt8 *)CFDataGetBytePtr(createdData);
+            if (!dataBuffer) {
+                goto finish;
+            }
+            result = createdData;
+        }
+    }
+
+   /* Add 1 for a terminating nul byte for plist XML.
+    */
+    uncompressedData = (void *)malloc(fullSize);
+    if (!uncompressedData) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    zstream.next_in   = (UInt8 *)buffer;
+    zstream.next_out  = uncompressedData;
+    zstream.avail_in  = compressedSize;
+    zstream.avail_out = fullSize;
+    zstream.zalloc    = Z_NULL;
+    zstream.zfree     = Z_NULL;
+    zstream.opaque    = Z_NULL;
+
+    zlib_result = inflateInit(&zstream);
+    if (Z_OK != zlib_result) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "zlib inflateInit failed.");
+        goto finish;
+    } else {
+        zstream_inited = true;
+    }
+
+    zlib_result = inflate(&zstream, Z_FINISH);
+    if (zlib_result == Z_STREAM_END) {
+        uncompressedSize = zstream.total_out;
+    } else if (zlib_result == Z_OK) {
+        // xxx - will we even see this result?
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "zlib inflate discrepancy, uncompressed size != original size.");
+        goto finish;
+    } else {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "zlib inflate failed: %s.",
+            zstream.msg ? zstream.msg : "unknown");
+        goto finish;
+    }
+
+    if (uncompressedSize != fullSize) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "zlib inflate discrepancy, uncompressed size != original size.");
+        goto finish;
+    }
+
+    result = CFDataCreateWithBytesNoCopy(allocator,
+        uncompressedData, fullSize, kCFAllocatorMalloc);
+    if (!result) {
+        OSKextLogMemError();
+    }
+
+finish:
+   /* Don't bother checking return, nothing we can do on fail.
+    */
+    if (zstream_inited) inflateEnd(&zstream);
+
+    if (!result) {
+        SAFE_FREE(uncompressedData);
+        SAFE_RELEASE(createdData);
+    }
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCreateKextsFromMkextFile(CFAllocatorRef allocator,
+    CFURLRef  anURL)
+{
+    CFArrayRef result = NULL;
+    CFDataRef  mkextData = NULL;   // must release
+
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    if (!CFURLCreateDataAndPropertiesFromResource(allocator, anURL,
+        &mkextData, /* properties */NULL, /* desiredProperties */NULL,
+        /* errorCode */ NULL)) {
+
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    result = __OSKextCreateKextsFromMkext(allocator, mkextData, anURL);
+    if (!result) {
+        goto finish;
+    }
+
+finish:
+    SAFE_RELEASE(mkextData);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef OSKextCreateKextsFromMkextData(CFAllocatorRef allocator,
+    CFDataRef mkextData)
+{
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    return __OSKextCreateKextsFromMkext(allocator, mkextData, NULL);
+}
+
+/*********************************************************************
+*********************************************************************/
+CFArrayRef __OSKextCreateKextsFromMkext(
+    CFAllocatorRef allocator,
+    CFDataRef mkextData,
+    CFURLRef  mkextURL)
+{
+    CFMutableArrayRef   result                     = NULL;
+    CFMutableArrayRef   kexts                      = NULL;  // must release
+    uint32_t            magic;
+    fat_iterator        fatIterator                = NULL;  // must fat_iterator_close()
+    mkext2_header     * mkextHeader;
+    void              * mkextEnd;
+    CFDictionaryRef     mkextPlist                 = NULL;  // must release
+    CFArrayRef          mkextInfoDictArray         = NULL;  // do not release
+    uint32_t            adlerChecksum;
+    uint32_t            mkextPlistOffset;
+    uint32_t            mkextPlistCompressedSize;
+    uint32_t            mkextPlistFullSize;
+    CFStringRef         errorString                = NULL;  // must release
+    char              * errorCString               = NULL;  // must free
+    CFDataRef           mkextPlistUncompressedData = NULL;  // must release
+    const char        * mkextPlistDataBuffer       = NULL;  // do not free
+    CFIndex             count, i;
+
+   /* Initialize lazy runtime data.
+    */
+    pthread_once(&__sOSKextInitialized, __OSKextInitialize);
+
+    kexts = CFArrayCreateMutable(allocator, 0,
+        &kCFTypeArrayCallBacks);
+    if (!kexts) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    magic = MAGIC32(CFDataGetBytePtr(mkextData));
+    if (ISFAT(magic)) {
+        fatIterator = fat_iterator_for_data(CFDataGetBytePtr(mkextData),
+            CFDataGetBytePtr(mkextData) + CFDataGetLength(mkextData),
+            1 /* mach-o only */);
+        if (!fatIterator) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+                "Can't read mkext fat header.");
+            goto finish;
+        }
+        mkextHeader = fat_iterator_find_arch(fatIterator,
+            OSKextGetArchitecture()->cputype,
+            OSKextGetArchitecture()->cpusubtype,
+            &mkextEnd);
+        if (!mkextHeader) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+                "Architecture %s not found in mkext.",
+                OSKextGetArchitecture()->name);
+            goto finish;
+        }
+    } else {
+        mkextHeader = (mkext2_header *)CFDataGetBytePtr(mkextData);
+        mkextEnd = (char *)mkextHeader + CFDataGetLength(mkextData);
+    }
+
+    if ((MKEXT_GET_MAGIC(mkextHeader) != MKEXT_MAGIC) ||
+        (MKEXT_GET_SIGNATURE(mkextHeader) != MKEXT_SIGN)) {
+
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+            "Bad mkext magic/signature.");
+        goto finish;
+    }
+    if ((int32_t)OSSwapBigToHostInt32(mkextHeader->length) !=
+        ((char *)mkextEnd - (char *)mkextHeader)) {
+
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+            "Mkext length field %d does not match mkext actual size %d.",
+            OSSwapBigToHostInt32(mkextHeader->length),
+            (int)((char *)mkextEnd - (char *)mkextHeader));
+        goto finish;
+    }
+
+    if ((OSSwapBigToHostInt32(mkextHeader->version) != MKEXT_VERS_2)) {
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+            "Unsupported mkext version 0x%x.",
+            OSSwapBigToHostInt32(mkextHeader->version));
+        goto finish;
+    }
+
+    mkextEnd = ((void *)mkextHeader + CFDataGetLength(mkextData));
+    adlerChecksum = mkext_adler32((uint8_t *)&(mkextHeader->version),
+        mkextEnd - (void *)&(mkextHeader->version));
+    if (OSSwapBigToHostInt32(mkextHeader->adler32) != adlerChecksum) {
+        OSKextLog(/* kext */ NULL,
+            kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+            "Mkext checksum error.");
+        goto finish;
+    }
+
+    mkextPlistOffset = OSSwapBigToHostInt32(mkextHeader->plist_offset);
+    mkextPlistCompressedSize =
+        OSSwapBigToHostInt32(mkextHeader->plist_compressed_size);
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+        "Mkext plist compressed size is %u.", mkextPlistCompressedSize);
+
+    mkextPlistFullSize = OSSwapBigToHostInt32(mkextHeader->plist_full_size);
+
+    OSKextLog(/* kext */ NULL,
+        kOSKextLogDebugLevel | kOSKextLogFileAccessFlag,
+        "Mkext plist full size is %u.", mkextPlistFullSize);
+
+    if (mkextPlistCompressedSize) {
+        mkextPlistUncompressedData = __OSKextUncompressMkext2FileData(
+            CFGetAllocator(mkextData),
+            (const UInt8 *)mkextHeader + mkextPlistOffset,
+            mkextPlistCompressedSize, mkextPlistFullSize);
+        if (!mkextPlistUncompressedData) {
+            goto finish;
+        }
+        mkextPlistDataBuffer = (const char *)
+            CFDataGetBytePtr(mkextPlistUncompressedData);
+    } else {
+        mkextPlistDataBuffer = (const char *)mkextHeader + mkextPlistOffset;
+    }
+
+   /* IOCFSerialize added a nul byte to the end of the string. Very nice of it.
+    */
+    mkextPlist = IOCFUnserialize(
+        mkextPlistDataBuffer, allocator,
+        kNilOptions, &errorString);
+    if (!mkextPlist || (CFGetTypeID(mkextPlist) != CFDictionaryGetTypeID())) {
+        errorCString = createUTF8CStringForCFString(errorString);
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+            "Failed to read XML from mkext: %s.",
+            errorCString ? errorCString : "(unknown error)");
+        goto finish;
+    }
+
+    mkextInfoDictArray = (CFArrayRef)CFDictionaryGetValue(
+        mkextPlist, CFSTR(kMKEXTInfoDictionariesKey));
+    if (!mkextInfoDictArray ||
+        (CFGetTypeID(mkextInfoDictArray) != CFArrayGetTypeID())) {
+
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+            "Mkext plist has no kexts.");
+        goto finish;
+    }
+
+    count = CFArrayGetCount(mkextInfoDictArray);
+    for (i = 0; i < count; i++) {
+        CFDictionaryRef infoDict =
+            (CFDictionaryRef)CFArrayGetValueAtIndex(mkextInfoDictArray, i);
+
+        OSKextRef aKext = __OSKextAlloc(allocator, NULL);
+        if (!aKext) {
+            OSKextLogMemError();
+            goto finish;
+        }
+        if (!__OSKextInitFromMkext(aKext, infoDict, mkextURL, mkextData)) {
+            CFRelease(aKext);
+            goto finish;
+        }
+        CFArrayAppendValue(kexts, aKext);
+    }
+
+    result = kexts;
+    CFRetain(result);
+
+finish:
+    SAFE_RELEASE(kexts);
+    SAFE_RELEASE(errorString);
+    SAFE_RELEASE(mkextPlist);
+    SAFE_RELEASE(mkextPlistUncompressedData);
+
+    SAFE_FREE(errorCString);
+    if (fatIterator) fat_iterator_close(fatIterator);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDataRef __OSKextExtractMkext2FileEntry(
+    OSKextRef   aKext,
+    CFDataRef   mkextData,
+    CFNumberRef offsetNum,
+    CFStringRef filename)  // NULL for executable
+{
+    CFDataRef           result = NULL;
+    const UInt8       * mkext = CFDataGetBytePtr(mkextData);
+    uint32_t            entryOffset;
+    mkext2_file_entry * fileEntry;
+    uint32_t            fullSize;
+    uint32_t            compressedSize;
+    char              * filenameCString = NULL;  // must free
+    char                mkextPath[PATH_MAX] = "";
+
+    if (aKext->mkextInfo->mkextURL) {
+        __OSKextGetFileSystemPath(/* kext: mkext, not the kext! */ NULL,
+            aKext->mkextInfo->mkextURL,
+            /* resolveToBase */ false, mkextPath);
+    }
+
+    if (filename) {
+        filenameCString = createUTF8CStringForCFString(filename);
+    }
+    // xxx - check on resource stuff in mkexts
+    OSKextLog(aKext,
+        kOSKextLogDetailLevel | kOSKextLogArchiveFlag,
+        "Extracting %s%s from %s.",
+        (filenameCString ? "resource file " : "executable"),
+        (filenameCString ? filenameCString : ""),
+        (mkextPath[0] ? mkextPath : "mkext data"));
+
+    if (!CFNumberGetValue(offsetNum, kCFNumberSInt32Type,
+        (SInt32 *)&entryOffset)) {
+
+        // xxx - log?
+        goto finish;
+    }
+
+    fileEntry = (mkext2_file_entry *)(mkext + entryOffset);
+    fullSize = OSSwapBigToHostInt32(fileEntry->full_size);
+    compressedSize = OSSwapBigToHostInt32(fileEntry->compressed_size);
+    if (compressedSize) {
+        result = __OSKextUncompressMkext2FileData(CFGetAllocator(aKext),
+            fileEntry->data,
+            compressedSize, fullSize);
+        if (!result) {
+            OSKextLog(aKext, kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+                "Failed to uncompress %s%s from %s.",
+                (filenameCString ? "resource file " : "executable"),
+                (filenameCString ? filenameCString : ""),
+                (mkextPath[0] ? mkextPath : "mkext data"));
+        }
+        goto finish;
+    } else {
+        result = CFDataCreate(CFGetAllocator(aKext), fileEntry->data, fullSize);
+    }
+
+finish:
+    SAFE_FREE(filenameCString);
+    return result;
+}
+
+#ifndef IOKIT_EMBEDDED
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextSwapHeaders(
+    CFDataRef kernelImage)
+{
+    u_char *file = (u_char *) CFDataGetBytePtr(kernelImage);
+
+    return macho_swap(file);
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextUnswapHeaders(
+    CFDataRef kernelImage)
+{
+    u_char *file = (u_char *) CFDataGetBytePtr(kernelImage);
+
+    return macho_unswap(file);
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextGetLastKernelLoadAddr(
+    CFDataRef  kernelImage, 
+    uint64_t * lastLoadAddrOut)
+{
+    boolean_t            result         = false;
+    const UInt8        * kernelImagePtr = CFDataGetBytePtr(kernelImage);
+    uint64_t             lastLoadAddr   = 0;
+    uint64_t             i;
+
+    if (ISMACHO64(MAGIC32(kernelImagePtr))) {
+        struct mach_header_64 * kernel_header =
+            (struct mach_header_64 *)kernelImagePtr;
+        struct segment_command_64 * seg_cmd = NULL;
+
+        seg_cmd = (struct segment_command_64 *)
+            ((uintptr_t)kernel_header + sizeof(*kernel_header));
+        for (i = 0; i < kernel_header->ncmds; i++){
+            if (seg_cmd->cmd == LC_SEGMENT_64) {
+                if (seg_cmd->vmaddr + seg_cmd->vmsize > lastLoadAddr) {
+                    lastLoadAddr = seg_cmd->vmaddr + seg_cmd->vmsize;
+                }
+            }
+            seg_cmd = (struct segment_command_64 *)
+                ((uintptr_t)seg_cmd + seg_cmd->cmdsize);
+        }
+    } else {
+        struct mach_header * kernel_header =
+            (struct mach_header *)kernelImagePtr;
+        struct segment_command * seg_cmd = NULL;
+
+        seg_cmd = (struct segment_command *)
+            ((uintptr_t)kernel_header + sizeof(*kernel_header));
+        for (i = 0; i < kernel_header->ncmds; i++){
+            if (seg_cmd->cmd == LC_SEGMENT) {
+                if (seg_cmd->vmaddr + seg_cmd->vmsize > lastLoadAddr) {
+                    lastLoadAddr = seg_cmd->vmaddr + seg_cmd->vmsize;
+                }
+            }
+            seg_cmd = (struct segment_command *)
+                ((uintptr_t)seg_cmd + seg_cmd->cmdsize);
+        }
+    }
+
+    if (lastLoadAddrOut) *lastLoadAddrOut = lastLoadAddr;
+    result = true;
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextGetSegmentAddressAndOffset(
+    CFDataRef kernelImage, const char *segname, 
+    uint32_t *fileOffsetOut, uint64_t *loadAddrOut)
+{
+    boolean_t result = false;
+    uint32_t fileOffset = 0;
+    uint64_t loadAddr = 0;
+    
+    if (!__OSKextIsArchitectureLP64()) {
+        struct mach_header *mach_header = (struct mach_header *) CFDataGetBytePtr(kernelImage);
+        struct segment_command *seg = macho_get_segment_by_name(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        fileOffset = seg->fileoff;
+        loadAddr = seg->vmaddr;
+    } else {
+        struct mach_header_64 *mach_header = (struct mach_header_64 *) CFDataGetBytePtr(kernelImage);
+        struct segment_command_64 *seg = macho_get_segment_by_name_64(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        fileOffset = seg->fileoff;
+        loadAddr = seg->vmaddr;
+    }
+
+    if (fileOffsetOut) *fileOffsetOut = fileOffset;
+    if (loadAddrOut) *loadAddrOut = loadAddr;
+    result = true;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextGetSegmentFileAndVMSize(
+    CFDataRef kernelImage, const char *segname, 
+    uint64_t *fileSizeOut, uint64_t *VMSizeOut)
+{
+    boolean_t result = false;
+    uint64_t filesize = 0;
+    uint64_t vmsize = 0;
+    
+    if (!__OSKextIsArchitectureLP64()) {
+        struct mach_header *mach_header = (struct mach_header *) CFDataGetBytePtr(kernelImage);
+        struct segment_command *seg = macho_get_segment_by_name(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        filesize = seg->filesize;
+        vmsize = seg->vmsize;
+    } else {
+        struct mach_header_64 *mach_header = (struct mach_header_64 *) CFDataGetBytePtr(kernelImage);
+        struct segment_command_64 *seg = macho_get_segment_by_name_64(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        filesize = seg->filesize;
+        vmsize = seg->vmsize;
+    }
+
+    if (fileSizeOut) *fileSizeOut = filesize;
+    if (VMSizeOut) *VMSizeOut = vmsize;
+    result = true;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextSetSegmentAddress(
+    CFDataRef kernelImage, const char *segname, uint64_t loadAddr)
+{
+    boolean_t result = false;
+    
+    if (!__OSKextIsArchitectureLP64()) {
+        struct mach_header *mach_header = (struct mach_header *) CFDataGetBytePtr(kernelImage);
+        struct segment_command *seg = macho_get_segment_by_name(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        seg->vmaddr = (uint32_t) loadAddr;
+    } else {
+        struct mach_header_64 *mach_header = (struct mach_header_64 *) CFDataGetBytePtr(kernelImage);
+        struct segment_command_64 *seg = macho_get_segment_by_name_64(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        seg->vmaddr = loadAddr;
+    }
+
+    result = true;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextSetSegmentVMSize(
+    CFDataRef kernelImage, const char *segname, uint64_t vmsize)
+{
+    boolean_t result = false;
+    
+    if (!__OSKextIsArchitectureLP64()) {
+        struct mach_header *mach_header = (struct mach_header *) CFDataGetBytePtr(kernelImage);
+        struct segment_command *seg = macho_get_segment_by_name(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        seg->vmsize = (uint32_t) vmsize;
+    } else {
+        struct mach_header_64 *mach_header = (struct mach_header_64 *) CFDataGetBytePtr(kernelImage);
+        struct segment_command_64 *seg = macho_get_segment_by_name_64(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        seg->vmsize = vmsize;
+    }
+
+    result = true;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextSetSegmentOffset(
+    CFDataRef kernelImage, const char *segname, uint64_t fileOffset)
+{
+    boolean_t result = false;
+    
+    if (!__OSKextIsArchitectureLP64()) {
+        struct mach_header *mach_header = (struct mach_header *) CFDataGetBytePtr(kernelImage);
+        struct segment_command *seg = macho_get_segment_by_name(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        seg->fileoff = (uint32_t) fileOffset;
+    } else {
+        struct mach_header_64 *mach_header = (struct mach_header_64 *) CFDataGetBytePtr(kernelImage);
+        struct segment_command_64 *seg = macho_get_segment_by_name_64(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        seg->fileoff = fileOffset;
+    }
+
+    result = true;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextSetSegmentFilesize(
+    CFDataRef kernelImage, const char *segname, uint64_t filesize)
+{
+    boolean_t result = false;
+    
+    if (!__OSKextIsArchitectureLP64()) {
+        struct mach_header *mach_header = (struct mach_header *) CFDataGetBytePtr(kernelImage);
+        struct segment_command *seg = macho_get_segment_by_name(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        seg->filesize = (uint32_t) filesize;
+    } else {
+        struct mach_header_64 *mach_header = (struct mach_header_64 *) CFDataGetBytePtr(kernelImage);
+        struct segment_command_64 *seg = macho_get_segment_by_name_64(mach_header, segname);
+        if (!seg) {
+            goto finish;
+        }
+        
+        seg->filesize = filesize;
+    }
+
+    result = true;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextSetSectionAddress(
+    CFDataRef kernelImage, const char *segname, 
+    const char *sectname, uint64_t loadAddr)
+{
+    boolean_t result = false;
+    
+    if (!__OSKextIsArchitectureLP64()) {
+        struct mach_header *mach_header = (struct mach_header *) CFDataGetBytePtr(kernelImage);
+        struct section *sect = macho_get_section_by_name(mach_header, segname, sectname);
+        if (!sect) {
+            goto finish;
+        }
+        
+        sect->addr = (uint32_t) loadAddr;
+    } else {
+        struct mach_header_64 *mach_header = (struct mach_header_64 *) CFDataGetBytePtr(kernelImage);
+        struct section_64 *sect = macho_get_section_by_name_64(mach_header, segname, sectname);
+        if (!sect) {
+            goto finish;
+        }
+        
+        sect->addr = loadAddr;
+    }
+
+    result = true;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextSetSectionSize(
+    CFDataRef kernelImage, const char *segname, 
+    const char *sectname, uint64_t size)
+{
+    boolean_t result = false;
+    
+    if (!__OSKextIsArchitectureLP64()) {
+        struct mach_header *mach_header = (struct mach_header *) CFDataGetBytePtr(kernelImage);
+        struct section *sect = macho_get_section_by_name(mach_header, segname, sectname);
+        if (!sect) {
+            goto finish;
+        }
+        
+        sect->size = (uint32_t) size;
+    } else {
+        struct mach_header_64 *mach_header = (struct mach_header_64 *) CFDataGetBytePtr(kernelImage);
+        struct section_64 *sect = macho_get_section_by_name_64(mach_header, segname, sectname);
+        if (!sect) {
+            goto finish;
+        }
+        
+        sect->size = size;
+    }
+
+    result = true;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static boolean_t __OSKextSetSectionOffset(
+    CFDataRef kernelImage, const char *segname, 
+    const char *sectname, uint32_t fileOffset)
+{
+    boolean_t result = false;
+    
+    if (!__OSKextIsArchitectureLP64()) {
+        struct mach_header *mach_header = (struct mach_header *) CFDataGetBytePtr(kernelImage);
+        struct section *sect = macho_get_section_by_name(mach_header, segname, sectname);
+        if (!sect) {
+            goto finish;
+        }
+        
+        sect->offset = fileOffset;
+    } else {
+        struct mach_header_64 *mach_header = (struct mach_header_64 *) CFDataGetBytePtr(kernelImage);
+        struct section_64 *sect = macho_get_section_by_name_64(mach_header, segname, sectname);
+        if (!sect) {
+            goto finish;
+        }
+        
+        sect->offset = fileOffset;
+    }
+
+    result = true;
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+#define FAKE_32BIT_LOAD_ADDRESS  (0x10000000)
+#define LP64_LOAD_ADDRESS_OFFSET (2 * 1024 * 1024 * 1024ULL)
+
+static uint64_t __OSKextGetFakeLoadAddress(CFDataRef kernelImage)
+{    
+    uint64_t                    result         = 0;
+    CFNumberRef                 loadAddressNum = NULL;  // must release
+    const UInt8               * executable     = NULL;  // do not free
+    const UInt8               * executableEnd  = NULL;  // do not free
+    fat_iterator                fatIterator    = NULL;  // must fat_iterator_close
+    struct mach_header_64     * machHeader     = NULL;  // do not free
+    void                      * machEnd        = NULL;  // do not free
+    struct segment_command_64 * textSegment    = NULL;  // do not free
+
+   /* We have no address-limits on 32-bit. Just fudge a number.
+    */
+    if (!__OSKextIsArchitectureLP64()) {
+        result = FAKE_32BIT_LOAD_ADDRESS;
+        goto finish;
+    }
+
+    if (!kernelImage) {
+        if ((kOSReturnSuccess != __OSKextSimpleKextRequest(/* kext */ NULL,
+            CFSTR(kKextRequestPredicateGetKernelLoadAddress),
+            (CFTypeRef *)&loadAddressNum)) ||
+            !loadAddressNum ||
+            (CFGetTypeID(loadAddressNum) != CFNumberGetTypeID()) ||
+            !CFNumberGetValue(loadAddressNum, kCFNumberSInt64Type, &result)) {
+
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogIPCFlag,
+                "Can't get running kernel load address.");
+            result = 0;
+            goto finish;
+        }
+        
+        goto finish;
+    }
+
+    executable = CFDataGetBytePtr(kernelImage);
+    executableEnd = executable + CFDataGetLength(kernelImage);
+    fatIterator = fat_iterator_for_data(executable, executableEnd,
+        1 /* mach-o only */);
+
+    if (!fatIterator) {
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Can't read kernel file.");
+        goto finish;
+    }
+    
+    machHeader = (struct mach_header_64 *)fat_iterator_find_arch(fatIterator,
+        OSKextGetArchitecture()->cputype, OSKextGetArchitecture()->cpusubtype,
+        (void **)&machEnd);
+    if (!machHeader) {
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Can't find architecture %s in kernel file.",
+                OSKextGetArchitecture()->name);
+        goto finish;
+    }
+
+    textSegment = macho_get_segment_by_name_64(machHeader, "__TEXT");
+    if (!textSegment) {
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel | kOSKextLogFileAccessFlag,
+            "Can't find text segment in kernel file.");
+        goto finish;
+    }
+    
+   /* LP64 uses a "kext basement", which is an offset below the end of the
+    * kernel's text segment.
+    */
+    result = mach_vm_round_page(textSegment->vmaddr + textSegment->vmsize) 
+        - LP64_LOAD_ADDRESS_OFFSET;
+
+finish:
+    if (fatIterator) {
+        fat_iterator_close(fatIterator);
+    }
+    SAFE_RELEASE(loadAddressNum);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static CFArrayRef __OSKextPrelinkKexts(
+    CFArrayRef        kextArray,
+    CFDataRef         kernelImage,
+    uint64_t          loadAddrBase,
+    uint64_t          sourceAddrBase,
+    KXLDContext     * kxldContext,
+    u_long          * loadSizeOut,
+    Boolean           needAllFlag,
+    Boolean           skipAuthenticationFlag,
+    Boolean           printDiagnosticsFlag,
+    Boolean           stripSymbolsFlag)
+{
+    CFArrayRef        result   = NULL;
+    boolean_t         success  = false;
+    CFMutableArrayRef loadList = NULL;
+    uint64_t          loadAddr = loadAddrBase;
+    uint64_t          sourceAddr = sourceAddrBase;
+    u_long            loadSize = 0;
+    OSKextLogSpec     linkLogLevel;
+    char            * kextIdentifierCString = NULL;  // must free
+    CFIndex           i;
+    int               badLinkCount = 0;
+
+    linkLogLevel = needAllFlag ? kOSKextLogErrorLevel : kOSKextLogWarningLevel;
+
+    /* Calculate the load list for the set of kexts. If needAllFlag is false,
+     * then kexts whose dependencies do not resolve will fail to link and will
+     * be excluded from the cache, while all others will get prelinked. 
+     */
+    
+    loadList = OSKextCopyLoadListForKexts(kextArray, needAllFlag);
+    if (!loadList) {
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel,
+            "Can't resolve dependencies amongst kexts for prelinked kernel.");
+        goto finish;
+    }
+
+    for (i = 0; i < CFArrayGetCount(loadList); ++i) {
+        OSKextRef aKext = (OSKextRef) CFArrayGetValueAtIndex(loadList, i);
+
+        if (!__OSKextCheckForPrelinkedKernel(aKext, needAllFlag, 
+            skipAuthenticationFlag, printDiagnosticsFlag)) {
+
+            if (needAllFlag) {
+                OSKextLog(/* kext */ aKext, linkLogLevel | kOSKextLogLinkFlag,
+                    "Aborting prelink.");
+                goto finish;
+            } else {
+                CFArrayRemoveValueAtIndex(loadList, i--);
+            }
+        }
+    }
+
+    /* Link each kext in the load list */
+
+    for (i = 0; i < CFArrayGetCount(loadList); ++i) {
+        OSKextRef aKext = (OSKextRef) CFArrayGetValueAtIndex(loadList, i);
+
+        SAFE_FREE_NULL(kextIdentifierCString);
+
+        if (!OSKextDeclaresExecutable(aKext)) {
+            continue;
+        }
+
+        kextIdentifierCString =
+            createUTF8CStringForCFString(OSKextGetIdentifier(aKext));
+
+       /* Set the load address of the kext.
+        */
+        loadAddr = loadAddrBase + loadSize;
+        sourceAddr = sourceAddrBase + loadSize;
+        
+       /* OSKextSetLoadAddress() creates aKext->loadInfo.
+        */
+        OSKextSetLoadAddress(aKext, loadAddr);
+        aKext->loadInfo->sourceAddress = sourceAddr;
+
+       /* Perform the link operation. Note we pass 0 for the
+        * kernelLoadAddress because we should have a valid address
+        * set for every kext when doing a prelinked kernel.
+        */
+        success = __OSKextPerformLink(aKext, kernelImage,
+            /* kernelLoadAddress */ 0, stripSymbolsFlag, kxldContext);
+        if (!success) {
+            if ( needAllFlag == false ) {
+                if (OSKextMatchesRequiredFlags(aKext,
+                                    kOSKextOSBundleRequiredRootFlag |
+                                    kOSKextOSBundleRequiredLocalRootFlag |
+                                    kOSKextOSBundleRequiredNetworkRootFlag)) {
+                    /* This is a "rooting" kext, if we have more than a few of
+                     * these fail to link then something bad has happened with
+                     * our environment, abort the prelink.  13080154
+                     */
+                    if (++badLinkCount > 3) {
+                        needAllFlag = true;
+                        linkLogLevel = kOSKextLogErrorLevel;
+                    }
+               }
+            }
+            OSKextLog(/* kext */ aKext, linkLogLevel | kOSKextLogLinkFlag,
+                "Prelink failed for %s; %s.",
+                kextIdentifierCString,
+                needAllFlag ? "aborting prelink" : "omitting from prelinked kernel");
+            if (needAllFlag) {
+                goto finish;
+            }
+            CFArrayRemoveValueAtIndex(loadList, i--);
+            continue;
+        }
+
+        loadSize += round_page(aKext->loadInfo->loadSize);
+    }
+
+    result = CFRetain(loadList);
+    *loadSizeOut = loadSize;
+
+finish:
+    SAFE_RELEASE(loadList);
+    SAFE_FREE(kextIdentifierCString);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static CFDataRef __OSKextCreatePrelinkInfoDictionary(
+    CFArrayRef loadList,
+    CFURLRef   volumeRootURL,
+    Boolean    includeAllPersonalities)
+{
+    CFDataRef                   result                  = NULL; // do not release
+
+    char                        kextPath[PATH_MAX]      = "";
+    char                        volumePath[PATH_MAX]    = "";
+    CFArrayRef                  allKextsByBundleID      = NULL; // must release
+    CFArrayRef                  kextPersonalities       = NULL; // must release
+    CFMutableArrayRef           kextInfoDictArray       = NULL; // must release
+    CFDataRef                   prelinkInfoData         = NULL; // must release
+    CFDataRef                   uuid                    = NULL; // must release
+    CFMutableDictionaryRef      kextInfoDict            = NULL; // must release
+    CFMutableDictionaryRef      prelinkInfoDict         = NULL; // must release
+    CFNumberRef                 cfnum                   = NULL; // must release
+    CFStringRef                 bundleVolPath           = NULL; // must release
+    CFStringRef                 executableRelPath       = NULL; // must release
+    CFStringRef                 archPersonalitiesKey    = NULL; // must release
+    CFSetRef                    loadListIDs             = NULL; // must release
+    char                      * kextVolPath             = NULL; // do not free
+    int64_t                     num                     = 0;
+    int                         i                       = 0;
+    int                         count                   = 0;
+
+    /* Get the C string for the volume root URL. */
+
+    if (volumeRootURL) {
+        if (!CFURLGetFileSystemRepresentation(volumeRootURL,
+            /* resolveToBase */ TRUE, (UInt8 *)volumePath, sizeof(volumePath))) {
+
+            OSKextLogStringError(/* kext */ NULL);
+            goto finish;
+        }
+    }
+
+    /* Create a dictionary for all prelinked kernel metadata */
+
+    prelinkInfoDict = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    if (!prelinkInfoDict) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    /* Create an array to hold all of the info dictionaries */
+
+    kextInfoDictArray = CFArrayCreateMutable(kCFAllocatorDefault,
+        CFArrayGetCount(loadList), &kCFTypeArrayCallBacks);
+    if (!kextInfoDictArray) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    CFDictionarySetValue(prelinkInfoDict, CFSTR(kPrelinkInfoDictionaryKey),
+        kextInfoDictArray);
+
+    /* We'll need the arch-specific personalities key in the loop body */
+
+    archPersonalitiesKey = __OSKextCreateCompositeKey(
+        CFSTR("kIOKitPersonalitiesKey"), OSKextGetArchitecture()->name);
+    if (!archPersonalitiesKey) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    /* Create an info dictionary for each kext in the load list */
+
+    count = CFArrayGetCount(loadList);
+    for (i = 0; i < count; ++i) {
+        Boolean   gotPath = FALSE;
+        OSKextRef aKext   = (OSKextRef)CFArrayGetValueAtIndex(loadList, i);
+
+        SAFE_RELEASE_NULL(kextInfoDict);
+        SAFE_RELEASE_NULL(bundleVolPath);
+
+       /* We need to know if we got a valid path down below.
+        * For logging it doesn't matter.
+        */
+        gotPath = __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+            /* resolveToBase */ true, kextPath);
+
+        OSKextLog(aKext, kOSKextLogStepLevel | kOSKextLogArchiveFlag,
+            "Adding %s to prelinked kernel.", kextPath);
+
+        /* Get the existing info dictionary from the kext */
+
+        kextInfoDict = OSKextCopyInfoDictionary(aKext);
+        if (!kextInfoDict) {
+            OSKextLogMemError();
+            goto finish;
+        }
+
+        /* We only want early boot kexts to have personalities in the
+         * prelinked kernel. If kexts with OSBundleRequired="Safe Boot" or no
+         * OSBundleRequired property start too early, they can cause problems
+         * with the boot process.  These kexts will still be prelinked, and
+         * they will be started when kextd is up and passes personalities for
+         * all kexts to the kernel.
+         */
+        if (!includeAllPersonalities) {
+            if (!__OSKextRequiredAtEarlyBoot(aKext)) {
+                CFDictionaryRemoveValue(kextInfoDict, CFSTR(kIOKitPersonalitiesKey));
+                CFDictionaryRemoveValue(kextInfoDict, archPersonalitiesKey);
+            }
+        }
+
+        /* Add the load address, source address, and kmod info address information.
+         */
+        if (OSKextDeclaresExecutable(aKext)) {
+            cfnum = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type,
+                &aKext->loadInfo->loadAddress);
+            if (!cfnum) {
+                OSKextLogMemError();
+                goto finish;
+            }
+            CFDictionarySetValue(kextInfoDict, CFSTR(kPrelinkExecutableLoadKey), cfnum);
+            SAFE_RELEASE_NULL(cfnum);
+
+            cfnum = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type,
+                &aKext->loadInfo->sourceAddress);
+            if (!cfnum) {
+                OSKextLogMemError();
+                goto finish;
+            }
+            CFDictionarySetValue(kextInfoDict, CFSTR(kPrelinkExecutableSourceKey), cfnum);
+            SAFE_RELEASE_NULL(cfnum);
+
+            num = CFDataGetLength(aKext->loadInfo->prelinkedExecutable);
+            cfnum = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &num);
+            if (!cfnum) {
+                OSKextLogMemError();
+                goto finish;
+            }
+            CFDictionarySetValue(kextInfoDict, CFSTR(kPrelinkExecutableSizeKey), cfnum);
+            SAFE_RELEASE_NULL(cfnum);
+
+            cfnum = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type,
+                &aKext->loadInfo->kmodInfoAddress);
+            if (!cfnum) {
+                OSKextLogMemError();
+                goto finish;
+            }
+            CFDictionarySetValue(kextInfoDict, CFSTR(kPrelinkKmodInfoKey), cfnum);
+            SAFE_RELEASE_NULL(cfnum);
+        }
+
+       /* If this is an interface kext, add its UUID.
+        */
+        if (OSKextDeclaresExecutable(aKext) && OSKextIsInterface(aKext)) {
+            uuid = OSKextCopyUUIDForArchitecture(aKext, OSKextGetArchitecture());
+            if (uuid) {
+                CFDictionarySetValue(kextInfoDict, CFSTR(kPrelinkInterfaceUUIDKey),
+                    uuid);
+                SAFE_RELEASE_NULL(uuid);
+            }
+        }
+
+       /* Add the kext's absolute path on the volume to the kernelcache.
+        */
+        if (gotPath) {
+
+            kextVolPath = __absPathOnVolume(kextPath, volumePath);
+            if (!kextVolPath) {
+                OSKextLogMemError();
+                goto finish;
+            }
+
+            bundleVolPath = CFStringCreateWithBytes(CFGetAllocator(aKext),
+                (UInt8 *)kextVolPath, strlen(kextVolPath),
+                kCFStringEncodingUTF8, false);
+            if (!bundleVolPath) {
+                OSKextLogMemError();
+                goto finish;
+            }
+            CFDictionarySetValue(kextInfoDict, CFSTR(kPrelinkBundlePathKey), bundleVolPath);
+
+           /* For optimizing dtrace we also add the relative path within the kext
+            * to its executable (if there is one).
+            */
+            executableRelPath = __OSKextCopyExecutableRelativePath(aKext);
+            if (executableRelPath) {
+                CFDictionarySetValue(kextInfoDict, CFSTR(kPrelinkExecutableRelativePathKey),
+                    executableRelPath);
+            }
+
+        }
+
+        /* Add this info dictionary to the info dict array */
+
+        CFArrayAppendValue(kextInfoDictArray, kextInfoDict);
+    }
+
+    /* Serialize the info dictionary */
+
+    prelinkInfoData = IOCFSerialize(prelinkInfoDict, kNilOptions);
+    if (!prelinkInfoData) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    result = CFRetain(prelinkInfoData);
+
+finish:
+    SAFE_RELEASE(allKextsByBundleID);
+    SAFE_RELEASE(kextPersonalities);
+    SAFE_RELEASE(kextInfoDictArray);
+    SAFE_RELEASE(prelinkInfoData);
+    SAFE_RELEASE(uuid);
+    SAFE_RELEASE(kextInfoDict);
+    SAFE_RELEASE(prelinkInfoDict);
+    SAFE_RELEASE(cfnum);
+    SAFE_RELEASE(bundleVolPath);
+    SAFE_RELEASE(executableRelPath);
+    SAFE_RELEASE(archPersonalitiesKey);
+    SAFE_RELEASE(loadListIDs);
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static Boolean
+__OSKextRequiredAtEarlyBoot(
+    OSKextRef   theKext)
+{
+    CFStringRef         bundleRequired  = NULL;
+
+    bundleRequired = (CFStringRef)OSKextGetValueForInfoDictionaryKey(theKext,
+        CFSTR(kOSBundleRequiredKey));
+
+    return (bundleRequired && kCFCompareEqualTo != 
+        CFStringCompare(bundleRequired, CFSTR(kOSBundleRequiredSafeBoot), 0));
+}
+
+#if 0 /* masking out compiler warnings */
+
+/*********************************************************************
+*********************************************************************/
+static CFArrayRef
+__OSKextCopyKextsByBundleID(void)
+{
+    CFArrayRef          result          = NULL;  // do not release
+    CFArrayRef          kextList        = NULL;  // must release
+    CFStringRef       * bundleIDs       = NULL;  // must free
+    OSKextRef         * theKexts        = NULL;  // must free
+    int                 count           = 0;
+    int                 i               = 0;
+
+    count = CFDictionaryGetCount(__sOSKextsByIdentifier);
+
+    /* Get all of the bundle IDs in the system */
+
+    bundleIDs = malloc(count * sizeof(CFStringRef));
+    if (!bundleIDs) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    CFDictionaryGetKeysAndValues(__sOSKextsByIdentifier,
+        (const void **)bundleIDs, NULL);
+
+    /* Get a kext for each of the bundle IDs */
+
+    theKexts = malloc(count * sizeof(OSKextRef));
+    if (!theKexts) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    for (i = 0; i < count; ++i) {
+        theKexts[i] = OSKextGetKextWithIdentifier(bundleIDs[i]);
+        if (!theKexts[i]) {
+            OSKextLog(/* kext */ NULL, 
+                kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+                "Internal error: failed to find a kext with bundle ID: %s",
+                CFStringGetCStringPtr(bundleIDs[i], kCFStringEncodingMacRoman));
+            goto finish;
+        }
+    }
+
+    kextList = CFArrayCreate(kCFAllocatorDefault, (const void **) theKexts,
+        count, &kCFTypeArrayCallBacks);
+    if (!kextList) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    result = CFRetain(kextList);
+finish:
+    SAFE_RELEASE(kextList);
+    SAFE_FREE(bundleIDs);
+    SAFE_FREE(theKexts);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+static CFSetRef
+__OSKextCopyBundleIDsForKexts(
+    CFArrayRef  theKexts)
+{
+    CFSetRef            result          = NULL; // do not release
+    CFSetRef            bundleIDSet     = NULL; // must release
+    CFStringRef       * bundleIDs       = NULL; // must free
+    OSKextRef           aKext           = NULL; // do not release
+    int                 count           = 0;
+    int                 i               = 0;
+
+    count = CFArrayGetCount(theKexts);
+    bundleIDs = malloc(count * sizeof(CFStringRef));
+    if (!bundleIDs) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    for (i = 0; i < count; ++i) {
+        aKext = (OSKextRef) CFArrayGetValueAtIndex(theKexts, i);
+        bundleIDs[i] = aKext->bundleID;
+    }
+
+    bundleIDSet = CFSetCreate(kCFAllocatorDefault,
+        (const void **) bundleIDs, count, &kCFTypeSetCallBacks);
+    if (!bundleIDSet) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    result = CFRetain(bundleIDSet);
+finish:
+    SAFE_RELEASE(bundleIDSet);
+    SAFE_FREE(bundleIDs);
+    return result;
+}
+
+#endif /* masking out compiler warnings */
+
+/*********************************************************************
+*********************************************************************/
+static u_long __OSKextCopyPrelinkedKexts(
+    CFMutableDataRef prelinkImage,
+    CFArrayRef       loadList,
+    u_long           fileOffsetBase,
+    uint64_t         sourceAddrBase)
+{
+    boolean_t   success     = false;
+    u_char    * prelinkData = CFDataGetMutableBytePtr(prelinkImage);
+    u_long      size        = 0;
+    u_long      totalSize   = 0;
+    u_long      fileOffset  = fileOffsetBase;
+    uint64_t    sourceAddr  = sourceAddrBase;
+    int i = 0;
+
+    /* Set the text segment and section address and offset */
+
+    success = __OSKextSetSegmentAddress(prelinkImage, kPrelinkTextSegment, 
+        sourceAddrBase);
+    if (!success) {
+        goto finish;
+    }
+    
+    success = __OSKextSetSegmentOffset(prelinkImage, kPrelinkTextSegment, 
+        fileOffsetBase);
+    if (!success) {
+        goto finish;
+    }
+
+    success = __OSKextSetSectionAddress(prelinkImage, kPrelinkTextSegment,
+        kPrelinkTextSection, sourceAddrBase);
+    if (!success) {
+        goto finish;
+    }
+
+    success = __OSKextSetSectionOffset(prelinkImage, kPrelinkTextSegment,
+        kPrelinkTextSection, fileOffset);
+    if (!success) {
+        goto finish;
+    }
+
+    /* Copy all kext executables */
+
+    for (i = 0; i < CFArrayGetCount(loadList); ++i) {
+        OSKextRef aKext = (OSKextRef) CFArrayGetValueAtIndex(loadList, i);
+
+        if (!OSKextDeclaresExecutable(aKext)) {
+            continue;
+        }
+
+       /* xxx - Is it safe to assume aKext->loadInfo exists here?
+        */
+        memcpy(prelinkData + fileOffset + size, 
+            CFDataGetBytePtr(aKext->loadInfo->prelinkedExecutable),
+            CFDataGetLength(aKext->loadInfo->prelinkedExecutable));
+
+        size += round_page(CFDataGetLength(aKext->loadInfo->prelinkedExecutable));
+    }
+
+    sourceAddr += size;
+    fileOffset += size;
+    totalSize += size;
+
+    /* Set the text segment and section size */
+
+    success = __OSKextSetSegmentVMSize(prelinkImage, kPrelinkTextSegment, size);
+    if (!success) {
+        goto finish;
+    }
+    
+    success = __OSKextSetSegmentFilesize(prelinkImage, kPrelinkTextSegment, size);
+    if (!success) {
+        goto finish;
+    }
+
+    success = __OSKextSetSectionSize(prelinkImage, kPrelinkTextSegment,
+        kPrelinkTextSection, size);
+    if (!success) {
+        goto finish;
+    }
+
+finish:
+    return totalSize;
+}
+
+
+/*********************************************************************
+*********************************************************************/
+static u_long __OSKextCopyPrelinkInfoDictionary(
+    CFMutableDataRef prelinkImage,
+    CFDataRef        prelinkInfoData,
+    u_long           fileOffset,
+    uint64_t         sourceAddr)
+{
+    boolean_t    success    = false;
+    u_char    * prelinkData = CFDataGetMutableBytePtr(prelinkImage);
+    u_long      size        = 0;
+
+    size = CFDataGetLength(prelinkInfoData);
+    memcpy(prelinkData + fileOffset, CFDataGetBytePtr(prelinkInfoData), size);
+
+    /* Set the info dictionary segment headers */
+
+    success = __OSKextSetSegmentAddress(prelinkImage, kPrelinkInfoSegment,
+        sourceAddr);
+    if (!success) {
+        goto finish;
+    }
+
+    success = __OSKextSetSegmentVMSize(prelinkImage, kPrelinkInfoSegment, 
+        round_page(size));
+    if (!success) {
+        goto finish;
+    }
+
+    success = __OSKextSetSegmentOffset(prelinkImage, kPrelinkInfoSegment,
+        fileOffset);
+    if (!success) {
+        goto finish;
+    }
+
+    success = __OSKextSetSegmentFilesize(prelinkImage, kPrelinkInfoSegment,
+        size);
+    if (!success) {
+        goto finish;
+    }
+
+    /* Set the info dictionary section headers */
+
+    success = __OSKextSetSectionAddress(prelinkImage, kPrelinkInfoSegment,
+        kPrelinkInfoSection, sourceAddr);
+    if (!success) {
+        goto finish;
+    }
+
+    success = __OSKextSetSectionOffset(prelinkImage, kPrelinkInfoSegment,
+        kPrelinkInfoSection, fileOffset);
+    if (!success) {
+        goto finish;
+    }
+
+    success = __OSKextSetSectionSize(prelinkImage, kPrelinkInfoSegment,
+        kPrelinkInfoSection, size);
+    if (!success) {
+        goto finish;
+    }
+
+finish:
+    return round_page(size);
+}
+
+/*********************************************************************
+*********************************************************************/
+CFDataRef OSKextCreatePrelinkedKernel(
+    CFDataRef           kernelImage,
+    CFArrayRef          kextArray,
+    CFURLRef            volumeRootURL,
+    uint32_t            flags,
+    CFDictionaryRef   * symbolsOut)
+{
+    CFDataRef                result             = NULL;
+    kern_return_t            kxldResult         = KERN_FAILURE;
+    boolean_t                success            = false;
+    boolean_t                swapped            = false;
+    KXLDContext            * kxldContext        = NULL;
+    KXLDFlags                kxldFlags          = kKxldFlagDefault;
+    CFArrayRef               loadList           = NULL;
+    CFDataRef                prelinkInfoData    = NULL;
+    CFMutableDataRef         prelinkImage       = NULL;
+    CFMutableDictionaryRef   symbols            = NULL;
+    u_long                   prelinkSize        = 0;
+    u_long                   size               = 0;
+    uint32_t                 baseFileOffset     = 0;
+    uint32_t                 fileOffset         = 0;
+    uint64_t                 textLoadAddr       = 0;
+    uint64_t                 textVMSize         = 0;
+    uint64_t                 baseLoadAddr       = 0;
+    uint64_t                 baseSourceAddr     = 0;
+    uint64_t                 sourceAddr         = 0;
+    
+    /* Set up kxld's link context */
+
+    /* <rdar://problem/10670709> and <rdar://problem/10778807>
+     * If kOSKextKernelcacheKASLRFlag is passed in we ask kxld to include the 
+     * relocation data that's needed by the KASLR booter. Otherwise, that data 
+     * should be omitted, so that older kernels see the same kernelcache layout 
+     * that they've always seen.
+     */
+    if (flags & kOSKextKernelcacheKASLRFlag) {
+        kxldFlags |= kKXLDFlagIncludeRelocs;
+    }
+    
+    kxldResult = kxld_create_context(&kxldContext,
+        __OSKextLinkAddressCallback, __OSKextLoggingCallback, kxldFlags,
+        OSKextGetArchitecture()->cputype, OSKextGetArchitecture()->cpusubtype);
+    if (kxldResult != KERN_SUCCESS) {
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel | kOSKextLogLinkFlag,
+             "Can't create link context.");
+        goto finish;
+    }
+
+    /* Swap kernel if necessary */
+    swapped = __OSKextSwapHeaders(kernelImage);
+
+   /* Get the last last VM load address specified in the kernel image
+    * (that is, the next "available" one).
+    */
+    success = __OSKextGetLastKernelLoadAddr(kernelImage, &baseSourceAddr);
+    if (!success) {
+        OSKextLog(/* kext */ NULL, kOSKextLogErrorLevel,
+            "Can't get last load address for kernel.");
+        goto finish;
+    }
+
+    baseFileOffset = round_page(CFDataGetLength(kernelImage));
+    baseSourceAddr = mach_vm_round_page(baseSourceAddr);
+
+    /* For x86_64 systems, we prelink the kexts into a VM region that starts 2GB
+     * from the top of the kernel __TEXT segment.
+     */
+	if (OSKextGetArchitecture()->cputype == CPU_TYPE_X86_64) {
+        success = __OSKextGetSegmentAddressAndOffset(kernelImage,
+            SEG_TEXT, NULL, &textLoadAddr);
+        if (!success) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+                "Could not get kernel text address.");
+            goto finish;
+        }
+
+        success = __OSKextGetSegmentFileAndVMSize(kernelImage,
+            SEG_TEXT, NULL, &textVMSize);
+        if (!success) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+                "Could not get kernel text vmsize.");
+            goto finish;
+        }
+
+        baseLoadAddr = mach_vm_round_page(textLoadAddr + textVMSize);
+        if (baseLoadAddr < __kOSKextMaxKextDisplacement_x86_64) {
+            OSKextLog(/* kext */ NULL,
+                kOSKextLogErrorLevel | kOSKextLogArchiveFlag,
+                "Kext base load address underflow.");
+            goto finish;
+        }
+
+        baseLoadAddr -= __kOSKextMaxKextDisplacement_x86_64;
+    } else {
+        baseLoadAddr = baseSourceAddr;
+    }
+
+    prelinkSize = baseFileOffset;
+    sourceAddr = baseSourceAddr;
+
+    /* Perform kext links */
+
+    loadList = __OSKextPrelinkKexts(kextArray, kernelImage, 
+        baseLoadAddr, sourceAddr, kxldContext, &size,
+        (flags & kOSKextKernelcacheNeedAllFlag),
+        (flags & kOSKextKernelcacheSkipAuthenticationFlag),
+        (flags & kOSKextKernelcachePrintDiagnosticsFlag),
+        (flags & kOSKextKernelcacheStripSymbolsFlag));
+    if (!loadList) {
+        goto finish;
+    }
+
+    prelinkSize += size;
+    sourceAddr += size;
+
+    /* Create the serialized info dictionary */
+
+    prelinkInfoData = __OSKextCreatePrelinkInfoDictionary(loadList,
+        volumeRootURL, (flags & kOSKextKernelcacheIncludeAllPersonalitiesFlag));
+    if (!prelinkInfoData) {
+        goto finish;
+    }
+
+    size = round_page(CFDataGetLength(prelinkInfoData));
+    prelinkSize += size;
+
+   /* Allocate a buffer to contain the prelinked kernel.
+    * It may end up smaller than prelinkSize when we copy
+    * the base kernel image, but it won't end up bigger!
+    */
+    prelinkImage = CFDataCreateMutable(kCFAllocatorDefault, prelinkSize);
+    if (!prelinkImage) {
+        OSKextLogMemError();
+        goto finish;
+    }
+
+    CFDataSetLength(prelinkImage, prelinkSize);
+
+    /* Copy the base kernel */
+
+    if (swapped) {
+        __OSKextUnswapHeaders(kernelImage);
+        swapped = false;
+    }
+
+    CFDataReplaceBytes(prelinkImage, CFRangeMake(0, CFDataGetLength(kernelImage)),
+        CFDataGetBytePtr(kernelImage), CFDataGetLength(kernelImage));
+
+    /* Reset the fileOffset and sourceAddr */
+
+    fileOffset = baseFileOffset;
+    sourceAddr = baseSourceAddr;
+
+    /* Copy the kexts */
+
+    size = __OSKextCopyPrelinkedKexts(prelinkImage, loadList, 
+        fileOffset, sourceAddr);
+
+    fileOffset += size;
+    sourceAddr += size;
+
+    /* Copy the info dictionary */
+
+    size = __OSKextCopyPrelinkInfoDictionary(prelinkImage, prelinkInfoData,
+        fileOffset, sourceAddr);
+    fileOffset += size;
+    sourceAddr += size;
+
+   /* Trim the new image to the size actually copied.
+    */
+    CFDataSetLength(prelinkImage, fileOffset);
+
+    /* Save the kexts' symbols if requested */
+    
+    if (symbolsOut) {
+        int i = 0;
+
+        symbols = CFDictionaryCreateMutable(kCFAllocatorDefault,
+            CFArrayGetCount(loadList), &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+        if (!symbols) {
+            goto finish;
+        }
+
+        for (i = 0; i < CFArrayGetCount(loadList); ++i) {
+            OSKextRef aKext = (OSKextRef) CFArrayGetValueAtIndex(loadList, i);
+            if (!aKext) {
+                printf("%u: NULL kext\n", i);
+                continue;
+            }
+
+            success = __OSKextExtractDebugSymbols(aKext, symbols);
+            if (!success) {
+                goto finish;
+            }
+        }
+
+        *symbolsOut = CFRetain(symbols);
+    }
+
+    result = CFRetain(prelinkImage);
+
+finish:
+    if (swapped) __OSKextUnswapHeaders(kernelImage);
+
+    SAFE_RELEASE(loadList);
+    SAFE_RELEASE(prelinkInfoData);
+    SAFE_RELEASE(prelinkImage);
+    SAFE_RELEASE(symbols);
+    if (kxldContext) kxld_destroy_context(kxldContext);
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean __OSKextCheckForPrelinkedKernel(
+    OSKextRef aKext,
+    Boolean   needAllFlag,
+    Boolean   skipAuthenticationFlag,
+    Boolean   printDiagnosticsFlag)
+{
+    char kextPath[PATH_MAX];
+    const NXArchInfo * arch = NULL;
+    OSKextLogSpec logLevel = needAllFlag ? kOSKextLogErrorLevel :
+        kOSKextLogWarningLevel;
+    
+    __OSKextGetFileSystemPath(aKext, /* otherURL */ NULL,
+        /* resolveToBase */ TRUE, kextPath);
+
+    if (!__OSKextIsValid(aKext)) {
+        OSKextLog(aKext,
+            logLevel | kOSKextLogArchiveFlag,
+            "%s is not valid; omitting from prelinked kernel.",
+            kextPath);
+        if (printDiagnosticsFlag) {
+            OSKextLogDiagnostics(aKext, kOSKextDiagnosticsFlagAll);
+        }
+        return false;
+    }
+
+    arch = OSKextGetArchitecture();
+    if (!OSKextSupportsArchitecture(aKext, arch)) {
+        OSKextLog(aKext,
+            logLevel | kOSKextLogArchiveFlag,
+            "%s doesn't support architecture %s; "
+            "omitting from prelinked kernel.",
+             kextPath, arch->name);
+        return false;
+    }
+
+    if (!skipAuthenticationFlag && !OSKextIsAuthentic(aKext)) {
+        OSKextLog(aKext,
+            logLevel | kOSKextLogArchiveFlag,
+            "%s is not authentic; omitting from prelinked kernel.",
+            kextPath);
+            if (printDiagnosticsFlag) {
+                OSKextLogDiagnostics(aKext, kOSKextDiagnosticsFlagAll);
+            }
+        return false;
+    }
+
+    return true;
+}
+#endif /* !IOKIT_EMBEDDED */
+
+
+#pragma mark Misc
+/*********************************************************************
+*********************************************************************/
+CFComparisonResult __OSKextCompareIdentifiers(
+    const void * val1,
+    const void * val2,
+    void       * context __unused)
+{
+    CFStringRef identifier1 = OSKextGetIdentifier((OSKextRef)val1);
+    CFStringRef identifier2 = OSKextGetIdentifier((OSKextRef)val2);
+    return CFStringCompare(identifier1, identifier2,
+        kCFCompareCaseInsensitive|kCFCompareForcedOrdering);
+}
+
+/*********************************************************************
+* If we have a volume path, strip it off the front of the path to the
+* kext so we have a volume-relative path--but keep the slash on the
+* beginning so that it looks absolute for the cache. We only look for
+* one trailing slash...sequential slashes in a path get boiled down
+* anyhow.
+*********************************************************************/
+char * __absPathOnVolume(
+    const char * path,
+    const char * volumePath)
+{
+    char * result = (char *)path;
+
+    if (volumePath && volumePath[0]) {
+        size_t volumePathLength = strlen(volumePath);
+        if (volumePath[volumePathLength - 1] == '/') {
+            volumePathLength--;
+        }
+        if (volumePathLength &&
+            !strncmp(result, volumePath, volumePathLength))
+        {
+            result += volumePathLength;
+        }
+    }
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFStringRef __OSKextCopyExecutableRelativePath(OSKextRef aKext)
+{
+    CFStringRef  result            = NULL;
+    CFURLRef     kextAbsURL        = NULL;  // must release
+    CFStringRef  kextAbsPath       = NULL;  // must release
+    CFURLRef     executableURL     = NULL;  // must release
+    CFURLRef     executableAbsURL  = NULL;  // must release
+    CFStringRef  executableAbsPath = NULL;  // must release
+    CFStringRef  executableRelPath = NULL;  // must release
+
+    kextAbsURL = CFURLCopyAbsoluteURL(aKext->bundleURL);
+    if (!kextAbsURL) {
+        goto finish;
+    }
+    kextAbsPath = CFURLCopyFileSystemPath(kextAbsURL, kCFURLPOSIXPathStyle);
+    if (!kextAbsPath) {
+        goto finish;
+    }
+
+    executableURL = _CFBundleCopyExecutableURLInDirectory(OSKextGetURL(aKext));
+    if (!executableURL) {
+        goto finish;
+    }
+    executableAbsURL = CFURLCopyAbsoluteURL(executableURL);
+    if (!executableAbsURL) {
+        goto finish;
+    }
+    executableAbsPath = CFURLCopyFileSystemPath(executableAbsURL, kCFURLPOSIXPathStyle);
+    if (!executableAbsPath) {
+        goto finish;
+    }
+    CFRange subRange;
+    
+    subRange.location = CFStringGetLength(kextAbsPath) + 1; /* +1 for the slash */
+    subRange.length = CFStringGetLength(executableAbsPath) - subRange.location;
+
+    result = CFStringCreateWithSubstring(kCFAllocatorDefault,
+        executableAbsPath, subRange);
+
+finish:
+
+    SAFE_RELEASE(kextAbsURL);
+    SAFE_RELEASE(kextAbsPath);
+    SAFE_RELEASE(executableURL);
+    SAFE_RELEASE(executableAbsURL);
+    SAFE_RELEASE(executableAbsPath);
+    SAFE_RELEASE(executableRelPath);
+
+    return result;
+}
+
+#if PRAGMA_MARK
+/********************************************************************/
+#pragma mark URL Utilities
+/********************************************************************/
+#endif
+
+/*********************************************************************
+*********************************************************************/
+CFStringRef _CFURLCopyAbsolutePath(CFURLRef anURL)
+{
+    CFStringRef result = NULL;
+    CFURLRef    absURL = NULL;  // must release
+
+    absURL = CFURLCopyAbsoluteURL(anURL);
+    if (!absURL) {
+        goto finish;
+    }
+    
+    result = CFURLCopyFileSystemPath(absURL, kCFURLPOSIXPathStyle);
+    
+finish:
+    SAFE_RELEASE(absURL);
+    return result;
+}
+
+#if PRAGMA_MARK
+/*********************************************************************
+#pragma mark Logging
+*********************************************************************/
+#endif
+
+static inline bool logSpecMatch(
+    OSKextLogSpec msgLogSpec,
+    OSKextLogSpec logFilter) __attribute__((always_inline));
+
+static inline bool logSpecMatch(
+    OSKextLogSpec msgLogSpec,
+    OSKextLogSpec logFilter)
+{
+    OSKextLogSpec filterKextGlobal  = logFilter & kOSKextLogKextOrGlobalMask;
+    OSKextLogSpec filterLevel       = logFilter & kOSKextLogLevelMask;
+    OSKextLogSpec filterFlags       = logFilter & kOSKextLogFlagsMask;
+
+    OSKextLogSpec msgKextGlobal    = msgLogSpec & kOSKextLogKextOrGlobalMask;
+    OSKextLogSpec msgLevel         = msgLogSpec & kOSKextLogLevelMask;
+    OSKextLogSpec msgFlags         = msgLogSpec & kOSKextLogFlagsMask;
+
+   /* Explicit messages always get logged.
+    */
+    if (msgLevel == kOSKextLogExplicitLevel) {
+        return true;
+    }
+
+   /* Warnings and errors are logged regardless of the flags.
+    */
+    if (msgLevel <= kOSKextLogBasicLevel && (msgLevel <= filterLevel)) {
+        return true;
+    }
+
+   /* A verbose message that isn't for a logging-enabled kext and isn't global
+    * does *not* get logged.
+    */
+    if (!msgKextGlobal && !filterKextGlobal) {
+        return false;
+    }
+
+   /* Warnings and errors are logged regardless of the flags.
+    * All other messages must fit the flags and
+    * have a level at or below the filter.
+    *
+    */
+    if ((msgFlags & filterFlags) && (msgLevel <= filterLevel)) {
+        return true;
+    }
+    return false;
+}
+
+static bool __OSKextShouldLog(
+    OSKextRef     aKext,
+    OSKextLogSpec msgLogSpec)
+{
+    if (!aKext || aKext->flags.loggingEnabled) {
+        msgLogSpec = msgLogSpec | kOSKextLogKextOrGlobalMask;
+    }
+
+    return logSpecMatch(msgLogSpec, __sUserLogFilter);
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextLog(
+    OSKextRef        aKext,
+    OSKextLogSpec    msgLogSpec,
+    const char     * format, ...)
+{
+    va_list argList;
+
+    va_start(argList, format);
+    OSKextVLog(aKext, msgLogSpec, format, argList);
+    va_end(argList);
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextVLog(
+    OSKextRef        aKext,
+    OSKextLogSpec    msgLogSpec,
+    const char     * format,
+    va_list          srcArgList)
+{
+    va_list          argList;
+    char           * outputCString = NULL;  // must free
+
+    if (!__sOSKextLogOutputFunction) {
+        goto finish;
+    }
+    
+    // xxx - I could check for a bad msgLogSpec (such as intersect or user)
+    // xxx - but we can't report the bad callsite so never mind.
+
+    if (!__OSKextShouldLog(aKext, msgLogSpec)) {
+        goto finish;
+    }
+
+   /* No goto from here until past va_end()!
+    */    
+    va_copy(argList, srcArgList);
+    vasprintf(&outputCString, format, argList);
+    va_end(argList);
+
+    if (outputCString) {
+        __sOSKextLogOutputFunction(aKext, msgLogSpec, "%s", outputCString);
+    }
+
+finish:
+    SAFE_FREE(outputCString);
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextLogCFString(
+    OSKextRef        aKext,
+    OSKextLogSpec    msgLogSpec,
+    CFStringRef      format, ...)
+{
+    va_list argList;
+
+    va_start(argList, format);
+    OSKextVLogCFString(aKext, msgLogSpec, format, argList);
+    va_end(argList);
+}
+
+/*********************************************************************
+*********************************************************************/
+void OSKextVLogCFString(
+    OSKextRef        aKext,
+    OSKextLogSpec    msgLogSpec,
+    CFStringRef      format,
+    va_list          srcArgList)
+{
+    va_list          argList;
+    CFStringRef      outputString = NULL;  // must release
+    size_t           cStringLength;
+    char           * outputCString = NULL;  // must free
+
+    if (!__sOSKextLogOutputFunction) {
+        goto finish;
+    }
+    
+    // xxx - I could check for a bad msgLogSpec (such as intersect or user)
+    // xxx - but we can't report the bad callsite so never mind.
+
+    if (!__OSKextShouldLog(aKext, msgLogSpec)) {
+        goto finish;
+    }
+
+   /* No goto from here until past va_end()!
+    */    
+    va_copy(argList, srcArgList);
+    outputString = CFStringCreateWithFormatAndArguments(kCFAllocatorDefault,
+        /* options */ NULL, format, srcArgList);
+    va_end(argList);
+    if (!outputString) {
+        goto finish;
+    }
+
+    cStringLength = CFStringGetMaximumSizeForEncoding(
+        CFStringGetLength(outputString), kCFStringEncodingUTF8);
+    outputCString = (char *)malloc(cStringLength);
+    if (!outputCString) {
+        goto finish;
+    }
+
+    if (!CFStringGetCString(outputString, outputCString, cStringLength,
+        kCFStringEncodingUTF8)) {
+
+        goto finish;
+    }
+
+    if (outputCString) {
+        __sOSKextLogOutputFunction(aKext, msgLogSpec, "%s", outputCString);
+    }
+
+finish:
+    SAFE_RELEASE(outputString);
+    SAFE_FREE(outputCString);
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+void __sOSKextDefaultLogFunction(
+    OSKextRef       aKext __unused,
+    OSKextLogSpec   msgLogSpec __unused,
+    const char    * format, ...)
+{
+    va_list   argList;
+    FILE    * stream = stderr;
+    
+    va_start(argList, format);
+    vfprintf(stream, format, argList);
+    va_end(argList);
+
+    fprintf(stream, "\n");
+    return;
+}
+
+/*********************************************************************
+*********************************************************************/
+void __OSKextLogKernelMessages(
+    OSKextRef aKext,
+    CFTypeRef kernelMessages)
+{
+    CFArrayRef  logInfoArray  = (CFArrayRef)kernelMessages;
+    CFArrayRef  flagsArray    = NULL;  // do not release
+    CFArrayRef  messagesArray = NULL;  // do not release
+    CFIndex     count, i;
+
+    if (!__sOSKextLogOutputFunction) {
+        goto finish;
+    }
+    
+    if (CFGetTypeID(logInfoArray) != CFArrayGetTypeID()) {
+        // xxx log error :-)
+        goto finish;
+    }
+
+    if (CFArrayGetCount(logInfoArray) != 2) {
+        // xxx log error :-)
+        goto finish;
+    }
+    
+    flagsArray = (CFArrayRef)CFArrayGetValueAtIndex(logInfoArray, 0);
+    messagesArray = (CFArrayRef)CFArrayGetValueAtIndex(logInfoArray, 1);
+
+    if ((CFGetTypeID(flagsArray) != CFArrayGetTypeID()) ||
+        (CFGetTypeID(messagesArray) != CFArrayGetTypeID()) ||
+        (CFArrayGetCount(flagsArray) != CFArrayGetCount(messagesArray))) {
+        
+        // xxx log error :-)
+        goto finish;
+    }
+
+    count = CFArrayGetCount(messagesArray);
+    for (i = 0; i < count; i++) {
+        CFNumberRef flagsNum = (CFNumberRef)CFArrayGetValueAtIndex(
+            flagsArray, i);
+        OSKextLogSpec msgLogSpec;
+        CFStringRef string = (CFStringRef)CFArrayGetValueAtIndex(
+            messagesArray, i);
+
+        if (CFNumberGetValue(flagsNum, kCFNumberSInt32Type, &msgLogSpec)) {
+            // xxx try this on the stack before allocating
+            // xxx - need to get the msgLogSpec from the kernel
+            char * cString = createUTF8CStringForCFString(string);
+            if (cString) {
+                __sOSKextLogOutputFunction(aKext, msgLogSpec, "(kernel) %s", cString);
+                SAFE_FREE_NULL(cString);
+            }
+        } else {
+            // xxx log error :-)
+        }
+    }
+
+finish:
+    return;
+}
+
+/*******************************************************************************
+* safe_mach_error_string()
+*******************************************************************************/
+static const char * safe_mach_error_string(mach_error_t error_code)
+{
+    const char * result = mach_error_string(error_code);
+    if (!result) {
+        result = "(unknown)";
+    }
+    return result;
+}

--- a/src/kext_tools/kext.subproj/OSKext.h
+++ b/src/kext_tools/kext.subproj/OSKext.h
@@ -1,0 +1,3241 @@
+/*
+ * Copyright (c) 2008, 2012 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#ifndef __OSKEXT_H__
+#define __OSKEXT_H__
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <System/libkern/OSReturn.h>
+#include <System/libkern/OSKextLib.h>
+#include <System/libkern/OSKextLibPrivate.h>
+#include <mach/mach.h>
+#include <mach-o/arch.h>
+
+// xxx - should I use "Clear" everywhere I use "Flush"
+
+/*!
+ * @header
+ * @ignore CF_EXPORT
+ *
+ * The OSKext library provides a comprehensive interface for creating,
+ * examining, and loading kernel extensions (kexts).
+ *
+ * <b>NOTICE:</b> This library is neither thread-safe nor garbage-collection
+ * safe. You must use your own locking with threads sharing access to OSKext.
+ * You can not use this library in an application with garbage collection.
+ */
+ 
+#pragma mark Types and Constants
+/*******************************************************************************
+* Types and Constants
+*******************************************************************************/
+
+/*!
+ * @typedef  OSKextRef
+ * @abstract A reference to a kernel extension object.
+ *
+ * @discussion
+ * The OSKextRef type refers to a KXKext object, which represents a kernel
+ * extension bundle on disk, from an archive, or loaded into the kernel.
+ * OSKext is an opaque type that defines the characteristics and behavior of
+ * OSKext objects.
+ *
+ * The kernel counterpart of OSKext is the OSKext libkern C++ class.
+ */
+typedef struct __OSKext * OSKextRef;
+
+#define kOSKextBundleExtension  "kext"
+#define kOSKextMkextExtension   "mkext"
+
+/*!
+ * @typedef OSKextDiagnosticsFlags
+ * @constant kOSKextDiagnosticsFlagAll
+ * @constant kOSKextDiagnosticsFlagValidation
+ * @constant kOSKextDiagnosticsFlagAuthentication
+ * @constant kOSKextDiagnosticsFlagDependencies
+ * @constant kOSKextDiagnosticsFlagWarnings
+ * @constant kOSKextDiagnosticsFlagBootLevel
+ */
+enum {
+    kOSKextDiagnosticsFlagNone           = (UInt32)       0x0U,
+
+    kOSKextDiagnosticsFlagValidation     = (UInt32)       0x1U,
+    kOSKextDiagnosticsFlagAuthentication = (UInt32)       0x2U,
+    kOSKextDiagnosticsFlagDependencies   = (UInt32)       0x4U,
+    kOSKextDiagnosticsFlagWarnings       = (UInt32)       0x8U,
+    kOSKextDiagnosticsFlagBootLevel      = (UInt32)      0x10U,
+
+    kOSKextDiagnosticsFlagAll            = (UInt32)0xFFFFFFFFU,
+};
+typedef UInt32 OSKextDiagnosticsFlags;
+
+/* notify(3) identifiers.
+ */
+CF_EXPORT const char * kOSKextLoadNotification;
+CF_EXPORT const char * kOSKextUnloadNotification;
+
+/* Top-level keys for diagnostics dicts. See @link OSKextCopyDiagnostics@/link.
+ */
+// xxx - not sure we need to include these, but it's convenient
+CF_EXPORT const CFStringRef kOSKextDiagnosticsValidationKey;
+CF_EXPORT const CFStringRef kOSKextDiagnosticsAuthenticationKey;
+CF_EXPORT const CFStringRef kOSKextDiagnosticsDependenciesKey;
+CF_EXPORT const CFStringRef kOSKextDiagnosticsWarningsKey;
+CF_EXPORT const CFStringRef kOSKextDiagnosticsBootLevelKey;
+
+#pragma mark Basic CF Functions
+/*********************************************************************
+* Basic CF Functions
+*********************************************************************/
+
+/*!
+ * @function OSKextGetTypeID
+ * @abstract Returns the type identifier for the OSKext opaque type.
+ *
+ * @result   The type identifier for the OSKext opaque type.
+ */
+CF_EXPORT CFTypeID
+OSKextGetTypeID(void)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+#pragma mark Module Configuration
+/*********************************************************************
+* Module Configuration
+*********************************************************************/
+
+/*!
+ * @function OSKextSetArchitecture
+ * @abstract Sets the architecture used for operations on kexts.
+ *
+ * @param    anArch
+ * An <code>NXArchInfo</code> pointer with cputype/subtype or name set.
+ * Ownership remains with the caller.
+ * Pass <code>NULL</code> to set the architecture to taht of the running kernel.
+ *  
+ * @result
+ * <code>true</code> if the architecture was set as desired,
+ * <code>false</code> if <code>anArch</code> was not found;
+ * if <code>false</code>, the architecture will now be that
+ * of the running kernel.
+ * xxx - should it just be left unchanged instead?
+ *
+ * @discussion
+ * The kext library uses this architecture for any architecture-specific
+ * operation, such as property lookups
+ * (see @link OSKextGetValueForInfoDictionaryKey@/link),
+ * dependency resolution, executable access during validation and linking.
+ * The kext architecture is initially that of the running kernel (not of
+ * the user-space process).
+ *
+ * This function looks up the system <code>NXArchInfo</code> struct
+ * for the struct passed in, first using the cputype/subtype, and if that fails,
+ * the name. You can therefore use this function to set the architecture
+ * from an architecture name alone by passing an <code>NXArchInfo</code> struct
+ * with the desired name,
+ * but the cputype/subtype set to CPU_TYPE_ANY and CPU_SUBTYPE_ANY.
+ *
+ * Changing the kext architecture causes all kexts to flush their load info
+ * and dependencies with @link OSKextFlushLoadInfo@/link.
+ */
+// xxx - should this also have a flushDependenciesFlag?
+CF_EXPORT Boolean
+OSKextSetArchitecture(const NXArchInfo * archInfo)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetArchitecture
+ * @abstract Gets the architecutre used for operations on kexts.
+ *
+ * @result
+ * The architecture used for operations on kexts.
+ * The caller does not own the returned pointer and should not free it.
+ *
+ * @discussion
+ * The kext library uses this architecture for any architecture-specific
+ * operation, such as property lookups
+ * (see @link OSKextGetValueForInfoDictionaryKey@/link),
+ * dependency resolution, executable access during validation and linking.
+ * The kext architecture is initially that of the running kernel (not of
+ * the user-space process).
+ */
+CF_EXPORT const NXArchInfo *
+OSKextGetArchitecture(void)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetRunningKernelArchitecture
+ * @abstract Returns the architecture of the running kernel.
+ *
+ * @result
+ * The architecture of the running kernel.
+ * The caller does not own the returned pointer and should not free it.
+ *
+ * @discussion
+ * This function consults the kernel task and returns a pointer to the
+ * <code>NXArchInfo</code> struct representing its architecture.
+ * The running kernel's architecture does not necessarily match that
+ * of user space tasks (for example, a 32-bit user space task could be
+ * running with a 64-bit kernel, or vice-versa).
+ */
+CF_EXPORT const NXArchInfo *
+OSKextGetRunningKernelArchitecture(void)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextSetLogFilter
+ * @abstract
+ * Set the logging filter for messages from the kext library
+ * or kernel.
+ *
+ * @param    logFilter  The log filter to set for user space.
+ * @param    kernelFlag <code>true</code> to set the kernel filter,
+ *                      <code>false</code> to set the user filter.
+ *
+ * @discussion
+ * The default log flag set for both user and kernel space is
+ * <code>@link kOSKextLogWarningLevel@/link |
+ * @link kOSKextLogVerboseFlagsMask@/link</code>.
+ * Log messages are output through the log function set by
+ * @link OSKextSetLogOutputFunction@/link.
+ *
+ * To suppress messages from the kext library or kernel completely,
+ * set the log flags to code>@link kOSKextLogSilentFilter@/link</code>.
+ * Functions whose explicit purpose is to print output,
+ * such as @link OSKextPrintDiagnostics@/link, will still print.
+ */
+CF_EXPORT void
+OSKextSetLogFilter(
+    OSKextLogSpec logFilter,
+    Boolean       kernelFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetLogFilter
+ * @abstract Returns the logging filter for user or kernel space.
+ *
+ * @param    kernelFlag <code>true</code> to get the kernel filter,
+ *                      <code>false</code> to get the user filter.
+ *
+ * @result
+ * The current log filter in effect.
+ *
+ * @discussion
+ * The default log flag set for both user and kernel space is
+ * <code>@link kOSKextLogWarningLevel@/link |
+ * @link kOSKextLogVerboseFlagsMask@/link</code>.
+ * Log messages are output through the log function set by
+ * @link OSKextSetLogOutputFunction@/link.
+ */
+OSKextLogSpec OSKextGetLogFilter(Boolean kernelFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @typedef OSKextLogOutputFunction
+ * @abstract
+ * Prototype of a callback function used to log messages from the library.
+ *
+ * @param    msgLogSpec  The log specification that triggered the log message.
+ * @param    format      A printf(3) style format string.
+ *
+ * @discussion
+ * The default log function simply prints to <code>stderr</code
+ * if <code>msgLogSpec</code> has any bits set.
+ * If you set the log function to <code>NULL</code>,
+ * no log messages will be printed.
+ *
+ * Log messages have no trailing newline, to accommodate system log facilities.
+ */
+/* xxx - no CF_EXPORT, compiler dies */
+typedef void (*OSKextLogOutputFunction)(
+    OSKextRef        aKext,
+    OSKextLogSpec    msgLogSpec,
+    const char     * format,
+    ...);
+
+/*!
+ * @function OSKextSetLogOutputFunction
+ * @abstract Sets the function called to log messages.
+ *
+ * @param    funct  The log function to set.
+ *
+ * @discussion
+ * The default log function simply prints to stderr. If you set the
+ * log function to <code>NULL</code>, no log messages will be printed.
+ *
+ * Log messages have no trailing newline, to accommodate system log facilities.
+ */
+CF_EXPORT void
+OSKextSetLogOutputFunction(OSKextLogOutputFunction func)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextLog
+ * @abstract Log a message at a given level and with flags.
+ *
+ * @param aKext           If not <code>NULL</code>, the OSKext object to which
+ *                        the log message applies.
+ * @param messageLogSpec  The level and flags with which to log the message.
+ * @param format          A printf-style format string to log,
+ *                        followed by optional arguments.
+ *
+ * @discussion
+ * Log messages are filtered based on <code>aKext</code>,
+ * <code>messageLogSpec</code>, and the current log filter as set by
+ * @link <code>OSKextSetLogFilter</code>@/link.
+ *
+ * Log messages have no trailing newline, to accommodate system log facilities.
+ */
+CF_EXPORT void
+OSKextLog(
+    OSKextRef     aKext,
+    OSKextLogSpec messageLogSpec,
+    const char  * format,
+    ...) __attribute__((format(printf, 3, 4)))
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextVLog
+ * @abstract Log a message at a given level and with flags.
+ *
+ * @param aKext           If not <code>NULL</code>, the OSKext object to which
+ *                        the log message applies.
+ * @param messageLogSpec  The level and flags with which to log the message.
+ * @param format          A printf-style format string to log.
+ * @param srcArgList      The corresponding argument list for the format string.
+ *
+ * @discussion
+ * Log messages are filtered based on <code>aKext</code>,
+ * <code>messageLogSpec</code>, and the current log filter as set by
+ * @link <code>OSKextSetLogFilter</code>@/link.
+ *
+ * Log messages have no trailing newline, to accommodate system log facilities.
+ */
+void OSKextVLog(
+    OSKextRef        aKext,
+    OSKextLogSpec    msgLogSpec,
+    const char     * format,
+    va_list          srcArgList)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextLogCFString
+ * @abstract Log a message at a given level and with flags.
+ *
+ * @param aKext           If not <code>NULL</code>, the OSKext object to which
+ *                        the log message applies.
+ * @param messageLogSpec  The level and flags with which to log the message.
+ * @param format          A printf-style format CFString to log,
+ *                        followed by optional arguments.
+ *
+ * @discussion
+ * Log messages are filtered based on <code>aKext</code>,
+ * <code>messageLogSpec</code>, and the current log filter as set by
+ * @link <code>OSKextSetLogFilter</code>@/link.
+ *
+ * Log messages have no trailing newline, to accommodate system log facilities.
+ */
+CF_EXPORT void
+OSKextLogCFString(
+    OSKextRef     aKext,
+    OSKextLogSpec messageLogSpec,
+    CFStringRef   format,
+    ...) CF_FORMAT_FUNCTION(3,4)
+                __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_4_3);
+
+/*!
+ * @function OSKextVLog
+ * @abstract Log a message at a given level and with flags.
+ *
+ * @param aKext           If not <code>NULL</code>, the OSKext object to which
+ *                        the log message applies.
+ * @param messageLogSpec  The level and flags with which to log the message.
+ * @param format          A printf-style format string to log.
+ * @param srcArgList      The corresponding argument list for the format string.
+ *
+ * @discussion
+ * Log messages are filtered based on <code>aKext</code>,
+ * <code>messageLogSpec</code>, and the current log filter as set by
+ * @link <code>OSKextSetLogFilter</code>@/link.
+ *
+ * Log messages have no trailing newline, to accommodate system log facilities.
+ */
+void OSKextVLogCFString(
+    OSKextRef        aKext,
+    OSKextLogSpec    msgLogSpec,
+    CFStringRef      format,
+    va_list          srcArgList)
+                __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_4_3);
+
+/*!
+ * @function OSKextSetSimulatedSafeBoot
+ * @abstract Sets whether safe boot mode is simulated in the library.
+ *
+ * @param    flag  <code>true</code> to simulate safe boot mode,
+ *                 <code>false</code> to not simulate.
+ *
+ * @discussion
+ * Kexts without a valid OSBundleRequired property are not allowed to load
+ * by the kernel when the system has started in safe boot mode.
+ * If you turn on simulated safe boot, the kext library can
+ * catch non-loadable kexts and present appropriate diagnostics.
+ */
+CF_EXPORT void
+OSKextSetSimulatedSafeBoot(Boolean flag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetSimulatedSafeBoot
+ * @abstract Returns whether safe boot mode is simulated in the library.
+ *
+ * @result
+ * <code>true</code> if safe boot mode is being simulated,
+ * <code>false</code> if not.
+ *
+ * @discussion
+ * Kexts without a valid OSBundleRequired property are not allowed to load
+ * by the kernel when the system has started in safe boot mode.
+ * When simulated safe boot is on, the kext library can
+ * catch non-loadable kexts and present appropriate diagnostics.
+ */
+CF_EXPORT Boolean
+OSKextGetSimulatedSafeBoot(void)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetActualSafeBoot
+ * @abstract Returns whether safe boot mode is active.
+ *
+ * @result
+ * <code>true</code> if safe boot mode is active,
+ * <code>false</code> if not.
+ *
+ * @discussion
+ * Kexts without a valid OSBundleRequired property are not allowed to load
+ * by the kernel when the system has started in safe boot mode.
+ * The kext library ignores actual safe boot mode, leaving decisions
+ * regarding safe boot to the kernel.
+ * If you want to analyze kexts in safe boot mode using the library,
+ * call @link OSKextSetSimulatedSafeBoot@/link.
+ */
+// xxx - we used to disallow kexts w/debug-log flags in safe boot, too
+CF_EXPORT Boolean
+OSKextGetActualSafeBoot(void)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetSystemExtensionsFolderURLs
+ * @abstract Returns the standard system extension folder URLs.
+ *
+ * @result
+ * An array containing the standard system extension folder URLs.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Get Rule@/link.
+ *
+ * @discussion
+ * To open all the kexts normally considered for loading by the system,
+ * pass the return value of this function to
+ * @link OSKextCreateKextsFromURLs@/link.
+ */
+CF_EXPORT CFArrayRef
+OSKextGetSystemExtensionsFolderURLs(void)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextSetRecordsDiagnostics
+ * @abstract Sets whether kexts record diagnostic information.
+ *
+ * @param   flags    Indicates which diagnostics to record.
+ *
+ * @discussion
+ * The kext library can record diagnostic information for kexts as
+ * problems are encountered. These diagnostics can consume a fair
+ * amount of memory, and should be generated only when desired.
+ * Recording of diagnostics is set to
+ * @link kOSKextDiagnosticsFlagNone@/link by default.
+ * Use this function to turn diagnostics recording off (or back on)
+ * for particular diagnostic types.
+ *
+ * Turning on diagnostics does not calculate or recalculate
+ * diagnostics. Call the various functions that operate on kexts
+ * to begin accumulating diagnostics.
+ *
+ * Turning diagnostics off does not clear any existing diagnostics.
+ * Use @link OSKextFlushDiagnostics@/link explicitly to clear
+ * any diagnostics currently stored.
+ *
+ * See also @link OSKextCopyDiagnostics@/link,
+ * @link OSKextValidate@/link,
+ * @link OSKextAuthenticate@/link, and
+ * @link OSKextResolveDependencies@/link.
+ */
+// Could list a pile of see also's here....
+CF_EXPORT void
+OSKextSetRecordsDiagnostics(OSKextDiagnosticsFlags flags)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetRecordsDiagnostics
+ * @abstract
+ * Returns what kinds of diagnostic information kexts record.
+ *
+ * @result
+ * Flags indicating which types of diagnostics are currently
+ * being recorded. You can bitwise-OR or -AND these with other flags
+ * to add or remove diagnostics being recorded with
+ * @link OSKextSetRecordsDiagnostics@/link.
+ */
+CF_EXPORT OSKextDiagnosticsFlags
+OSKextGetRecordsDiagnostics(void)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+
+/*!
+ * @function OSKextSetUsesCaches
+ * @abstract Sets whether the kext library uses cache files.
+ *
+ * @param   flag
+ *          <code>true</code> to use caches,
+ *          <code>false</code> to not use caches.
+ *
+ * @discussion
+ * The kext library normally uses caches to speed up reading kexts from
+ * the system extensions folders.
+ * Use this function to turn off use of caches; this will cause reading
+ * of kexts to be dramatically slower.
+ *
+ * See also @link OSKextGetUsesCaches@/link.
+ */
+CF_EXPORT void
+OSKextSetUsesCaches(Boolean flag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetUsesCaches
+ * @abstract
+ * Returns whether the OSKext library uses cache files.
+ *
+ * @result
+ * <code>true</code> if the library uses caches to speed up reading of kexts,
+ * <code>false</code> if it doesn't.
+ *
+ * @discussion
+ * The kext library normally uses caches to speed up reading kexts from
+ * the system extensions folders.
+ * Use this function to check whether the library is using caches.
+ *
+ * See also @link OSKextGetUsesCaches@/link.
+ */
+CF_EXPORT Boolean
+OSKextGetUsesCaches(void)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+#pragma mark Instance Management
+/*********************************************************************
+* Instance Management
+*********************************************************************/
+
+/*!
+ * @function OSKextCreate
+ * @abstract Read a single kext from an on-disk bundle, without plugins.
+ *
+ * @param    allocator
+ *           The allocator to use to allocate memory for the new object.
+ *           Pass <code>NULL</code> or <code>kCFAllocatorDefault</code>
+ *           to use the current default allocator.
+ * @param    anURL
+ *           The location of the bundle for which to create an OSKext object.
+ * @result
+ * An OSKext object created from the bundle at anURL.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-103029 Create Rule@/link.
+ *
+ * Returns <code>NULL</code> if there was a memory allocation problem or
+ * if the bundle doesn't exist at anURL (see Discussion).
+ * May return an existing OSKext object with the reference count incremented.
+ *
+ * @discussion
+ * Once a kext has been created, it is cached in memory; the kext bundle cache
+ * is flushed only periodically. OSKextCreate does not check that a cached kext
+ * bundle still exists in the filesystem. If a kext bundle is deleted
+ * from the filesystem, it is therefore possible for OSKextCreate
+ * to return a cached bundle that has actually been deleted.
+ *
+ * OSKext uses a CFBundle briefly during initialization, but in order
+ * to save memory and allow re-reading of kext bundle contents
+ * from disk, does not retain it. Applications can save further memory
+ * by flushing info dictionaries so that they are read from disk again
+ * when needed; see @link OSKextFlushInfoDictionary@/link.
+ */
+CF_EXPORT OSKextRef
+OSKextCreate(
+    CFAllocatorRef allocator,
+    CFURLRef       anURL)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCreateKextsFromURL
+ * @abstract Reads all kexts at an on-disk URL along with their plugins.
+ *
+ * @param    allocator
+ *           The allocator to use to allocate memory for the new objects.
+ *           Pass <code>NULL</code> or <code>kCFAllocatorDefault</code>
+ *           to use the current default allocator.
+ * @param    anURL       The URL to scan for kernel extensions.
+ * @result
+ * Returns an array containing the kext objects created,
+ * or <code>NULL</code> on failure.
+ *
+ * @discussion
+ * This function scans <code>anURL</code> for kexts.
+ * If <code>anURL</code> represents a kext,
+ * this function reads that kext and its plugins.
+ * If <code>anURL</code> represents a non-kext directory,
+ * this functions scans the directory's immediate contents for kext bundles
+ * and their plugins. It does not scan recursively; only plugins one level
+ * deep are read.
+ *
+ * If given an URL for a kext that is a plugin of another kext, this
+ * function does not scan for further plugins.
+ *
+ * This function does not scan for or read mkext files. Use
+ * @link OSKextCreateKextsFromMkextFile@/link to read an mkext file.
+ *
+ * See @link OSKextCreate OSKextCreate @/link for information
+ * about kext object caching.
+ */
+CFArrayRef OSKextCreateKextsFromURL(
+    CFAllocatorRef allocator,
+    CFURLRef anURL)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCreateKextsFromURLs
+ * @abstract Reads all kexts at an array on-disk URLs along with their plugins.
+ *
+ * @param    allocator
+ *           The allocator to use to allocate memory for the new objects.
+ *           Pass <code>NULL</code> or <code>kCFAllocatorDefault</code>
+ *           to use the current default allocator.
+ * @param    arrayOfURLs The URLs to scan for kernel extensions.
+ * @result
+ * Returns an array containing the kext objects created,
+ * or <code>NULL</code> on failure.
+ *
+ * @discussion
+ * This function scans each URL in <code>arrayOfURLs</code> for kexts.
+ * If a given URL represents a kext,
+ * this function reads that kext and its plugins.
+ * If the URL represents a non-kext directory, this functions scans the
+ * directory's immediate contents for kext bundles and their plugins.
+ * It does not scan recursively; only plugins one level deep are read.
+ *
+ * If given an URL for a kext that is a plugin of another kext, this
+ * function does not scan for further plugins.
+ *
+ * This function does not scan for or read mkext files. Use
+ * @link OSKextCreateKextsFromMkextFile@/link to read an mkext file.
+ *
+ * See @link OSKextCreate@/link for discussion about kext object caching.
+ */
+CF_EXPORT CFArrayRef
+OSKextCreateKextsFromURLs(
+    CFAllocatorRef allocator,
+    CFArrayRef arrayOfURLs)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCreateWithIdentifier
+ * @abstract Search for and create a kext given its bundle identifier.
+ *
+ * @param    allocator
+ *           The allocator to use to allocate memory for the new object.
+ *           Pass <code>NULL</code> or <code>kCFAllocatorDefault</code>
+ *           to use the current default allocator.
+ * @param    kextIdentifier
+ *           The bundle identifier for which to create a OSKext object.
+ * @result
+ * A OSKext object with the requested bundle identifier,
+ * created according to the search described below.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-103029 Create Rule @/link.
+ *
+ * Returns <code>NULL</code> if there was a memory allocation problem,
+ * if no bundle can be found for <code>kextIdentifier</code>,
+ * or if the bundle found can't be opened (see Discussion).
+ * May return an existing OSKext object with the reference count incremented.
+ *
+ * @discussion
+ * This function searches the system to create a kext
+ * for <code>kextIdentifier</code>.
+ * It first consults the kernel to get the path for a loaded kext
+ * with that identifier.
+ * If a kext bundle exists at that path and its identifier and version
+ * match what's loaded in the kernel, a kext object for that bundle is returned.
+ * Failing that, this function falls back to searching the directories
+ * provided by
+ * <code>@link OSKextGetSystemExtensionsFolderURLs OSKextGetSystemExtensionsFolderURLs@/link,
+ * attempting to match a loaded kext's identifier and version,
+ * and finally falling back to an identifier match only.
+ *
+ * The returned kext will have its load info set as if
+ * <code>@link OSKextReadLoadedKextInfo OSKextReadLoadedKextInfo@/link
+ * had been called (but other kexts are not affected).
+ * You can use functions such as
+ * <code>@link OSKextIsLoaded OSKextIsLoaded@/link</code>
+ * to check whether the kext created is loaded in the kernel.
+ *
+ * See @link OSKextCreate OSKextCreate @/link for information
+ * about kext object caching.
+ */
+CF_EXPORT OSKextRef
+OSKextCreateWithIdentifier(
+    CFAllocatorRef allocator,
+    CFStringRef    kextIdentifier)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetAllKexts
+ * @abstract
+ * Returns an array containing all of the kexts currently open in the application.
+ *
+ * @result
+ * A CFArray object containing OSKext objects for each open kext
+ * in the application. Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Get Rule@/link.
+ *
+ * @discussion
+ * This function is potentially expensive, so use with care.
+ */
+CF_EXPORT CFArrayRef
+OSKextGetAllKexts(void)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetKextWithURL
+ * @abstract Locate an opened kext given its URL.
+ *
+ * @param    anURL
+ *           The URL of the opened kext to locate.
+
+ * @result
+ * An OSKext object, or <code>NULL</code> if the kext was not found
+ * (either because it has not been opened or it failed to open).
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Get Rule@/link.
+ *
+ * @discussion
+ * For a kext to be located by this function,
+ * the kext object must have already been created.
+ * This function allows you to check quickly for a kext without actually
+ * attempting to open it.
+*/
+CF_EXPORT OSKextRef
+OSKextGetKextWithURL(
+    CFURLRef anURL)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetKextWithIdentifier
+ * @abstract Locate a kext given its program-defined identifier.
+ *
+ * @param    aBundleID
+ *           The identifier of the kext to locate.
+ *           Note that identifier names are case-sensitive.
+ * @result
+ * An OSKext object, or <code>NULL</code> if the kext was not found.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Get Rule@/link.
+ *
+ * @discussion
+ * For a kext to be located using its identifier,
+ * the kext object must have already been created.
+ * The principal intended purpose for locating kexts by identifier
+ * is resolving dependencies between kexts.
+ * If a kext is created, then the kext bundle is deleted from the filesystem
+ * and this function invoked afterwards, it will still return the original kext.
+ *
+ * If multiple kexts with the same identifier exist in the application
+ * created from distinct kext bundles, this function returns the kext
+ * with the greatest version. If multiple kexts with the same identifier
+ * and version exist, this function returns the last such kext created.
+ *
+ * Kext identifiers are created by entering a value for the key
+ * CFBundleIdentifier in the kext bundle's Info.plist file.
+ *
+ * To guarantee uniqueness, identifiers take the form
+ * of Java style package names, such as com.myCompany.foo.bar.
+ */
+// xxx - check on same-version ordering with folks
+CF_EXPORT OSKextRef
+OSKextGetKextWithIdentifier(
+    CFStringRef aBundleID)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyKextsWithIdentifiers
+ * @abstract
+ * Locate a list of kexts given their program-defined identifiers.
+ *
+ * @param    bundleIDs
+ *           The array of identifiers of the kexts to locate.
+ *           Note that identifier names are case-sensitive.
+ * @result
+ * An array of OSKext objects, or <code>NULL</code>
+ * if an allocation error occurs.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Create Rule@/link.
+ *
+ * @discussion
+ * See @link OSKextGetKextWithIdentifier@/link for general information
+ * on looking up kexts by identifier.
+ */
+CF_EXPORT CFMutableArrayRef 
+OSKextCopyKextsWithIdentifiers(
+    CFArrayRef bundleIDs)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetKextWithIdentifierAndVersion
+ * @abstract
+ * Locate a kext given its program-defined identifier and version.
+ *
+ * @param    aBundleID
+ *           The identifier of the kext to locate.
+ *           Note that identifier names are case-sensitive.
+ * @param    aVersion
+ *           The version of the kext to locate.
+ * @result
+ * An OSKext object, or <code>NULL</code> if the kext was not found.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Get Rule@/link.
+ *
+ * @discussion
+ * For a kext to be located using its identifier and version,
+ * the kext object must have already been created.
+ * See @link OSKextGetKextWithIdentifierAndVersion@/link for more.
+ */
+// xxx - check on same-version ordering with folks
+CF_EXPORT OSKextRef
+OSKextGetKextWithIdentifierAndVersion(
+    CFStringRef aBundleID, OSKextVersion aVersion)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetKextsWithIdentifier
+ * @abstract Locate all kexts with a given program-defined identifier.
+ *
+ * @param    aBundleID
+ *           The identifier of the kext to locate.
+ *           Note that identifier names are case-sensitive.
+ * @result
+ * An CFArray of kext objects with the given identifier,
+ * or <code>NULL</code> on error.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-103029 Create Rule@/link.
+ *
+ * @discussion
+ * This function is useful for locating duplicates of a given kext.
+ *
+ * See @link OSKextGetKextWithIdentifier@/link for general information
+ * on looking up kexts by identifier.
+ */
+CF_EXPORT CFArrayRef
+OSKextCopyKextsWithIdentifier(
+    CFStringRef aBundleID)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetLoadedKextWithIdentifier
+ * @abstract
+ * Locate the loaded kext with a given program-defined identifier.
+ *
+ * @param    aBundleID
+ *           The identifier of the kext to locate.
+ *           Note that identifier names are case-sensitive.
+ * @result
+ * An OSKext object, or <code>NULL</code> if the kext was not found.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Get Rule@/link.
+ *
+ * @discussion
+ * You must call @link OSKextReadLoadedKextInfo@/link before calling this
+ * function for it to find anything.
+ *
+ * See @link OSKextGetKextWithIdentifier@/link for general information
+ * on looking up kexts by identifier.
+ */
+CF_EXPORT OSKextRef
+OSKextGetLoadedKextWithIdentifier(
+    CFStringRef aBundleID)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetCompatibleKextWithIdentifier
+ * @abstract
+ * Locate the kext with a given program-defined identifier
+ * that is compatible with a requested version.
+ *
+ * @param    aBundleID
+ *           The identifier of the kext to locate.
+ *           Note that identifier names are case-sensitive.
+ * @param    requestedVersion
+ *           The version that the kext must be compatible with.
+ * @result
+ * An OSKext object, or <code>NULL</code> if the kext was not found.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Get Rule@/link.
+ *
+ * @discussion
+ * A kext is compatible with a version if that version lies between
+ * its CFBundleVersion and its OSBundleCompatibleVersion (inclusive).
+ *
+ * See @link OSKextGetKextWithIdentifier@/link for general information
+ * on looking up kexts by identifier.
+ */
+CF_EXPORT OSKextRef
+OSKextGetCompatibleKextWithIdentifier(
+    CFStringRef  aBundleID,
+    OSKextVersion requestedVersion)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+#pragma mark Basic Accessors
+/*********************************************************************
+* Basic Accessors
+*********************************************************************/
+
+/*!
+ * @function OSKextGetURL
+ * @abstract Returns the CFURL of a kext bundle.
+ *
+ * @param    aKext  The kext to get the URL for.
+ * @result   A CFURL object. Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Get Rule@/link.
+ *
+ * @discussion
+ * This function returns the CFURL that <code>aKext</code>
+ * was originally created with.
+ * It should be resolved to its base for comparison with other kext
+ * URLs.
+ */
+CF_EXPORT CFURLRef
+OSKextGetURL(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2); // always absolute
+
+/*!
+ * @function OSKextGetIdentifier
+ * @abstract Returns the bundle identifier from a kext's information property list.
+ *
+ * @param    aKext  The kext to get the identifier for.
+ * @result
+ * A CFString object containing the kext bundle's identifier,
+ * or <code>NULL</code> if none was specified in the information property list.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Get Rule@/link.
+ */
+CF_EXPORT CFStringRef
+OSKextGetIdentifier(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetValueForInfoDictionaryKey
+ * @abstract
+ * Returns a (possibly architecture-specific) value
+ * in a kext's information dictionary.
+ *
+ * @param    aKext  The kext to get the property for.
+ * @param    key    The base key identifying the property.
+ * @result
+ * A value corresponding to <code>key</code> in <code>aKext</code>'s
+ * information dictionary.
+ * If available, an architecture-specific value is returned,
+ * otherwise the global value is returned. Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-SW1 Get Rule@/link.
+ *
+ * @discussion
+ * This function first looks for a property value specific to the current kext
+ * architecture, as set with @link OSKextSetArchitecture@/link,
+ * by appending an underscore plus the architecture name to the base key.
+ * If such a value is not found, it looks for the property using the base key.
+ * For example, if the currently set architecture is i386, and
+ * IOKitPersonalities is requested, this function looks up the key 
+ * IOKitPersonalities_i386; if that doesn't exist, then it uses
+ * IOKitPersonalities.
+ *
+ * Some properties are not allowed to be made architecture-specific;
+ * if such keys are defined, they are ignored by this function:
+ *
+ * * CFBundleIdentifier
+ * * CFBundleVersion
+ * * CFBundleExecutable
+ * * OSBundleIsInterface
+ * * OSKernelResource
+ *
+ * This function looks up architecture-specific values for generic bundle
+ * properties, such as CFBundlePackageType, but such values are of course
+ * ignored by CFBundle.
+ *
+ * If you want to look up a property with a raw key, get the information
+ * dictionary directly using  @link OSKextCopyInfoDictionary@/link or
+ * by opening a CFBundle for the kext's URL.
+ *
+ * This function reads the info dictionary from disk if necessary.
+ * See @link OSKextFlushInfoDictionary@/link.
+ */
+CF_EXPORT CFTypeRef
+OSKextGetValueForInfoDictionaryKey(
+    OSKextRef   aKext,
+    CFStringRef key)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyInfoDictionary
+ * @abstract Returns a copy of a kext's information dictionary.
+ *
+ * @param    aKext  The kext to get the information dictionary for.
+ * @result
+ * A CFDictionary object containing the data stored in the kext's
+ * information property list.
+ * OSKext may add extra keys to this dictionary for its own use.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-103029 Create Rule@/link.
+ *
+ * @discussion
+ * This function uses @link IOCFUnserialize@/link to parse the XML
+ * of the info dictionary, in order to match the parsing used in the kernel.
+ */
+CF_EXPORT CFMutableDictionaryRef
+OSKextCopyInfoDictionary(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextFlushInfoDictionary
+ * @abstract Releases a kext's info dictionary.
+ *
+ * @param    aKext  The kext that should release its info dictionary.
+ *                  If <code>NULL</code>, all open kexts' info dictionaries
+ *                  are flushed.
+ *
+ * @discussion
+ * OSKexts accumulate a fair amount of information as they are created
+ * and used; when many kext objects are created the total memory
+ * consumption can be significant. If an application won't be using
+ * kexts for long periods of time, it can flush this information
+ * to save memory; the information will later be re-read from disk
+ * or recreated as necessary.
+ *
+ * Flushing info dictionaries also allows kext objects to synchronize
+ * with updates on disk; they will automatically re-sort in the
+ * internal lookup tables to reflect changed versions, for example.
+ * (xxx - well they will! that's not fully implemented yet)
+ *
+ * See also @link OSKextFlushDependencies@/link,
+ * @link OSKextFlushLoadInfo@/link,
+ * and @link OSKextFlushDiagnostics@/link.
+ *
+ * Kext objects created from an mkext cannot flush their info
+ * dictionaries.
+ */
+CF_EXPORT void
+OSKextFlushInfoDictionary(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetVersion
+ * @abstract Returns the version of a kext.
+ *
+ * @param    aKext  The kext to get the version for.
+ * @result   The version of the kext as a 64-bit integer.
+ *
+ * @discussion
+ * xxx - needs more info on version format
+ * xxx - need to fix definition of OSKextVersion.
+ */
+CF_EXPORT OSKextVersion
+OSKextGetVersion(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetCompatibleVersion
+ * @abstract Returns the compatible version of a kext
+ *
+ * @param    aKext  The kext to get the compatible version for.
+ * @result   The compatible version of the kext as a 64-bit integer.
+ *
+ * @discussion
+ * This function returns the value of a kext's OSBundleCompatibleVersion
+ * property, parsed into a 64-bit integer that can be compared using
+ * standard integer comparison operators.
+ *
+ * xxx - needs more info on version format, ref to tn: http://developer.apple.com/technotes/tn/tn1132.html
+ */
+CF_EXPORT OSKextVersion
+OSKextGetCompatibleVersion(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyUUIDForArchitecture
+ * @abstract
+ * Returns the compiler-generated UUID of a kext for a given architecture.
+ *
+ * @param    aKext   The kext to get the UUID for.
+ * @param    anArch  The architecture desired.
+ *                   Pass <code>NULL</code> to get the UUID for the
+ *                   current architecture.
+ * @result
+ * A CFData object containing the UUID of the kext's executable
+ * for <code>anArch</code>, or the currently set architecture if
+ * <code>anArch</code> is <code>NULL</code>.
+ *
+ * @discussion
+ * UUIDs are used in addition to bundle versions to check the identify of
+ * kexts loaded in the kernel.
+ */
+CF_EXPORT CFDataRef
+OSKextCopyUUIDForArchitecture(OSKextRef aKext,
+    const NXArchInfo * anArch)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsKernelComponent
+ * @abstract Returns whether a kext represents a kerne programming interface.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> represents
+ * a kerne programming interface, <code>false</code> otherwise.
+ *
+ * @discussion
+ * A small set of kexts represent interfaces built into the kernel that can
+ * be linked against individually. These are commonly known as
+ * kernel programming interfaces (KPIs),
+ * and the kexts containing them as "pseudokexts".
+ *
+ * If a kext is a kernel component, then it is also always an interface
+ * (see @link OSKextIsInterface@/link).
+ */
+CF_EXPORT Boolean
+OSKextIsKernelComponent(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsInterface
+ * @abstract
+ * Returns whether a kext acts as a linkage subset for another kext,
+ * also known as a symbol set.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> is an interface kext,
+ * <code>false</code> otherwise.
+ *
+ * @discussion
+ * An interface kext has no actual code in its executable, but merely
+ * re-exports a set of symbols (typically a subset)
+ * from those of its dependencies.
+ *
+ * Currently the only interface kexts are the kernel component kexts
+ * the define the kernel programming interfaces for Mac OS X.
+ */
+CF_EXPORT Boolean
+OSKextIsInterface(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsLibrary
+ * @abstract Returns whether a kext can be declared as a library.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> is a library kext, <code>false</code>
+ * otherwise.
+ *
+ * @discussion
+ * A kext is a library kext if it has a valid OSBundleCompatibleVersion
+ * property. Another kext can link against a library kext by listing
+ * the library's identifier and required version in its OSBundleLibraries
+ * property.
+ */
+CF_EXPORT Boolean
+OSKextIsLibrary(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextDeclaresExecutable
+ * @abstract Returns whether a kext declares a CFBundleExecutable property.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> has a nonempty CFBundleExecutable
+ * property, <code>false</code> otherwise.
+ *
+ * @discussion
+ * A kext with an executable is either a loadable kext with actual executable
+ * code, or an interface kext whose executable serves to restrict linkage
+ * to a subset of the symbols of another kext. See @link OSKextIsInterface@/link
+ * for more on the latter type.
+ */
+CF_EXPORT Boolean
+OSKextDeclaresExecutable(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextHasLogOrDebugFlags
+ * @abstract
+ * Returns whether a kext has OSBundleEnableKextLogging set to a true value or
+ * any of its IOKitPersonalities has a nonzero IOKitDebug property.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> has a true OSBundleEnableKextLogging
+ * property or if any personality for the currently set architecture has a
+ * nonzero IOKitDebug property, <code>false</code> otherwise.
+ *
+ * @discussion
+ * Kexts built for distribution should not have any logging or debug flags set.
+ */
+CF_EXPORT Boolean
+OSKextHasLogOrDebugFlags(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsLoggingEnabled
+ * @abstract Returns whether a kext is included in more verbose logging.
+ *
+ * @param    aKext     The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> will be included in more
+ * verbose logging, <code>false</code> if not.
+ *
+ * @discussion
+ * Normally log messages about kexts are not logged above the basic level
+ * (<code>@link OSKextLogSpec@/link</code>).
+ * If this property is set on a kext, then such messages will be logged.
+ * A kext can set this in its info dictionary with the
+ * @link OSBundleEnableKextLogging@/link property.
+ */
+CF_EXPORT Boolean
+OSKextIsLoggingEnabled(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsLoggingEnabled
+ * @abstract Sets whether a kext is included in more verbose logging.
+ *
+ * @param    aKext     The kext to examine.
+ * @param    flag      <code>true</code> to enable verbose kext logging,
+ *                     <code>false</code> to disable.
+ *
+ * @discussion
+ * Normally log messages about kexts are not logged above the basic level
+ * (<code>@link OSKextLogSpec@/link</code>).
+ * If this property is set on a kext, then such messages will be logged.
+ *
+ * A kext can set this in its info dictionary with the
+ * @link OSBundleEnableKextLogging@/link property.
+ * This property is one of the few that can be changed at run time.
+ */
+CF_EXPORT void
+OSKextSetLoggingEnabled(
+    OSKextRef aKext,
+    Boolean flag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsLoadableInSafeBoot
+ * @abstract Returns whether the kernel will load a kext during safe boot.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * <code>true</code> if the kernel will allow <code>aKext</code> during
+ * safe boot, <code>false</code> otherwise.
+ *
+ * @discussion
+ * A kext is loadable during safe boot if it has an OSBundleRequired
+ * property for the kernel's architecture with a value of
+ * "Root", "Local-Root", "Network-Root", "Console", or "Safe Boot".
+ *
+ * This function does not generally cover the issue of loadability due
+ * to problems with validation, authentication, or dependency resolution.
+ * To determine whether a kext can actually be loaded, use
+ * @link OSKextIsLoadable@/link.
+ */
+CF_EXPORT Boolean
+OSKextIsLoadableInSafeBoot(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextDependenciesAreLoadableInSafeBoot
+ * @abstract
+ * Returns whether the kernel will load all of a kext's dependencies
+ * during safe boot.
+ *
+ * @param    aKext  The kext whose dependencies to examine.
+ * @result
+ * <code>true</code> if the kernel will allow <code>aKext</code>'s dependencies
+ * during safe boot, <code>false</code> otherwise.
+ *
+ * @discussion
+ * A kext is loadable during safe boot if it has an OSBundleRequired
+ * property for the kernel's architecture with a value of
+ * "Root", "Local-Root", "Network-Root", "Console", or "Safe Boot".
+ *
+ * This function does not generally cover the issue of loadability due
+ * to problems with validation, authentication, or dependency resolution.
+ * To determine whether a kext can actually be loaded, use
+ * @link OSKextIsLoadable@/link.
+ */
+CF_EXPORT Boolean
+OSKextDependenciesAreLoadableInSafeBoot(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_4_3);
+
+/*!
+ * @function OSKextCopyArchitectures
+ * @abstract
+ * Returns a list of <code>NXArchInfo</code> structs for the architectures
+ * found in a kext's executable.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * A <code>NULL</code>-terminated list of <code>NXArchInfo</code>
+ * struct pointers describing
+ * the architectures supported by <code>aKext</code>,
+ * or <code>NULL</code> if <code>aKext</code> has no executable.
+ * The caller is responsible for freeing the list, but not the individual
+ * <code>NXArchInfo</code> pointers.
+ */
+CF_EXPORT const NXArchInfo **
+OSKextCopyArchitectures(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextSupportsArchitecture
+ * @abstract Returns whether a kext has an executable for a given architecture.
+ *
+ * @param    aKext     The kext to examine.
+ * @param    anArch    The <code>NXArchInfo</code> description to check.
+ *                     If <code>NULL</code>, uses the currently set architecture.
+ * @result
+ * <code>true</code> if <code>aKext</code>'s executable contains code for
+ * <code>anArch</code>.
+ *
+ * @discussion
+ */
+// null for current (NOT host) arch
+Boolean    OSKextSupportsArchitecture(OSKextRef aKext,
+    const NXArchInfo * anArch)
+__OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);  // if NULL, uses current default
+
+/*!
+ * @function OSKextCopyPlugins
+ * @abstract Retrieve the plugins of a kext.
+ *
+ * @param    aKext  The kext to get plugins for.
+ * @result
+ * An array containing the kexts that are plugins of <code>aKext</code>.
+ *
+ * @discussion
+ * This function scans the plugins folder of <code>aKext</code>
+ * and returns an array of the kexts found.
+ * This may result in the creation of new kext objects.
+ *
+ * If <code>aKext</code> is a plugin of another kext 
+ * see @link OSKextIsPlugin@/link),
+ * this function returns an empty array.
+ */
+CF_EXPORT CFArrayRef
+OSKextCopyPlugins(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+                
+/*!
+ * @function OSKextIsPlugin
+ * @abstract Returns whether a kext is a plugin of some other kext.
+ *
+ * @param    aKext     The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> is a plugin of another kext,
+ * <code>false</code> otherwise.
+ *
+ * @discussion
+ * This function uses a simple algorithm that just checks for the substring
+ * ".kext/" in the absolute path leading up to the kext's bundle name.
+ */
+CF_EXPORT Boolean
+OSKextIsPlugin(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyContainerForPluginKext
+ * @abstract Returns the kext that is the container for a plugin kext.
+ *
+ * @param    aKext     The kext to find a parent for.
+ * @result
+ * The kext that contains <code>aKext</code> in its PlugIns folder,
+ * or <code>NULL</code> if <code>aKext</code> is not a plugin.
+ * Ownership follows the
+ * @link //apple_ref/doc/uid/20001148-103029 Create Rule@/link.
+ *
+ * @discussion
+ * This function creates a kext object for the longest portion of the
+ * path leading to <code>aKext</code>, then checks to see whether
+ * <code>aKext</code> is a plugin of that kext by <code>CFBundle</code>'s
+ * semantics. If so, that kext is returned.
+ * This may result in the creation of a new kext.
+ */
+CF_EXPORT OSKextRef
+OSKextCopyContainerForPluginKext(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyPersonalitiesArray
+ * @abstract Returns the personalities of a kext for the current kext architecture.
+ *
+ * @param    aKext  The kext to retrieve personalities for.
+ * @result   An array of IOKit personality dictionaries.
+ *
+ * @discussion
+ * IOKitPersonalities in kexts require some processing before being sent
+ * to the kernel, and the functions that send personalities expect an array
+ * rather than a dictionary. This function facilitates such use.
+ *
+ * Use @link OSKextGetValueForInfoDictionaryKey@/link to retrieve the raw
+ * personalities dictionary for the current architecture.
+ */
+CF_EXPORT CFArrayRef
+OSKextCopyPersonalitiesArray(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+// xxx - would it be awful to have a function that takes a CFTypeRef that's
+// xxx - a single kext, an array of kexts, or NULL for all open kexts?
+
+/*!
+ * @function OSKextCopyPersonalitiesOfKexts
+ * @abstract
+ * Returns the personalities of multiple kexts for the current kext architecture.
+ *
+ * @param    kextArray  The kexts to retrieve personalities for.
+ *           Pass <code>NULL</code> to retrieve personalities for all open kexts.
+ * @result   An array of IOKit personality dictionaries.
+ *
+ * @discussion
+ * IOKitPersonalities in kexts require some processing before being sent
+ * to the kernel, and the functions that send personalities expect an array
+ * rather than a dictionary. This function facilitates such use.
+ */
+CF_EXPORT CFArrayRef
+OSKextCopyPersonalitiesOfKexts(CFArrayRef kextArray)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyExecutableForArchitecture
+ * @abstract
+ * Returns a kext's Mach-O executable, thinned to a single architecture
+ * if desired.
+ *
+ * @param    aKext   The kext to retrieve the executable from.
+ * @param    anArch  The architecture desired.
+ *                   Pass <code>NULL</code> to get the whole, unthinned exectuable.
+ * @result
+ * A <code>CFData</code> object containing the code
+ * for the specified architecture, or <code>NULL</code> if it can't be found.
+ *
+ * @discussion
+ * Note that this function does not use the default kext architecture set by
+ * @link OSKextSetArchitecture@/link when given no architecture.
+ */
+CF_EXPORT CFDataRef
+OSKextCopyExecutableForArchitecture(OSKextRef aKext,
+    const NXArchInfo * anArch)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyResource
+ * @abstract Returns a named resource from a kext's bundle.
+ *
+ * @param    aKext         The kext to get a resource from.
+ * @param    resourceName  The name of the requested resource.
+ * @param    resourceType  The abstract type of the requested resource.
+ *                         The type is expressed as a filename extension,
+ *                         such as <code>jpg</code>.
+ *                         Pass <code>NULL</code> if you don't need
+ *                         to search by type.
+ *
+ * @result
+ * A <code>CFData</code> object containing the resource file's contents,
+ * or <code>NULL</code> if the resource can't be found.
+ *
+ * @discussion
+ * For a kext created from an on-disk URL, this function uses CFBundle
+ * semantics to locate the resource file. Note that localized resources
+ * and resource subdirectories are not available to kexts calling
+ * @link //apple_ref/c/func/OSKextRequestResource OSKextRequestResource@/link
+ * from within the kernel (because the process providing them runs as root).
+ * You can store such resources in a kext bundle and use them in applications,
+ * but they will not be available to the kext loaded in kernel.
+ */
+CF_EXPORT CFDataRef
+OSKextCopyResource(
+                   OSKextRef   aKext,
+                   CFStringRef resourceName,
+                   CFStringRef resourceType)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsInExcludeList
+ * @abstract Return true if given kext is in the kext exclude list.
+ *
+ * @param    aKext         The kext to check against exclude list.
+ * @param    useCache      Tells us whether or not to use the cached exclude 
+ *                         list dictionary.
+ *
+ * @result
+ * <code>true</code> if <code>aKext</code> is in the kext exclude list,
+ * <code>false</code> otherwise.
+ *
+ * @discussion
+ * Checks to see if the given kext is in the kext exclude list (see:
+ * /System/Library/Extensions/AppleKextExcludeList.kext)
+ * If useCache is TRUE, we will use the cached copy of the exclude list.
+ * If useCache is FALSE, we will refresh the cache from disk.  The
+ * kext exclude list rarely changes but to insure you have the most
+ * recent copy in the cache you may pass FALSE for the first call and TRUE for
+ * subsequent calls (when dealing with a large list of kexts).
+ * aKext can be NULL with useCache set to FALSE if you wish the invalidate the
+ * cache without passing in a kext.
+ */
+#ifdef __MAC_10_9
+CF_EXPORT Boolean
+OSKextIsInExcludeList(
+                      OSKextRef aKext,
+                      Boolean   useCache)
+__OSX_AVAILABLE_STARTING(__MAC_10_9, __IPHONE_NA);
+#endif // __MAC_10_9
+
+#pragma mark Dependency Resolution
+/*********************************************************************
+* Dependency Resolution
+*********************************************************************/
+
+/*!
+ * @function OSKextResolveDependencies
+ * @abstract Calculate the dependency graph for a kext.
+ *
+ * @param    aKext   The kext to resolve dependencies for.
+ * @result
+ * <code>true</code> if all dependencies are successfully resolved,
+ * <code>false</code> otherwise.
+ *
+ * @discussion
+ * This function examines the OSBundleLibraries property of <code>aKext</code>
+ * and looks for compatible open kexts. Priority is given to kexts marked as
+ * loaded (see @link OSKextReadLoadedKextInfo@/link and
+ * @link OSKextFlushLoadInfo@/link). Otherwise the most recent
+ * compatible version is used; if multiple kexts with the same identifier and
+ * version exist, the last one created is used.
+ *
+ * Any problems resolving dependencies are stored in a diagnostics dictionary,
+ * which you can retrieve using @link OSKextCopyDiagnostics@/link.
+ *
+ * If a kext's dependencies have already been resolved, this function does
+ * no work and returns <code>true</code>.
+ * If you want to recalculate a kext's dependencies, call
+ * @link OSKextFlushDependencies@/link first.
+ */
+// xxx - check on same-version ordering with folks
+CF_EXPORT Boolean
+OSKextResolveDependencies(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextFlushDependencies
+ * @abstract Clears the dependency graph of a kext.
+ *
+ * @param    aKext   The kext to flush dependencies for.
+ *                   Pass <code>NULL</code> to flush dependencies for all kexts.
+ *
+ * @discussion
+ * OSKexts accumulate a fair amount of information as they are created
+ * and used; when many kext objects are created the total memory
+ * consumption can be significant. If an application won't be using
+ * kexts for long periods of time, it can flush this information
+ * to save memory; the information will later be re-read from disk
+ * or recreated as necessary.
+ *
+ * Flushing dependencies is also useful when readling loaded kext
+ * information from the kernel with @link OSKextReadLoadedKextInfo@/link
+ * (in fact, that function takes a flag to do it as part of its work).
+ * Dependency resolution gives priority to kexts marked as loaded,
+ * so it's wise to call flush dependencies before reading load info
+ * and before doing any operation that resolves dependencies.
+ * Conversely, if you want to resolve dependencies without consideration
+ * for which kexts are loaded, call @link OSKextFlushLoadInfo@/link
+ * beforehand (with or without the flag to flush dependencies).
+ *
+ * This function also clears any dependency resolution diagnostics.
+ * See also @link OSKextFlushInfoDictionary@/link,
+ * @link OSKextFlushLoadInfo@/link,
+ * and @link OSKextFlushDiagnostics@/link.
+ */
+CF_EXPORT void
+OSKextFlushDependencies(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyDeclaredDependencies
+ * @abstract Returns the kexts identified in a kext's OSBundleLibraries property.
+ *
+ * @param    aKext         The kext to get dependencies for.
+ * @param    needAllFlag   If <code>true</code>, the function returns
+ *                         <code>NULL</code> if any dependency isn't found.
+ * @result
+ * A <code>CFArray</code> containing the kexts found.
+ * If <code>needAllFlag</code> is <code>false</code>, the array may be missing
+ * some kexts. If <code>needAllFlag</code> is <code>true</code> and not all
+ * dependencies are found, this function returns <code>NULL</code>.
+ *
+ * @discussion
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+CF_EXPORT CFArrayRef
+OSKextCopyDeclaredDependencies(
+    OSKextRef aKext,
+    Boolean   needAllFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+    
+
+/*!
+ * @function OSKextCopyLinkDependencies
+ * @abstract Returns the kexts that a kext links directly against.
+ *
+ * @param    aKext         The kext to get dependencies for.
+ * @param    needAllFlag   If <code>true</code>, the function returns
+ *                         <code>NULL</code> if any dependency isn't found.
+ * @result
+ * A <code>CFArray</code> containing the kexts found.
+ * If <code>needAllFlag</code> is <code>false</code>, the array may be missing
+ * some kexts. If <code>needAllFlag</code> is <code>true</code> and not all
+ * dependencies are found, this function returns <code>NULL</code>.
+ *
+ * @discussion
+ * Link dependencies are how loaded kext relationships are tracked
+ * in the kernel (as shown by the <code>kextstat(8)</code> program).
+ * Some library kexts contain no executable, merely collecting sets of
+ * other libraries for convenience or compatiblity purposes.
+ * This function follows through such indirect libraries to find kexts
+ * with executables that <code>aKext</code> will actually link against.
+ *
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+ // xxx - need to insert a manpage link on kextstat
+CF_EXPORT CFArrayRef
+OSKextCopyLinkDependencies(
+    OSKextRef aKext,
+    Boolean   needAllFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyLoadList
+ * @abstract
+ * Returns the entire list of kexts in the load graph of a kext
+ * (including that kext).
+ *
+ * @param    aKext         The kext to get the load list for.
+ * @param    needAllFlag   If <code>true</code>, the function returns
+ *                         <code>NULL</code> if any dependency isn't found.
+ * @result
+ * A <code>CFArray</code> containing the kexts found.
+ * If <code>needAllFlag</code> is <code>false</code>, the array may be missing
+ * some kexts. If <code>needAllFlag</code> is <code>true</code> and not all
+ * dependencies are found, this function returns <code>NULL</code>.
+ *
+ * @discussion
+ * The fully-resolved load list represents all the kexts needed to load
+ * <code>aKext</code> into the kernel, in an order guaranteed to work for
+ * sequential starting and matching with IOKit personalities.
+ *
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+CF_EXPORT CFMutableArrayRef
+OSKextCopyLoadList(
+    OSKextRef aKext,
+    Boolean   needAllFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyLoadListForKexts
+ * @abstract
+ * Returns the entire list of kexts in load order of the merged load graph 
+ * of the provided list of kexts (including those kexts).
+ *
+ * @param       kexts       The kexts to get the load list for.
+ * @param       needAllFlag If <code>true</code>, the function returns 
+ *                          <code>NULL</code> if any dependency isn't found.
+ *
+ * @result
+ * A <code>CFArray</code> containing the kexts found.
+ * If <code>needAllFlag</code> is <code>false</code>, the array may be missing
+ * some kexts. If <code>needAllFlag</code> is <code>true</code> and not all
+ * dependencies are found, this function returns <code>NULL</code>.
+ *
+ * @discussion
+ * The fully-resolved load list represents all of the kexts needed to load
+ * every kext in <code>kexts</code> into the kernel, in an order guaranteed to
+ * work for sequential starting and matching with IOKit personalities.
+ * 
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+CF_EXPORT CFMutableArrayRef 
+OSKextCopyLoadListForKexts(
+    CFArrayRef  kexts, 
+    Boolean     needAllFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+
+/*!
+ * @function OSKextCopyAllDependencies
+ * @abstract
+ * Returns all kexts that a given kexts depends on, directly or indirectly.
+ *
+ * @param    aKext         The kext to get dependencies for.
+ * @param    needAllFlag   If <code>true</code>, the function returns
+ *                         <code>NULL</code> if any dependency isn't found.
+ * @result
+ * A <code>CFArray</code> containing the kexts found.
+ * If <code>needAllFlag</code> is <code>false</code>, the array may be missing
+ * some kexts. If <code>needAllFlag</code> is <code>true</code> and not all
+ * dependencies are found, this function returns <code>NULL</code>.
+ *
+ * @discussion
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+CF_EXPORT CFMutableArrayRef
+OSKextCopyAllDependencies(
+    OSKextRef aKext,
+    Boolean   needAllFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyIndirectDependencies
+ * @abstract
+ * Returns all kexts that a given kexts depends on indirectly.
+ *
+ * @param    aKext         The kext to get dependencies for.
+ * @param    needAllFlag   If <code>true</code>, the function returns
+ *                         <code>NULL</code> if any dependency isn't found.
+ * @result
+ * A <code>CFArray</code> containing the kexts found.
+ * If <code>needAllFlag</code> is <code>false</code>, the array may be missing
+ * some kexts. If <code>needAllFlag</code> is <code>true</code> and not all
+ * dependencies are found, this function returns <code>NULL</code>.
+ *
+ * @discussion
+ * Note that the list of indirect dependencies includes all kexts declared
+ * as dependencies by the direct dependencies of <code>aKext</code> -
+ * it may therefore include a direct dependency as well if some other
+ * kext in the load graph declares it.
+ *
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+// xxx - This one isn't really useful, is it?
+CFMutableArrayRef OSKextCopyIndirectDependencies(
+    OSKextRef aKext,
+    Boolean   needAllFlag)
+__OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextDependsOnKext
+ * @abstract
+ * Returns whether a kext depends on a given library kext,
+ * directly or indirectly.
+ * 
+ * @param    aKext         The kext to examine.
+ * @param    libraryKext   The possible library kext.
+ * @param    directFlag
+ *           If <code>true</code>, only checks for a direct declared dependency;
+ *           if <code>false</code> check for direct or indirect dependencies.
+ * @result
+ * <code>true</code> if <code>aKext</code> depends on <code>libraryKext</code>,
+ * either directly or indirectly per <code>directFlag</code>.
+ * Returns <code>false</code> otherwise.
+ *
+ * @discussion
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ *
+ * This function works with actual dependency resolution, not potential.
+ * If there are multiple kexts with the same bundle identifier,
+ * <code>aKext</code> may not be the one chosen during resolution
+ * and so it might appear that no kexts depend on it, even though they could.
+ */
+CF_EXPORT Boolean
+OSKextDependsOnKext(
+    OSKextRef aKext,
+    OSKextRef libraryKext,
+    Boolean   directFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyDependents
+ * @abstract
+ * Return all kexts that depend on a given kext, directly or indirectly.
+ *
+ * @param    aKext         The kext to get dependents for.
+ * @param    directFlag
+ *           <code>true</code> to get only kexts that declare a direct
+ *           dependency on <code>aKext</code>,
+ *           <code>false</code> to get all dependents, direct or indirect.
+ * @result
+ * An array of all kexts that ultimately depend on <code>aKext</code>,
+ * directly or indirectly according to <code>directFlag</code>.
+ *
+ * @discussion
+ * This function calls @link OSKextResolveDependencies@/link on all open
+ * kexts to find dependencies. This can be somewhat expensive.
+ *
+ * This function works with actual dependency resolution, not potential.
+ * If there are multiple kexts with the same bundle identifier,
+ * <code>aKext</code> may not be the one chosen during resolution
+ * and so it might appear that no kexts depend on it, even though they could.
+ */
+CF_EXPORT CFMutableArrayRef
+OSKextCopyDependents(OSKextRef aKext,
+    Boolean directFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsCompatibleWithVersion
+ * @abstract Returns whether a library kext is compatible with a given version.
+ *
+ * @param    aKext      The kext to examine.
+ * @param    aVersion   The kext version to check compatibility with
+ *
+ * @result
+ * <code>truer</code> if <code>aKext</code> has a compatible version and
+ * if <code>aVersion</code> is between the version and compatible version of
+ * <code>aKext</code> (inclusive), <code>false</code> otherwise.
+ *
+ * @discussion
+ */
+CF_EXPORT Boolean
+OSKextIsCompatibleWithVersion(
+    OSKextRef    aKext,
+    OSKextVersion aVersion)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextLogDependencyGraph
+ * @abstract Prints the resolved dependency graph of a kext.
+ *
+ * @param    aKext         The kext to log the dependency graph of.
+ * @param    bundleIDFlag  <code>true</code> to log kexts by bundle ID,
+ *                         <code>false</code> to log them by URL. 
+ * @param    linkFlag      <code>true</code> to log the link graph only,
+ *                         <code>false</code> to log the full dependency graph.
+ *
+ * @discussion
+ * <code>linkFlag</code> allows you to display the dependencies as they will
+ * be recorded in the kernel when the kext is loaded.
+ * If it is <code>true</code>, then only kexts with executables are included
+ * in the logged dependency graph. If it is <code>false</code>, all kexts
+ * needed to load </code>aKext</code> are included.
+ *
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+CF_EXPORT void
+OSKextLogDependencyGraph(OSKextRef aKext,
+    Boolean bundleIDFlag,
+    Boolean linkFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextFindLinkDependencies
+ * @abstract Finds kexts that define symbols a kext needs resolved.
+ *
+ * @param    aKext              The kext to examine.
+ * @param    nonKPIFlag
+ *           <code>false</code> to look in com.apple.kpi.* kernel component
+ *           for kernel symbols;
+ *           <code>true</code> to look in com.apple.kernel.* kernel components
+ *           instead (not recommended for later versions of Mac OS X).
+ * @param    allowUnsupportedFlag
+ *           <code>false</code> to skip unsupported libraries in the search;
+ *           <code>true</code> to include them.
+ * @param    onedefSymbolsOut
+ *           A dictionary containing symbols that were found once;
+ *           keys are the symbols, values are the kexts defining the key symbol.
+ *           Ownership follows the Create Rule. 
+ *           Pass <code>NULL</code> to not retrieve.
+ * @param    undefinedSymbolsOut
+ *           A dictionary containing symbols that weren't found;
+ *           keys are the symbols, values are undefined.
+ *           Ownership follows the Create Rule. 
+ *           Pass <code>NULL</code> to not retrieve.
+ * @param    multiplyDefinedSymbolsOut
+ *           A dictionary containing symbols found in multiple library kexts;
+ *           keys are the symbols, values are the kexts defining the key symbol.
+ *           Ownership follows the Create Rule. 
+ *           Pass <code>NULL</code> to not retrieve.
+ * @param    multipleDefinitionLibraries
+ *           A array of all library kexts in which multiply defined symbols
+ *           were found; sorted by CFBundleIdentifier.
+
+ *           Ownership follows the Create Rule. 
+ *           Pass <code>NULL</code> to not retrieve.
+ * @result
+ * An array of kexts that export symbols referenced by <code>aKext</code>,
+ * sorted by CFBundleIdentifier.
+ *
+ * @discussion
+ * This function searches in all open kexts for symbols referenced by
+ * <code>aKext</code>, ignoring the OSBundleLibraries property.
+ * You can use this function to find out what you should list
+ * in a kext's OSBundleLibraries property.
+ *
+ * If <code>undefinedSymbolsOut</code> has a nonzero count,
+ * the symbols named by its keys could not be found in any open kext.
+ *
+ * If <code>multiplyDefinedSymbolsOut</code> has a nonzero count,
+ * some of the result kexts define the same symbol,
+ * and if those duplicates are listed
+ * in OSBundleLibraries a link failure will occur.
+ * You can inspect the contents of <code>multiplyDefinedSymbolsOut</code>
+ * and <code>multipleDefinitionLibraries</code>
+ * by hand to sort out which libraries you should actually declare.
+ *
+ * This function is fairly expensive, as it has to search through all open
+ * kexts' information dictionaries, and all library kexts' executables.
+ */
+CFArrayRef OSKextFindLinkDependencies(
+    OSKextRef         aKext,
+    Boolean           nonKPIFlag,
+    Boolean           allowUnsupportedFlag,
+    CFDictionaryRef * undefinedSymbolsOut,
+    CFDictionaryRef * onedefSymbolsOut,
+    CFDictionaryRef * multiplyDefinedSymbolsOut,
+    CFArrayRef      * multipleDefinitionLibrariesOut)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+#pragma mark Linking and Loading; Other Kernel Operations
+/*********************************************************************
+* Linking and Loading; Other Kernel Operations
+*********************************************************************/
+
+/*!
+ * @function OSKextLoad
+ * @abstract Loads a kext and its dependencies into the kernel.
+ *
+ * @param    aKext   The kext to load.
+ * @result
+ * kOSReturnSuccess if <code>aKext</code> is successfully loaded
+ * into the kernel, or was already loaded, or an error result if not.
+ *
+ * @discussion
+ * The calling process must have an effective user ID of 0 (root)
+ * to load kexts into the kernel.
+ *
+ * A kext and all its dependencies must pass all validation and authentication
+ * tests to be loadable. See @link OSKextIsLoadable@/link for more information.
+ *
+ * All kexts loaded into the kernel are started, but IOKit personalities
+ * are not sent to the IOCatalogue.
+ * See @link OSKextSendPersonalitiesToKernel@/link.
+ *
+ * This function calls @link OSKextFlushLoadInfo@/link and clears dependencies
+ * for all open kexts. It then calls @link OSKextCopyLoadList@/link
+ * to find dependencies and @link OSKextReadLoadedKextInfo@/link on the
+ * resulting load list.
+ */
+// xxx - need to list errors that may be returned
+CF_EXPORT OSReturn
+OSKextLoad(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextLoadWithOptions
+ * @abstract Loads a kext and its dependencies into the kernel.
+ *
+ * @param    aKext                       The kext to load.
+ * @param    startExclusion
+ *           <code>kOSKextExcludeAll</code> to omit starting <code>aKext</code>
+ *           and any of its dependencies not already started,
+ *           <code>kOSKextExcludeKext</code> to start the dependencies of
+ *           <code>aKext</code> but not <code>aKext</code> itself,
+ *           or <code>kOSKextExcludeNone</code> to start all loaded kexts.
+ * @param    addPersonalitiesExclusion
+ *           <code>kOSKextExcludeAll</code> to omit sending
+ *           IOKitPersonalities to the IOCatalogue for <code>aKext</code>
+ *           and any of its dependencies
+ *           (though they may already be in the IOCatalogue),
+ *           <code>kOSKextExcludeKext</code> to send personalities for the
+ *           dependencies of <code>aKext</code> but not <code>aKext</code> itself,
+ *           or <code>kOSKextExcludeNone</code> to send all personalities.
+ * @param    personalityNames
+ *           The names of IOKitPersonalities in <code>aKext</code> to send,
+ *           <code>addPersonalitiesExclusion</code> allowing.
+ *           If <code>NULL</code> all personalities are sent.
+ *           This parameter only affects <code>aKext</code>; if dependency
+ *           personalities are sent, they are all sent.
+ * @param   delayAutounloadFlag
+ *           <code>true</code> to cause the kernel's automatic kext unloader
+ *           to skip <code>aKext</code> for one cycle, giving extra time
+ *           to set up a debug session. <code>false</code> for normal behavior.
+ *
+ * @result
+ * Returns <code>kOSReturnSuccess</code> on success, other values on failure.
+ *
+ * @discussion
+ * This function allows a kext to be loaded but not started or matched
+ * (for IOKit kexts), which is useful in some debug scenarios.
+ * After calling this function, you may need to call @link OSKextStart@/link
+ * to start <code>aKext</code> (along with its dependencies).
+ * You may also need to call @link OSKextSendPersonalitiesToKernel@/link
+ * for any kexts excluded from matching via
+ * <code>addPersonalitiesExclusion</code>.
+ * 
+ * The calling process must have an effective user ID of 0 (root)
+ * to load kexts into the kernel.
+ *
+ * A kext and all its dependencies must pass all validation and authentication
+ * tests to be loadable. See @link OSKextIsLoadable@/link for more information.
+ *
+ * This function calls @link OSKextFlushLoadInfo@/link and clears dependencies
+ * for all open kexts. It then calls @link OSKextCopyLoadList@/link
+ * to find dependencies and @link OSKextReadLoadedKextInfo@/link on the
+ * resulting load list.
+ */
+// xxx - need to list errors that may be returned
+CF_EXPORT OSReturn
+OSKextLoadWithOptions(
+    OSKextRef           aKext,
+    OSKextExcludeLevel  startExclusion,
+    OSKextExcludeLevel  addPersonalitiesExclusion,
+    CFArrayRef          personalityNames,
+    Boolean             delayAutounloadFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+  
+/*!
+ * @function OSKextGenerateDebugSymbols
+ * @abstract Generate debug symbols for a kext and its dependencies.
+ *
+ * @param aKext
+ *        The kext to generate debug symbols for.
+ * @param kernelImage
+ *        The kernel Mach-O or symbol file to use for linking.
+ *        If <code>NULL</code>, the running kernel is used.
+ *
+ * @result
+ * A dictionary whose keys are the bundle IDs of the kexts for which symbols
+ * have been generated with ".sym" appended, and whose values are CFData
+ * objects containing the symbol files. Returns <code>NULL</code> on error.
+ *
+ * @discussion
+ * The result includes only non-interface kexts that have an executable
+ * and a load address set.
+ * Load addresses are set by @link OSKextReadLoadedKextInfo@/link or by
+ * @link OSKextSetLoadAddress@/link.
+ *
+ * If using the running kernel for load addresses, the current architecture
+ * set with @link OSKextSetArchitecture@/link must match that of the running
+ * kernel or this function returns <code>NULL</code>.
+ *
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+CF_RETURNS_RETAINED
+CF_EXPORT CFDictionaryRef
+OSKextGenerateDebugSymbols(
+    OSKextRef aKext,
+    CFDataRef kernelImage)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_NA);
+
+/*!
+ * @function OSKextNeedsLoadAddressForDebugSymbols
+ * @abstract
+ * Returns whether a kext needs a load address set to generate debug symbols.
+ *
+ * @param    aKext    The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> needs a load address set
+ * in order to generate debug symbols with
+ * @link OSKextGenerateDebugSymbols@/link, <code>false</code> otherwise.
+ */
+CF_EXPORT Boolean
+OSKextNeedsLoadAddressForDebugSymbols(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_NA);
+
+/*!
+ * OSKextUnload
+ * @abstract Unloads a kext from the kernel if possible.
+ *
+ * @param    aKext   The kext to unload.
+ * @param    terminateServiceAndRemovePersonalities
+ * If <code>true</code>, and the kext to unload has no kexts loaded
+ * against it, all IOService objects defined by that kext will be
+ * asked to terminate so that the unload can proceed, and the personalities
+ * for the kext will be removed from the IOCatalogue.
+ *
+ * @result
+ * <code>kOSReturnSuccess</code> on success, an error code
+ * (typically <code>kOSKextReturnInUse</code>) on failure.
+ *
+ * @discussion
+ * The calling process must have an effective user ID of 0 (root)
+ * to unload kexts from the kernel.
+ * A kext cannot be unloaded if it has any loaed dependents.
+ *
+ * See also the @link IOCatalogueTerminate@/link function.
+ */
+// xxx - need to list errors that may be returned
+CF_EXPORT OSReturn
+OSKextUnload(OSKextRef aKext,
+    Boolean terminateServiceAndRemovePersonalities)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * OSKextUnload
+ * @abstract Unloads a kext from the kernel if possible, based on its
+ *           CFBundleIdentifier.
+ *
+ * @param    kextIdentifier   The CFBundleIDentifier of the kext to unload.
+ * @param    terminateServiceAndRemovePersonalities
+ * If <code>true</code>, and the kext to unload has no kexts loaded
+ * against it, all IOService objects defined by that kext will be
+ * asked to terminate so that the unload can proceed, and the personalities
+ * for the kext will be removed from the IOCatalogue.
+ *
+ * @result
+ * <code>kOSReturnSuccess</code> on success, an error code
+ * (typically <code>kOSKextReturnInUse</code>) on failure.
+ *
+ * @discussion
+ * The calling process must have an effective user ID of 0 (root)
+ * to unload kexts from the kernel.
+ * A kext cannot be unloaded if it has any loaed dependents.
+ *
+ * See also the @link IOCatalogueTerminate@/link function.
+ */
+// xxx - need to list errors that may be returned
+CF_EXPORT OSReturn
+OSKextUnloadKextWithIdentifier(CFStringRef kextIdentifier,
+    Boolean terminateServiceAndRemovePersonalities)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsStarted
+ * @abstract Returns whether a kext loaded in the kernel is started.
+ *
+ * @param    aKext   The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> is active and running in the kernel,
+ * <code>false</code> if not loaded or loaded and not started.
+ *
+ * @discussion
+ * This function returns the state recorded the last time
+ * @link OSKextReadLoadedKextInfo@/link was called.
+ */
+CF_EXPORT Boolean
+OSKextIsStarted(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextStart
+ * @abstract Starts a kext loaded in the kernel if possible.
+ *
+ * @param    aKext   The kext to start.
+ * @result
+ * <code>kOSReturnSuccess</code> on success, an error code on failure.
+ *
+ * @discussion
+ * This function allows an application to start a kext that is loaded
+ * in the kernel (typically via @link OSKextLoadWithOptions@/link),
+ * and any of its dependencies that aren't also started.
+ * If the kext is already started, this does nothing.
+ *
+ * To start a kext means to call its start function, which is distinct from
+ * the start method of an IOService object.
+ * 
+ * The calling process must have an effective user ID of 0 (root)
+ * to start kexts in the kernel.
+// xxx - need to list errors that may be returned
+ */
+CF_EXPORT OSReturn
+OSKextStart(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextStop
+ * @abstract Stops a kext loaded in the kernel if possible.
+ *
+ * @param    aKext   The kext to stop.
+ * @result
+ * <code>kOSReturnSuccess</code> on success, an error code on failure.
+ *
+ * @discussion
+ * This function allows an application to stop a kext that is loaded
+ * in the kernel without unloading it. This may be useful in certain
+ * debugging scenarios.
+ *
+ * A kext cannot be stopped via this function if it has any dependents
+ * that reference it, any client references within the kernel,
+ * or any instances of libkern/IOKit C++ classes.
+ *
+ * To stop a kext means to call its stop function, which is distinct from
+ * the stop method of an IOService object.
+ * 
+ * The calling process must have an effective user ID of 0 (root)
+ * to stop kexts in the kernel.
+ */
+// xxx - should it be allowed to stop a kext with dependents that are
+// xxx - themselves not started?
+// xxx - need to list errors that may be returned
+CF_EXPORT OSReturn
+OSKextStop(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextSendPersonalitiesToKernel
+ * @abstract Sends an array of IOKit personalities to the kernel.
+ *
+ * @param    personalities   The personalities to send.
+ * @param    resetFlag       <code>TRUE</code> if the IOCatalogue should be reset,
+ *                           <code>FALSE</code> not.
+ * @result
+ * <code>kOSReturnSuccess</code> on success, an error code on failure.
+ *
+ * @discussion
+ * This function sends an anonymous array of personalities to the
+ * I/O Kit's IOCatalogue object in the kernel,
+ * resetting the IOCatalogue if <code>resetFlag</code> is <code>TRUE</code>.
+ * Resetting causes the IOCatalogue to contain only the kernel's built-in
+ * personalities and those sent using this function.
+ * (See also <code>@link IOCatalogueReset@/link</code>.)
+ *
+ * You can get personalities from kexts using
+ * <code>@link OSKextCopyPersonalitiesArray@/link</code> or
+ * <code>@link OSKextCopyPersonalitiesOfKexts@/link</code>.
+ * 
+ * The calling process must have an effective user ID of 0 (root)
+ * to send personalities to the kernel.
+ */
+// xxx - need to list errors that may be returned
+CF_EXPORT OSReturn
+OSKextSendPersonalitiesToKernel(CFArrayRef personalities, Boolean resetFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextSendKextPersonalitiesToKernel
+ * @abstract
+ * Sends the personalities of a single kext to the kernel, optionally
+ * filtered by name.
+ *
+ * @param    aKext              The kext whose personalities to send.
+ * @param    personalityNames
+ *           An array of names. Only personalities from <code>aKext</code>
+ *           with these names are sent to the kernel.
+ * @result
+ * <code>kOSReturnSuccess</code> on success, an error code on failure.
+ *
+ * @discussion
+ * If any names in <code>personalityNames</code> are not found,
+ * they are simply skipped rather than causing an error.
+ *
+ * This function may be useful in certain debugging scenarios,
+ * where a particular personality is causing problems.
+ * 
+ * The calling process must have an effective user ID of 0 (root)
+ * to send personalities to the kernel.
+ */
+// xxx - should names not found cause an error?
+// xxx - need to list errors that may be returned
+CF_EXPORT OSReturn
+OSKextSendKextPersonalitiesToKernel(
+    OSKextRef  aKext,
+    CFArrayRef personalityNames)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextSendPersonalitiesOfKextsToKernel
+ * Sends the personalities of multiple kexts to the kernel in a single
+ * operation.
+ *
+ * @param    kextArray     The kexts whose personalities to send.
+ * @param    resetFlag       <code>TRUE</code> if the IOCatalogue should be reset,
+ *                           <code>FALSE</code> not.
+ * @result
+ * <code>kOSReturnSuccess</code> on success, an error code on failure.
+ *
+ * @discussion
+ * This function performs one data transfer to the kernel, collecting
+ * all the personalities of the kexts in <code>kextArray</code>,
+ * and resetting the IOCatalogue if <code>resetFlag</code> is <code>TRUE</code>.
+ * Resetting causes the IOCatalogue to contain only the kernel's built-in
+ * personalities and those sent using this function.
+ * (See also <code>@link IOCatalogueReset@/link</code>.)
+ * 
+ * The calling process must have an effective user ID of 0 (root)
+ * to send personalities to the kernel.
+ */
+// xxx - need to list errors that may be returned
+CF_EXPORT OSReturn
+OSKextSendPersonalitiesOfKextsToKernel(CFArrayRef kextArray, Boolean resetFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextRemoveKextPersonalitiesFromKernel
+ * Removes all personalities for a kext's bundle identifier from the kernel.
+ *
+ * @param    aKext     The kext whose personalities to remove.
+ * @result
+ * <code>kOSReturnSuccess</code> on success, an error code on failure.
+ *
+ * @discussion
+ * This function removes from the kernel's IOCatalogue all personalities
+ * whose CFBundleIdentifiers match that of <code>aKext</code> so that no
+ * further load requests for <code>aKext</code> will be made. This is
+ * typically done when it is discovered that <code>aKext</code> cannot
+ * be loaded from user space (if it fails to load in the kernel, matching
+ * personalities are automatically removed).
+ *
+ * Note that kexts other than <code>aKext</code> might have published
+ * personalities in the IOCatalogue under <code>aKext</code>'s identifier.
+ * Such personalities will also be removed, since they trigger load requests
+ * for a kext that cannot be loaded. The OSKext library adds an
+ * IOPersonalityPublisher property to such personalities, that gives the
+ * bundle identifier of the originating kext.
+ *
+ * This function differs from
+ * @link OSKextRemovePersonalitiesForIdentifierFromKernel@/link
+ * by having a kext object to check for logging or other purposes.
+ * 
+ * The calling process must have an effective user ID of 0 (root)
+ * to remove personalities from the kernel.
+ */
+// xxx - need to list errors that may be returned
+// xxx - this is a not-so-thin shim over IOCatalogueSendData (kIOCatalogueRemoveDrivers)
+// xxx - might we just want the function to take a bundle ID?
+// xxx - does IOCatalogueSendData really require root access?
+CF_EXPORT OSReturn
+OSKextRemoveKextPersonalitiesFromKernel(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextRemovePersonalitiesForIdentifierFromKernel
+ * Removes all personalities for a given bundle identifier from the kernel.
+ *
+ * @param    aBundleID     The bundle identifier for which to remove personalities.
+ * @result
+ * <code>kOSReturnSuccess</code> on success, an error code on failure.
+ *
+ * @discussion
+ * This function removes from the kernel's IOCatalogue all personalities
+ * whose CFBundleIdentifiers are <code>aBundleID</code> so that no
+ * further load requests for the kext with that identifier will be made.
+ * This is typically done when it is discovered no kext can be found for
+ * <code>aBundleID</code>.
+ *
+ * This function differs from
+ * @link OSKextRemoveKextPersonalitiesFromKernel@/link
+ * by not having a kext object to check for logging or other purposes.
+ * 
+ * The calling process must have an effective user ID of 0 (root)
+ * to remove personalities from the kernel.
+ */
+// xxx - need to list errors that may be returned
+// xxx - this is a not-so-thin shim over IOCatalogueSendData (kIOCatalogueRemoveDrivers)
+// xxx - I want 2 separate functions for logging; a kext can have flags in it
+// xxx - does IOCatalogueSendData really require root access?
+CF_EXPORT OSReturn
+OSKextRemovePersonalitiesForIdentifierFromKernel(CFStringRef aBundleID)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCreateLoadedKextInfo
+ * @abstract Returns information about loaded kexts in a dictionary.
+ *
+ * @param    kextIdentifiers   An array of kext identifiers to read from the kernel.
+ *                             Pass <code>NULL</code> to read info for all loaded kexts.
+ * @result
+ * An array of dictionaries containing information about loaded kexts.
+ *
+ * @discussion
+ * This function is deprecated in Mac OS X 10.7.
+ * Use @link OSKextCopyLoadedKextInfo/@link instead.
+ *
+ * This function gets information from the kernel without affecting any
+ * kext objects. If you want to update open kext objects to reflect
+ * whether they are loaded in the kernel, use @link OSKextReadLoadedKextInfo@/link.
+ *
+ * See <code>@link OSKextCopyLoadedKextInfo@/link</code> for the list of properties
+ * returned.
+ */
+// xxx - need to document the keys from OSKextLib.h.
+CF_EXPORT CFArrayRef
+OSKextCreateLoadedKextInfo(
+    CFArrayRef kextIdentifiers)
+                __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_6, __MAC_10_7, __IPHONE_3_2, __IPHONE_4_3);
+
+/*!
+ * @function OSKextCopyLoadedKextInfo
+ * @abstract Returns information about loaded kexts in a dictionary.
+ *
+ * @param    kextIdentifiers   An array of kext identifiers to read from the kernel.
+ *                             Pass <code>NULL</code> to read info for all loaded kexts.
+ * @param    infoKeys          An array of info keys to read from the kernel.
+ *                             Pass <code>NULL</code> to read all information.
+ * @result
+ * A dictionary, keyed by bundle identifier, of dictionaries containing information about loaded kexts.
+ *
+ * @discussion
+ * This function gets information from the kernel without affecting any
+ * kext objects in process memory.
+ * If you want to update open kext objects to reflect
+ * whether they are loaded in the kernel,
+ * use @link OSKextReadLoadedKextInfo@/link.
+ *
+ * The properties returned by this function are listed below.
+ * Some are taken directly from the kext's information property list,
+ * and some are generated at run time.
+ * Never assume a given key will be present for a kext.
+ *
+ * <ul>
+ *   <li><code>CFBundleIdentifier</code> - CFString</li>
+ *   <li><code>CFBundleVersion</code> - CFString (note: version strings may be canonicalized
+ *       but their numeric values will be the same; "1.2.0" may become "1.2", for example)</li>
+ *   <li><code>OSBundleCompatibleVersion</code> - CFString</li>
+ *   <li><code>OSBundleIsInterface</code> - CFBoolean</li>
+ *   <li><code>OSKernelResource</code> - CFBoolean</li>
+ *   <li><code>OSBundleCPUType</code> - CFNumber</li>
+ *   <li><code>OSBundleCPUSubtype</code> - CFNumber</li>
+ *   <li><code>OSBundleMachOHeaders</code> - CFData (this property is not available via the
+ *       public @link KextManagerCopyLoadedKextInfo/@link function)</li>
+ *   <li><code>OSBundlePath</code> - CFString (this is merely a hint stored in the kernel;
+ *       the kext is not guaranteed to be at this path)</li>
+ *   <li><code>OSBundleExecutablePath</code> - CFString
+ *       (the absolute path to the executable within the kext bundle; a hint as above)</li>
+ *   <li><code>OSBundleUUID</code> - CFData (the UUID of the kext executable, if it has one)</li>
+ *   <li><code>OSBundleStarted</code> - CFBoolean (true if the kext is running)</li>
+ *   <li><code>OSBundlePrelinked</code> - CFBoolean (true if the kext is loaded from a prelinked kernel)</li>
+ *   <li><code>OSBundleLoadTag</code> - CFNumber (the "Index" given by kextstat)</li>
+ *   <li><code>OSBundleLoadAddress</code> - CFNumber</li>
+ *   <li><code>OSBundleLoadSize</code> - CFNumber</li>
+ *   <li><code>OSBundleWiredSize</code> - CFNumber</li>
+ *   <li><code>OSBundleDependencies</code> - CFArray of load tags identifying immediate link dependencies</li>
+ *   <li><code>OSBundleRetainCount</code> - CFNumber (the OSObject retain count of the kext itself)</li>
+ *   <li><code>OSBundleClasses</code> - CFArray of CFDictionary containing info on C++ classes
+ *       defined by the kext:</li>
+ *       <ul>
+ *         <li><code>OSMetaClassName</code> - CFString</li>
+ *         <li><code>OSMetaClassSuperclassName</code> - CFString, absent for root classes</li>
+ *         <li><code>OSMetaClassTrackingCount</code> - CFNumber giving the instance count
+ *             of the class itself, <i>plus</i> 1 for each direct subclass with any instances</li>
+ *       </ul>
+ * </ul>
+ */
+CF_EXPORT CFDictionaryRef
+OSKextCopyLoadedKextInfo(
+    CFArrayRef kextIdentifiers,
+    CFArrayRef infoKeys)
+                __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_4_3);
+
+/*!
+ * @function OSKextReadLoadedKextInfo
+ * @abstract Updates kext objects with load info from the kernel.
+ *
+ * @param kextIdentifiers   An array of kext identifiers to read
+ *                          from the kernel;
+ *                          all matching kexts have their load info updated.
+ *                          Pass <code>NULL</code> to update load info for all kexts.
+ * @param flushDependenciesFlag
+ *        <code>true</code> to clear dependency information from kexts,
+ *        <code>false</code> to leave it in place.
+ *
+ * @result
+ * <code>kOSReturnSuccess</code> if all information is successfully updated,
+ * an error code otherwise. Specifically, if the current architecture set
+ * by @link OSKextSetArchitecture@/link is not that of the running kernel,
+ * this function returns <code>kOSKextReturnExecutableArchNotFound</code>.
+ *
+ * @discussion
+ * The load status of kexts primarily affects dependency resolution in the
+ * kext library, in that kexts marked as loaded are given priority over
+ * all other kexts of the same identifier.
+ * See @link OSKextResolveDependencies@/link for more.
+ *
+ * This function calls @link OSKextFlushLoadInfo@/link on the kexts,
+ * which clears any previous load info for them
+ * (or for all kexts if <code>kextIdentifiers</code> is <code>NULL</code>).
+ * If <code>flushDependenciesFlag</code> is <code>true</code>,
+ * resolved dependencies (which may not match the loaded kexts
+ * in the kernel) are also flushed.
+ * Load addresses are then set from the kernel,
+ * but dependencies are resolved as needed.
+ *
+ * If <code>flushDependenciesFlag</code> is <code>false</code>,
+ * existing dependency graphs are maintained, allowing you to
+ * check whether the dependencies, as resolved before reading
+ * load information, reflect loaded kexts (by getting the load list
+ * via @link OSKextCopyLoadList@/link and checking the kexts in it
+ * with @link OSKextIsLoaded@/link).
+ */
+// xxx - need to list errors that may be returned
+CF_EXPORT OSReturn
+OSKextReadLoadedKextInfo(
+    CFArrayRef kexts,
+    Boolean    flushDependenciesFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsLoaded
+ * @abstract Returns whether a kext is loaded in the kernel.
+ *
+ * @param    aKext   The kext to examine.
+ * @result
+ * <code>true</code> if a kext with the same identifier, version, and UUID
+ * as <code>aKext</code> is loaded in the kernel, <code>false</code> otherwise.
+ *
+ * @discussion
+ * You must call @link OSKextReadLoadedKextInfo@/link for this flag to be meaningful,
+ * which in turn requires the current library architecture to match that
+ * of the running kernel.
+ * Use @link OSKextOtherVersionIsLoaded@/link to check whether
+ * a different version of <code>aKext</code> is loaded.
+ */
+CF_EXPORT Boolean
+OSKextIsLoaded(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetLoadAddress
+ * @abstract Returns the actual or simulated kernel load address of a kext.
+ *
+ * @param    aKext   The kext to examine.
+ * @result
+ * The load address of <code>aKext</code>, whether read from the kernel using
+ * @link OSKextReadLoadedKextInfo@/link or set for symbol generation using
+ * @link OSKextSetLoadAddress@/link.
+ *
+ * @discussion
+ * Load addresses are accessed as 64-bit numbers even for 32-bit architectures;
+ * cast or truncate the value as necessary.
+ *
+ * You must call @link OSKextReadLoadedKextInfo@/link or
+ * @link OSKextSetLoadAddress@/link for the load address to be nonzero.
+ */
+CF_EXPORT uint64_t
+OSKextGetLoadAddress(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextSetLoadAddress
+ * @abstract
+ * Sets the simulated kernel load address of a kext for symbol generation.
+ *
+ * @param    aKext   The kext to set a load address for.
+ * @result
+ * <code>true</code> if the address was set, <code>false</code> if not
+ * (because it's too large for the current architecture).
+ *
+ * @discussion
+ * Load addresses are accessed as 64-bit numbers even for 32-bit architectures.
+ * If you attempt to set a load address that is too large for a 32-bit link,
+ * this function returns <code>false</code>.
+ * See @link OSKextSetArchitecture@/link.
+ *
+ * Setting a load address manually is useful for generating debug symbols
+ * with @link OSKextGenerateDebugSymbols@/link.
+ */
+CF_EXPORT Boolean
+OSKextSetLoadAddress(OSKextRef aKext, uint64_t anAddress)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextOtherVersionIsLoaded
+ * @abstract
+ * Returns whether another version of a given kext is loaded in the kernel.
+ *
+ * @param    aKext   The kext to examine.
+ * @result
+ * <code>true</code> if a kext with the same identifier,
+ * but a different version or UUID
+ * from <code>aKext</code>, is loaded in the kernel.
+ * Returns <code>false</code> if <code>aKext</code> is loaded or if
+ * no kext with the same identifier is loaded.
+ *
+ * @discussion
+ * You must call @link OSKextReadLoadedKextInfo@/link for this flag to be meaningful,
+ * which in turn requires the current library architecture to match that
+ * of the running kernel.
+ * Use @link OSKextIsLoaded@/link to check whether <code>aKext</code>
+ * itself is loaded.
+ */
+CF_EXPORT Boolean
+OSKextOtherVersionIsLoaded(OSKextRef aKext, Boolean * uuidFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextGetLoadTag
+ * @abstract
+ * Returns the load tag of a kext if it's loaded in the kernel.
+ *
+ * @param    aKext   The kext to examine.
+ * @result
+ * The load tag (also known as the index or kmod id) of <code>aKext</code>,
+ * if it's loaded in the kernel (use @link OSKextIsLoaded@/link to check that).
+ * Returns 0 if <code>aKext</code> is not loaded or if it can't be determined
+ * whether it is loaded.
+ *
+ * @discussion
+ * You must call @link OSKextReadLoadedKextInfo@/link for the load tag
+ * to be meaningful, which in turn requires the current library architecture
+ * to match that of the running kernel.
+ * Use @link OSKextIsLoaded@/link to check whether <code>aKext</code>
+ * is loaded.
+ */
+CF_EXPORT uint32_t
+OSKextGetLoadTag(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextFlushLoadInfo
+ * @abstract Clears all load and dependency information from a kext.
+ *
+ * @param aKext
+ *        The kext to clear. If <code>NULL</code>, all open
+ *        kexts have their load info flushed.
+ * @param flushDependenciesFlag
+ *        <code>true</code> to clear dependency information from kexts,
+ *        <code>false</code> to leave it in place.
+ *
+ * @discussion
+ * Flushing load information releases the internal load information
+ * structs of a kext, including load flags, the bundle executable,
+ * link/load diagnostics, and if <code>flushDependenciesFlag</code> is true,
+ * the dependencies.
+ *
+ * OSKexts accumulate a fair amount of information as they are created
+ * and used; when many kext objects are created the total memory
+ * consumption can be significant. If an application won't be using
+ * kexts for long periods of time, it can flush this information
+ * to save memory; the information will later be re-read from disk
+ * or recreated as necessary.
+ *
+ * Flushing load info is also useful after readling loaded kext
+ * information from the kernel with @link OSKextReadLoadedKextInfo@/link
+ * or after working with executables. Executables in particular
+ * consume a lot of application memory, often unnecessarily, since
+ * the code is loaded and running in the kernel.
+ *
+ * See also @link OSKextFlushInfoDictionaries@/link,
+ * @link OSKextFlushDependencies@/link,
+ * and @link OSKextFlushDiagnostics@/link.
+ */
+CF_EXPORT void
+OSKextFlushLoadInfo(
+    OSKextRef aKext,
+    Boolean flushDependenciesFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyAllRequestedIdentifiers
+ * @abstract
+ * Copies the list of all unique bundle identifiers of kext load requests
+ * that the kernel has received since power-on.
+ *
+ * @result
+ * A CFArray object, or <code>NULL</code> if the copy failed.
+ * Ownership follows the 
+ * @link //apple_ref/doc/uid/20001148-103029 Create Rule@/link.
+ *
+ */
+CF_EXPORT CFArrayRef 
+OSKextCopyAllRequestedIdentifiers(void)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+#pragma mark Sanity Checking and Diagnostics
+/*********************************************************************
+* Sanity Checking and Diagnostics
+*********************************************************************/
+
+/*!
+ * @function OSKextParseVersionCFString
+ * @abstract
+ * Parses a kext version from a CFString.
+ *
+ * @param    versionString  The kext version string to parse.
+ * @result
+ * The numeric rendering of <code>versionString</code>, which can
+ * compared arithmetically with other valid version numbers.
+ * Returns -1 if the version couldn't be parsed.
+ */
+CF_EXPORT OSKextVersion
+OSKextParseVersionCFString(CFStringRef versionString)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextValidate
+ * @abstract
+ * Sanity checks a kext's info dictionary and executable for the currently
+ * set architecture.
+ *
+ * @param    aKext  The kext to validate.
+ * @result
+ * <code>true</code> if <code>aKext</code> passes all validation tests,
+ * <code>false</code> otherwise.
+ *
+ * @discussion
+ * This function forces full validation of a kext, collecting all
+ * errors found in the validation diagnostics if recording is turned on
+ * (with @link OSKextSetRecordsDiagnostics@/link). You can get the diagnostics
+ * using @link OSKextCopyDiagnostics@/link.
+ *
+ * If safe boot is currently simulated (see
+ * @link OSKextSetSimulatedSafeBoot@/link),
+ * any kext not loadable during safe boot will fail validation.
+ */
+// compare with CFBundlePreflightExecutable()
+CF_EXPORT Boolean
+OSKextValidate(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsValid
+ * @abstract
+ * Returns whether a kext is valid or not.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> passes all validation tests,
+ * <code>false</code> otherwise.
+ *
+ * @discussion
+ * This function avoids doing full validation if any problems have been
+ * discovered with the kext during other operations. To perform a full
+ * validation of all possible problems, use @link OSKextValidate@/link.
+ */
+CF_EXPORT Boolean
+OSKextIsValid(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextValidateDependencies
+ * @abstract Validates all dependencies of a kext.
+ *
+ * @param    aKext  The kexts whose dependencies to validate.
+ * @result
+ * <code>true</code> if all dependencies of <code>aKext</code> are valid,
+ * <code>false</code> if any of them are not.
+ *
+ * @discussion
+ * This function calls @link OSKextValidate@/link on <code>aKext</code> and
+ * all the current dependencies of <code>aKext</code>.
+ * Use @link OSKextCopyDiagnostics@/link
+ * with a flag of @link kOSKextDiagnosticsFlagDependencies@/link
+ * to get the dependency-resolution failures caused by invalid dependencies.
+ *
+ * If safe boot is currently simulated (see
+ * @link OSKextSetSimulatedSafeBoot@/link),
+ * any kext not loadable during safe boot will fail validation.
+ *
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+CF_EXPORT Boolean
+OSKextValidateDependencies(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextAuthenticate
+ * @abstract Authenticates file ownership and permissions of a kext.
+ *
+ * @param    aKext   The kext to examine.
+ * @result
+ * <code>true</code> if all directories and files in <code>aKext</code>'s
+ * bundle or mkext source have secure ownership and permissions,
+ * <code>false</code> if they do not, or if authentication could not be done.
+ *
+ * @discussion
+ * This function forces full authentication of a kext, collecting all
+ * errors found in the authentication diagnostics, collecting all
+ * errors found in the validation diagnostics if recording is turned on
+ * (with @link OSKextSetRecordsDiagnostics@/link). You can get the diagnostics
+ * using @link OSKextCopyDiagnostics@/link.
+ *
+ * For a kext to be loadable into the kernel, it must be owned by
+ * user root, group wheel, and its constituent files and directories
+ * must be nonwritable by group and other.
+ * A kext created from an mkext file uses that mkext file for authentication
+ * (see @link OSKextCreateKextsFromMkextFile@/link.
+ */
+CF_EXPORT Boolean
+OSKextAuthenticate(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+#ifdef __MAC_10_9
+/*!
+ * @function OSKextIsSigned
+ * @abstract
+ * Returns whether a kext is code signed or not.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> is signed,
+ * <code>false</code> otherwise.
+ *
+ * @discussion
+ * This function checks to see if code signing resources are in place in the
+ * kext bundle.
+ */
+CF_EXPORT Boolean
+OSKextIsSigned(OSKextRef aKext)
+            __OSX_AVAILABLE_STARTING(__MAC_10_9, __IPHONE_NA);
+#endif // __MAC_10_9
+
+/*!
+ * @function OSKextIsAuthentic
+ * @abstract
+ * Returns whether a kext is authentic or not.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> passes all authentication tests,
+ * <code>false</code> otherwise.
+ *
+ * @discussion
+ * This function avoids doing full authentication if any problems have been
+ * discovered with the kext during other operations. To perform a full
+ * validation of all possible problems, use @link OSKextValidate@/link.
+ */
+CF_EXPORT Boolean
+OSKextIsAuthentic(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextAuthenticateDependencies
+ * @abstract Authenticates all dependencies of a kext.
+ *
+ * @param    aKext  The kexts whose dependencies to authenticate.
+ * @result
+ * <code>true</code> if all dependencies of <code>aKext</code> are authentic,
+ * <code>false</code> if any of them are not.
+ *
+ * @discussion
+ * This function calls @link OSKextAuthenticate@/link on <code>aKext</code>
+ * and all the current dependencies of <code>aKext</code>.
+ * Use @link OSKextCopyDiagnostics@/link
+ * with a flag of @link kOSKextDiagnosticsFlagDependencies@/link
+ * to get the dependency-resolution failures caused by inauthentic dependencies.
+ *
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+CF_EXPORT Boolean
+OSKextAuthenticateDependencies(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextIsLoadable
+ * @abstract
+ * Returns whether a kext appears loadable for the current architecture.
+ *
+ * @param    aKext   The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> has no problems with validation,
+ * authentication, or dependency resolution for the current architecture,
+ * and if it's eligible for the current safe boot mode.
+ * Returns <code>false</code> otherwise.
+ *
+ * @discussion
+ * This function resolves dependencies for <code>aKext</code>,
+ * validates and authenticsates <code>aKext</code> and its dependencies,
+ * and if safe boot is simulated also checks the OSBundleRequired property
+ * of <code>aKext</code> and its dependencies. If all these tests pass,
+ * the kext is considered loadable for the current architecture
+ * (which need not match that of the running kernel).
+ *
+ * See @link OSKextSetArchitecture@/link and
+ * @link OSKextSetSimulatedSafeBoot@/link.
+ *
+ * This function calls @link OSKextResolveDependencies@/link to find
+ * dependencies.
+ */
+CF_EXPORT Boolean
+OSKextIsLoadable(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCopyDiagnostics
+ * @abstract Returns diagnostics information for a kext.
+ *
+ * @param    aKext      The kext to get diagnostics for.
+ * @param    typeFlags  Flags indicating which diagnostics to retrieve.
+ * @result
+ * A dictionary containing diagnostics for <cod>aKext</code>, suitable
+ * for display in an outline view or printout.
+ *
+ * @discussion
+ * You can use this function after validating, authenticating, resolving
+ * dependencies, or generating debug symbols to get all the problems encountered
+ * with those operations.
+ *
+ * The exact keys and values used for diagnostics are for informational purposes
+ * only, are not formally defined, and may change without warning.
+ *
+ * You can use @link OSKextLogDiagnostics@/link to print nicely-formatted
+ * reports of any problems found with kexts.
+ */
+// xxx - need to tie in with the kernel & linker to get link failures
+CFDictionaryRef OSKextCopyDiagnostics(OSKextRef aKext,
+        OSKextDiagnosticsFlags typeFlags)
+__OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextLogDiagnostics
+ * @abstract Logs specified diagnostics for a kext.
+ *
+ * @param    aKext      The kext to log diagnostics for.
+ * @param    typeFlags  Flags indicating which diagnostics to log.
+ *
+ * @discussion
+ * You can use this function after validating, authenticating, resolving
+ * dependencies, or generating debug symbols to display all the problems
+ * encountered with those operations.
+ */
+CF_EXPORT void
+OSKextLogDiagnostics(
+    OSKextRef              aKext,
+    OSKextDiagnosticsFlags typeFlags)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextFlushDiagnostics
+ * @abstract Clears all diagnostics information from a kext.
+ *
+ * @param   aKext
+ *          The kext to clear diagnostics from.
+ *          Pass <code>NULL</code> to flush diagnostics from all open kexts.
+ * @param   typeFlags  Flags indicating which diagnostics to flush.
+ *
+ * @discussion
+ * OSKexts accumulate a fair amount of information as they are created
+ * and used; when many kext objects are created the total memory
+ * consumption can be significant. If an application won't be using
+ * kexts for long periods of time, it can flush this information
+ * to save memory; the information will later be re-read from disk
+ * or recreated as necessary.
+ *
+ * See also @link OSKextFlushInfoDictionaries@/link,
+ * @link OSKextFlushDependencies@/link,
+ * and @link OSKextFlushLoadInfo@/link.
+ */
+CF_EXPORT void
+OSKextFlushDiagnostics(OSKextRef aKext, OSKextDiagnosticsFlags typeFlags)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+#pragma mark Mkext and Prelinked Kernel Files
+/*********************************************************************
+* Mkext and Prelinked Kernel Files
+*********************************************************************/
+// xxx - Use "Flag" or "Mask"?
+typedef uint32_t OSKextRequiredFlags;
+#define kOSKextOSBundleRequiredNone              0x0
+#define kOSKextOSBundleRequiredRootFlag          0x1ULL
+#define kOSKextOSBundleRequiredLocalRootFlag     0x1ULL << 1
+#define kOSKextOSBundleRequiredNetworkRootFlag   0x1ULL << 2
+#define kOSKextOSBundleRequiredSafeBootFlag      0x1ULL << 3
+#define kOSKextOSBundleRequiredConsoleFlag       0x1ULL << 4
+
+/*!
+ * @function OSKextIsFromMkext
+ * @abstract Returns whether a kext was created from an mkext archive.
+ *
+ * @param    aKext  The kext to examine.
+ * @result
+ * <code>true</code> if <code>aKext</code> was created from an mkext archive,
+ * <code>false</code> if it was created from an on-disk bundle.
+ *
+ * @discussion
+ * A kext created from an mkext will have only its info dictionary, executable,
+ * and any resources listed in its the OSBundleStartupResources property.
+ */
+CF_EXPORT Boolean
+OSKextIsFromMkext(OSKextRef aKext)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextMatchesRequiredFlags
+ * @abstract
+ * Returns whether a kext matches a given set of flags for inclusion in an
+ * mkext archive.
+ *
+ * @param    aKext          The kext to examine.
+ * @param    requiredFlags
+ *           Flags indicating which values of OSBundleRequired
+ *           are needed.
+ * @result
+ * <code>true</code> if <code>aKext</code>'s OSBundleRequired property
+ * matches one of the specified flags, <code>false</code> otherwise.
+ *
+ * @discussion
+ * This function is used to select kexts for inclusion in an mkext archive.
+ * See @link OSKextFilterRequiredKexts@/link and
+ * @link OSKextCreateMkext@/link.
+ */
+CF_EXPORT Boolean
+OSKextMatchesRequiredFlags(OSKextRef aKext,
+    OSKextRequiredFlags requiredFlags)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextFilterRequiredKexts
+ * @abstract
+ * Filters an array of kexts based on a set of flags
+ * for inclusion in an mkext archive.
+ *
+ * @param    kextArray
+ *           The kexts to filter.
+ *           Pass <code>NULL</code> to filter all open kexts.
+ * @param    requiredFlags
+ *           Flags indicating which values of OSBundleRequired
+ *           are needed.
+ * @result
+ * An array of kexts matching <code>requiredFlags</code>.
+ *
+ * @discussion
+ * This function is used to select kexts for inclusion in an mkext archive.
+ * See @link OSKextCreateMkext@/link.
+ * 
+ */
+CF_EXPORT CFArrayRef
+OSKextFilterRequiredKexts(CFArrayRef kextArray,
+    OSKextRequiredFlags requiredFlags)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCreateMkext
+ * @abstract Create an mkext file from an array of kexts and set of flags.
+ *
+ * @param    allocator
+ *           The allocator to use to allocate memory for the new object.
+ *           Pass <code>NULL</code> or <code>kCFAllocatorDefault</code>
+ *           to use the current default allocator.
+ * @param    kextArray
+ *           The kexts to include in the mkext.
+ *           Pass <code>NULL</code> to use all open kexts.
+ * @param    volumeRootURL
+ *           If non-<code>NULL</code>, kexts with this URL as a prefix
+ *           strip it when saving their paths in the mkext.
+ *           This allows creation of mkexts for volumes
+ *           other than the current startup volume.
+ * @param    requiredFlags
+ *           A set of flags that filters <code>kextArray</code> to a subset
+ *           of kexts required for specific startup scenarios
+ *           (typically local disk vs. network).
+ * @param    compressFlag
+ *           <code>true</code> to compress data in the mkext,
+ *           <code>false</code> to include them at full size.
+ *           COMPRESSED MKEXTS ARE NOT SUPPORTED IN THE KERNEL YET.
+ * @result
+ * A <code>CFData</code> object containing the mkext file data on success,
+ * <code>NULL</code> on failure.
+ *
+ * @discussion
+ * This function creates a single-architecture mkext file for the currently
+ * set library architecture (see @link OSKextSetArchitecture@/link). Kexts
+ * with executables lacking code for that architecture are not included.
+ *
+ * If you want to create a multi-architecture mkext, create a set of single
+ * architecture mkext files and use lipo(1) or combine them programmatically.
+ *
+ * This function generates mkext files in a new format that only works on
+ * Mac OS X 10.6 or later.
+ */
+// xxx - add a version param and generate old-format mkexts?
+// xxx - add flag to take only most recent version of a given bundle ID?
+CF_EXPORT CFDataRef
+OSKextCreateMkext(
+    CFAllocatorRef      allocator,
+    CFArrayRef          kextArray,
+    CFURLRef            volumeRootURL,
+    OSKextRequiredFlags requiredFlags,
+    Boolean             compressFlag)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+    
+/*!
+ * @function OSKextCreateKextsFromMkextFile
+ * @abstract Reads all kexts from an mkext file on disk. 
+ *
+ * @param    alocator
+ *           The allocator to use to allocate memory for the new objects.
+ *           Pass <code>NULL</code> or <code>kCFAllocatorDefault</code>
+ *           to use the current default allocator.
+ * @param    mkextURL
+ *           The mkext file URL from which to create kexts.
+ * @result
+ * Returns an array containing the kext objects created,
+ * or <code>NULL</code> on failure.
+ *
+ * @discussion
+ * This function creates kext objects from an mkext file rather than from
+ * bundles on disk. Kexts created with this function are authenticated using
+ * the mkext file at <code>mkextURL</code>.
+ *
+ * A kext created from an mkext has only its info dictionary, executable,
+ * and any resources listed in its the OSBundleStartupResources property.
+ *
+ * Kexts created from an mkext are not uniqued using filesystem URLs,
+ * which belong to bundles actually in the filesystem;
+ * @link OSKextCreate@/link will never return a kext extracted from an mkext
+ * that originally had the URL given (even though the new mkext format
+ * stores that original URL).
+ * This also means that if you open the same mkext file multiple times,
+ * you will create distinct, identical copies of the kexts in that mkext file.
+ */
+CF_EXPORT CFArrayRef
+OSKextCreateKextsFromMkextFile(CFAllocatorRef allocator,
+    CFURLRef mkextURL)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @function OSKextCreateKextsFromMkextData
+ * @abstract Reads all kexts from an mkext file in memory. 
+ *
+ * @param    alocator
+ *           The allocator to use to allocate memory for the new objects.
+ *           Pass <code>NULL</code> or <code>kCFAllocatorDefault</code>
+ *           to use the current default allocator.
+ * @param    mkextData
+ *           The mkext file data from which to create kexts.
+ * @result
+ * Returns an array containing the kext objects created,
+ * or <code>NULL</code> on failure.
+ *
+ * @discussion
+ * This function creates kext objects from an mkext file in memory
+ * rather than from bundles on disk. Lacking any file in the filesystem,
+ * kexts created with this function can not be authenticated.
+ *
+ * A kext created from an mkext has only its info dictionary, executable,
+ * and any resources listed in its the OSBundleStartupResources property.
+ *
+ * Kexts created from an mkext are not uniqued using filesystem URLs,
+ * which belong to bundles actually in the filesystem;
+ * @link OSKextCreate@/link will never return a kext extracted from an mkext
+ * that originally had the URL given (even though the new mkext format
+ * stores that original URL).
+ * This also means that if you open the same mkext file multiple times,
+ * you will create distinct, identical copies of the kexts in that mkext file.
+ */
+CF_EXPORT CFArrayRef
+OSKextCreateKextsFromMkextData(CFAllocatorRef allocator,
+    CFDataRef mkextData)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2);
+
+/*!
+ * @enum OSKextKernelcacheFlags
+ * @abstract The flags that affect the behavior of
+ *           @link OSKextCreatePrelinkedKernel@/link.
+ *
+ * @constant kOSKextKernelcacheNeedAllFlag
+ *           If set and any kext fails to link,
+ *           @link OSKextCreatePrelinkedKernel@/link returns <code>NULL</code>.
+ * @constant kOSKextKernelcacheSkipAuthenticationFlag
+ *           If set, kexts are not authenticated for inclusion in the prelinked
+ *           kernel.
+ * @constant kOSKextKernelcachePrintDiagnosticsFlag
+ *           If set, problems with the kexts that prevent inclusion of a kext in
+ *           the prelinked kernel are logged via
+ *           @link OSKextLogDiagnostics OSKextLogDiagnostics@/link.
+ * @constant kOSKextKernelcacheIncludeAllPersonalitiesFlag
+ *           If set, all kext personalities will be included in the prelinked
+ *           kernel, regardless of whether they're required.
+ * @constant kOSKextKernelcacheStripSymbols
+ *           If set, symbol tables are stripped from kexts before they are
+ *           placed in the prelinked kernel.  If symbolsOut is
+ *           non-<code>NULL</code>, symbolicated binaries will still be returned
+ *           to the caller.
+ * @constant kOSKextKernelcacheKASLRFlag
+ *           If set, generate DYSYMTAB load commands for KASLR support.
+ */
+enum {
+    kOSKextKernelcacheNeedAllFlag = (1 << 0),
+    kOSKextKernelcacheSkipAuthenticationFlag = (1 << 1),
+    kOSKextKernelcachePrintDiagnosticsFlag = (1 << 2),
+    kOSKextKernelcacheIncludeAllPersonalitiesFlag = (1 << 3),
+    kOSKextKernelcacheStripSymbolsFlag = (1 << 4),
+    kOSKextKernelcacheKASLRFlag = (1 << 5),
+};
+
+/*!
+ * @function OSKextCreatePrelinkedKernel
+ * @abstract Creates a prelinked kernel from a kernel file and all open kexts.
+ *
+ * @param    kernelImage     The kernel image to use.
+ * @param    kextArray
+ *           The kexts to include in the prelinked kernel.
+ *           Pass <code>NULL</code> to consult the running kernel
+ *           for kexts to include from those open;
+ *           the current architecture must match the runninng kernel's.
+ * @param    volumeRootURL
+ *           If non-<code>NULL</code>, kexts with this URL as a prefix
+ *           strip it when saving their paths in the prelinked kernel.
+ *           This allows creation of prelinked kernels from folders
+ *           other than /System/Library/Extensions.
+ * @param    flags
+ *           See @link OSKextKernelcacheFlags@/link.
+ * @param    symbolsOut
+ *           If non-<code>NULL</code> debug symbols for <code>kernelImage</code>
+ *           and all kexts included in the result are returned by reference.
+ *
+ * @result
+ * A <code>CFData</code> object containing the prelinked kernel image based
+ * on the running kernel.
+ * Returns <code>NULL</code> if <code>needAllFlag</code> is <code>true</code>
+ * and any kext fails to link.
+ */
+CF_EXPORT CFDataRef
+OSKextCreatePrelinkedKernel(
+    CFDataRef           kernelImage,
+    CFArrayRef          kextArray,
+    CFURLRef            volumeRootURL,
+    uint32_t            flags,
+    CFDictionaryRef   * symbolsOut)
+                __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_NA);
+
+
+__END_DECLS
+
+#endif /* __OSKEXT_H__ */

--- a/src/kext_tools/kext.subproj/OSKextPrivate.h
+++ b/src/kext_tools/kext.subproj/OSKextPrivate.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#ifndef __OSKEXTPRIVATE_H__
+#define __OSKEXTPRIVATE_H__
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <System/libkern/OSKextLib.h>
+#include <System/libkern/OSKextLibPrivate.h>
+#include <mach-o/arch.h>
+#include <paths.h>
+#include <sys/stat.h>
+
+#include "OSKext.h"
+
+/* If you aren't IOKitUser or kext_tools, you shouldn't be using this
+ * file. Its contents will change without warning.
+ */
+ 
+#if PRAGMA_MARK
+/********************************************************************/
+#pragma mark Standard System Extensions Folders
+/********************************************************************/
+#endif
+/*
+ * We use "/System/Library/Extensions" and "/Library/Extensions" - 11860417
+ */
+#define _kOSKextNumSystemExtensionsFolders (2)
+
+#define _kOSKextSystemLibraryExtensionsFolder           \
+            "/System/Library/Extensions"
+#define _kOSKextLibraryExtensionsFolder                 \
+            "/Library/Extensions"
+#define _kOSKextAppleInternalLibraryExtensionsFolder    \
+            "/AppleInternal/Library/Extensions"
+
+#if PRAGMA_MARK
+/********************************************************************/
+#pragma mark Kext Cache Folders & Files
+/********************************************************************/
+#endif
+/*********************************************************************
+* All kext cache files now live under /System/Library/Caches in
+* com.apple.kext.caches. The system extensions folders are duplicated
+* under this node, and at their bottom are the individual cache files
+* for id->URL mapping, and for I/O Kit personalities (owned by the
+* kext_tools project, specifically kextd(8) and kextcache(8)).
+*
+* Here's a schematic:
+* ______________________________________________________________________
+* /System/Library/Caches/com.apple.kext.caches/System/Library/Extensions/ ...
+*     ID->URL Cache: KextIdentifiers.plist.gz (OSBundles?)
+*     Personalities Cache: IOKitPersonalities_<arch>.plist.gz
+*
+* System boot caches (prelinked kernel and mkext) are in the
+* com.apple.kext.caches folder. See the kext_tools project for more.
+*********************************************************************/
+#define _kOSKextCachesRootFolder                       \
+            "/System/Library/Caches/com.apple.kext.caches"
+
+#define _kOSKextDirectoryCachesSubfolder   "Directories"
+#define _kOSKextStartupCachesSubfolder     "Startup"
+
+#define _kOSKextStartupMkextFilename       "Extensions.mkext"
+#define _kOSKextStartupMkextFolderPath     _kOSKextCachesRootFolder       "/" \
+                                           _kOSKextStartupCachesSubfolder
+#define _kOSKextStartupMkextPath           _kOSKextStartupMkextFolderPath "/" \
+                                           _kOSKextStartupMkextFilename
+
+#define _kOSKextIdentifierCacheBasename    "KextIdentifiers"
+#define _kOSKextPrelinkedKernelBasename    "kernelcache"
+
+#define _kOSKextCacheFileMode      (0644)
+#define _kOSKextCacheFileModeMask  (0777)
+#define _kOSKextCacheFolderMode    (0755)
+
+#if PRAGMA_MARK
+/********************************************************************/
+#pragma mark Cache Functions
+/********************************************************************/
+#endif
+
+typedef enum {
+    _kOSKextCacheFormatRaw,
+    _kOSKextCacheFormatCFXML,
+    _kOSKextCacheFormatCFBinary,
+    _kOSKextCacheFormatIOXML,
+} _OSKextCacheFormat;
+
+Boolean _OSKextReadCache(
+    CFTypeRef                 folderURLsOrURL,  // CFArray or CFURLRef
+    CFStringRef               cacheName,
+    const NXArchInfo        * arch,
+    _OSKextCacheFormat        format,
+    Boolean                   parseXMLFlag,
+    CFPropertyListRef       * cacheContentsOut);
+Boolean _OSKextCreateFolderForCacheURL(CFURLRef cacheURL);
+Boolean _OSKextWriteCache(
+    CFTypeRef                 folderURLsOrURL,  // CFArray or CFURLRef
+    CFStringRef               cacheName,
+    const NXArchInfo        * arch,
+    _OSKextCacheFormat        format,
+    CFPropertyListRef         plist);
+Boolean _OSKextReadFromIdentifierCacheForFolder(
+    CFURLRef            anURL,
+    CFMutableArrayRef * kextsOut);
+Boolean _OSKextWriteIdentifierCacheForKextsInDirectory(
+    CFArrayRef kextArray,
+    CFURLRef   directoryURL,
+    Boolean    forceFlag);
+CFArrayRef _OSKextCopyKernelRequests(void);
+OSReturn _OSKextSendResource(
+    CFDictionaryRef request,
+    OSReturn        requestResult,
+    CFDataRef       resource);
+
+#if PRAGMA_MARK
+/********************************************************************/
+#pragma mark URL Utilities
+/********************************************************************/
+#endif
+
+CFStringRef _CFURLCopyAbsolutePath(CFURLRef anURL);
+
+#if PRAGMA_MARK
+/********************************************************************/
+#pragma mark Misc Functions
+/********************************************************************/
+#endif
+
+/* Used by embedded so they can better control which kexts they get.
+ * This must be called when no kexts are opened.
+ */
+void _OSKextSetStrictRecordingByLastOpened(Boolean flag);
+
+
+#if PRAGMA_MARK
+/********************************************************************/
+#pragma mark Logging Macros for Common Errors
+/********************************************************************/
+#endif
+
+#if DEBUG
+
+#define OSKextLogMemError()   \
+    OSKextLog(NULL, \
+        kOSKextLogErrorLevel | kOSKextLogGeneralFlag, \
+        "Error - memory allocation failure, %s, line %d.", __FILE__, __LINE__)
+#define OSKextLogStringError(kext)   \
+    OSKextLog((kext), \
+        kOSKextLogErrorLevel | kOSKextLogGeneralFlag, \
+        "Error - string/URL conversion failure, %s, line %d.", __FILE__, __LINE__)
+
+#else /* DEBUG */
+
+#define OSKextLogMemError()   \
+    OSKextLog(NULL, \
+        kOSKextLogErrorLevel | kOSKextLogGeneralFlag, \
+        "Memory allocation failure.")
+#define OSKextLogStringError(kext)   \
+    OSKextLog((kext), \
+        kOSKextLogErrorLevel | kOSKextLogGeneralFlag, \
+        "String/URL conversion failure.")
+
+#endif /* DEBUG */
+
+#endif /* __OSKEXTPRIVATE_H__ */

--- a/src/kext_tools/kext.subproj/OSKextVersion.c
+++ b/src/kext_tools/kext.subproj/OSKextVersion.c
@@ -1,0 +1,497 @@
+/*
+ * Copyright (c) 2000-2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#ifdef KERNEL
+#include <sys/systm.h>
+#include <libkern/OSKextLibPrivate.h>
+#else
+#include <libc.h>
+#include <System/libkern/OSKextLibPrivate.h>
+#endif /* KERNEL */
+#include <System/libkern/OSKextLibPrivate.h>
+
+// xxx - This file is duplicated in IOKitUser; would like to have it shared.
+
+#define VERS_MAJOR_DIGITS        (4)
+#define VERS_MINOR_DIGITS        (2)
+#define VERS_REVISION_DIGITS     (2)
+#define VERS_STAGE_DIGITS        (1)
+#define VERS_STAGE_LEVEL_DIGITS  (3)
+
+#define VERS_MAJOR_MAX           (9999)
+#define VERS_STAGE_LEVEL_MAX      (255)
+
+#define VERS_MAJOR_MULT    (100000000)
+#define VERS_MINOR_MULT      (1000000)
+#define VERS_REVISION_MULT     (10000)
+#define VERS_STAGE_MULT         (1000)
+
+
+typedef enum {
+    kOSKextVersionStageInvalid     = 0,
+    kOSKextVersionStageDevelopment = 1,
+    kOSKextVersionStageAlpha       = 3,
+    kOSKextVersionStageBeta        = 5,
+    kOSKextVersionStageCandidate   = 7,
+    kOSKextVersionStageRelease     = 9,
+} OSKextVersionStage;
+
+
+/*********************************************************************
+*********************************************************************/
+static int __vers_isdigit(char c) {
+    return (c == '0' ||
+        c == '1' || c == '2' || c == '3' ||
+        c == '4' || c == '5' || c == '6' ||
+        c == '7' || c == '8' || c == '9');
+}
+
+/*********************************************************************
+*********************************************************************/
+static int __vers_isspace(char c) {
+    return (c == ' ' ||
+        c == '\t' ||
+        c == '\r' ||
+        c == '\n');
+}
+
+/*********************************************************************
+*********************************************************************/
+static int __vers_digit_for_char(char c) {
+    switch (c) {
+      case '0': return 0; break;
+      case '1': return 1; break;
+      case '2': return 2; break;
+      case '3': return 3; break;
+      case '4': return 4; break;
+      case '5': return 5; break;
+      case '6': return 6; break;
+      case '7': return 7; break;
+      case '8': return 8; break;
+      case '9': return 9; break;
+      default:  return -1; break;
+    }
+
+    return -1;
+}
+
+/*********************************************************************
+*********************************************************************/
+static int __VERS_isreleasestate(char c) {
+    return (c == 'd' || c == 'a' || c == 'b' || c == 'f');
+}
+
+
+/*********************************************************************
+*********************************************************************/
+static OSKextVersionStage __OSKextVersionStageForString(const char ** string_p) {
+    const char * string;
+
+    if (!string_p || !*string_p) {
+        return kOSKextVersionStageInvalid;
+    }
+
+    string = *string_p;
+
+    if (__vers_isspace(string[0]) || string[0] == '\0') {
+        return kOSKextVersionStageRelease;
+    } else {
+        switch (string[0]) {
+          case 'd':
+              if (__vers_isdigit(string[1])) {
+                  *string_p = &string[1];
+                  return kOSKextVersionStageDevelopment;
+              }
+              break;
+          case 'a':
+              if (__vers_isdigit(string[1])) {
+                  *string_p = &string[1];
+                  return kOSKextVersionStageAlpha;
+              }
+              break;
+          case 'b':
+              if (__vers_isdigit(string[1])) {
+                  *string_p = &string[1];
+                  return kOSKextVersionStageBeta;
+              }
+              break;
+          case 'f':
+              if (__vers_isdigit(string[1])) {
+                  *string_p = &string[1];
+                  return kOSKextVersionStageCandidate;
+              } else if (string[1] == 'c' && __vers_isdigit(string[2])) {
+                  *string_p = &string[2];
+                  return kOSKextVersionStageCandidate;
+              } else {
+                  return kOSKextVersionStageInvalid;
+              }
+              break;
+          default:
+              return kOSKextVersionStageInvalid;
+              break;
+        }
+    }
+
+    return kOSKextVersionStageInvalid;
+}
+
+/*********************************************************************
+*********************************************************************/
+static const char * __OSKextVersionStringForStage(OSKextVersionStage stage)
+{
+    switch (stage) {
+      case kOSKextVersionStageInvalid:     return NULL; break;
+      case kOSKextVersionStageDevelopment: return "d"; break;
+      case kOSKextVersionStageAlpha:       return "a"; break;
+      case kOSKextVersionStageBeta:        return "b"; break;
+      case kOSKextVersionStageCandidate:   return "f"; break;
+      case kOSKextVersionStageRelease:     return ""; break;
+    }
+
+    return NULL;
+}
+
+/*********************************************************************
+*********************************************************************/
+OSKextVersion OSKextParseVersionString(const char * versionString)
+{
+    OSKextVersion   result             = -1;
+    int             vers_digit         = -1;
+    int             num_digits_scanned = 0;
+    OSKextVersion   vers_major         = 0;
+    OSKextVersion   vers_minor         = 0;
+    OSKextVersion   vers_revision      = 0;
+    OSKextVersion   vers_stage         = 0;
+    OSKextVersion   vers_stage_level   = 0;
+    const char    * current_char_p;
+
+    if (!versionString || *versionString == '\0') {
+        return -1;
+    }
+
+    current_char_p = (const char *)&versionString[0];
+
+   /*****
+    * Check for an initial digit of the major release number.
+    */
+    vers_major = __vers_digit_for_char(*current_char_p);
+    if (vers_major < 0) {
+        return -1;
+    }
+
+    current_char_p++;
+    num_digits_scanned = 1;
+
+   /* Complete scan for major version number. Legal characters are
+    * any digit, period, any buildstage letter.
+    */
+    while (num_digits_scanned < VERS_MAJOR_DIGITS) {
+        if (__vers_isspace(*current_char_p) || *current_char_p == '\0') {
+            vers_stage = kOSKextVersionStageRelease;
+            goto finish;
+        } else if (__vers_isdigit(*current_char_p)) {
+            vers_digit = __vers_digit_for_char(*current_char_p);
+            if (vers_digit < 0) {
+                return -1;
+            }
+            vers_major = (vers_major) * 10 + vers_digit;
+            current_char_p++;
+            num_digits_scanned++;
+        } else if (__VERS_isreleasestate(*current_char_p)) {
+            goto release_state;
+        } else if (*current_char_p == '.') {
+            current_char_p++;
+            goto minor_version;
+        } else {
+            return -1;
+        }
+    }
+
+   /* Check for too many digits.
+    */
+    if (num_digits_scanned == VERS_MAJOR_DIGITS) {
+         if (*current_char_p == '.') {
+            current_char_p++;
+        } else if (__vers_isdigit(*current_char_p)) {
+            return -1;
+        }
+    }
+
+minor_version:
+
+    num_digits_scanned = 0;
+
+   /* Scan for minor version number. Legal characters are
+    * any digit, period, any buildstage letter.
+    */
+    while (num_digits_scanned < VERS_MINOR_DIGITS) {
+        if (__vers_isspace(*current_char_p) || *current_char_p == '\0') {
+            vers_stage = kOSKextVersionStageRelease;
+            goto finish;
+        } else if (__vers_isdigit(*current_char_p)) {
+            vers_digit = __vers_digit_for_char(*current_char_p);
+            if (vers_digit < 0) {
+                return -1;
+            }
+            vers_minor = (vers_minor) * 10 + vers_digit;
+            current_char_p++;
+            num_digits_scanned++;
+        } else if (__VERS_isreleasestate(*current_char_p)) {
+            goto release_state;
+        } else if (*current_char_p == '.') {
+            current_char_p++;
+            goto revision;
+        } else {
+            return -1;
+        }
+    }
+
+   /* Check for too many digits.
+    */
+    if (num_digits_scanned == VERS_MINOR_DIGITS) {
+         if (*current_char_p == '.') {
+            current_char_p++;
+        } else if (__vers_isdigit(*current_char_p)) {
+            return -1;
+        }
+    }
+
+revision:
+
+    num_digits_scanned = 0;
+
+   /* Scan for revision version number. Legal characters are
+    * any digit, any buildstage letter (NOT PERIOD).
+    */
+    while (num_digits_scanned < VERS_REVISION_DIGITS) {
+        if (__vers_isspace(*current_char_p) || *current_char_p == '\0') {
+            vers_stage = kOSKextVersionStageRelease;
+            goto finish;
+        } else if (__vers_isdigit(*current_char_p)) {
+            vers_digit = __vers_digit_for_char(*current_char_p);
+            if (vers_digit < 0) {
+                return -1;
+            }
+            vers_revision = (vers_revision) * 10 + vers_digit;
+            current_char_p++;
+            num_digits_scanned++;
+        } else if (__VERS_isreleasestate(*current_char_p)) {
+            goto release_state;
+        } else {
+            return -1;
+        }
+    }
+
+   /* Check for too many digits.
+    */
+    if (num_digits_scanned == VERS_REVISION_DIGITS) {
+         if (*current_char_p == '.') {
+            current_char_p++;
+        } else if (__vers_isdigit(*current_char_p)) {
+            return -1;
+        }
+    }
+
+release_state:
+
+   /*****
+    * Check for the release state.
+    */
+    if (__vers_isspace(*current_char_p) || *current_char_p == '\0') {
+        vers_stage = kOSKextVersionStageRelease;
+        goto finish;
+    } else {
+        vers_stage = __OSKextVersionStageForString(&current_char_p);
+        if (vers_stage == kOSKextVersionStageInvalid) {
+            return -1;
+        }
+    }
+
+
+// stage level
+
+    num_digits_scanned = 0;
+
+   /* Scan for stage level number. Legal characters are
+    * any digit only.
+    */
+    while (num_digits_scanned < VERS_STAGE_LEVEL_DIGITS) {
+        if (__vers_isspace(*current_char_p) || *current_char_p == '\0') {
+            if (num_digits_scanned) {
+                goto finish;
+            } else {
+                return -1;
+            }
+        } else if (__vers_isdigit(*current_char_p)) {
+            vers_digit = __vers_digit_for_char(*current_char_p);
+            if (vers_digit < 0) {
+                return -1;
+            }
+            vers_stage_level = (vers_stage_level) * 10 + vers_digit;
+            current_char_p++;
+            num_digits_scanned++;
+        } else {
+            return -1;
+        }
+    }
+
+   /* Check for too many digits.
+    */
+    if ((num_digits_scanned == VERS_STAGE_LEVEL_DIGITS) &&
+        ! (__vers_isspace(*current_char_p) || (*current_char_p == '\0'))) {
+
+        return -1;
+    }
+
+    if (vers_stage_level > VERS_STAGE_LEVEL_MAX) {
+        return -1;
+    }
+
+finish:
+
+    if (vers_stage == kOSKextVersionStageCandidate && vers_stage_level == 0) {
+        return -1;
+    }
+
+    result = (vers_major * VERS_MAJOR_MULT) +
+             (vers_minor * VERS_MINOR_MULT) +
+             (vers_revision * VERS_REVISION_MULT) +
+             (vers_stage * VERS_STAGE_MULT) +
+             vers_stage_level; 
+
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+Boolean OSKextVersionGetString(
+    OSKextVersion   aVersion,
+    char          * buffer,
+    uint32_t        bufferLength)
+{
+    int             cpos = 0;
+    OSKextVersion   vers_major = 0;
+    OSKextVersion   vers_minor = 0;
+    OSKextVersion   vers_revision = 0;
+    OSKextVersion   vers_stage = 0;
+    OSKextVersion   vers_stage_level = 0;
+    const char    * stage_string = NULL;  // don't free
+
+   /* No buffer or length less than longest possible vers string,
+    * return 0.
+    */
+    if (!buffer || bufferLength < kOSKextVersionMaxLength) {
+        return FALSE;
+    }
+
+    bzero(buffer, bufferLength * sizeof(char));
+
+    if (aVersion < 0) {
+        strlcpy(buffer, "(invalid)", bufferLength);
+        return TRUE;
+    }
+    if (aVersion == 0) {
+        strlcpy(buffer, "(missing)", bufferLength);
+        return TRUE;
+    }
+
+    vers_major = aVersion / VERS_MAJOR_MULT;
+    if (vers_major > VERS_MAJOR_MAX) {
+        strlcpy(buffer, "(invalid)", bufferLength);
+        return TRUE;
+    }
+
+    vers_minor = aVersion - (vers_major * VERS_MAJOR_MULT);
+    vers_minor /= VERS_MINOR_MULT;
+
+    vers_revision = aVersion -
+        ( (vers_major * VERS_MAJOR_MULT) + (vers_minor * VERS_MINOR_MULT) );
+    vers_revision /= VERS_REVISION_MULT;
+
+    vers_stage = aVersion -
+        ( (vers_major * VERS_MAJOR_MULT) + (vers_minor * VERS_MINOR_MULT) +
+          (vers_revision * VERS_REVISION_MULT));
+    vers_stage /= VERS_STAGE_MULT;
+
+    vers_stage_level = aVersion -
+        ( (vers_major * VERS_MAJOR_MULT) + (vers_minor * VERS_MINOR_MULT) +
+          (vers_revision * VERS_REVISION_MULT) + (vers_stage * VERS_STAGE_MULT));
+    if (vers_stage_level > VERS_STAGE_LEVEL_MAX) {
+        strlcpy(buffer, "(invalid)", bufferLength);
+        return TRUE;
+    }
+
+    cpos = snprintf(buffer, bufferLength, "%u", (uint32_t)vers_major);
+
+   /* Always include the minor version; it just looks weird without.
+    */
+    buffer[cpos] = '.';
+    cpos++;
+    cpos += snprintf(buffer+cpos, bufferLength - cpos, "%u", (uint32_t)vers_minor);
+
+   /* The revision is displayed only if nonzero.
+    */
+    if (vers_revision) {
+        buffer[cpos] = '.';
+        cpos++;
+        cpos += snprintf(buffer+cpos, bufferLength - cpos, "%u",
+			(uint32_t)vers_revision);
+    }
+
+    stage_string = __OSKextVersionStringForStage(vers_stage);
+    if (!stage_string) {
+        strlcpy(buffer, "(invalid)", bufferLength);
+        return TRUE;
+    }
+    if (stage_string[0]) {
+        strlcat(buffer, stage_string, bufferLength);
+        cpos += strlen(stage_string);
+    }
+
+    if (vers_stage < kOSKextVersionStageRelease) {
+        snprintf(buffer+cpos, bufferLength - cpos, "%u", (uint32_t)vers_stage_level);
+    }
+
+    return TRUE;
+}
+
+/*********************************************************************
+*********************************************************************/
+#ifndef KERNEL
+OSKextVersion OSKextParseVersionCFString(CFStringRef versionString)
+{
+    OSKextVersion result = -1;
+    char         versBuffer[kOSKextVersionMaxLength];
+    
+    if (CFStringGetCString(versionString, versBuffer,
+        sizeof(versBuffer), kCFStringEncodingASCII)) {
+
+        result = OSKextParseVersionString(versBuffer);
+    }
+    return result;
+}
+#endif

--- a/src/kext_tools/kext.subproj/PROVENANCE.md
+++ b/src/kext_tools/kext.subproj/PROVENANCE.md
@@ -1,0 +1,34 @@
+# kext.subproj — vendored Apple OSKext (faithful port, #182)
+
+Apple's `OSKext` engine + helpers, vendored **verbatim** from:
+
+- **`IOKitUser-907.100.13`** (OS X 10.8.5 — deliberately **pre-SIP**, so no
+  codesign enforcement, no kernelcache/AuxKC collection machinery to strip)
+- Source: `github.com/apple-oss-distributions/IOKitUser` @ tag
+  `IOKitUser-907.100.13`, path `kext.subproj/`
+- License: **APSL 2.0** (headers intact)
+
+This is the `OSKext` bundle/dependency/load engine that the faithful
+`kext_tools` port (#182) is built on — bundle discovery, Info.plist parsing,
+`OSBundleLibraries` dependency-graph resolution, version/compat, validation.
+
+## Status: VENDORED, NOT YET BUILT (Phase 0 groundwork)
+
+These files are **not** wired into the build yet — they sit here verbatim as
+the starting point. The phased port (see the plan) is:
+
+1. **Phase 0** — vendor (this commit) → a fast standalone `libkext` compile
+   (compile-only CI job, sysroot from the `continuous` image) so we can
+   iterate the 15.7k-LOC `OSKext.c` against NextBSD's `libCoreFoundation` /
+   `libIOKit` in minutes, not full ISO builds.
+2. **Re-back XNU → kld** — `OSKextLoad`/unload/query swap from the
+   `kext_request` Mach trap to `kldload`/`kldstat`/`kldunload`; personalities
+   from `IOCatalogueSendData` to the libIOKit/hwregd matcher; KXLD/mkext/
+   prelink deleted (the kernel's `kld` links). Codesign stubbed (no SIP).
+3. **Phase 1** — dependency-graph resolution (first user-visible win) feeding
+   the bulk conversion (#179) and kextd (#177).
+
+Plan: https://pkgdemon.github.io/nextbsd-oskext-port-plan.html
+
+The minimal kld-backed `kextload`/`kextstat`/`kextunload` trio in the parent
+directory remains the shipping tooling until this port graduates.

--- a/src/kext_tools/kext.subproj/bootfiles.h
+++ b/src/kext_tools/kext.subproj/bootfiles.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/*
+ * FILE: bootfiles.h
+ * AUTH: Soren Spies (sspies)
+ * DATE: 22 March 2006 (Copyright Apple Computer, Inc)
+ * DESC: constants for boot caches
+ */
+
+#ifndef __BOOTFILES_H__
+#define __BOOTFILES_H__
+
+#include <paths.h>
+
+/* Boot != Root directories in Apple_Boot */
+#define kBootDirR "com.apple.boot.R"
+#define kBootDirP "com.apple.boot.P"
+#define kBootDirS "com.apple.boot.S"
+
+/* Boot != Root key for firmware's /chosen  */
+#define kBootRootActiveKey      "bootroot-active"
+
+/* Recovery OS directory in Apple_Boot */
+#define kRecoveryBootDir        "com.apple.recovery.boot"
+
+/* Recovery OS NVRAM variables & values */
+// No recovery-boot-mode or Installer automation vars -> generic recovery
+// with all functions available.  boot.efi boots the Recovery OS
+// regardless of the value assigned to recovery-boot-mode.
+#define kRecoveryBootVar        "recovery-boot-mode"
+#define kRecoveryBootModeGuest      "guest"         // guest boot (usu. once)
+#define kRecoveryBootModeLocked     "locked"        // system is FMM-locked
+#define kRcevoeryBootModeRecovery   "recovery"      // OS->booter: generic pls
+
+// Variable indicating that the user had trouble at EFI Login.
+// Indicates to the OS that it should allow Bluetooth pairing, etc
+// For now, this variable is set to "true" by the booter.
+// The OS should unset this variable.
+#define kRecoveryBootEFILoginHelpVar "recovery-boot-efilogin-help"
+
+/* The kernel */
+#define kDefaultKernel        "/mach_kernel"
+#define kKernelSymfile        (_PATH_VARRUN "mach.sym")
+// kKernelSymfile obsolete, remove when load.c deleted
+
+/* The system extensions folder */
+#define kSystemExtensionsDir  "/System/Library/Extensions"
+/* The library extensions folder */
+#define kLibraryExtensionsDir  "/Library/Extensions"
+
+
+/* The booter configuration file */
+#define kBootConfig           "/Library/Preferences/SystemConfiguration/com.apple.Boot.plist"
+#define kKernelFlagsKey       "Kernel Flags"
+#define kMKextCacheKey        "MKext Cache"
+#define kKernelNameKey        "Kernel"
+#define kKernelCacheKey       "Kernel Cache"
+#define kRootUUIDKey          "Root UUID"
+#define kRootMatchKey         "Root Match"
+
+#endif /* __BOOTFILES_H__ */

--- a/src/kext_tools/kext.subproj/fat_util.c
+++ b/src/kext_tools/kext.subproj/fat_util.c
@@ -1,0 +1,457 @@
+/*
+ * Copyright (c) 2006-2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <mach-o/arch.h>
+
+#include <stdio.h>
+#include <fcntl.h>
+
+#include <mach/vm_types.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+#include "fat_util.h"
+#include "macho_util.h"
+
+/*******************************************************************************
+*
+*******************************************************************************/
+struct __fat_iterator {
+    void              * file_start;
+    void              * file_end;
+    struct fat_header * fat_header;
+    struct fat_arch   * fat_arches;
+    uint32_t            num_arches;
+    uint32_t            arch_index;
+
+    int unmap    : 1;     // we own the data
+    int iterable : 1;     // is fat or a thin mach-o
+};
+
+/*******************************************************************************
+*
+*******************************************************************************/
+static int __fat_iterator_init(
+    struct __fat_iterator * iter,
+    const void * file_data,
+    const void * file_end,
+    int macho_only)
+{
+    int      result = -1;
+    size_t   length = file_end - file_data;
+    uint32_t magic;
+
+    if (length < sizeof(magic)) {
+        goto finish;
+    }
+
+    iter->file_start = (void *)file_data;
+    iter->file_end   = (void *)file_end;
+
+    magic = MAGIC32(file_data);
+
+    if (ISFAT(magic)) {
+        void * arches_end;
+
+        if (length < sizeof(struct fat_header)) {
+            goto finish;
+        }
+
+        iter->fat_header = (struct fat_header *)file_data;
+        iter->fat_arches = (struct fat_arch *)((char *)iter->fat_header +
+            sizeof(struct fat_header));
+        iter->num_arches = OSSwapBigToHostInt32(
+            iter->fat_header->nfat_arch);
+        arches_end = (void *)iter->fat_arches +
+            (iter->num_arches * sizeof(struct fat_arch));
+
+        if (arches_end > iter->file_end) {
+
+            goto finish;
+        }
+
+        iter->iterable = 1;
+
+    } else if (ISMACHO(magic)) {
+
+        if (length < sizeof(struct mach_header)) {
+            goto finish;
+        }
+
+        iter->iterable = 1;
+        iter->num_arches = 1;
+        iter->arch_index = 0;
+
+    } else if (macho_only) {
+        goto finish;
+    }
+
+    result = 0;
+
+finish:
+    return result;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+fat_iterator fat_iterator_open(const char * path, int macho_only)
+{
+    struct __fat_iterator * result = NULL;
+    struct __fat_iterator local_iter;
+
+    int fd = -1;
+    struct stat stat_buf;
+    vm_address_t file_data = (vm_address_t)MAP_FAILED;    // must munmap()
+
+    memset(&local_iter, 0, sizeof(local_iter));
+
+    fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        goto finish;
+    }
+
+    if (fstat(fd, &stat_buf) == -1) {
+        goto finish;
+    }
+
+    if (stat_buf.st_size < (off_t)sizeof(struct mach_header)) {
+        goto finish;
+    }
+
+    file_data = (vm_address_t)mmap(0, stat_buf.st_size, PROT_READ,
+        MAP_FILE|MAP_PRIVATE, fd, 0);
+    if (file_data == (vm_address_t)MAP_FAILED) {
+        goto finish;
+    }
+
+    local_iter.unmap = 1;
+
+    if (-1 == __fat_iterator_init(&local_iter, (char *)file_data,
+        (char *)file_data + stat_buf.st_size, macho_only)) {
+
+        goto finish;
+    }
+
+    result = (struct __fat_iterator *)malloc(sizeof(struct __fat_iterator));
+    if (!result) {
+        goto finish;
+    }
+    bzero(result, sizeof(struct __fat_iterator));
+    memcpy(result, &local_iter, sizeof(struct __fat_iterator));
+
+finish:
+    if (fd != -1) close(fd);
+
+    if (!result) {
+        if (file_data != (vm_address_t)MAP_FAILED) {
+            munmap((void *)file_data, stat_buf.st_size);
+        }
+    }
+    return (fat_iterator)result;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+fat_iterator fat_iterator_for_data(
+    const void * file_data,
+    const void * file_end,
+    int macho_only)
+{
+    struct __fat_iterator * result = NULL;
+    struct __fat_iterator local_iter;
+
+    memset(&local_iter, 0, sizeof(local_iter));
+
+    if (-1 == __fat_iterator_init(&local_iter, file_data,
+        file_end, macho_only)) {
+
+        goto finish;
+    }
+
+    result = (struct __fat_iterator *)malloc(
+        sizeof(struct __fat_iterator));
+    if (!result) {
+        goto finish;
+    }
+    bzero(result, sizeof(struct __fat_iterator));
+    memcpy(result, &local_iter, sizeof(struct __fat_iterator));
+
+finish:
+    return (fat_iterator)result;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+void fat_iterator_close(fat_iterator iter)
+{
+
+    if (iter->unmap) {
+        if (iter->file_start) {
+            munmap((void *)iter->file_start, iter->file_end -
+                iter->file_start);
+        }
+    }
+
+    free(iter);
+
+    return;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+int fat_iterator_num_arches(
+    fat_iterator iter)
+{
+    return iter->num_arches;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+int fat_iterator_is_iterable(fat_iterator iter)
+{
+    return iter->iterable;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+void * fat_iterator_next_arch(
+    fat_iterator iter,
+    void ** file_end)
+{
+    void * result = NULL;
+
+    if (!iter->fat_header) {
+        if (iter->arch_index == 0) {
+            result = iter->file_start;
+            if (file_end) {
+                *file_end = iter->file_end;
+            }
+            iter->arch_index++;
+        }
+    } else {
+        if (iter->arch_index < iter->num_arches) {
+            struct fat_arch * arch_start;
+            void * arch_end;
+
+            arch_start = (struct fat_arch *)((void *)iter->fat_arches +
+                (iter->arch_index * sizeof(struct fat_arch)));
+
+            result = ((void *)iter->file_start +
+                OSSwapBigToHostInt32(arch_start->offset));
+            arch_end = (void *)result + OSSwapBigToHostInt32(arch_start->size);
+
+            if (arch_end > iter->file_end) {
+                result = NULL;
+                iter->arch_index = iter->num_arches;
+                goto finish;
+            }
+
+            if (file_end) {
+                *file_end = arch_end;
+            }
+
+            iter->arch_index++;
+        }
+    }
+
+finish:
+    return result;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+void fat_iterator_reset(fat_iterator iter)
+{
+    iter->arch_index = 0;
+    return;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+int fat_iterator_find_fat_arch(
+    fat_iterator iter,
+    cpu_type_t cputype,
+    cpu_subtype_t cpusubtype,
+    struct fat_arch * fat_arch_out)
+{
+    int result = 0;
+    uint32_t magic;
+
+    uint32_t nfat_arch;
+
+    struct fat_arch * fat_arches;
+    struct fat_arch * fat_arches_copy = NULL;  // must free
+
+    struct fat_arch * found_arch;
+
+    magic = MAGIC32(iter->file_start);
+
+    if (iter->fat_header) {
+        uint32_t fat_arches_size;
+        uint32_t index;
+
+        nfat_arch = iter->num_arches;
+        fat_arches_size = nfat_arch * sizeof(struct fat_arch);
+
+        fat_arches_copy = (struct fat_arch *)(malloc(fat_arches_size));
+        if (!fat_arches_copy) {
+            goto finish;
+        }
+
+        fat_arches = fat_arches_copy;
+
+        memcpy(fat_arches, iter->fat_arches, fat_arches_size);
+
+       /* NXFindBestFatArch() requires all the fat info to be in host
+        * byte order.
+        */
+        for (index = 0; index < nfat_arch; index++) {
+            fat_arches[index].cputype =
+                OSSwapBigToHostInt32(fat_arches[index].cputype);
+            fat_arches[index].cpusubtype =
+                OSSwapBigToHostInt32(fat_arches[index].cpusubtype);
+            fat_arches[index].offset =
+                OSSwapBigToHostInt32(fat_arches[index].offset);
+            fat_arches[index].size =
+                OSSwapBigToHostInt32(fat_arches[index].size);
+            fat_arches[index].align =
+                OSSwapBigToHostInt32(fat_arches[index].align);
+        }
+    } else {
+        struct fat_arch fake_fat_arches;
+        uint8_t  swap;
+        struct mach_header * mach_hdr;
+
+        nfat_arch = 1;
+
+        bzero(&fake_fat_arches, sizeof(fake_fat_arches));
+
+        fat_arches = &fake_fat_arches;
+
+        swap = ISSWAPPEDMACHO(magic);
+        mach_hdr = (struct mach_header *)iter->file_start;
+        fat_arches[0].cputype = CondSwapInt32(swap, mach_hdr->cputype);
+        fat_arches[0].cpusubtype = CondSwapInt32(swap, mach_hdr->cpusubtype);
+
+        fat_arches[0].offset = 0;
+        fat_arches[0].size = iter->file_end - iter->file_start;
+        fat_arches[0].align = 1;  // not used anyhow
+    }
+
+    found_arch = NXFindBestFatArch(cputype, cpusubtype, fat_arches, nfat_arch);
+    if (found_arch) {
+        result = 1;
+        if (fat_arch_out) {
+            memcpy(fat_arch_out, found_arch, sizeof(*fat_arch_out));
+        }
+    }
+
+finish:
+    if (fat_arches_copy) {
+        free(fat_arches_copy);
+    }
+
+    return result;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+void * fat_iterator_find_arch(
+    fat_iterator iter,
+    cpu_type_t cputype,
+    cpu_subtype_t cpusubtype,
+    void ** arch_end_ptr)
+{
+    struct fat_arch   found_arch;
+    void            * arch_start = NULL;
+    void            * arch_end   = NULL;
+
+    if (!fat_iterator_find_fat_arch(iter, cputype, cpusubtype, &found_arch)) {
+        goto finish;
+    }
+    
+    // These are already swapped so don't swap them here.
+    arch_start = iter->file_start + found_arch.offset;
+    arch_end = arch_start + found_arch.size;
+
+    if (arch_end_ptr) {
+        *arch_end_ptr = arch_end;
+    }
+
+finish:
+
+    return arch_start;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+void * fat_iterator_find_host_arch(
+    fat_iterator iter,
+    void ** arch_end_ptr)
+{
+    const NXArchInfo * archinfo;
+
+    archinfo = NXGetLocalArchInfo();
+    if (!archinfo) {
+        return NULL;
+    }
+    return fat_iterator_find_arch(iter, archinfo->cputype,
+        archinfo->cpusubtype, arch_end_ptr);
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+const void * fat_iterator_file_start(fat_iterator iter)
+{
+    return iter->file_start;
+    return NULL;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+const void * fat_iterator_file_end(fat_iterator iter)
+{
+    return iter->file_end;
+    return NULL;
+}

--- a/src/kext_tools/kext.subproj/fat_util.h
+++ b/src/kext_tools/kext.subproj/fat_util.h
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2006-2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#ifndef __FAT_UTIL_H__
+#define __FAT_UTIL_H__
+
+#include <mach-o/fat.h>
+
+/*!
+ * @define  MAGIC32
+ * @abstract  Get the 32-bit magic number from a file data pointer.
+ * @param ptr A pointer to a file whose magic number you want to get.
+ * @result    Returns an unsigned 32-bit integer containing
+ *            the first four bytes of the file data.
+ */
+#define MAGIC32(ptr)          (*((uint32_t *)(ptr)))
+
+#define ISFAT(magic)          ((magic) == OSSwapHostToBigInt32(FAT_MAGIC))
+
+/*!
+ * @typedef fat_iterator
+ * @abstract An opaque type for iterating architectures
+ *           in a Mach-O or universal binary file.
+ * @discussion A fat_iterator allows you to access every architecture in a
+ *           Macho-O or universal binary file. Initialized with either kind,
+ *           you use the fat_iterator_next_arch function to scan through each
+ *           architecture (which will be one for a Mach-O file, and one or more
+ *           for a universal binary file).
+ */
+typedef struct __fat_iterator * fat_iterator;
+
+
+/*!
+ * @function fat_iterator_open
+ * @abstract Create an iterator for a Mach-O or universal binary file.
+ * @discussion
+ *        The fat_iterator_open function opens and maps the named file,
+ *        creates a fat_iterator for it, and returns the iterator.
+ *        When finished with the iterator, use fat_iterator_close and the
+ *        file will be unmapped.
+ * @param path The pathname of the file to open.
+ * @param macho_only Pass true to require the file data be either fat or a
+ *         thin Mach-O file or
+ *         false to allow a non-fat file to contain any kind of data.
+ * @result Returns a fat_iterator you can use to access the architectures
+ *         in the named file.
+ *         Returns NULL if the file can't be opened,
+ *         if macho_only is true and the file is neither fat nor a Mach-O file,
+ *         or if the iterator can't be created.
+ */
+fat_iterator fat_iterator_open(const char * path, int macho_only);
+
+/*!
+ * @function fat_iterator_for_data
+ * @abstract Create an iterator for in-memory Mach-O or universal binary data.
+ * @discussion
+ *        The fat_iterator_for_data function creates and returns an iterator
+ *        for in-memory Mach-O or universal binary data, which must be complete.
+ *        The iterator does not own the data, so be sure not to free or unmap
+ *        it before you close the iterator.
+ * @param file_data A pointer to the start of the file data.
+ * @param file_end A pointer to the end of the file data, which the iterator
+ *        uses for bounds checking.
+ * @param macho_only Pass true to require the file data be either fat or a
+ *         thin Mach-O file or
+ *         false to allow a non-fat file to contain any kind of data.
+ * @result Returns a fat_iterator you can use to access the architectures
+ *         in the file data.
+ *         Returns NULL if the file can't be opened,
+ *         if macho_only is true and the file is neither fat nor a Mach-O file,
+ *         or if the iterator can't be created.
+ */
+fat_iterator fat_iterator_for_data(
+    const void * file_data,
+    const void * file_end,
+    int macho_only);
+
+/*!
+ * @function fat_iterator_close
+ * @abstract Close and free a fat_iterator.
+ * @discussion
+ *        The fat_iterator_close function unmaps a fat_iterator's file data
+ *        if necessary and frees the iterator.
+ * @param iter The fat_iterator to close.
+ */
+void fat_iterator_close(fat_iterator iter);
+
+/*!
+ * @function fat_iterator_num_arches
+ * @abstract Return how many arches are in the data of a fat iterator.
+ * @param iter The fat_iterator to check.
+ * @result Returns the number of arches that will be iterated over, total.
+ */
+int fat_iterator_num_arches(
+    fat_iterator iter);
+
+/*!
+ * @function fat_iterator_is_iterable
+ * @abstract Return whether a fat_iterator can actually iterate.
+ * @discussion
+ *        The fat_iterator_is_iterable function returns true if it represents
+ *        a fat file or a thin Mach-O file, false otherwise.
+ * @param iter The fat_iterator to check.
+ * @result Returns true if the iterator represents
+ *        a fat file or a thin Mach-O file, false otherwise.
+ */
+int fat_iterator_is_iterable(
+    fat_iterator iter);
+
+/*!
+ * @function fat_iterator_next_arch
+ * @abstract Return the next architecture in a fat_iterator.
+ * @discussion
+ *        The fat_iterator_next_arch function returns a pointer to the start
+ * of the data for the next architecture in the iterator's file, or NULL if the
+ * architectures have been fully traversed (or if the iterator is not valid).
+ * @param iter The fat_iterator to iterate.
+ * @param file_end If provided, this indirect pointer is filled
+ *        with the address of the end of the data for the architecture returned.
+ *        Other macho utility functions use this for bounds checking.
+ * @result Returns a pointer to the mach_header
+ * struct for the next architecture in the iterator's file, or NULL if the
+ * architectures have been fully traversed (or if the iterator is not valid).
+ */
+void * fat_iterator_next_arch(
+    fat_iterator iter,
+    void ** arch_end);
+
+/*!
+ * @function fat_iterator_reset
+ * @abstract Rewinds a fat_iterator.
+ * @discussion
+ *        The fat_iterator_reset function sets the iterator to start from
+ *        the beginning of the file so that you can iterate it again.
+ * @param iter The fat_iterator to reset.
+ */
+void fat_iterator_reset(fat_iterator iter);
+
+/*!
+ * @function fat_iterator_find_fat_arch
+ * @abstract Find the specified fat_arch entry in a fat_iterator,
+ *           if present.
+ * @discussion
+ *        The fat_iterator_find_arch function fills in a provided
+ * fat_arch struct for the specified architecture
+ * in the iterator's file, or NULL if that architecture is not represented.
+ * @param iter The fat_iterator to get the arch data from.
+ * @param cputype The CPU type code requested (see <mach/machine.h> for a list).
+ * @param cpusubtype The CPU subtype requested.
+ *        Use CPU_SUBTYPE_MULTIPLE for a generic processor family request.
+ * @param fat_arch A pointer to the fat_arch struct to fill in.
+ *        All fields filled in are in host byte order.
+ * @result Returns 1 if the
+ * specified architecture is found in the iterator's file,
+ * or 0 if the specified architecture is not represented.
+ */
+int fat_iterator_find_fat_arch(
+    fat_iterator iter,
+    cpu_type_t cputype,
+    cpu_subtype_t cpusubtype,
+    struct fat_arch * fat_arch);
+
+/*!
+ * @function fat_iterator_find_arch
+ * @abstract Return the specified architecture in a fat_iterator, if present.
+ * @discussion
+ *        The fat_iterator_find_arch function returns a pointer
+ * to the start of the data for the specified architecture
+ * in the iterator's file, or NULL if that architecture is not represented.
+ * @param iter The fat_iterator to get the arch data from.
+ * @param cputype The CPU type code specified (see <mach/machine.h> for a list).
+ * @param cpusubtype The CPU subtype specified.
+ *        Use CPU_SUBTYPE_MULTIPLE for a generic processor family request.
+ * @param file_end If provided, this indirect pointer is filled
+ *        with the address of the end of the data for the architecture returned.
+ *        Other macho utility functions use this for bounds checking.
+ * @result Returns a pointer to the file data
+ * for the specified architecture in the iterator's file,
+ * or NULL if the specified architecture is not represented.
+ */
+void * fat_iterator_find_arch(
+    fat_iterator iter,
+    cpu_type_t cputype,
+    cpu_subtype_t cpusubtype,
+    void ** arch_end_ptr);
+
+/*!
+ * @function fat_iterator_find_host_arch
+ * @abstract Return the host architecture in a fat_iterator, if present.
+ * @discussion
+ *        The fat_iterator_find_host_arch function returns a pointer
+ * to the start of the data for the host architecture in the iterator's file,
+ * or NULL if the host architecture is not represented.
+ * @param iter The fat_iterator to get the host arch data from.
+ * @param file_end If provided, this indirect pointer is filled
+ *        with the address of the end of the data for the architecture returned.
+ *        Other macho utility functions use this for bounds checking.
+ * @result Returns a pointer to the file data
+ * for the host architecture in the iterator's file,
+ * or NULL if the host architecture is not represented.
+ */
+void * fat_iterator_find_host_arch(
+    fat_iterator iter,
+    void ** arch_end_ptr);
+
+/*!
+ * @function fat_iterator_file_start
+ * @abstract Returns a pointer to the start of a fat_iterator's file.
+ * @discussion
+ *        The fat_iterator_reset returns a pointer to the start
+ *        of a fat_iterator's file, so that you can access it directly.
+ * @param iter The fat_iterator to get the file start for.
+ * @result Returns a pointer to the beginning of the file accessed
+ *         by the fat_iterator.
+ */
+const void * fat_iterator_file_start(fat_iterator iter);
+
+/*!
+ * @function fat_iterator_file_end
+ * @abstract Returns a pointer to the end of a fat_iterator's file.
+ * @discussion
+ *        The fat_iterator_reset returns a pointer to the end
+ *        of a fat_iterator's file, so that you can do bounds checking.
+ * @param iter The fat_iterator to get the file end for.
+ * @result Returns a pointer to the end of the file accessed
+ *         by the fat_iterator.
+ */
+const void * fat_iterator_file_end(fat_iterator iter);
+
+
+#endif /* __FAT_UTIL_H__ */

--- a/src/kext_tools/kext.subproj/kextmanager_mig.defs
+++ b/src/kext_tools/kext.subproj/kextmanager_mig.defs
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+#include <mach/std_types.defs>
+#include <mach/mach_types.defs>
+
+subsystem kextmanager 70000;
+serverprefix _;
+
+#include <mach/std_types.defs>
+#include <mach/mach_types.defs>
+//import <TargetConditionals.h>;
+// RY: Looks like TargetConditionals is not working with MIG
+// Using NO_SECURITY_FRAMEWORK instead of !TARGET_OS_IPHONE
+#ifndef NO_SECURITY_FRAMEWORK
+import <Security/Authorization.h>;
+#endif /* NO_SECURITY_FRAMEWORK */
+import <IOKit/kext/kextmanager_types.h>;
+import <mach/kmod.h>;
+import <sys/param.h>;
+
+
+// !! Everything here MUST MATCH kextmanager_types.h !!
+// (yes, it's unfortunate that we have to duplicate typedefs)
+
+type kext_result_t = int;
+// tracks __darwin_uuid_t in sys/_types.h (or CFUUIDBytes in CFUUID.h)
+type uuid_t = array [16] of uint8_t;
+// length must match MNAMELEN (sys/mount.h)
+#if __DARWIN_64_BIT_INO_T
+type mountpoint_t = array [MAXPATHLEN] of char;
+#else
+type mountpoint_t = array [90] of char;
+#endif
+// length limit chosen arbitrarily (matches kextmanager_types.h)
+type property_key_t = array [128] of char;
+// length must match KMOD_MAX_NAME from <mach/kmod.h>
+type kext_bundle_id_t = array [64] of char;
+// length must match MAXPATHLEN from <sys/param.h>
+type posix_path_t = array [1024] of char;
+
+/*
+ * serialized XML data (server->client)
+ */
+// nowadays this is binary plist data but we keep the name for now
+type xmlDataOut = ^ array [] of MACH_MSG_TYPE_BYTE
+        ctype : xmlDataOut_t;
+type xmlDataIn = ^ array [] of MACH_MSG_TYPE_BYTE
+        ctype : xmlDataIn_t;
+#ifndef NO_SECURITY_FRAMEWORK
+type AuthRefIn = struct [8] of unsigned32
+        ctype : AuthorizationExternalForm;
+#endif /* NO_SECURITY_FRAMEWORK */
+
+// for finding icons
+routine kextmanager_path_for_bundle_id(
+    server           : mach_port_t;
+    bundle_id        : kext_bundle_id_t;
+    out path         : posix_path_t;
+    out kext_result  : kext_result_t);
+
+// for loginwindow to find "OSBundleHelper"
+routine kextmanager_create_property_value_array(
+    server           : mach_port_t;
+    prop_key         : property_key_t;
+    out data         : xmlDataOut, dealloc);
+
+// login / logout tracking
+#ifndef NO_SECURITY_FRAMEWORK
+skip;  /* was kextmanager_user_did_log_in */
+#endif /* NO_SECURITY_FRAMEWORK */
+
+skip;  /* was kextmanager_user_will_log_out */
+skip;  /* was kextmanager_get_logged_in_userid */
+
+skip;  /* was kextmanager_record_nonsecure_kextload */
+
+// reboot blocking (are caches up to date?)
+routine kextmanager_lock_reboot(
+            server      : mach_port_t;
+    sreplyport reply    : mach_port_make_send_once_t;   // exposed reply port
+            reaper      : mach_port_make_send_t;        // death tracking
+            waitForLock : int;
+    out     busyVol     : mountpoint_t;                 // if available
+    out     busyStatus  : int);
+
+// kextcache locking
+// if not waiting for lock, lockStatus = EBUSY if unavailable
+routine kextmanager_lock_volume(
+            server      : mach_port_t;
+    sreplyport reply    : mach_port_make_send_once_t;   // exposed reply port
+            reaper      : mach_port_make_send_t;        // death tracking
+            vol_uuid    : uuid_t;
+            waitForLock : int;
+    out     lockStatus  : int);
+
+routine kextmanager_unlock_volume(
+            server      : mach_port_t;
+            clientIdent : mach_port_make_send_t;
+            vol_uuid    : uuid_t;
+            exitStatus  : int);
+
+// kextload locking (trylock-style)
+routine kextmanager_lock_kextload(
+    server           : mach_port_t;
+    clientPort       : mach_port_make_send_t;
+    out lockstatus   : int);
+
+routine kextmanager_unlock_kextload(
+    server           : mach_port_t;
+    clientPort       : mach_port_make_send_t);
+
+/* This spot used to be kextmanager_record_path_for_bundle_id(),
+ * but the kernel records the paths of all loaded kexts now so
+ * it's no longer necessary.
+ */
+skip;
+
+routine kextmanager_load_kext(
+    server                        : mach_port_t;
+    ServerAuditToken remote_creds : audit_token_t;
+    load_data                     : xmlDataIn);

--- a/src/kext_tools/kext.subproj/kextmanager_types.h
+++ b/src/kext_tools/kext.subproj/kextmanager_types.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008, 2012 Apple Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/*
+ * FILE: kextmanager_types.h
+ * AUTH: I/O Kit Team (Copyright Apple Computer, 2002, 2006-7)
+ * DATE: June 2002, September 2006, August 2007
+ * DESC: typedefs for the kextmanager_mig.defs's MiG-generated code 
+ *
+ */
+
+#ifndef __KEXT_TYPES_H__
+#define __KEXT_TYPES_H__
+
+#include <mach/mach_types.h>        // allows to compile standalone
+#include <mach/kmod.h>
+#include <sys/param.h>
+#include <sys/mount.h>
+#include <uuid/uuid.h>              // uuid_t
+
+#define KEXTD_SERVER_NAME       "com.apple.KernelExtensionServer"
+#define PROPERTYKEY_LEN         128
+
+typedef int kext_result_t;
+typedef char mountpoint_t[MNAMELEN];
+typedef char property_key_t[PROPERTYKEY_LEN];
+typedef char kext_bundle_id_t[KMOD_MAX_NAME];
+typedef char posix_path_t[MAXPATHLEN];
+
+// nowadays this is binary plist data but we keep the name for now
+typedef char * xmlDataOut_t;
+typedef char * xmlDataIn_t;
+
+#endif /* __KEXT_TYPES_H__ */

--- a/src/kext_tools/kext.subproj/macho_util.c
+++ b/src/kext_tools/kext.subproj/macho_util.c
@@ -1,0 +1,1290 @@
+/*
+ * Copyright (c) 2006-2008, 2012 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#include <unistd.h>
+#include <string.h>
+
+#include <stdio.h>
+#include <fcntl.h>
+
+#include <Kernel/mach/vm_types.h>
+#include <Kernel/mach/vm_param.h>
+
+#include <mach-o/swap.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+#include "macho_util.h"
+
+static boolean_t macho_swap_32(u_char *file);
+static boolean_t macho_swap_64(u_char *file);
+
+static boolean_t macho_unswap_32(u_char *file);
+static boolean_t macho_unswap_64(u_char *file);
+
+/*******************************************************************************
+*
+*******************************************************************************/
+macho_seek_result macho_find_symbol(
+    const void          * file_start,
+    const void          * file_end,
+    const char          * name,
+          uint8_t       * nlist_type,
+    const void         ** symbol_address)
+{
+    macho_seek_result       result = macho_seek_result_not_found;
+    macho_seek_result       symtab_result = macho_seek_result_not_found;
+    uint8_t                 swap = 0;
+    char                    sixtyfourbit = 0;
+    struct symtab_command * symtab = NULL;
+    struct nlist          * syms_address;
+    struct nlist_64       * syms_address_64;
+    const void            * string_list;
+    char                  * symbol_name;
+    unsigned int            symtab_offset;
+    unsigned int            str_offset;
+    unsigned int            num_syms;
+    unsigned int            syms_bytes;
+    unsigned int            sym_index;
+
+    if (symbol_address) {
+         *symbol_address = 0;
+    }
+
+    symtab_result = macho_find_symtab(file_start, file_end, &symtab);
+    if (symtab_result != macho_seek_result_found) {
+        goto finish;
+    }
+
+    if (ISSWAPPEDMACHO(MAGIC32(file_start))) {
+        swap = 1;
+    }
+    if (ISMACHO64(MAGIC32(file_start))) {
+        sixtyfourbit = 1;
+    }
+
+    symtab_offset = CondSwapInt32(swap, symtab->symoff);
+    str_offset = CondSwapInt32(swap, symtab->stroff);
+    num_syms   = CondSwapInt32(swap, symtab->nsyms);
+
+    syms_address = (struct nlist *)(file_start + symtab_offset);
+    syms_address_64 = (struct nlist_64 *)(file_start + symtab_offset);
+
+    string_list = file_start + str_offset;
+    if (sixtyfourbit) {
+        syms_bytes = num_syms * sizeof(struct nlist_64);
+    } else {
+        syms_bytes = num_syms * sizeof(struct nlist);
+    }
+
+    if ((char *)syms_address + syms_bytes > (char *)file_end) {
+        result = macho_seek_result_error;
+        goto finish;
+    }
+
+    for (sym_index = 0; sym_index < num_syms; sym_index++) {
+        struct nlist    * seekptr;
+        struct nlist_64 * seekptr_64;
+        uint32_t          string_index;
+        uint8_t           n_type;
+        uint8_t           n_sect;
+        uint64_t          n_value;
+
+        if (sixtyfourbit) {
+            seekptr_64   = &syms_address_64[sym_index];
+            string_index = CondSwapInt32(swap, seekptr_64->n_un.n_strx);
+            n_type       = seekptr_64->n_type;
+            n_sect       = seekptr_64->n_sect;
+            n_value      = CondSwapInt64(swap, seekptr_64->n_value);
+        } else {
+            seekptr      = &syms_address[sym_index];
+            string_index = CondSwapInt32(swap, seekptr->n_un.n_strx);
+            n_type       = seekptr->n_type;
+            n_sect       = seekptr->n_sect;
+            n_value      = (uint64_t)CondSwapInt32(swap, seekptr->n_value);
+        }
+
+        if (string_index == 0 || n_type & N_STAB) {
+            continue;
+        }
+        symbol_name = (char *)(string_list + string_index);
+
+        if (strcmp(name, symbol_name) == 0) {
+
+            if (nlist_type) {
+                *nlist_type = n_type;
+            }
+            switch (n_type & N_TYPE) {
+                case N_SECT:
+                    {
+                        void * v_sect_info = macho_find_section_numbered(
+                            file_start, file_end, n_sect);
+    
+    
+                        if (!v_sect_info) {
+                            break;  // out of the switch
+                        }
+                        
+                        if (symbol_address) {
+                            if (sixtyfourbit) {
+                                struct section_64 * sect_info_64 =
+                                    (struct section_64 *)v_sect_info;
+        
+                                // this isn't right for 64bit? compare below
+                                size_t reloffset = (n_value -
+                                    CondSwapInt64(swap, sect_info_64->addr));
+        
+                                *symbol_address = file_start;
+                                *symbol_address += CondSwapInt32(swap,
+                                    sect_info_64->offset);
+                                *symbol_address += reloffset;
+                            } else {
+                                struct section * sect_info =
+                                    (struct section *)v_sect_info;
+        
+                                size_t reloffset = (n_value -
+                                    CondSwapInt32(swap, sect_info->addr));
+        
+                                *symbol_address = file_start;
+                                *symbol_address += CondSwapInt32(swap,
+                                    sect_info->offset);
+                                *symbol_address += reloffset;
+                            }
+                        }
+                        result = macho_seek_result_found;
+                        goto finish;
+                    }
+                    break;
+    
+                case N_UNDF:
+                    result = macho_seek_result_found_no_value;
+                    goto finish;
+                    break;
+  
+                case N_ABS:
+                    result = macho_seek_result_found_no_value;
+                    goto finish;
+                    break;
+  
+              /* We don't chase indirect symbols as they can be external.
+               */
+                case N_INDR:
+                    result = macho_seek_result_found_no_value;
+                    goto finish;
+                    break;
+    
+                default:
+                    goto finish;
+                    break;
+            }
+        }
+    }
+
+finish:
+    return result;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+typedef struct {
+    struct symtab_command * symtab;
+} _symtab_scan;
+
+static macho_seek_result __macho_lc_is_symtab(
+    struct load_command * lc_cmd,
+    const void          * file_end,
+    uint8_t               swap,
+    void                * user_data);
+
+/******************************************************************************/
+
+macho_seek_result macho_find_symtab(
+    const void             * file_start,
+    const void             * file_end,
+    struct symtab_command ** symtab)
+{
+    macho_seek_result result = macho_seek_result_not_found;
+    _symtab_scan      sym_data;
+
+    bzero(&sym_data, sizeof(sym_data));
+
+    if (symtab) {
+        *symtab = NULL;
+    }
+
+    result = macho_scan_load_commands(file_start,
+        file_end, &__macho_lc_is_symtab, &sym_data);
+
+    if (result == macho_seek_result_found) {
+        if (symtab) {
+            *symtab = sym_data.symtab;
+        }
+    }
+
+    return result;
+}
+
+/******************************************************************************/
+
+static macho_seek_result __macho_lc_is_symtab(
+    struct load_command * lc_cmd,
+    const void          * file_end,
+    uint8_t               swap,
+    void                * user_data)
+{
+    macho_seek_result   result = macho_seek_result_not_found;
+    _symtab_scan      * sym_data = (_symtab_scan *)user_data;
+    uint32_t            cmd;
+
+    if ((void *)(lc_cmd + sizeof(struct load_command)) > file_end) {
+        result = macho_seek_result_error;
+        goto finish;
+    }
+
+    cmd = CondSwapInt32(swap, lc_cmd->cmd);
+
+    if (cmd == LC_SYMTAB) {
+        uint32_t cmd_size = CondSwapInt32(swap, lc_cmd->cmdsize);
+
+        if ((cmd_size != sizeof(struct symtab_command)) ||
+            ((void *)(lc_cmd + sizeof(struct symtab_command)) > file_end)) {
+            result = macho_seek_result_error;
+            goto finish;
+        }
+        sym_data->symtab = (struct symtab_command *)lc_cmd;
+        result = macho_seek_result_found;
+        goto finish;
+    }
+
+finish:
+    return result;
+}
+
+/*******************************************************************************
+ *
+ *******************************************************************************/
+typedef struct {
+    struct dysymtab_command * dysymtab;
+} _dysymtab_scan;
+
+static macho_seek_result __macho_lc_is_dysymtab(
+                                                struct load_command * lc_cmd,
+                                                const void          * file_end,
+                                                uint8_t               swap,
+                                                void                * user_data);
+
+/******************************************************************************/
+
+macho_seek_result macho_find_dysymtab(
+                                      const void             * file_start,
+                                      const void             * file_end,
+                                      struct dysymtab_command ** dysymtab)
+{
+    macho_seek_result result = macho_seek_result_not_found;
+    _dysymtab_scan      dysym_data;
+    
+    bzero(&dysym_data, sizeof(dysym_data));
+    
+    if (dysymtab) {
+        *dysymtab = NULL;
+    }
+    
+    result = macho_scan_load_commands(file_start,
+                                      file_end, &__macho_lc_is_dysymtab, &dysym_data);
+    
+    if (result == macho_seek_result_found) {
+        if (dysymtab) {
+            *dysymtab = dysym_data.dysymtab;
+        }
+    }
+    
+    return result;
+}
+
+/******************************************************************************/
+
+static macho_seek_result __macho_lc_is_dysymtab(
+                                                struct load_command * lc_cmd,
+                                                const void          * file_end,
+                                                uint8_t               swap,
+                                                void                * user_data)
+{
+    macho_seek_result   result = macho_seek_result_not_found;
+    _dysymtab_scan      * dysym_data = (_dysymtab_scan *)user_data;
+    uint32_t            cmd;
+    
+    if ((void *)(lc_cmd + sizeof(struct load_command)) > file_end) {
+        result = macho_seek_result_error;
+        goto finish;
+    }
+    
+    cmd = CondSwapInt32(swap, lc_cmd->cmd);
+    
+    if (cmd == LC_DYSYMTAB) {
+        uint32_t cmd_size = CondSwapInt32(swap, lc_cmd->cmdsize);
+        
+        if ((cmd_size != sizeof(struct dysymtab_command)) ||
+            ((void *)(lc_cmd + sizeof(struct dysymtab_command)) > file_end)) {
+            result = macho_seek_result_error;
+            goto finish;
+        }
+        dysym_data->dysymtab = (struct dysymtab_command *)lc_cmd;
+        result = macho_seek_result_found;
+        goto finish;
+    }
+    
+finish:
+    return result;
+}
+
+/*******************************************************************************
+* macho_find_uuid()
+*
+* Returns a pointer to the UUID bytes.
+*******************************************************************************/
+struct _uuid_scan {
+    unsigned int   uuid_size;
+    char         * uuid;
+};
+
+macho_seek_result __uuid_callback(
+    struct load_command * load_command,
+    const void * file_end,
+    uint8_t swap __unused,
+    void * user_data)
+{
+    struct _uuid_scan * uuid_stuff = (struct _uuid_scan *)user_data;
+    if (load_command->cmd == LC_UUID) {
+        struct uuid_command * uuid_command = (struct uuid_command *)load_command;
+        if (((void *)load_command + load_command->cmdsize) > file_end) {
+            return macho_seek_result_error;
+        }
+        uuid_stuff->uuid_size = sizeof(uuid_command->uuid);
+        uuid_stuff->uuid = (char *)uuid_command->uuid;
+        return macho_seek_result_found;
+    }
+    return macho_seek_result_not_found;
+}
+
+macho_seek_result macho_find_uuid(
+    const void * file_start,
+    const void * file_end,
+    char       **uuid)
+{
+    macho_seek_result  result;
+    struct _uuid_scan seek_uuid;
+
+    result = macho_scan_load_commands(
+        file_start, file_end,
+        __uuid_callback, (const void **)&seek_uuid);
+    if (result == macho_seek_result_found && uuid) {
+        *uuid = seek_uuid.uuid;
+    }
+
+    return result;
+}
+
+/*******************************************************************************
+* macho_find_section_numbered()
+*
+* Returns a pointer to a section in a mach-o file based on its global index
+* (which starts at 1, not zero!). The section number is typically garnered from
+* some other mach-o struct, such as a symtab entry. Returns NULL if the numbered
+* section can't be found.
+*******************************************************************************/
+typedef struct {
+    char       sixtyfourbit;
+    uint8_t    sect_num;
+    uint8_t    sect_counter;
+    void     * sect_info;  // struct section or section_64 depending
+} _sect_scan;
+
+static macho_seek_result __macho_sect_in_lc(
+    struct load_command * lc_cmd,
+    const void          * file_end,
+    uint8_t               swap,
+    void                * user_data);
+
+/******************************************************************************/
+
+void * macho_find_section_numbered(
+    const void * file_start,
+    const void * file_end,
+    uint8_t      sect_num)
+{
+    _sect_scan sect_data;
+
+    bzero(&sect_data, sizeof(sect_data));
+
+    sect_data.sect_num = sect_num;
+
+    if (ISMACHO64(MAGIC32(file_start))) {
+        sect_data.sixtyfourbit = 1;
+    }
+
+    if (macho_seek_result_found == macho_scan_load_commands(
+        file_start, file_end, &__macho_sect_in_lc, &sect_data)) {
+
+        return sect_data.sect_info;
+    }
+
+    return NULL;
+}
+
+/******************************************************************************/
+
+static macho_seek_result __macho_sect_in_lc(
+    struct load_command * lc_cmd,
+    const void          * file_end,
+    uint8_t               swap,
+    void                * user_data)
+{
+    macho_seek_result   result    = macho_seek_result_not_found;
+    _sect_scan        * sect_data = (_sect_scan *)user_data;
+    uint32_t            cmd;
+
+    if (sect_data->sect_counter > sect_data->sect_num) {
+        result = macho_seek_result_stop;
+        goto finish;
+    }
+
+    if ((void *)(lc_cmd + sizeof(struct load_command)) > file_end) {
+        result = macho_seek_result_error;
+        goto finish;
+    }
+
+    cmd = CondSwapInt32(swap, lc_cmd->cmd);
+
+    if (cmd == LC_SEGMENT_64) {
+        struct segment_command_64 * seg_cmd =
+            (struct segment_command_64 *)lc_cmd;
+        uint32_t                    cmd_size;
+        uint32_t                    num_sects;
+        uint32_t                    sects_size;
+        struct section_64         * seek_sect;
+        uint32_t                    sect_index;
+
+        cmd_size = CondSwapInt32(swap, seg_cmd->cmdsize);
+        num_sects = CondSwapInt32(swap, seg_cmd->nsects);
+        sects_size = num_sects * sizeof(*seek_sect);
+
+        if (cmd_size != (sizeof(*seg_cmd) + sects_size)) {
+            result = macho_seek_result_error;
+            goto finish;
+        }
+
+        if (((void *)lc_cmd + cmd_size) > file_end) {
+            result = macho_seek_result_error;
+            goto finish;
+        }
+
+        for (sect_index = 0; sect_index < num_sects; sect_index++) {
+
+            seek_sect = (struct section_64 *)((void *)lc_cmd +
+                sizeof(*seg_cmd) +
+                (sect_index * sizeof(*seek_sect)));
+
+            sect_data->sect_counter++;
+
+            if (sect_data->sect_counter == sect_data->sect_num) {
+                sect_data->sect_info = seek_sect;
+                result = macho_seek_result_found;
+                goto finish;
+            }
+        }
+    } else if (cmd == LC_SEGMENT) {
+        struct segment_command    * seg_cmd = (struct segment_command *)lc_cmd;
+        uint32_t                    cmd_size;
+        uint32_t                    num_sects;
+        uint32_t                    sects_size;
+        struct section            * seek_sect;
+        uint32_t                    sect_index;
+
+        cmd_size = CondSwapInt32(swap, seg_cmd->cmdsize);
+        num_sects = CondSwapInt32(swap, seg_cmd->nsects);
+        sects_size = num_sects * sizeof(*seek_sect);
+
+        if (cmd_size != (sizeof(*seg_cmd) + sects_size)) {
+            result = macho_seek_result_error;
+            goto finish;
+        }
+
+        if (((void *)lc_cmd + cmd_size) > file_end) {
+            result = macho_seek_result_error;
+            goto finish;
+        }
+
+        for (sect_index = 0; sect_index < num_sects; sect_index++) {
+
+            seek_sect = (struct section *)((void *)lc_cmd +
+                sizeof(*seg_cmd) +
+                (sect_index * sizeof(*seek_sect)));
+
+            sect_data->sect_counter++;
+
+            if (sect_data->sect_counter == sect_data->sect_num) {
+                sect_data->sect_info = seek_sect;
+                result = macho_seek_result_found;
+                goto finish;
+            }
+        }
+    }
+
+finish:
+    return result;
+}
+
+/*******************************************************************************
+ * macho_find_source_version()
+ *
+ * Returns the contents of the version field of an LC_SOURCE_VERSION load
+ * command.
+ *******************************************************************************/
+static macho_seek_result __source_version_callback(
+                                  struct load_command * load_command,
+                                  const void * file_end,
+                                  uint8_t swap __unused,
+                                  void * user_data)
+{
+    uint64_t    *versionPtr = (uint64_t *) user_data;
+
+    if (load_command->cmd == LC_SOURCE_VERSION) {
+        struct source_version_command * sv_command = (struct source_version_command *)load_command;
+        if (((void *)load_command + load_command->cmdsize) > file_end) {
+            return macho_seek_result_error;
+        }
+        *versionPtr = sv_command->version;
+        return macho_seek_result_found;
+    }
+    return macho_seek_result_not_found;
+}
+
+macho_seek_result macho_find_source_version(
+                                  const void * file_start,
+                                  const void * file_end,
+                                  uint64_t   * version)
+{
+    macho_seek_result  result;
+
+    *version = 0;
+    result = macho_scan_load_commands(file_start, file_end, __source_version_callback, version);
+    return result;
+}
+
+/*******************************************************************************
+*
+*******************************************************************************/
+#define CMDSIZE_MULT_32  (4)
+#define CMDSIZE_MULT_64  (8)
+
+macho_seek_result macho_scan_load_commands(
+    const void        * file_start,
+    const void        * file_end,
+    macho_lc_callback   lc_callback,
+    void              * user_data)
+{
+    macho_seek_result       result = macho_seek_result_not_found;
+    struct mach_header    * mach_header = (struct mach_header *)file_start;
+
+    uint8_t                 swap = 0;
+    uint32_t                cmdsize_mult = CMDSIZE_MULT_32;
+
+    uint32_t                num_cmds;
+    uint32_t                sizeofcmds;
+    char                  * cmds_end;
+
+    uint32_t                cmd_index;
+    struct load_command  * load_commands;
+    struct load_command  * seek_lc;
+
+    switch (MAGIC32(file_start)) {
+      case MH_MAGIC_64:
+        cmdsize_mult = CMDSIZE_MULT_64;
+        break;
+      case MH_CIGAM_64:
+        cmdsize_mult = CMDSIZE_MULT_64;
+        swap = 1;
+        break;
+      case MH_CIGAM:
+        swap = 1;
+        break;
+      case MH_MAGIC:
+        break;
+      default:
+        result = macho_seek_result_error;
+        goto finish;
+        break;
+    }
+
+    if (cmdsize_mult == CMDSIZE_MULT_64) {
+        load_commands = (struct load_command *)
+            (file_start + sizeof(struct mach_header_64));
+    } else {
+        load_commands = (struct load_command *)
+            (file_start + sizeof(struct mach_header));
+    }
+
+    if (file_start >= file_end || (((void *)load_commands) > file_end)) {
+        result = macho_seek_result_error;
+        goto finish;
+    }
+
+    num_cmds   = CondSwapInt32(swap, mach_header->ncmds);
+    sizeofcmds = CondSwapInt32(swap, mach_header->sizeofcmds);
+    cmds_end = (char *)load_commands + sizeofcmds;
+
+    if (cmds_end > (char *)file_end) {
+        result = macho_seek_result_error;
+        goto finish;
+    }
+
+    seek_lc = load_commands;
+
+    for (cmd_index = 0; cmd_index < num_cmds; cmd_index++) {
+        uint32_t cmd_size;
+        char * lc_end;
+
+        cmd_size = CondSwapInt32(swap, seek_lc->cmdsize);
+        lc_end = (char *)seek_lc + cmd_size;
+
+        if ((cmd_size % cmdsize_mult != 0) || (lc_end > cmds_end)) {
+            result = macho_seek_result_error;
+            goto finish;
+        }
+
+        result = lc_callback(seek_lc, file_end, swap, user_data);
+
+        switch (result) {
+          case macho_seek_result_not_found:
+            /* Not found, keep scanning. */
+            break;
+
+          case macho_seek_result_stop:
+            /* Definitely found that it isn't there. */
+            result = macho_seek_result_not_found;
+            goto finish;
+            break;
+
+          case macho_seek_result_found:
+            /* Found it! */
+            goto finish;
+            break;
+
+          default:
+            /* Error, fall through default case. */
+            result = macho_seek_result_error;
+            goto finish;
+            break;
+        }
+
+        seek_lc = (struct load_command *)((char *)seek_lc + cmd_size);
+    }
+
+finish:
+    return result;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+boolean_t macho_swap(
+    u_char    * file)
+{
+    boolean_t result = FALSE;
+    struct mach_header *hdr = (struct mach_header *) file;
+
+    if (hdr->magic == MH_CIGAM) {
+        result = macho_swap_32(file);
+    } else if (hdr->magic == MH_CIGAM_64) {
+        result = macho_swap_64(file);
+    }
+
+    return result;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+static boolean_t macho_swap_32(
+    u_char    * file)
+{
+    boolean_t result = FALSE;
+    struct mach_header *hdr = (struct mach_header *) file;
+    struct load_command *lc = (struct load_command *) &hdr[1];
+    struct segment_command *seg = NULL;
+    u_long offset = 0;
+    u_int cmd = 0;
+    u_int cmdsize = 0;
+    u_int i = 0;
+
+    if (!hdr || hdr->magic != MH_CIGAM) goto finish;
+
+    swap_mach_header(hdr, NXHostByteOrder());
+
+    offset = sizeof(*hdr);
+    for (i = 0; i < hdr->ncmds; ++i) {
+        lc = (struct load_command *) (file + offset);
+
+        cmd = OSSwapInt32(lc->cmd);
+        cmdsize = OSSwapInt32(lc->cmdsize);
+        offset += cmdsize;
+
+        if (cmd == LC_SEGMENT) {
+            seg = (struct segment_command *) lc;
+            swap_segment_command(seg, NXHostByteOrder());
+        } else {
+            swap_load_command(lc, NXHostByteOrder());
+        }
+    }
+
+    result = TRUE;
+finish:
+    return result;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+boolean_t macho_swap_64(
+    u_char    * file)
+{
+    boolean_t result = FALSE;
+    struct mach_header_64 *hdr = (struct mach_header_64 *) file;
+    struct load_command *lc = (struct load_command *) &hdr[1];
+    struct segment_command_64 *seg = NULL;
+    u_long offset = 0;
+    u_int cmd = 0;
+    u_int cmdsize = 0;
+    u_int i = 0;
+
+    if (!hdr || hdr->magic != MH_CIGAM_64) goto finish;
+
+    swap_mach_header_64(hdr, NXHostByteOrder());
+
+    offset = sizeof(*hdr);
+    for (i = 0; i < hdr->ncmds; ++i) {
+        lc = (struct load_command *) (file + offset);
+
+        cmd = OSSwapInt32(lc->cmd);
+        cmdsize = OSSwapInt32(lc->cmdsize);
+        offset += cmdsize;
+
+        if (cmd == LC_SEGMENT_64) {
+            seg = (struct segment_command_64 *) lc;
+            swap_segment_command_64(seg, NXHostByteOrder());
+        } else {
+            swap_load_command(lc, NXHostByteOrder());
+        }
+    }
+
+    result = TRUE;
+finish:
+    return result;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+boolean_t macho_unswap(
+    u_char    * file)
+{
+    boolean_t result = FALSE;
+    struct mach_header *hdr = (struct mach_header *) file;
+
+    if (hdr->magic == MH_MAGIC) {
+        result = macho_unswap_32(file);
+    } else if (hdr->magic == MH_MAGIC_64) {
+        result = macho_unswap_64(file);
+    }
+
+    return result;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+boolean_t macho_unswap_32(
+    u_char    * file)
+{
+    boolean_t result = FALSE;
+    enum NXByteOrder order = 0;
+    struct mach_header *hdr = (struct mach_header *) file;
+    struct load_command *lc = (struct load_command *) &hdr[1];
+    struct segment_command *seg = NULL;
+    u_long offset = 0;
+    u_int i = 0;
+
+    if (NXHostByteOrder() == NX_LittleEndian) {
+        order = NX_BigEndian;
+    } else {
+        order = NX_LittleEndian;
+    }
+
+    if (!hdr || hdr->magic != MH_MAGIC) goto finish;
+
+    offset = sizeof(*hdr);
+    for (i = 0; i < hdr->ncmds; ++i) {
+        lc = (struct load_command *) (file + offset);
+        offset += lc->cmdsize;
+
+        if (lc->cmd == LC_SEGMENT) {
+            seg = (struct segment_command *) lc;
+            swap_segment_command(seg, order);
+        } else {
+            swap_load_command(lc, order);
+        }
+            
+    }
+
+    swap_mach_header(hdr, order);
+
+    result = TRUE;
+finish:
+    return result;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+boolean_t macho_unswap_64(
+    u_char    * file)
+{
+    boolean_t result = FALSE;
+    enum NXByteOrder order = 0;
+    struct mach_header_64 *hdr = (struct mach_header_64 *) file;
+    struct load_command *lc = (struct load_command *) &hdr[1];
+    struct segment_command_64 *seg = NULL;
+    u_long offset = 0;
+    u_int i = 0;
+
+    if (NXHostByteOrder() == NX_LittleEndian) {
+        order = NX_BigEndian;
+    } else {
+        order = NX_LittleEndian;
+    }
+
+    if (!hdr || hdr->magic != MH_MAGIC_64) goto finish;
+
+    offset = sizeof(*hdr);
+    for (i = 0; i < hdr->ncmds; ++i) {
+        lc = (struct load_command *) (file + offset);
+        offset += lc->cmdsize;
+
+        if (lc->cmd == LC_SEGMENT_64) {
+            seg = (struct segment_command_64 *) lc;
+            swap_segment_command_64(seg, order);
+        } else {
+            swap_load_command(lc, order);
+        }
+    }
+
+    swap_mach_header_64(hdr, order);
+
+    result = TRUE;
+finish:
+    return result;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+struct segment_command * macho_get_segment_by_name(
+    struct mach_header    * mach_header,
+    const char            * segname)
+{
+    struct segment_command *segment = NULL;
+    struct load_command *lc = NULL;
+    u_char *base = (u_char *) mach_header;
+    size_t offset = sizeof(*mach_header);
+    u_int i = 0;
+    
+    if (mach_header->magic != MH_MAGIC) goto finish;
+    
+    for (i = 0; i < mach_header->ncmds; ++i) {
+        lc = (struct load_command *) (base + offset);
+        
+        if (lc->cmd == LC_SEGMENT) {
+            segment = (struct segment_command *) lc;
+            if (!strncmp(segment->segname, segname, sizeof(segment->segname))) {
+                break;
+            }
+            segment = NULL;
+        }
+        
+        offset += lc->cmdsize;
+    }
+
+finish:    
+    return segment;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+struct segment_command_64 * macho_get_segment_by_name_64(
+    struct mach_header_64      * mach_header,
+    const char                 * segname)
+{
+    struct segment_command_64 *segment = NULL;
+    struct load_command *lc = NULL;
+    u_char *base = (u_char *) mach_header;
+    size_t offset = sizeof(*mach_header);
+    u_int i = 0;
+    
+    if (mach_header->magic != MH_MAGIC_64) goto finish;
+    
+    for (i = 0; i < mach_header->ncmds; ++i) {
+        lc = (struct load_command *) (base + offset);
+        
+        if (lc->cmd == LC_SEGMENT_64) {
+            segment = (struct segment_command_64 *) lc;
+            if (!strncmp(segment->segname, segname, sizeof(segment->segname))) {
+                break;
+            }
+            segment = NULL;
+        }
+        
+        offset += lc->cmdsize;
+    }
+    
+finish:    
+    return segment;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+struct section * macho_get_section_by_name(
+    struct mach_header    * mach_header,
+    const char            * segname,
+    const char            * sectname)
+{
+    struct segment_command *segment = NULL;
+    struct section *section = NULL;
+    u_int i = 0;
+    
+    if (mach_header->magic != MH_MAGIC) goto finish;
+
+    segment = macho_get_segment_by_name(mach_header, segname);
+    if (!segment) goto finish;
+    
+    section = (struct section *) (&segment[1]);
+    for (i = 0; i < segment->nsects; ++i, ++section) {
+        if (!strncmp(section->sectname, sectname, sizeof(section->sectname))) {
+            break;
+        }
+    }
+    
+    if (i == segment->nsects) {
+        section = NULL;
+    }
+    
+finish:
+    return section;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+struct section_64 * macho_get_section_by_name_64(
+    struct mach_header_64     * mach_header,
+    const char                * segname,
+    const char                * sectname)
+{
+    struct segment_command_64 *segment = NULL;
+    struct section_64 *section = NULL;
+    u_int i = 0;
+    
+    if (mach_header->magic != MH_MAGIC_64) goto finish;
+    
+    segment = macho_get_segment_by_name_64(mach_header, segname);
+    if (!segment) goto finish;
+    
+    section = (struct section_64 *) (&segment[1]);
+    for (i = 0; i < segment->nsects; ++i, ++section) {
+        if (!strncmp(section->sectname, sectname, sizeof(section->sectname))) {
+            break;
+        }
+    }
+    
+    if (i == segment->nsects) {
+        section = NULL;
+    }
+    
+finish:
+    return section;
+}
+
+/*******************************************************************************
+*******************************************************************************/
+boolean_t macho_remove_linkedit(u_char *macho, u_long *linkedit_size)
+{
+    boolean_t result = FALSE;
+    struct mach_header *mach_hdr;
+    struct mach_header_64 *mach_hdr64;
+    u_char *src, *dst;
+    uint32_t ncmds, cmdsize;
+    boolean_t swap = FALSE;
+    u_int i;
+
+    swap = macho_swap(macho);
+
+    mach_hdr = (struct mach_header *) macho;
+    mach_hdr64 = (struct mach_header_64 *) macho;
+
+    /* Find the start of the load commands */
+
+    if (mach_hdr->magic == MH_MAGIC) {
+        src = dst = macho + sizeof(*mach_hdr);
+        ncmds = mach_hdr->ncmds;
+    } else if (mach_hdr->magic == MH_MAGIC_64) {
+        src = dst = macho + sizeof(*mach_hdr64);
+        ncmds = mach_hdr64->ncmds;
+    } else {
+        goto finish;
+    }
+
+    /* Remove any LINKEDIT-related load commands */
+
+    for (i = 0; i < ncmds; ++i, src += cmdsize) {
+        struct load_command * lc = (struct load_command *) src;
+        struct segment_command *seg = (struct segment_command *) src;
+        struct segment_command_64 *seg64 = (struct segment_command_64 *) src;
+        boolean_t strip = FALSE;
+
+        cmdsize = lc->cmdsize;
+
+        /* We delete the LINKEDIT segment and any symtab load commands */
+
+        switch (lc->cmd) {
+        case LC_SEGMENT:
+            if (!strncmp(seg->segname, SEG_LINKEDIT, sizeof(SEG_LINKEDIT) - 1)) {
+                strip = TRUE;
+                *linkedit_size = seg->vmsize;
+            }
+            break;
+        case LC_SEGMENT_64:
+            if (!strncmp(seg64->segname, SEG_LINKEDIT, sizeof(SEG_LINKEDIT) - 1)) {
+                strip = TRUE;
+                *linkedit_size = seg64->vmsize;
+            }
+            break;
+        case LC_SYMTAB:
+        case LC_DYSYMTAB:
+            strip = TRUE;
+            break;
+        }
+
+        if (strip) {
+            if (mach_hdr->magic == MH_MAGIC) {
+                mach_hdr->ncmds--;
+                mach_hdr->sizeofcmds -= cmdsize;
+            } else {
+                mach_hdr64->ncmds--;
+                mach_hdr64->sizeofcmds -= cmdsize;
+            }
+            bzero(src, lc->cmdsize);
+        } else {
+            memmove(dst, src, cmdsize);
+            dst += cmdsize;
+        }
+    }
+
+    result = TRUE;
+finish:
+    if (swap) macho_unswap(macho);
+    return result;
+}
+
+/*******************************************************************************
+ * remove the symbol table and string table from the LINKEDIT segment, leaving *
+ * any relocation data within the segment.                                     *
+*******************************************************************************/
+boolean_t macho_trim_linkedit(
+    u_char  *macho,
+    u_long  *amount_trimmed)
+{
+    boolean_t result = FALSE;
+    struct mach_header *mach_hdr;
+    struct mach_header_64 *mach_hdr64;
+    u_char *src, *dst;
+    uint32_t ncmds, cmdsize;
+    boolean_t swap = FALSE;
+    boolean_t is32bit = FALSE;
+    u_int i;
+    u_char *linkedit_segment = NULL;
+    struct symtab_command *symtab = NULL;
+    struct dysymtab_command *dysymtab = NULL;
+
+    *amount_trimmed = 0;    /* initialize */
+
+    swap = macho_swap(macho);
+
+    mach_hdr = (struct mach_header *) macho;
+    mach_hdr64 = (struct mach_header_64 *) macho;
+
+    /* Find the start of the load commands */
+
+    if (mach_hdr->magic == MH_MAGIC) {
+        src = dst = macho + sizeof(*mach_hdr);
+        ncmds = mach_hdr->ncmds;
+        is32bit = TRUE;
+    } else if (mach_hdr->magic == MH_MAGIC_64) {
+        src = dst = macho + sizeof(*mach_hdr64);
+        ncmds = mach_hdr64->ncmds;
+        is32bit = FALSE;
+    } else {
+        goto finish;
+    }
+
+    /* find any LINKEDIT-related load commands */
+
+    for (i = 0; i < ncmds; ++i, src += cmdsize) {
+        struct load_command * lc = (struct load_command *) src;
+        struct segment_command *seg = (struct segment_command *) src;
+        struct segment_command_64 *seg64 = (struct segment_command_64 *) src;
+
+        cmdsize = lc->cmdsize;
+
+        /* First, identify the load commands of interest */
+        switch (lc->cmd) {
+            case LC_SEGMENT:
+                if (!strncmp(seg->segname, SEG_LINKEDIT, sizeof(SEG_LINKEDIT) - 1)) {
+                    linkedit_segment = src;
+                }
+                break;
+                
+            case LC_SEGMENT_64:
+                if (!strncmp(seg64->segname, SEG_LINKEDIT, sizeof(SEG_LINKEDIT) - 1)) {
+                    linkedit_segment = src;
+                }
+                break;
+                
+            case LC_SYMTAB:
+                symtab = (struct symtab_command *) src;
+                break;
+                
+            case LC_DYSYMTAB:
+                dysymtab = (struct dysymtab_command *) src;
+                break;
+        }
+    }
+
+    /* was a LINKEDIT segment found? (it damned well better be there!) */
+    if (linkedit_segment == NULL)
+        goto finish;	/* yowza! */
+
+    /* if no DYSYMTAB command was found, just remove the entire LINKEDIT segment */
+    if (dysymtab == NULL) {
+        if (swap) macho_unswap(macho);
+        return (macho_remove_linkedit(macho, amount_trimmed));
+    }
+    else {
+
+        /* Calculate size of symbol table (including strings):
+         *   # of symbols * sizeof (nlist | nlist_64)...
+         *   + size of string table...
+         *   aligned to 8-byte boundary
+         */
+        u_long symtab_size = (((symtab->nsyms
+                                * (is32bit ? sizeof(struct nlist) : sizeof(struct nlist_64)))
+                               + symtab->strsize) + 7 ) & ~7;
+
+        /* calculate size of relocation entries */
+        u_long reloc_size = dysymtab->nlocrel * sizeof(struct relocation_info);
+
+        /* cache old vmsize */
+        u_long  old_vmsize = 
+            (is32bit
+                ? ((struct segment_command *)    linkedit_segment)->vmsize
+                : ((struct segment_command_64 *) linkedit_segment)->vmsize);
+
+        /* calculate new segment size after removal of symtab/stringtab data */
+        u_long  new_vmsize = round_page(reloc_size);
+
+        /* If the relocation entries are positioned within the LINKEDIT segment AFTER
+         * the symbol table, those entries must be moved within the segment. Otherwise,
+         * the segment can simply be truncated to remove the symbol table.
+         */
+        if (symtab->symoff < dysymtab->locreloff) {
+            /* move them up within the segment, overwriting the existing symbol table */
+            memmove(macho + symtab->symoff, macho + dysymtab->locreloff, reloc_size);
+            
+            /* update the header field */
+            dysymtab->locreloff = symtab->symoff;
+            
+            /* clear now-unused data within the segment */
+            bzero(macho + dysymtab->locreloff + reloc_size, symtab_size);
+        }
+        else {
+            /* symtab/stringtab entries are located after the relocation entries
+             * in the segment. Therefore, we just have to truncate the segment
+             * appropriately
+             */
+            bzero(macho + symtab->symoff, symtab_size);	/* wipe any existing data */
+        }
+
+        /* update LINKEDIT segment command with new size */
+        if (is32bit) {
+            ((struct segment_command *) linkedit_segment)->vmsize = 
+            ((struct segment_command *) linkedit_segment)->filesize = new_vmsize;
+        }
+        else {
+            ((struct segment_command_64 *) linkedit_segment)->vmsize = 
+            ((struct segment_command_64 *) linkedit_segment)->filesize = new_vmsize;
+        }
+
+        /* notify caller of # of bytes removed from segment */
+        *amount_trimmed = old_vmsize - new_vmsize;
+    }
+
+    /* now that the LINKEDIT segment contents have been adjusted properly, we must
+     * remove the actual SYMTAB load command from the header
+     */
+    src = dst;  /* reset for second pass through header */
+    for (i = 0; i < ncmds; ++i, src += cmdsize) {
+        struct load_command * lc = (struct load_command *) src;
+
+        cmdsize = lc->cmdsize;
+
+        if (lc->cmd == LC_SYMTAB) {
+            if (is32bit) {
+                mach_hdr->ncmds--;
+                mach_hdr->sizeofcmds -= cmdsize;
+            } else {
+                mach_hdr64->ncmds--;
+                mach_hdr64->sizeofcmds -= cmdsize;
+            }
+            bzero(src, lc->cmdsize);	/* zap the SYMTAB command */
+        }
+        else {
+            /* move remaining load commands up within the header */
+            if (dst != src) {
+                memmove(dst, src, cmdsize);
+            }
+            dst += cmdsize;
+        }
+    }
+
+    result = TRUE;
+finish:
+    if (swap) macho_unswap(macho);
+    return result;
+}

--- a/src/kext_tools/kext.subproj/macho_util.h
+++ b/src/kext_tools/kext.subproj/macho_util.h
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2006-2008, 2012 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#ifndef __MACHO_UTIL_H__
+#define __MACHO_UTIL_H__
+
+#include <mach-o/loader.h>
+#include <mach-o/nlist.h>
+#include <uuid/uuid.h>
+
+/*******************************************************************************
+********************************************************************************
+**                   DO NOT USE THIS API. IT IS VOLATILE.                     **
+********************************************************************************
+*******************************************************************************/
+
+/*! @header macho_util
+Handy functions for working with Mach-O files. Very rudimentary, use at your
+own risk.
+*/
+
+/*!
+ * @define  MAGIC32
+ * @abstract  Get the 32-bit magic number from a file data pointer.
+ * @param ptr A pointer to a file whose magic number you want to get.
+ * @result    Returns an unsigned 32-bit integer containing
+ *            the first four bytes of the file data.
+ */
+#define MAGIC32(ptr)          (*((uint32_t *)(ptr)))
+
+#define ISMACHO(magic)        (((magic) == MH_MAGIC) || \
+                               ((magic) == MH_CIGAM) || \
+                               ((magic) == MH_MAGIC_64) || \
+                               ((magic) == MH_CIGAM_64))
+#define ISSWAPPEDMACHO(magic)  (((magic) == MH_CIGAM) || \
+                               ((magic) == MH_CIGAM_64))
+#define ISMACHO64(magic)      (((magic) == MH_MAGIC_64) || \
+                               ((magic) == MH_CIGAM_64))
+
+/*******************************************************************************
+*
+*******************************************************************************/
+#define CondSwapInt32(flag, value)  ((flag) ? OSSwapInt32((value)) : \
+                                    (uint32_t)(value))
+#define CondSwapInt64(flag, value)  ((flag) ? OSSwapInt64((value)) : \
+                                    (uint64_t)(value))
+/*!
+ * @enum macho_seek_result
+ * @abstract Results of a lookup within a Mach-O file.
+ * @discussion This enum lists the possible return values for a Mach-O lookup.
+ * @constant macho_seek_result_error Invalid arguments or bad Mach-O file.
+ * @constant macho_seek_result_found The requested item was found.
+ * @constant macho_seek_result_not_found The requested item was not found.
+ *           For functions called repeatedly (such as the macho_lc_callback),
+ *           this means the item may be found on a subsequent invocation.
+ * @constant macho_seek_result_stop The requested item will not be found.
+ *           This is only returned by functions that may be called repeatedly,
+ *           when they can determine conclusively that the requested item does not exist.
+ */
+typedef enum {
+    macho_seek_result_error          = -1,
+    macho_seek_result_found          = 0,
+    macho_seek_result_found_no_value = 1,
+    macho_seek_result_not_found      = 2,
+    macho_seek_result_stop           = 3,
+} macho_seek_result;
+
+/*!
+ * @function macho_find_symbol
+ * @abstract Finds symbol data in a mapped Mach-O file.
+ * @discussion
+ *        The macho_find_symbol function searches a memory-mapped Mach-O file
+ *        for a given symbol,
+ *        indirectly returning the address within that mapped file
+ *        containing the data for that symbol.
+ *        Only symbols of type N_SECT, N_UNDF result in an address;
+ *        for N_ABS and N_INDR the result will be macho_seek_result_found_no_value.
+ * @param file_start A pointer to the beginning of the mapped Mach-O file.
+ * @param file_end A pointer to the end of the mapped Mach-O file.
+ * @param name The name of the symbol to find.
+ * @param nlist_type The address of a uint8_t that will be filled with the type
+ *        of the located symbol.
+ * @param symbol_address The address of a pointer that will be filled
+ *        with the location of the symbol's data in the mapped file,
+ *        if the address can be calculated.
+ * @result Returns macho_seek_result_found if the symbol is found,
+ * macho_seek_result_not_found if the symbol is not defined in the given file,
+ * or macho_seek_result_error if an error occurs.
+ */
+macho_seek_result macho_find_symbol(
+    const void          * file_start,
+    const void          * file_end,
+    const char          * name,
+          uint8_t       * nlist_type,
+    const void         ** symbol_address);
+
+/*!
+ * @function macho_find_symtab
+ * @abstract Finds a mapped Mach-O file's symbol table.
+ * @discussion
+ *        The macho_find_symtab function locates the symbol table of a Mach-O
+ *        file. Only the LC_SYMTAB load command is located, not the LC_DSYMTAB.
+ * @param mach_header A pointer to the beginning of the mapped Mach-O file.
+ * @param file_end A pointer to the end of the mapped Mach-O file.
+ * @param symtab A pointer to the address of a symtab_command struct;
+ *        if provided, this is filled with the address of the file's symbol table.
+ * @result Returns macho_seek_result_found if the symbol table is found,
+ * macho_seek_result_not_found if a symbol table is not defined in the given file,
+ * or macho_seek_result_error if an error occurs.
+ */
+macho_seek_result macho_find_symtab(
+    const void             * file_start,
+    const void             * file_end,
+    struct symtab_command ** symtab);
+
+/*!
+ * @function macho_find_dysymtab
+ * @abstract Finds a mapped Mach-O file's dynamic link-edit symbol table info.
+ * @discussion
+ *        The macho_find_dysymtab function locates the dynamic link-edit symbol 
+ *        table of a Mach-O file. Only the LC_DYSYMTAB load command is located, 
+ *        not the LC_SYMTAB.
+ * @param mach_header A pointer to the beginning of the mapped Mach-O file.
+ * @param file_end A pointer to the end of the mapped Mach-O file.
+ * @param dysymtab A pointer to the address of a dysymtab_command struct;
+ *        if provided, this is filled with the address of the file's symbol table.
+ * @result Returns macho_seek_result_found if the symbol table is found,
+ * macho_seek_result_not_found if a symbol table is not defined in the given file,
+ * or macho_seek_result_error if an error occurs.
+ */
+macho_seek_result macho_find_dysymtab(
+                                      const void               * file_start,
+                                      const void               * file_end,
+                                      struct dysymtab_command ** dysymtab);
+
+/*!
+ * @function macho_find_uuid
+ * @abstract Finds a mapped Mach-O file's UUID.
+ * @discussion
+ *        The macho_find_uuid function locates the UUID of a Mach-O file.
+ * @param mach_header A pointer to the beginning of the mapped Mach-O file.
+ * @param file_end A pointer to the end of the mapped Mach-O file.
+ * @param uuid A pointer to the start of the UUID bytes;
+ *        if provided, this is filled with the address of the UUID bytes.
+ * @result Returns macho_seek_result_found if the UUID is found,
+ * macho_seek_result_not_found if a UUID is not defined in the given file,
+ * or macho_seek_result_error if an error occurs.
+ */
+macho_seek_result macho_find_uuid(
+    const void * file_start,
+    const void * file_end,
+    char       **uuid);
+
+/*!
+ * @function macho_find_section_numbered
+ * @abstract Finds an ordinal section in a Mach-O file.
+ * @discussion
+ *        The macho_find_section_numbered function locates an ordinally-numbered
+ *        section within a Mach-O file, which is needed for calculating proper
+ *        offsets and addresses of such things as nlist entries.
+ *        Sections are numbered in a Mach-O file starting with 1, since zero
+ *        is reserved to mean "no section".
+ *        Since you will likely be passing a section number directly from other
+ *        structure within the same Mach-O file, this should not be a problem.
+ * @param mach_header A pointer to the beginning of the mapped Mach-O file.
+ * @param file_end A pointer to the end of the mapped Mach-O file.
+ * @param sect_num The ordinal number of the section to get, starting with 1.
+ * @result Returns a pointer to the requested section struct if it exists;
+ *         otherwise returns NULL.
+ */
+// cast to (struct section[_64] *)
+void * macho_find_section_numbered(
+    const void * file_start,
+    const void * file_end,
+    uint8_t sect_num);
+
+/*!
+ * @typedef macho_lc_callback
+ * @abstract The callback function used when scanning Mach-O load commands
+ *           with macho_scan_load_commands.
+ * @discussion macho_lc_callback defines the callback function
+ * invoked by macho_scan_load_commands for each load command it encounters.
+ * The scan function passes a pointer to a user data struct that you can use
+ * for search parameters, running information, and search results.
+ * @param load_command A pointer to the Mach-O load command being processed.
+ * @param file_end A pointer to the end of the mapped Mach-O file,
+ *        to be used for bounds checking.
+ * @param swap A boolean flag indicating whether the Mach-O file's byte order
+ *        is opposite the host's.
+ *        If nonzero, the callback needs to swap all multibyte values
+ *        read from the Mach-O file.
+ * @param user_data A pointer to user-defined data that is passed unaltered
+ *        across invocations of the callback function.
+ * @result Returns macho_seek_result_found if the requested item is found,
+ * macho_seek_result_not_found if is not found on this call,
+ * macho_seek_result_stop if the function determined that it does not exist,
+ * or macho_seek_result_error if an error occurs
+ * (particularly if any data structure to be accessed
+ * would run past the end of the file).
+ */
+typedef macho_seek_result (*macho_lc_callback)(
+    struct load_command * load_command,
+    const void          * file_end,
+    uint8_t               swap,
+    void                * user_data
+);
+
+/*!
+ * @function macho_find_source_version
+ * @abstract Finds a mapped Mach-O file's LC_SOURCE_VERSION.
+ * @discussion
+ *        The macho_find_source_version function locates the source version
+ *        load command of a Mach-O file.
+ * @param mach_header A pointer to the beginning of the mapped Mach-O file.
+ * @param file_end A pointer to the end of the mapped Mach-O file.
+ * @param version A pointer to a uint64_t variable into which to store the
+ *        contents of the 'version' field of the LC_SOURCE_VERSION load
+ *        command from the mach-o header.
+ * @result Returns macho_seek_result_found if the source version is found,
+ * macho_seek_result_not_found if a source version is not defined in the
+ * given file, or macho_seek_result_error if an error occurs.
+ */
+macho_seek_result macho_find_source_version(
+                                            const void * file_start,
+                                            const void * file_end,
+                                            uint64_t   * version);
+
+/*!
+ * @function macho_scan_load_commands
+ * @abstract Iterates over the load commands of a Mach-O file using a callback.
+ * @discussion
+ *        The macho_scan_load_commands iterates over the load commands within a
+ *        Mach-O file, invoking a user-supplied callback until that callback
+ *        returns a result indicating the scan should stop.
+ * @param mach_header A pointer to the beginning of the mapped Mach-O file.
+ * @param file_end A pointer to the end of the mapped Mach-O file.
+ * @param lc_callback A function that is invoked on each load command
+ *        of the Mach-O file until the callback function
+ *        indicates the scan is finished.
+ * @param user_data A pointer to user-defined data that is passed unaltered
+ *        across invocations of the callback function.
+ * @result Returns a pointer to the requested section struct if it exists;
+ *         otherwise returns NULL.
+ */
+macho_seek_result macho_scan_load_commands(
+    const void        * file_start,
+    const void        * file_end,
+    macho_lc_callback   lc_callback,
+    void              * user_data);
+
+boolean_t macho_swap(
+    u_char            * file);
+
+boolean_t macho_unswap(
+    u_char            * file);
+
+struct segment_command * macho_get_segment_by_name(
+    struct mach_header    * mach_header,
+    const char            * segname);
+
+struct segment_command_64 * macho_get_segment_by_name_64(
+    struct mach_header_64      * mach_header,
+    const char                 * segname);
+
+struct section * macho_get_section_by_name(
+    struct mach_header    * mach_header,
+    const char            * segname,
+    const char            * sectname);
+
+struct section_64 * macho_get_section_by_name_64(
+    struct mach_header_64     * mach_header,
+    const char                * segname,
+    const char                * sectname);
+
+boolean_t macho_remove_linkedit(
+    u_char    * macho,
+    u_long    * linkedit_size);
+
+boolean_t macho_trim_linkedit(
+    u_char    *macho,
+    u_long    *amount_trimmed);
+
+#endif /* __MACHO_UTIL_H__ */

--- a/src/kext_tools/kext.subproj/misc_util.c
+++ b/src/kext_tools/kext.subproj/misc_util.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+#include "misc_util.h"
+
+/*********************************************************************
+*********************************************************************/
+char * createUTF8CStringForCFString(CFStringRef aString)
+{
+    char * result = NULL;
+    CFIndex bufferLength = 0;
+
+    if (!aString) {
+        goto finish;
+    }
+
+    bufferLength = sizeof('\0') +
+        CFStringGetMaximumSizeForEncoding(CFStringGetLength(aString),
+	    kCFStringEncodingUTF8);
+
+    result = (char *)malloc(bufferLength * sizeof(char));
+    if (!result) {
+        goto finish;
+    }
+    if (!CFStringGetCString(aString, result, bufferLength,
+        kCFStringEncodingUTF8)) {
+
+        SAFE_FREE_NULL(result);
+        goto finish;
+    }
+
+finish:
+    return result;
+}
+
+/*********************************************************************
+*********************************************************************/
+CFStringRef createCFStringForData(CFDataRef aData, CFIndex maxBytes)
+{
+    CFMutableStringRef  result = NULL;
+    const uint8_t     * bytes  = NULL;  // do not free
+    CFIndex            count, i;
+    
+    result = CFStringCreateMutable(kCFAllocatorDefault, /* maxLength */ 0);
+    if (!result) {
+        goto finish;
+    }
+    
+    count = CFDataGetLength(aData);
+
+    CFStringAppend(result, CFSTR("<"));
+
+    if (count) {
+        bytes = CFDataGetBytePtr(aData);;
+        for (i = 0; i < count && i < maxBytes; i++) {
+            CFStringAppendFormat(result, /* options */ NULL, CFSTR("%02x%s"),
+                (unsigned)(bytes[i]),
+                (i > 0 && !((i + 1) % 4) && (i + 1 < count)) ? " " : "");
+        }
+        if (maxBytes < count) {
+            CFStringAppendFormat(result, /* options */ NULL,
+                CFSTR("...(%u bytes total)"), (unsigned)count);
+        }
+    }
+    CFStringAppend(result, CFSTR(">"));
+
+finish:
+    return result;
+}

--- a/src/kext_tools/kext.subproj/misc_util.h
+++ b/src/kext_tools/kext.subproj/misc_util.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#ifndef __MISC_UTIL_H__
+#define __MISC_UTIL_H__
+
+
+#include <CoreFoundation/CoreFoundation.h>
+
+#define SAFE_FREE(ptr)  do {          \
+    if (ptr) free(ptr);               \
+    } while (0)
+#define SAFE_FREE_NULL(ptr)  do {     \
+    if (ptr) free(ptr);               \
+    (ptr) = NULL;                     \
+    } while (0)
+#define SAFE_RELEASE(ptr)  do {       \
+    if (ptr) CFRelease(ptr);          \
+    } while (0)
+#define SAFE_RELEASE_NULL(ptr)  do {  \
+    if (ptr) CFRelease(ptr);          \
+    (ptr) = NULL;                     \
+    } while (0)
+
+#define RANGE_ALL(a)   CFRangeMake(0, CFArrayGetCount(a))
+
+
+char * createUTF8CStringForCFString(CFStringRef aString);
+CFStringRef createCFStringForData(CFDataRef aData, CFIndex maxBytes);
+
+#endif /* __MISC_UTIL_H__ */

--- a/src/kext_tools/kext.subproj/printPList_new.c
+++ b/src/kext_tools/kext.subproj/printPList_new.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#include <libc.h>
+#include "printPList_new.h"
+#include "misc_util.h"
+
+static void _indent(CFMutableStringRef string, unsigned indentLevel)
+{
+    unsigned int i;
+
+    for (i = 0; i < indentLevel; i++) {
+        CFStringAppendCString(string, " ", kCFStringEncodingUTF8);
+    }
+    return;
+}
+
+static void _appendCFString(
+    CFMutableStringRef string,
+    CFStringRef aString,
+    Boolean withQuotes)
+{
+    char * quote = "";
+
+    if (withQuotes) quote = "\"";
+    CFStringAppendFormat(string, NULL, CFSTR("%s%@%s"), quote, aString, quote);
+    return;
+}
+
+static void _appendCFURL(CFMutableStringRef string,
+    CFURLRef anURL)
+{
+    CFURLRef absURL = NULL;     // must release
+    CFStringRef absPath = NULL; // must release
+    char pathBuffer[PATH_MAX];
+
+    absURL = CFURLCopyAbsoluteURL(anURL);
+    if (!absURL) {
+        goto finish;
+    }
+
+    absPath = CFURLCopyFileSystemPath(anURL, kCFURLPOSIXPathStyle);
+    if (!absPath) {
+        goto finish;
+    }
+    CFURLGetFileSystemRepresentation(anURL, true, (UInt8 *)pathBuffer,
+        PATH_MAX);
+    CFStringAppendCString(string, pathBuffer, kCFStringEncodingUTF8);
+
+finish:
+    if (absURL)  CFRelease(absURL);
+    if (absPath) CFRelease(absPath);
+    return;
+}
+
+static void _appendPlist(
+    CFMutableStringRef string,
+    CFTypeRef          plist,
+    CFTypeRef          plistRoot,
+    PListStyle         style,
+    unsigned           indentLevel)
+{
+    CFTypeID typeID = 0;
+    unsigned int indentIncrement = 4;
+
+    if (!plist) {
+        return;
+    }
+
+   /* Don't indent the top-level keys/indices of the plist.
+    */
+    if (plist == plistRoot) {
+        indentIncrement = 0;
+    }
+
+    typeID = CFGetTypeID(plist);
+
+    if (typeID == CFDictionaryGetTypeID()) {
+        CFDictionaryRef dict = (CFDictionaryRef)plist;
+        CFIndex count, i;
+        CFStringRef * keys = NULL;   // must free
+        CFTypeRef * values = NULL; // must free
+        count = CFDictionaryGetCount(dict);
+        keys = (CFStringRef *)malloc(count * sizeof(CFStringRef));
+        values = (CFTypeRef *)malloc(count * sizeof(CFTypeRef));
+
+        CFDictionaryGetKeysAndValues(dict, (const void **)keys,
+            (const void **)values);
+
+        if (style == kPListStyleDiagnostics) {
+            // no newline at beginning of diagnostics printout
+            if (plist != plistRoot) {
+                CFStringAppendCString(string, "\n", kCFStringEncodingUTF8);
+            }
+        } else {
+            // no indent before first brace, it's on the end of the line
+            CFStringAppendCString(string, "{\n", kCFStringEncodingUTF8);
+        }
+        for (i = 0; i < count; i++) {
+
+            _indent(string, indentLevel + indentIncrement);
+            _appendCFString(string, keys[i],
+                /* quotes */ (style != kPListStyleDiagnostics));
+
+            if ( (CFBooleanGetTypeID() == CFGetTypeID(values[i])) &&
+                 (style == kPListStyleDiagnostics) ) {
+                 
+                 CFStringAppendFormat(string, NULL, CFSTR("\n"));
+                 continue;  // diagnostics doesn't print bools!
+             }
+
+            if (style == kPListStyleDiagnostics) {
+                CFStringAppendCString(string, ": ", kCFStringEncodingUTF8);
+            } else {
+                CFStringAppendCString(string, " = ", kCFStringEncodingUTF8);
+            }
+            if (CFGetTypeID(values[i]) == CFStringGetTypeID()) {
+                CFIndex keyLength = CFStringGetLength(keys[i]);
+                CFIndex valueLength = CFStringGetLength(values[i]);
+
+               /* drop value for a really long key+string combo down a line */
+                if (indentLevel + indentIncrement + keyLength + valueLength > 72) {
+                    CFStringAppendCString(string, "\n", kCFStringEncodingUTF8);
+                    _indent(string, indentLevel + (4 + indentIncrement));
+                }
+            }
+            _appendPlist(string, values[i], plistRoot, style, indentLevel +
+                indentIncrement);
+
+           /* Put newlines bewteen top-level dict properties for diagnostics.
+            */
+            if (style == kPListStyleDiagnostics && (i + 1 < count)) {
+                if (plist == plistRoot) {
+                    CFStringAppendCString(string, "\n", kCFStringEncodingUTF8);
+                }
+            }
+        }
+        if (style != kPListStyleDiagnostics) {
+            _indent(string, indentLevel);
+            CFStringAppendCString(string, "}\n", kCFStringEncodingUTF8);
+        }
+        free(keys);
+        free(values);
+    } else if (typeID == CFArrayGetTypeID()) {
+        CFArrayRef array = (CFArrayRef)plist;
+        CFIndex count, i;
+        count = CFArrayGetCount(array);
+
+        // no indent before first parenthesis
+        // no newline at beginning of diagnostics printout
+        if (style == kPListStyleDiagnostics && (plist != plistRoot)) {
+            // no newline at beginning of diagnostics printout
+            if (plist != plistRoot) {
+                CFStringAppendCString(string, "\n", kCFStringEncodingUTF8);
+            }
+        } else {
+            CFStringAppendCString(string, "(\n", kCFStringEncodingUTF8);
+        }
+        for (i = 0; i < count; i++) {
+            _indent(string, indentLevel + indentIncrement);
+            _appendPlist(string, CFArrayGetValueAtIndex(array, i), plistRoot,
+                style, indentLevel + indentIncrement);
+        }
+        if (style != kPListStyleDiagnostics) {
+            _indent(string, indentLevel);
+            CFStringAppendCString(string, ")\n", kCFStringEncodingUTF8);
+        }
+    } else if (typeID == CFStringGetTypeID()) {
+        _appendCFString(string, (CFStringRef)plist,
+            /* quotes */ ((indentLevel > 0) && (style != kPListStyleDiagnostics)));
+        CFStringAppendCString(string, "\n", kCFStringEncodingUTF8);
+    } else if (typeID == CFURLGetTypeID()) {
+        _appendCFURL(string, (CFURLRef)plist);
+        CFStringAppendCString(string, "\n", kCFStringEncodingUTF8);
+    } else if (typeID == CFDataGetTypeID()) {
+        // only show a little bit of the data up front
+        CFStringRef dataString = createCFStringForData((CFDataRef)plist, 16);
+        if (dataString) {
+            CFStringAppend(string, dataString);
+            CFStringAppendCString(string, "\n", kCFStringEncodingUTF8);
+            SAFE_RELEASE(dataString);
+        } else {
+            CFStringAppendCString(string, "(data object)\n", kCFStringEncodingUTF8);
+        }
+    } else if (typeID == CFNumberGetTypeID()) {
+        CFStringAppendFormat(string, NULL, CFSTR("%@"), (CFNumberRef)plist);
+        CFStringAppendCString(string, "\n", kCFStringEncodingUTF8);
+    } else if (typeID == CFBooleanGetTypeID()) {
+        CFBooleanRef booleanValue = (CFBooleanRef)plist;
+        CFStringAppendFormat(string, NULL, CFSTR("%s\n"),
+            CFBooleanGetValue(booleanValue) ? "true" : "false");
+    } else if (typeID == CFDateGetTypeID()) {
+        CFStringAppendCString(string, "(date object)\n", kCFStringEncodingUTF8);
+    } else {
+        CFStringAppendCString(string, "(unknown object)\n", kCFStringEncodingUTF8);
+    }
+
+    return;
+}
+
+void printPList_new(FILE * stream, CFTypeRef plist, PListStyle style)
+{
+    CFMutableStringRef string = NULL;  // must release
+    CFIndex bufSize;
+    char * c_string = NULL; // must free
+
+    string = createCFStringForPlist_new(plist, style);
+    if (!string) {
+        goto finish;
+    }
+
+    bufSize = CFStringGetMaximumSizeForEncoding(CFStringGetLength(string),
+	    kCFStringEncodingUTF8) + sizeof('\0');
+    c_string = (char *)malloc(bufSize);
+    if (!c_string) {
+        goto finish;
+    }
+
+    if (CFStringGetCString(string, c_string, bufSize, kCFStringEncodingUTF8)) {
+        fprintf(stream, "%s", c_string);
+    }
+
+finish:
+    if (string) CFRelease(string);
+    if (c_string) free(c_string);
+    return;
+}
+
+// use in GDB
+void showPList_new(CFPropertyListRef plist, PListStyle style)
+{
+    printPList_new(stdout, plist, style);
+    return;
+}
+
+CFMutableStringRef createCFStringForPlist_new(CFTypeRef plist, PListStyle style)
+{
+    CFMutableStringRef string = NULL;  // must release
+
+    string = CFStringCreateMutable(kCFAllocatorDefault, 0);
+    if (!string) {
+        goto finish;
+    }
+
+    _appendPlist(string, plist, plist, style, 0);
+
+finish:
+    return string;
+}

--- a/src/kext_tools/kext.subproj/printPList_new.h
+++ b/src/kext_tools/kext.subproj/printPList_new.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ * 
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+#ifndef __PRINTPLIST_NEW_H__
+#define __PRINTPLIST_NEW_H__
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+typedef UInt32 PListStyle;
+#define kPListStyleClassic      (1)
+#define kPListStyleDiagnostics  (2)
+
+void printPList_new(FILE * stream, CFPropertyListRef plist, PListStyle style);
+void showPList_new(CFPropertyListRef plist, PListStyle style);
+CFMutableStringRef createCFStringForPlist_new(CFTypeRef plist, PListStyle style);
+
+__END_DECLS
+
+#endif /* __PRINTPLIST_NEW_H__ */


### PR DESCRIPTION
First step of the faithful `kext_tools`/`OSKext` port (#182, approach A): vendor Apple's real `OSKext` engine + helpers **verbatim**.

- Source: `IOKitUser-907.100.13` (OS X 10.8.5 — deliberately **pre-SIP**: no codesign enforcement, no kernelcache/AuxKC collection machinery to strip), **APSL 2.0**, headers intact.
- Lands in `src/kext_tools/kext.subproj/` — 18 files, ~23k LOC (`OSKext.c` is 15.7k).
- **Not wired into the build.** The kext_tools Makefile `SUBDIR` builds only the kld-backed trio, so this source sits verbatim and the ISO build is unaffected (stays green). See `PROVENANCE.md`.

### Why pre-SIP 10.8
`OSKext.c` is ~15.7k LOC here vs ~21k in newer releases — pre-SIP avoids the codesign/kernelcache surface entirely, which is the right base for a `kld`-backed loader (we don't want SIP).

### Next (follow-up PRs)
1. A **fast standalone `libkext` compile** CI job (sysroot from `continuous`) so we iterate `OSKext.c` against NextBSD's `libCoreFoundation`/`libIOKit` in minutes, not full ISO builds.
2. Re-back load/unload/query from the `kext_request` Mach trap onto `kld`; personalities → libIOKit/hwregd; delete KXLD/mkext/prelink; stub codesign.
3. Phase 1 — dependency-graph resolution (first user-visible win), feeding #179/#177.

Plan: https://pkgdemon.github.io/nextbsd-oskext-port-plan.html