### PR TITLE
kextload: print validation diagnostics on load failure

### DIFF
--- a/src/kext_tools/kextload/kextload.c
+++ b/src/kext_tools/kextload/kextload.c
@@ -15,6 +15,7 @@
 #include <mach/mach_types.h>	/* kern_return_t, before OSKext.h -> OSReturn.h */
 
 #include <err.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -26,6 +27,23 @@ url_for_path(const char *path)
 {
 	return CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault,
 	    (const UInt8 *)path, (CFIndex)strlen(path), true);
+}
+
+/*
+ * Route OSKext library log/diagnostic output to stderr so a failed load
+ * explains itself (which property/executable check failed) instead of just
+ * an opaque OSReturn. Mirrors what Apple's kextload does.
+ */
+static void
+tool_log(OSKextRef aKext __unused, OSKextLogSpec spec __unused,
+    const char *format, ...)
+{
+	va_list ap;
+
+	va_start(ap, format);
+	vfprintf(stderr, format, ap);
+	va_end(ap);
+	fprintf(stderr, "\n");
 }
 
 int
@@ -48,6 +66,15 @@ main(int argc, char *argv[])
 	argv += optind;
 	if (argc < 1)
 		errx(2, "usage: kextload [-r repo_dir] bundle.kext ...");
+
+	/*
+	 * Record diagnostics and route library messages to stderr, so a
+	 * validation/dependency failure prints the specific reason.
+	 */
+	OSKextSetLogOutputFunction(&tool_log);
+	OSKextSetLogFilter(kOSKextLogDetailLevel | kOSKextLogVerboseFlagsMask,
+	    /* kernelFlag */ false);
+	OSKextSetRecordsDiagnostics(kOSKextDiagnosticsFlagAll);
 
 	/*
 	 * Populate the repository so OSBundleLibraries resolve. OSKext's
@@ -83,6 +110,8 @@ main(int argc, char *argv[])
 		} else {
 			warnx("%s: load failed (OSReturn 0x%x)", argv[i],
 			    (unsigned)r);
+			/* Print the specific validation/dependency problems. */
+			OSKextLogDiagnostics(k, kOSKextDiagnosticsFlagAll);
 			rc = 1;
 		}
 		CFRelease(k);


### PR DESCRIPTION
Enable diagnostic recording + route OSKext log output to stderr + dump diagnostics on `OSKextLoad` failure, so a failed load prints the specific failing check instead of an opaque `OSReturn`. Needed to diagnose why ELF kexts still fail validation after #200/#201. Also a permanent usability improvement (matches Apple's kextload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)