### PR TITLE
OSKext: accept ELF .ko executables (fix kextload validation rejecting all kexts)

### DIFF
--- a/src/kext_tools/kext.subproj/OSKext.c
+++ b/src/kext_tools/kext.subproj/OSKext.c
@@ -5196,6 +5196,17 @@ Boolean OSKextSupportsArchitecture(OSKextRef aKext,
     }
 
     exec = CFDataGetBytePtr(executable);
+
+   /* NextBSD: an ELF .ko is a thin object built for one architecture (the
+    * kernel's), and kld validates it at load. The Mach-O/fat inspection below
+    * can't parse it, so treat any ELF as supporting the running arch. (#182)
+    */
+    if (CFDataGetLength(executable) >= 4 && exec[0] == 0x7f &&
+        exec[1] == 'E' && exec[2] == 'L' && exec[3] == 'F') {
+        result = true;
+        goto finish;
+    }
+
     fatIterator = fat_iterator_for_data(exec,
         exec + CFDataGetLength(executable), 1 /* mach-o only */);
     if (!fatIterator) {
@@ -11178,6 +11189,19 @@ Boolean __OSKextValidateExecutable(OSKextRef aKext)
 
     mach_header = (const struct mach_header *)CFDataGetBytePtr(executable);
     file_end = (((const char *)mach_header) + CFDataGetLength(executable));
+
+   /* NextBSD: kext executables are ELF .ko, not Mach-O. The kmod_info symbol
+    * inspection below is Mach-O-specific (macho_find_symbol) and would mark a
+    * perfectly good ELF kext "executable bad". The kernel's kld linker fully
+    * validates the ELF at load, so accept any ELF object here. (#182)
+    */
+    if (CFDataGetLength(executable) >= 4) {
+        const unsigned char *elf = (const unsigned char *)mach_header;
+        if (elf[0] == 0x7f && elf[1] == 'E' && elf[2] == 'L' && elf[3] == 'F') {
+            result = true;
+            goto finish;
+        }
+    }
 
     seek_result = macho_find_symbol(
             mach_header, file_end, __kOSKextKmodInfoSymbol, &nlist_type,


### PR DESCRIPTION
## Bug
After `kextload` graduated to the OSKext engine (#199), it **can't load any NextBSD kext**:
```
# kextload /System/Library/Extensions/Nmdm.kext
Can't load Nmdm.kext - validation problems.
kextload: ... load failed (OSReturn 0xdc00800c)   # kOSKextReturnValidation
```
OSKext validates a kext's executable as **Mach-O** before loading:
- `__OSKextValidateExecutable` → `macho_find_symbol(kmod_info)` → not found in an ELF → `kOSKextDiagnosticExecutableBadKey` → kext invalid.
- `OSKextSupportsArchitecture` → `fat_iterator_for_data(..., mach-o only)` → NULL for ELF → arch-not-found.

NextBSD kext executables are **ELF `.ko`**, so both reject them. The old bare-`kldload` kextload didn't validate, which is why it worked before #199. Caught by `nextbsd-kernel-modules`' qemu `kext-boot-test`.

## Fix
In both functions, detect ELF magic (`0x7f 'E' 'L' 'F'`) on the executable bytes and accept it (valid / supports-arch). The kernel's **kld linker validates the ELF at load**, so userland doesn't need to parse it as Mach-O. The Mach-O code paths are untouched for any genuinely Mach-O input.

## Effect
`kextload` can load real ELF kexts again (`Nmdm.kext`, and the Tier-0 `IntelWiFi.kext`). The ISO `ci` build validates OSKext.c still compiles; the runtime proof is the `nextbsd-kernel-modules` boot-test once `continuous` rebuilds with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)