### PR TITLE
OSKext: don't require OSBundleLibraries for dependency-less kexts

### DIFF
--- a/src/kext_tools/kext.subproj/OSKext.c
+++ b/src/kext_tools/kext.subproj/OSKext.c
@@ -10952,11 +10952,15 @@ Boolean __OSKextValidate(OSKextRef aKext, CFMutableArrayRef propPath)
         /* diagnosticValue */ propPath,
         /* expectedType */ CFDictionaryGetTypeID(),
         /* legalValues */ NULL,
-        /* required */ (OSKextDeclaresExecutable(aKext) &&
-                       !OSKextIsKernelComponent(aKext)),
+       /* NextBSD: OSBundleLibraries lists other *kexts* that must be loaded
+        * first. A kext with no kext-on-kext dependencies links directly against
+        * the kernel via kld, so it legitimately has none — don't require it.
+        * (Apple required it because every Mach-O kext links at least a kpi
+        * library; NextBSD ELF .ko resolve kernel symbols directly.) (#182)
+        */
+        /* required */ false,
         /* typeRequired */ true,
-        /* nonnilRequired */ (OSKextDeclaresExecutable(aKext) &&
-                       !OSKextIsKernelComponent(aKext)),
+        /* nonnilRequired */ false,
         /* valueOut */ (CFTypeRef *)&dictValue,
         /* valueIsNonnil */ NULL);
     result = result && checkResult;
@@ -10965,13 +10969,9 @@ Boolean __OSKextValidate(OSKextRef aKext, CFMutableArrayRef propPath)
     * All following "else if" mean the kext has at least one.
     */
     if (!dictValue || !CFDictionaryGetCount(dictValue)) {
-        if (OSKextDeclaresExecutable(aKext) &&
-            !OSKextIsKernelComponent(aKext)) {
-
-            __OSKextAddDiagnostic(aKext, kOSKextDiagnosticsFlagValidation,
-                kOSKextDiagnosticMissingPropertyKey,
-                propPath, /* note */ NULL);
-        }
+       /* NextBSD: no OSBundleLibraries is not a validation problem — a kext
+        * with no kext dependencies links against the kernel directly. (#182)
+        */
     } else if (OSKextIsKernelComponent(aKext)) {
         // xxx - should I catch kernel components that declare dependencies
         // xxx - in case somebody screws up the System.kexts? :-P


### PR DESCRIPTION
## Bug (continuation of #200)
After #200 fixed the ELF *executable* validation gate, `kextload Nmdm.kext` **still** fails with the same `OSReturn 0xdc00800c` (`kOSKextReturnValidation`). The remaining gate is in `__OSKextValidate`:

```c
/* required */    (OSKextDeclaresExecutable(aKext) && !OSKextIsKernelComponent(aKext)),
/* nonnilRequired */ (OSKextDeclaresExecutable(aKext) && !OSKextIsKernelComponent(aKext)),
```

It makes **`OSBundleLibraries` required and non-nil** for any kext that declares an executable and isn't a kernel component. On macOS that's always satisfied (every Mach-O kext links at least one `com.apple.kpi.*` library). NextBSD kexts are **ELF `.ko` that kld links directly against the kernel** — `OSBundleLibraries` only matters for kext-on-kext load ordering. `Nmdm.kext` (and the Tier-0 `IntelWiFi.kext`, whose linuxkpi/wlan deps are baked into the kernel) have **no kext dependencies**, so they carry no `OSBundleLibraries` and validation rejects them.

## Fix
Make `OSBundleLibraries` optional in validation: `required=false`, `nonnilRequired=false`, and drop the missing-property validation diagnostic when it's absent. When present it's still type-checked and its entries still fully validated.

## Effect
`kextload` validates and loads a dependency-less ELF kext. This is the last gate before the nextbsd-kernel-modules qemu boot-test (`kextload Nmdm.kext`) goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)