### PR TITLE
#196: graduate kextload/kextunload onto OSKext (Phase 2 complete)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1379,27 +1379,10 @@ chroot "$WORK/rootfs" ldd /bin/launchctl \
 echo "==> launchctl built + ldd verified"
 
 #
-# 3q1. build kext_tools (src/kext_tools) — minimal kld-backed
-#      kextload/kextstat/kextunload. NextBSD kext proof-of-concept (#183):
-#      prove a FreeBSD .ko wrapped as a .kext loads via an Apple-shaped tool.
-#      kextload/kextunload parse the bundle with CFBundle (libCoreFoundation,
-#      step 3p) and load through kld; kextstat is pure kld. No OSKext /
-#      codesign / personalities — faithful kext_tools port tracked in #182.
-#      Install: /usr/sbin/{kextload,kextstat,kextunload} (match macOS).
-#
-echo "==> building kext_tools (src/kext_tools)"
-mkdir -p "$WORK/rootfs/usr/sbin"
-make -C "$ROOT/src/kext_tools" \
-    DESTDIR="$WORK/rootfs" \
-    SYSROOT="$WORK/rootfs" \
-    all install
-ls -lh "$WORK/rootfs/usr/sbin/kextload" \
-       "$WORK/rootfs/usr/sbin/kextstat" \
-       "$WORK/rootfs/usr/sbin/kextunload"
-chroot "$WORK/rootfs" ldd /usr/sbin/kextload \
-    | grep -q "libCoreFoundation.so.* => /usr/lib/system/" \
-    || { echo "FAIL: kextload doesn't resolve libCoreFoundation"; exit 1; }
-echo "==> kext_tools built + installed"
+# 3q1. kext_tools (src/kext_tools) now builds at step 3r4a, AFTER libIOKit:
+#      kextload/kextunload graduated to the OSKext engine (#196) and link
+#      libkext.a + libIOKit, which isn't installed yet at this point. (This was
+#      previously a kld-only kextload/kextstat/kextunload trio, #183.)
 
 #
 # 3r. build hwregd (src/hwregd/hwregd.c).
@@ -1898,25 +1881,28 @@ chroot "$WORK/rootfs" ldconfig -r | grep -q libIOKit \
 echo "==> libIOKit built + installed"
 
 #
-# 3r4a. build libkext + kextdeps (src/kext_tools; #182 Phase 1 / #196).
-#       Apple's OSKext engine -> static libkext.a; kextdeps is the
-#       OSKext-backed dependency-resolution CLI. Built HERE (after libIOKit)
-#       because kextdeps links libIOKit (IORegistryEntryCreateCFProperty),
-#       which isn't installed at the kext_tools step (3q1). Install:
-#       /usr/sbin/kextdeps. Then a runtime smoke proves the OSBundleLibraries
-#       dependency-graph topological sort works on the real image — possible
-#       now that CF runs (#195).
+# 3r4a. build kext_tools (src/kext_tools; #182 / #196) — AFTER libIOKit.
+#       libkext.a is Apple's OSKext engine; kextload/kextunload/kextdeps link it
+#       (+ libIOKit, for IORegistryEntryCreateCFProperty), so the whole subdir
+#       builds here. kextload = dependency-ordered load, kextunload =
+#       bundle-aware unload, kextdeps = dependency resolution; kextstat stays
+#       kld-only. Install: /usr/sbin/{kextload,kextunload,kextstat,kextdeps}.
+#       A runtime smoke then proves the OSBundleLibraries dependency sort works
+#       on the real image (possible now that CF runs, #195).
 #
-echo "==> building libkext + kextdeps (src/kext_tools)"
-make -C "$ROOT/src/kext_tools/kext.subproj" SYSROOT="$WORK/rootfs"
-make -C "$ROOT/src/kext_tools/kextdeps" \
+echo "==> building kext_tools (libkext + OSKext-backed CLIs)"
+mkdir -p "$WORK/rootfs/usr/sbin"
+make -C "$ROOT/src/kext_tools" \
     DESTDIR="$WORK/rootfs" \
     SYSROOT="$WORK/rootfs" \
     all install
