### PR TITLE
#196: ship kextdeps in the image + dependency-resolution smoke

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1897,6 +1897,47 @@ chroot "$WORK/rootfs" ldconfig -r | grep -q libIOKit \
     || { echo "FAIL: ldconfig hints missing libIOKit"; exit 1; }
 echo "==> libIOKit built + installed"
 
+#
+# 3r4a. build libkext + kextdeps (src/kext_tools; #182 Phase 1 / #196).
+#       Apple's OSKext engine -> static libkext.a; kextdeps is the
+#       OSKext-backed dependency-resolution CLI. Built HERE (after libIOKit)
+#       because kextdeps links libIOKit (IORegistryEntryCreateCFProperty),
+#       which isn't installed at the kext_tools step (3q1). Install:
+#       /usr/sbin/kextdeps. Then a runtime smoke proves the OSBundleLibraries
+#       dependency-graph topological sort works on the real image — possible
+#       now that CF runs (#195).
+#
+echo "==> building libkext + kextdeps (src/kext_tools)"
+make -C "$ROOT/src/kext_tools/kext.subproj" SYSROOT="$WORK/rootfs"
+make -C "$ROOT/src/kext_tools/kextdeps" \
+    DESTDIR="$WORK/rootfs" \
+    SYSROOT="$WORK/rootfs" \
+    all install
+ls -lh "$WORK/rootfs/usr/sbin/kextdeps"
+chroot "$WORK/rootfs" ldd /usr/sbin/kextdeps \
+    | grep -q "libCoreFoundation.so.* => /usr/lib/system/" \
+    || { echo "FAIL: kextdeps doesn't resolve libCoreFoundation"; exit 1; }
+
+# Runtime smoke: resolve a 2-kext graph (Leaf -> Base via OSBundleLibraries)
+# and assert kextdeps emits Base BEFORE Leaf in the load order.
+echo "==> kextdeps dependency-resolution smoke"
+mkdir -p "$WORK/rootfs/usr/tests/kext_tools"
+cp -R "$ROOT/src/kext_tools/tests/smoke" "$WORK/rootfs/usr/tests/kext_tools/smoke"
+kd_out=$(chroot "$WORK/rootfs" /usr/sbin/kextdeps \
+    -r /usr/tests/kext_tools/smoke \
+    /usr/tests/kext_tools/smoke/Leaf.kext 2>&1) \
+    || { echo "$kd_out"; echo "FAIL: kextdeps exited nonzero"; exit 1; }
+echo "$kd_out"
+echo "$kd_out" | grep -q "org.nextbsd.test.base" \
+    || { echo "FAIL: base missing from load order"; exit 1; }
+echo "$kd_out" | grep -q "org.nextbsd.test.leaf" \
+    || { echo "FAIL: leaf missing from load order"; exit 1; }
+kd_base=$(echo "$kd_out" | grep -n "org.nextbsd.test.base" | head -1 | cut -d: -f1)
+kd_leaf=$(echo "$kd_out" | grep -n "org.nextbsd.test.leaf" | head -1 | cut -d: -f1)
+[ "$kd_base" -lt "$kd_leaf" ] \
+    || { echo "FAIL: load order wrong — base ($kd_base) must precede leaf ($kd_leaf)"; exit 1; }
+echo "==> kextdeps built + installed + dependency smoke passed"
+
 # iokittest — libIOKit iter 1 walk test client. Walks the hwregd
 # registry through the IOKit facade and prints IOKIT-WALK-OK. run.sh
 # runs it and checks for the marker.

--- a/src/kext_tools/Makefile
+++ b/src/kext_tools/Makefile
@@ -13,11 +13,11 @@
 SUBDIR=	kextload kextstat kextunload
 
 # NOTE: kext.subproj (libkext.a) and kextdeps (the OSKext dependency-resolution
-# CLI, #182 Phase 1) are deliberately NOT in SUBDIR yet. kextdeps links
-# libIOKit, which isn't installed in the rootfs at the point build.sh builds
-# kext_tools, and shipping a mid-port dev tool in the image is premature. They
-# are wired in (with the build reordered after libIOKit, + a proper test) when
-# the OSKext-backed tools graduate. To build them standalone against a sysroot:
+# CLI, #182 Phase 1) are intentionally NOT in this SUBDIR. kextdeps links
+# libIOKit, which is installed LATER than this trio in build.sh (step 3q1),
+# whereas libIOKit lands at 3r4 — so they are built by their own build.sh step
+# (3r4a, after libIOKit) + a dependency-resolution smoke (#196), not here.
+# To build them standalone against a sysroot:
 #   make -C kext.subproj SYSROOT=<root> && make -C kextdeps SYSROOT=<root>
 
 .include <bsd.subdir.mk>

--- a/src/kext_tools/kextdeps/Makefile
+++ b/src/kext_tools/kextdeps/Makefile
@@ -20,11 +20,11 @@ CFLAGS+=	-DPRIVATE=1 -D__APPLE_API_PRIVATE
 WARNS=		0
 CFLAGS+=	-Wno-everything
 
