### PR TITLE
OSKext: kldload the kext executable by absolute path

### DIFF
--- a/src/kext_tools/kext.subproj/OSKext.c
+++ b/src/kext_tools/kext.subproj/OSKext.c
@@ -8659,8 +8659,15 @@ OSReturn __OSKextLoadWithArgsDict(
                 kCFStringEncodingUTF8)) {
             continue;   /* codeless kext: no executable to kldload */
         }
+        /*
+         * NextBSD: resolve to an absolute path. A kext discovered via a
+         * repository scan (OSKextCreateKextsFromURL) carries a URL relative to
+         * the repo dir, so resolveToBase=false yields e.g. "Nmdm.kext/..." —
+         * kldload(2) would then fail to find it from the caller's CWD. Resolve
+         * to base so we always hand kldload a full path. (#182)
+         */
         __OSKextGetFileSystemPath(thisKext, /* otherURL */ NULL,
-            /* resolveToBase */ false, bundlePath);
+            /* resolveToBase */ true, bundlePath);
         snprintf(execPath, sizeof(execPath), "%s/Contents/MacOS/%s",
             bundlePath, execName);
 


### PR DESCRIPTION
## Bug (found via #202 diagnostics + boot-test progress)
After the executable-location (#203), validation (#200), OSBundleLibraries (#201), and authentication fixes, `kextload` now reaches the actual `kldload` — and fails there:
```
Failed to load Nmdm.kext - kldload(Nmdm.kext/Contents/MacOS/Nmdm): ...
```
The path is **relative**. The load loop built the `kldload(2)` argument with `resolveToBase=false`; a kext discovered by `OSKextCreateKextsFromURL` (how `kextload` populates the `/System/Library/Extensions` repo) has a repo-relative URL, so the path came out as `Nmdm.kext/Contents/MacOS/Nmdm`. `kldload` can't find that from the caller's CWD.

## Fix
Resolve to base (`resolveToBase=true`) so the path handed to `kldload` is absolute — matching what `__OSKextMapExecutable` already does to open the executable.

## Effect
The dependency-ordered `kldload` runs against a real absolute path. This should be the last gate before the boot-test loads `Nmdm.kext` green. (Paired with an nbkm test change that captures the full `kldload` error line, so any remaining failure is legible.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)