-ls -lh "$WORK/rootfs/usr/sbin/kextdeps"
-chroot "$WORK/rootfs" ldd /usr/sbin/kextdeps \
+ls -lh "$WORK/rootfs/usr/sbin/kextload" \
+       "$WORK/rootfs/usr/sbin/kextunload" \
+       "$WORK/rootfs/usr/sbin/kextstat" \
+       "$WORK/rootfs/usr/sbin/kextdeps"
+chroot "$WORK/rootfs" ldd /usr/sbin/kextload \
     | grep -q "libCoreFoundation.so.* => /usr/lib/system/" \
-    || { echo "FAIL: kextdeps doesn't resolve libCoreFoundation"; exit 1; }
+    || { echo "FAIL: kextload doesn't resolve libCoreFoundation"; exit 1; }
 
 # Runtime smoke: resolve a 2-kext graph (Leaf -> Base via OSBundleLibraries)
 # and assert kextdeps emits Base BEFORE Leaf in the load order.

--- a/src/kext_tools/Makefile
+++ b/src/kext_tools/Makefile
@@ -1,23 +1,19 @@
-# kext_tools — minimal kld-backed kextload / kextstat / kextunload.
+# kext_tools — OSKext-backed kextload / kextunload + kextdeps, and the
+# kld-only kextstat.
 #
-# NextBSD proof-of-concept trio (nextbsd#183): prove a FreeBSD .ko wrapped
-# as an Apple .kext bundle loads via an Apple-shaped tool. kextload/kextunload
-# parse the bundle with CFBundle (libCoreFoundation, built at build.sh step
-# 3p) and drive the load through the FreeBSD kld syscalls; kextstat is pure
-# kld. No OSKext, no codesign, no IOKitPersonalities — the faithful
-# kext_tools/OSKext port is tracked in nextbsd#182.
+# kextload/kextunload/kextdeps link libkext.a (Apple's OSKext engine, #182):
+# dependency-ordered load, bundle-aware unload, dependency resolution. kextstat
+# stays pure kld (kldnext/kldstat) — its data comes from kld either way, so the
+# OSKext query would add no fidelity. No codesign; personalities are kextd (#177).
 #
-# Build:   cd src/kext_tools && make
-# Install: make DESTDIR=/path/to/rootfs SYSROOT=/path/to/rootfs install
+# Because libkext consumers link libIOKit, the whole subdir is built by build.sh
+# AFTER libIOKit is installed (step 3r4a), not at the old pre-libIOKit point.
+# kext.subproj (libkext.a, INTERNALLIB) is listed first so it builds before its
+# consumers.
+#
+# Build:   cd src/kext_tools && make SYSROOT=/path/to/rootfs
+# Install: make DESTDIR=/path/to/rootfs SYSROOT=/path/to/rootfs all install
 
-SUBDIR=	kextload kextstat kextunload
-
-# NOTE: kext.subproj (libkext.a) and kextdeps (the OSKext dependency-resolution
-# CLI, #182 Phase 1) are intentionally NOT in this SUBDIR. kextdeps links
-# libIOKit, which is installed LATER than this trio in build.sh (step 3q1),
-# whereas libIOKit lands at 3r4 — so they are built by their own build.sh step
-# (3r4a, after libIOKit) + a dependency-resolution smoke (#196), not here.
-# To build them standalone against a sysroot:
-#   make -C kext.subproj SYSROOT=<root> && make -C kextdeps SYSROOT=<root>
+SUBDIR=	kext.subproj kextload kextstat kextunload kextdeps
 
 .include <bsd.subdir.mk>

--- a/src/kext_tools/kextload/Makefile
+++ b/src/kext_tools/kextload/Makefile
@@ -1,8 +1,19 @@
 PROG=	kextload
 SRCS=	kextload.c
 