-# libkext + CoreFoundation + zlib only. No -lIOKit: libkext's iocf_compat.c
-# provides the IOCFSerialize/IOCFUnserialize symbols OSKext needs, so nothing
-# is pulled from libIOKit — and it isn't installed in the rootfs at this build
-# step anyway. (-lz: OSKext's cache paths use inflate*/gz*.)
-LDADD+=	${KT}/kext.subproj/libkext.a -lCoreFoundation -lz
+# libkext + CoreFoundation + IOKit + zlib. -lIOKit is required: OSKext calls
+# IORegistryEntryCreateCFProperty (__OSKextReadRegistryNumberProperty). It is
+# available because build.sh builds kextdeps (step 3r4a) AFTER libIOKit (3r4).
+# (-lz: OSKext's cache paths use inflate*/gz*.)
+LDADD+=	${KT}/kext.subproj/libkext.a -lCoreFoundation -lIOKit -lz
 DPADD+=	${KT}/kext.subproj/libkext.a
 
 .include <bsd.prog.mk>

--- a/src/kext_tools/kextdeps/kextdeps.c
+++ b/src/kext_tools/kextdeps/kextdeps.c
@@ -47,6 +47,7 @@ int
 main(int argc, char *argv[])
 {
 	const char *repo = "/System/Library/Extensions";
+	CFArrayRef  repoKexts = NULL;	/* hold repo kexts alive — see below */
 	int         ch, rc = 0, i;
 
 	while ((ch = getopt(argc, argv, "r:")) != -1) {
@@ -71,20 +72,21 @@ main(int argc, char *argv[])
 
 	/*
 	 * Populate the repository so OSBundleLibraries named by the target
-	 * kexts can be resolved. Without it only dependencies that happen to be
-	 * among the named kexts will resolve.
+	 * kexts can be resolved. OSKext's registry dicts (sKextsByIdentifier,
+	 * sKextsByURL) are NON-RETAINING — the kext objects are kept alive only
+	 * by this array — so we must hold it until after dependency resolution
+	 * below, or the dependencies vanish from the registry mid-resolve.
 	 */
 	if (access(repo, F_OK) == 0) {
 		CFURLRef repoURL = url_for_path(repo, true);
 
 		if (repoURL != NULL) {
-			CFArrayRef all = OSKextCreateKextsFromURL(
+			repoKexts = OSKextCreateKextsFromURL(
 			    kCFAllocatorDefault, repoURL);
 
-			if (all != NULL) {
+			if (repoKexts != NULL) {
 				printf("repository %s: %ld kext(s)\n", repo,
-				    (long)CFArrayGetCount(all));
-				CFRelease(all);
+				    (long)CFArrayGetCount(repoKexts));
 			}
 			CFRelease(repoURL);
 		}
@@ -130,5 +132,8 @@ main(int argc, char *argv[])
 		CFRelease(kext);
 	}
 
+	if (repoKexts != NULL) {
+		CFRelease(repoKexts);	/* safe to drop now resolution is done */
+	}
 	return (rc);
 }

--- a/src/kext_tools/tests/smoke/Base.kext/Contents/Info.plist
+++ b/src/kext_tools/tests/smoke/Base.kext/Contents/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- kextdeps smoke fixture (#182/#196): a codeless "library" kext with no
+     dependencies. Declares OSBundleCompatibleVersion so other kexts may list
+     it in OSBundleLibraries. -->
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>org.nextbsd.test.base</string>
+	<key>CFBundleName</key>
+	<string>SmokeBase</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>KEXT</string>
+	<key>CFBundleVersion</key>
+	<string>1.0.0</string>
+	<key>OSBundleCompatibleVersion</key>
+	<string>1.0.0</string>
+</dict>
+</plist>

--- a/src/kext_tools/tests/smoke/Leaf.kext/Contents/Info.plist
+++ b/src/kext_tools/tests/smoke/Leaf.kext/Contents/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- kextdeps smoke fixture (#182/#196): depends on org.nextbsd.test.base via
+     OSBundleLibraries. kextdeps must resolve the graph and emit base BEFORE
+     leaf in the load order. -->
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>org.nextbsd.test.leaf</string>
+	<key>CFBundleName</key>
+	<string>SmokeLeaf</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>KEXT</string>
+	<key>CFBundleVersion</key>
+	<string>1.0.0</string>
+	<key>OSBundleLibraries</key>
+	<dict>
+		<key>org.nextbsd.test.base</key>
+		<string>1.0.0</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
First part of #196 (OSKext Phase 2). Now that CF runs at runtime (#195 merged),
`kextdeps` can be built into the image and validated end-to-end.

## Changes
- **build.sh step 3r4a** (new, after libIOKit): build `libkext.a`, then build +
  install `kextdeps` to `/usr/sbin`. Placed after libIOKit because `kextdeps`
  links it (`IORegistryEntryCreateCFProperty`) — that's why it couldn't live in
  the earlier `kext_tools` step (3q1).
- **Runtime dependency smoke:** resolve a 2-kext graph (`Leaf` → `Base` via
  `OSBundleLibraries`) in the rootfs and assert `kextdeps` emits `base` **before**
  `leaf`. This is the real test — it exercises the genuinely hard part of the
  OSKext engine (the topological sort) on the actual image.
- Fixtures in `src/kext_tools/tests/smoke`.

## Validation
The ISO `ci` build builds + installs `kextdeps` and runs the smoke (hard
`|| exit 1`). Green = `kextdeps` runs and resolves dependencies correctly.

## Remaining for #196
Graduate `kextload`/`kextunload`/`kextstat` onto OSKext (dependency-ordered
load / reverse-dep unload) — follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)