### PR TITLE
OSKext: locate kext executable via Contents/MacOS fallback (the real kextload blocker)

### DIFF
--- a/src/kext_tools/kext.subproj/OSKext.c
+++ b/src/kext_tools/kext.subproj/OSKext.c
@@ -5679,13 +5679,42 @@ CFDataRef __OSKextMapExecutable(
             _CFBundleCopyExecutableURLInDirectory(OSKextGetURL(aKext));
     }
 
+   /* NextBSD: _CFBundleCopyExecutableURLInDirectory() does not resolve a
+    * kext's deep-bundle executable in this CoreFoundation port. Every NextBSD
+    * kext uses the canonical Contents/MacOS/<CFBundleExecutable> layout that
+    * ko2kext produces, so fall back to constructing that path directly and
+    * checking it exists. (#182)
+    */
+    if (!aKext->loadInfo->executableURL) {
+        executableName = OSKextGetValueForInfoDictionaryKey(aKext,
+            kCFBundleExecutableKey);
+
+        if (executableName) {
+            char nameCString[PATH_MAX];
+            char candidatePath[PATH_MAX];
+
+            if (CFStringGetCString(executableName, nameCString,
+                    sizeof(nameCString), kCFStringEncodingUTF8) &&
+                snprintf(candidatePath, sizeof(candidatePath),
+                    "%s/Contents/MacOS/%s", kextPath, nameCString) <
+                    (int)sizeof(candidatePath) &&
+                access(candidatePath, F_OK) == 0) {
+
+                aKext->loadInfo->executableURL =
+                    CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault,
+                        (const UInt8 *)candidatePath, strlen(candidatePath),
+                        /* isDirectory */ false);
+            }
+        }
+    }
+
    /* Did we fail to get an executable URL, even though the kext has a
     * CFBundleExecutable? Tag the kext with a diagnostic.
     */
     if (!aKext->loadInfo->executableURL) {
         executableName = OSKextGetValueForInfoDictionaryKey(aKext,
             kCFBundleExecutableKey);
-            
+
         if (executableName) {
             __OSKextAddDiagnostic(aKext,
                 kOSKextDiagnosticsFlagValidation,


### PR DESCRIPTION
## Root cause (found via the #202 diagnostics)
With `kextload` now printing diagnostics, the real failure is:
```
Validation Failures:
    Kext has a CFBundleExecutable property but the executable can't be found:
        Nmdm
```
`__OSKextMapExecutable` locates the executable with `_CFBundleCopyExecutableURLInDirectory()`. In this CoreFoundation port that does **not** resolve a kext's deep-bundle `Contents/MacOS/<CFBundleExecutable>`, so it returns NULL → OSKext tags `kOSKextDiagnosticExecutableMissingKey` → kext invalid → `OSReturn 0xdc00800c`.

This — not the ELF executable format (#200) or required `OSBundleLibraries` (#201) — is why **no** kext could load. Those two fixes were correct but downstream; the executable was never being located in the first place.

## Fix
When CFBundle returns no executable URL, construct the canonical `<kext>/Contents/MacOS/<CFBundleExecutable>` path (exactly what `ko2kext` writes and every NextBSD kext uses) and use it if it exists (`access(2)`). No reliance on CFBundle internals.

## Effect
`kextload` can finally locate, validate, and load an ELF kext. Next: nextbsd-kernel-modules boot-test (`kextload Nmdm.kext`) should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)