-# CFBundle bundle parsing → kldload(2). Needs the CF runtime.
-LDADD+=	-lCoreFoundation -l_FoundationICU -ldispatch \
-	-lsystem_kernel -lpthread -lBlocksRuntime
+# Graduated to the OSKext engine (#196): links libkext.a (../kext.subproj) +
+# CoreFoundation + IOKit + zlib, same as kextdeps. Built AFTER libIOKit by
+# build.sh (kextdeps needs IORegistryEntryCreateCFProperty). OSKext.h needs the
+# compat headers + availability shim; WARNS=0/-Wno-everything matches the lib.
+KT=	${.CURDIR}/..
+
+CFLAGS+=	-I${KT}/kext.subproj -I${KT}/compat -I${KT}/../libIOKit
+CFLAGS+=	-include ${KT}/compat/apple-availability-shim.h
+CFLAGS+=	-DPRIVATE=1 -D__APPLE_API_PRIVATE
+WARNS=		0
+CFLAGS+=	-Wno-everything
+
+LDADD+=	${KT}/kext.subproj/libkext.a -lCoreFoundation -lIOKit -lz
+DPADD+=	${KT}/kext.subproj/libkext.a
 
 .include <bsd.prog.mk>

--- a/src/kext_tools/kextload/kextload.c
+++ b/src/kext_tools/kextload/kextload.c
@@ -1,77 +1,94 @@
 /*
- * kextload — load a .kext bundle (NextBSD proof-of-concept).
+ * kextload — load a kext and its dependencies, in order (NextBSD #182/#196).
  *
- * Reads CFBundleExecutable from the bundle's Info.plist (via CFBundle) and
- * kldload(2)s Contents/MacOS/<executable> by full path. Apple's kextload
- * drives OSKext/KXKextManager; for NextBSD a .kext is packaging over the
- * unmodified FreeBSD .ko, so kld does the actual load. No codesign, no
- * dependency resolution, no IOKitPersonalities in this phase — proof-of-
- * concept trio (nextbsd#183); the faithful kext_tools/OSKext port is tracked
- * in nextbsd#182.
+ * Graduated from the minimal #183 kld loader to Apple's OSKext engine: it
+ * resolves the kext's OSBundleLibraries dependency graph and kldload(2)s the
+ * dependency-ordered load list (OSKextLoad). A repository (default
+ * /System/Library/Extensions) supplies the libraries the kext names. kld
+ * performs each load; there is no codesign and personalities are kextd's job
+ * (#177). For a self-contained kext with no dependencies this is equivalent to
+ * the old single kldload, but it now loads libraries first, correctly.
  *
- * We construct the executable path from the known .kext layout rather than
- * CFBundleCopyExecutableURL: swift-corelibs CFBundle on FreeBSD does not
- * resolve the macOS Contents/MacOS/ executable location, but it does parse
- * the Info.plist — so reading the key + building the path is both robust and
- * faithful to the fixed bundle layout.
+ * Usage:  kextload [-r repo_dir] <bundle.kext> [<bundle.kext> ...]
  */
 #include <CoreFoundation/CoreFoundation.h>
-
-#include <sys/param.h>
-#include <sys/linker.h>
+#include <mach/mach_types.h>	/* kern_return_t, before OSKext.h -> OSReturn.h */
 
 #include <err.h>
-#include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
+
+#include "OSKext.h"
+
+static CFURLRef
+url_for_path(const char *path)
+{
+	return CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault,
+	    (const UInt8 *)path, (CFIndex)strlen(path), true);
+}
 
 int
