### PR TITLE
#195: libCoreFoundation — define _CFGetCurrentDirectory (unblocks running CF tools)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1307,7 +1307,14 @@ cc -fblocks \
 chroot "$WORK/rootfs" ldd /usr/tests/freebsd-launchd-mach/test_corefoundation \
     | grep -q "libCoreFoundation.so.* => /usr/lib/system/" \
     || { echo "FAIL: ldd doesn't resolve test_corefoundation to /usr/lib/system/libCoreFoundation.so"; exit 1; }
-echo "==> test_corefoundation built + ldd verified"
+# Actually RUN it (nextbsd#195): CF resolves _CFGetCurrentDirectory /
+# _CFThreadSetName eagerly during library init, so a CF-linked binary that only
+# ldd-resolves can still fail to *start*. Running the smoke proves CF
+# initializes + the CFDictionary/CFString/plist paths work — the runtime gate
+# this step was missing.
+chroot "$WORK/rootfs" /usr/tests/freebsd-launchd-mach/test_corefoundation \
+    || { echo "FAIL: test_corefoundation did not run cleanly (CF runtime broken)"; exit 1; }
+echo "==> test_corefoundation built + ldd verified + ran"
 
 #
 # 3p1. Phase I1c (moved): build the launchd daemon (src/launchd/src).

--- a/src/libCoreFoundation/CFFileUtilities.c
+++ b/src/libCoreFoundation/CFFileUtilities.c
@@ -87,6 +87,15 @@ CF_PRIVATE Boolean _CFDeleteFile(const char *path) {
     return ret;
 }
 
+// NextBSD (#195): _CFGetCurrentDirectory is declared in CFInternal.h and used by
+// CFURL.c, but the POSIX definition was missing from this port — leaving the
+// symbol undefined in libCoreFoundation.so. Because CF resolves it eagerly
+// during library init, every CF-linked tool failed to start with
+// 'Undefined symbol "_CFGetCurrentDirectory"'. Back it with getcwd(3).
+CF_EXPORT Boolean _CFGetCurrentDirectory(char *path, int maxlen) {
+    return getcwd(path, maxlen) != NULL;
+}
+
 static Boolean _CFReadBytesFromPathAndGetFD(CFAllocatorRef alloc, const char *path, void **bytes, CFIndex *length, CFIndex maxLength, int extraOpenFlags, int *fd) {    // maxLength is the number of bytes desired, or 0 if the whole file is desired regardless of length.
     struct statinfo statBuf;
     


### PR DESCRIPTION
Fixes #195.

## Problem
Every CoreFoundation-linked program fails to **start** at runtime:
```
ld-elf.so.1: libCoreFoundation.so.6: Undefined symbol "_CFGetCurrentDirectory"
```
`_CFGetCurrentDirectory` is declared (`CFInternal.h`) and called (`CFURL.c`) but
has **no definition** anywhere in `src/libCoreFoundation`. CF references it
eagerly during library init, so the dynamic loader fails before `main` — taking
down the `kextload` trio, `kextdeps`, launchctl, and any other CF tool.

## Fix
- Define `_CFGetCurrentDirectory` (POSIX `getcwd` wrapper) in
  `CFFileUtilities.c`.
- `build.sh`: run `test_corefoundation` (was `ldd`-only — almost certainly
  *because* running it hit this bug). This makes the ISO build prove CF actually
  initializes + runs, in-PR, with no image republish needed.

`_CFThreadSetName` is already correct in source (`CFPlatform.c`,
`TARGET_OS_BSD`); rebuilding the image ships it.

## Validation
The ISO `ci` build now compiles CF with the symbol **and runs**
`test_corefoundation` in the rootfs — green = CF tools start and the
CFDictionary/CFString/plist paths work.

Unblocks #196 (OSKext Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)