-main(int argc, char **argv)
+main(int argc, char *argv[])
 {
-	const char *bundlePath;
-	CFURLRef bundleURL;
-	CFBundleRef bundle;
-	CFStringRef execName;
-	char exec[MAXPATHLEN], execPath[MAXPATHLEN];
-	int fileid;
+	const char *repo = "/System/Library/Extensions";
+	CFArrayRef  repoKexts = NULL;	/* non-retaining registry: hold alive */
+	int         ch, rc = 0, i;
 
-	if (argc != 2)
-		errx(1, "usage: kextload <bundle.kext>");
-	bundlePath = argv[1];
-
-	bundleURL = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault,
-	    (const UInt8 *)bundlePath, (CFIndex)strlen(bundlePath), true);
-	if (bundleURL == NULL)
-		errx(1, "cannot make URL for %s", bundlePath);
-
-	bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
-	CFRelease(bundleURL);
-	if (bundle == NULL)
-		errx(1, "%s: not a bundle", bundlePath);
-
-	execName = CFBundleGetValueForInfoDictionaryKey(bundle,
-	    CFSTR("CFBundleExecutable"));
-	if (execName == NULL ||
-	    CFGetTypeID(execName) != CFStringGetTypeID() ||
-	    !CFStringGetCString(execName, exec, sizeof(exec),
-	    kCFStringEncodingUTF8)) {
-		CFRelease(bundle);
-		errx(1, "%s: no CFBundleExecutable in Info.plist", bundlePath);
-	}
-	CFRelease(bundle);
-
-	snprintf(execPath, sizeof(execPath), "%s/Contents/MacOS/%s",
-	    bundlePath, exec);
-
-	/* A full path bypasses kern.module_path; the .ko loads by content. */
-	fileid = kldload(execPath);
-	if (fileid < 0) {
-		if (errno == EEXIST) {
-			printf("kextload: %s already loaded\n", bundlePath);
-			return (0);
+	while ((ch = getopt(argc, argv, "r:")) != -1) {
+		switch (ch) {
+		case 'r':
+			repo = optarg;
+			break;
+		default:
+			errx(2, "usage: kextload [-r repo_dir] bundle.kext ...");
 		}
-		err(1, "kldload(%s)", execPath);
 	}
-	printf("kextload: loaded %s (id %d)\n", bundlePath, fileid);
-	return (0);
+	argc -= optind;
+	argv += optind;
+	if (argc < 1)
+		errx(2, "usage: kextload [-r repo_dir] bundle.kext ...");
+
+	/*
+	 * Populate the repository so OSBundleLibraries resolve. OSKext's
+	 * registry is non-retaining, so the array must outlive the loads.
+	 */
+	if (access(repo, F_OK) == 0) {
+		CFURLRef u = url_for_path(repo);
+
+		if (u != NULL) {
+			repoKexts = OSKextCreateKextsFromURL(kCFAllocatorDefault, u);
+			CFRelease(u);
+		}
+	}
+
+	for (i = 0; i < argc; i++) {
+		CFURLRef  u = url_for_path(argv[i]);
+		OSKextRef k = (u != NULL)
+		    ? OSKextCreate(kCFAllocatorDefault, u) : NULL;
+		OSReturn  r;
+
+		if (u != NULL)
+			CFRelease(u);
+		if (k == NULL) {
+			warnx("%s: cannot open kext bundle", argv[i]);
+			rc = 1;
+			continue;
+		}
+
+		r = OSKextLoad(k);
+		if (r == kOSReturnSuccess) {
+			printf("kextload: loaded %s (dependency-ordered)\n",
+			    argv[i]);
+		} else {
+			warnx("%s: load failed (OSReturn 0x%x)", argv[i],
+			    (unsigned)r);
+			rc = 1;
+		}
+		CFRelease(k);
+	}
+
+	if (repoKexts != NULL)
+		CFRelease(repoKexts);
+	return (rc);
 }

--- a/src/kext_tools/kextunload/Makefile
+++ b/src/kext_tools/kextunload/Makefile
@@ -1,8 +1,19 @@
 PROG=	kextunload
 SRCS=	kextunload.c
 
-# CFBundle bundle parsing → kldunload(2). Needs the CF runtime.
-LDADD+=	-lCoreFoundation -l_FoundationICU -ldispatch \
-	-lsystem_kernel -lpthread -lBlocksRuntime
+# Graduated to the OSKext engine (#196): links libkext.a (../kext.subproj) +
+# CoreFoundation + IOKit + zlib, same as kextdeps. Built AFTER libIOKit by
+# build.sh (kextdeps needs IORegistryEntryCreateCFProperty). OSKext.h needs the
+# compat headers + availability shim; WARNS=0/-Wno-everything matches the lib.
+KT=	${.CURDIR}/..
+
+CFLAGS+=	-I${KT}/kext.subproj -I${KT}/compat -I${KT}/../libIOKit
+CFLAGS+=	-include ${KT}/compat/apple-availability-shim.h
+CFLAGS+=	-DPRIVATE=1 -D__APPLE_API_PRIVATE
+WARNS=		0
+CFLAGS+=	-Wno-everything
+
+LDADD+=	${KT}/kext.subproj/libkext.a -lCoreFoundation -lIOKit -lz
+DPADD+=	${KT}/kext.subproj/libkext.a
 
 .include <bsd.prog.mk>

--- a/src/kext_tools/kextunload/kextunload.c
+++ b/src/kext_tools/kextunload/kextunload.c
@@ -1,73 +1,89 @@
 /*
- * kextunload — unload a .kext bundle's module (NextBSD proof-of-concept).
+ * kextunload — unload a kext (NextBSD #182/#196).
  *
- * Reads CFBundleExecutable from the bundle's Info.plist (the .ko registers
- * under that name when kextload kldload's Contents/MacOS/<executable>), finds
- * the matching loaded kld file, and kldunload(2)s it. kld-backed; proof-of-
- * concept trio (nextbsd#183), faithful kext_tools/OSKext port tracked in
- * nextbsd#182.
+ * Graduated from the minimal #183 kld unloader to Apple's OSKext engine:
+ * OSKextUnload maps the kext bundle to its loaded kld module (by
+ * CFBundleExecutable) and kldunload(2)s it; OSKextUnloadKextWithIdentifier
+ * does the same given a CFBundleIdentifier. Unload is idempotent (a kext that
+ * isn't loaded is treated as success).
+ *
+ * Usage:  kextunload <bundle.kext> ...
+ *         kextunload -b <CFBundleIdentifier> ...
  */
 #include <CoreFoundation/CoreFoundation.h>
-
-#include <sys/param.h>
-#include <sys/linker.h>
+#include <mach/mach_types.h>	/* kern_return_t, before OSKext.h -> OSReturn.h */
 
 #include <err.h>
-#include <libgen.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
+
+#include "OSKext.h"
 
 int
-main(int argc, char **argv)
+main(int argc, char *argv[])
 {
-	const char *bundlePath;
-	CFURLRef bundleURL;
-	CFBundleRef bundle;
-	CFStringRef execName;
-	char want[MAXPATHLEN];
-	int fileid;
+	Boolean byIdentifier = false;
+	int     ch, rc = 0, i;
 
-	if (argc != 2)
-		errx(1, "usage: kextunload <bundle.kext>");
-	bundlePath = argv[1];
-
-	bundleURL = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault,
-	    (const UInt8 *)bundlePath, (CFIndex)strlen(bundlePath), true);
-	if (bundleURL == NULL)
-		errx(1, "cannot make URL for %s", bundlePath);
-
-	bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
-	CFRelease(bundleURL);
-	if (bundle == NULL)
-		errx(1, "%s: not a bundle", bundlePath);
-
-	execName = CFBundleGetValueForInfoDictionaryKey(bundle,
-	    CFSTR("CFBundleExecutable"));
-	if (execName == NULL ||
-	    CFGetTypeID(execName) != CFStringGetTypeID() ||
-	    !CFStringGetCString(execName, want, sizeof(want),
-	    kCFStringEncodingUTF8)) {
-		CFRelease(bundle);
-		errx(1, "%s: no CFBundleExecutable in Info.plist", bundlePath);
-	}
-	CFRelease(bundle);
-
-	/* The kld file registers under the executable's basename. */
-	for (fileid = kldnext(0); fileid > 0; fileid = kldnext(fileid)) {
-		struct kld_file_stat stat;
-		char name[MAXPATHLEN];
-
-		stat.version = sizeof(stat);
-		if (kldstat(fileid, &stat) < 0)
-			continue;
-		strlcpy(name, stat.name, sizeof(name));
-		if (strcmp(basename(name), want) == 0) {
-			if (kldunload(fileid) < 0)
-				err(1, "kldunload(%s)", want);
-			printf("kextunload: unloaded %s (was id %d)\n",
-			    bundlePath, fileid);
-			return (0);
+	while ((ch = getopt(argc, argv, "b")) != -1) {
+		switch (ch) {
+		case 'b':
+			byIdentifier = true;
+			break;
+		default:
+			errx(2, "usage: kextunload [-b] "
+			    "<bundle.kext | identifier> ...");
 		}
 	}
-	errx(1, "kextunload: %s not loaded", bundlePath);
+	argc -= optind;
+	argv += optind;
+	if (argc < 1)
+		errx(2, "usage: kextunload [-b] "
+		    "<bundle.kext | identifier> ...");
+
+	for (i = 0; i < argc; i++) {
+		OSReturn r;
+
+		if (byIdentifier) {
+			CFStringRef id = CFStringCreateWithCString(
+			    kCFAllocatorDefault, argv[i], kCFStringEncodingUTF8);
+
+			if (id == NULL) {
+				warnx("%s: bad identifier", argv[i]);
+				rc = 1;
+				continue;
+			}
+			r = OSKextUnloadKextWithIdentifier(id,
+			    /* terminateAndRemovePersonalities */ true);
+			CFRelease(id);
+		} else {
+			CFURLRef  u = CFURLCreateFromFileSystemRepresentation(
+			    kCFAllocatorDefault, (const UInt8 *)argv[i],
+			    (CFIndex)strlen(argv[i]), true);
+			OSKextRef k = (u != NULL)
+			    ? OSKextCreate(kCFAllocatorDefault, u) : NULL;
+
+			if (u != NULL)
+				CFRelease(u);
+			if (k == NULL) {
+				warnx("%s: cannot open kext bundle", argv[i]);
+				rc = 1;
+				continue;
+			}
+			r = OSKextUnload(k,
+			    /* terminateAndRemovePersonalities */ true);
+			CFRelease(k);
+		}
+
+		if (r == kOSReturnSuccess) {
+			printf("kextunload: unloaded %s\n", argv[i]);
+		} else {
+			warnx("%s: unload failed (OSReturn 0x%x)", argv[i],
+			    (unsigned)r);
+			rc = 1;
+		}
+	}
+
+	return (rc);
 }


### PR DESCRIPTION
Completes #196 (OSKext Phase 2). The kld trio graduates to the OSKext engine.

## Changes
- **kextload** → `OSKextLoad`: resolves `OSBundleLibraries` and kldload(2)s the
  **dependency-ordered** load list (libraries first). `-r repo` supplies deps
  (default `/System/Library/Extensions`).
- **kextunload** → `OSKextUnload` / `OSKextUnloadKextWithIdentifier`: bundle (or
  `-b <identifier>`) → kld module mapping + kldunload, idempotent.
- Both now link `libkext.a` + CoreFoundation + IOKit + zlib (same as kextdeps).
- **kextstat stays pure kld** — its data comes from kld either way (OSKext's
  loaded-info query is itself kld-backed; kld doesn't track bundle IDs
  in-kernel), so routing it through OSKext would add no fidelity and only link
  weight. Documented in the Makefile.
- **build.sh:** the whole `kext_tools` subdir now builds at step 3r4a (after
  libIOKit), since the OSKext-backed CLIs link libIOKit. `SUBDIR` gains
  `kext.subproj` (libkext.a, built first) + `kextdeps`; the old pre-libIOKit
  trio step is removed.

## Validation
ISO `ci` build builds + links all four CLIs and runs the kextdeps dependency
smoke. Actual load/unload exercises a running kernel (boot-test territory) and
is out of scope here.

Closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)