### PR TITLE
ISO: install IntelWiFi.kext into /System/Library/Extensions (C2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,18 @@ jobs:
           else
             echo "WARN: no modules continuous asset; shipping kernel built-ins only"
           fi
+          # Driver kexts (IntelWiFi.kext, ...) with bundled firmware. build.sh
+          # installs *.kext into /System/Library/Extensions. Non-fatal if absent.
+          mkdir -p kext-artifact
+          if gh release download continuous \
+               -R nextbsd-redux/nextbsd-kernel-modules \
+               --pattern "intelwifi-kext.tar.gz" \
+               --output /tmp/intelwifi-kext.tar.gz --clobber; then
+            tar -C kext-artifact -xzf /tmp/intelwifi-kext.tar.gz
+            echo "kext bundles: $(find kext-artifact -maxdepth 1 -type d -name '*.kext' 2>/dev/null | wc -l)"
+          else
+            echo "WARN: no intelwifi-kext asset; ISO ships without IntelWiFi.kext"
+          fi
 
       - name: build ISO inside FreeBSD VM
         uses: vmactions/freebsd-vm@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,15 +134,18 @@ jobs:
           else
             echo "WARN: no modules continuous asset; shipping kernel built-ins only"
           fi
-          # Driver kexts (IntelWiFi.kext, ...) with bundled firmware. build.sh
-          # installs *.kext into /System/Library/Extensions. Non-fatal if absent.
-          mkdir -p kext-artifact
+          # Driver-kext tarballs (IntelWiFi.kext, ... with bundled firmware).
+          # Downloaded as-is; build.sh extracts + installs them INSIDE the VM.
+          # We deliberately do NOT extract the ~268MB kext here: after the
+          # multi-GB modules obj tree, host-side extraction risked exhausting
+          # the runner disk (left a partial 99K kext). Syncing the ~100MB
+          # tarball is cheap. Non-fatal if absent.
+          mkdir -p kext-dl
           if gh release download continuous \
                -R nextbsd-redux/nextbsd-kernel-modules \
                --pattern "intelwifi-kext.tar.gz" \
-               --output /tmp/intelwifi-kext.tar.gz --clobber; then
-            tar -C kext-artifact -xzf /tmp/intelwifi-kext.tar.gz
-            echo "kext bundles: $(find kext-artifact -maxdepth 1 -type d -name '*.kext' 2>/dev/null | wc -l)"
+               --output kext-dl/intelwifi-kext.tar.gz --clobber; then
+            echo "kext tarball: $(ls -lh kext-dl/intelwifi-kext.tar.gz | awk '{print $5}')"
           else
             echo "WARN: no intelwifi-kext asset; ISO ships without IntelWiFi.kext"
           fi

--- a/build.sh
+++ b/build.sh
@@ -661,22 +661,33 @@ fi
 #      a Tier-0 stopgap until kextload registers it dynamically, nextbsd#205).
 #      OSKext authenticates kexts, so every bundle component must be root:wheel
 #      and non-group/other-writable. Optional: absent artifact => none shipped.
+#      The kext tarballs are extracted HERE (in the VM), not on the host: the
+#      ~268MB IntelWiFi.kext would risk exhausting the runner disk after the
+#      multi-GB modules obj tree, so only the ~100MB tarball is synced in.
 #
-NEXTBSD_KEXT_ARTIFACT="${NEXTBSD_KEXT_ARTIFACT:-$ROOT/kext-artifact}"
-if [ -d "$NEXTBSD_KEXT_ARTIFACT" ] && \
-   [ -n "$(find "$NEXTBSD_KEXT_ARTIFACT" -maxdepth 1 -type d -name '*.kext' 2>/dev/null | head -1)" ]; then
+NEXTBSD_KEXT_DL="${NEXTBSD_KEXT_DL:-$ROOT/kext-dl}"
+if [ -d "$NEXTBSD_KEXT_DL" ] && \
+   [ -n "$(find "$NEXTBSD_KEXT_DL" -maxdepth 1 -name '*.tar.gz' 2>/dev/null | head -1)" ]; then
     echo "==> installing driver kexts into /System/Library/Extensions"
     mkdir -p "$WORK/rootfs/System/Library/Extensions"
-    find "$NEXTBSD_KEXT_ARTIFACT" -maxdepth 1 -type d -name '*.kext' | while IFS= read -r kext; do
+    kextstage=$(mktemp -d)
+    for tb in "$NEXTBSD_KEXT_DL"/*.tar.gz; do
+        [ -e "$tb" ] || continue
+        echo "    extracting $(basename "$tb")"
+        tar -C "$kextstage" -xzf "$tb"
+    done
+    find "$kextstage" -maxdepth 1 -type d -name '*.kext' | while IFS= read -r kext; do
         b=$(basename "$kext")
         rm -rf "$WORK/rootfs/System/Library/Extensions/$b"
         cp -R "$kext" "$WORK/rootfs/System/Library/Extensions/"
         chown -R 0:0 "$WORK/rootfs/System/Library/Extensions/$b"
         chmod -R go-w "$WORK/rootfs/System/Library/Extensions/$b"
-        echo "    installed $b ($(du -sh "$WORK/rootfs/System/Library/Extensions/$b" | cut -f1))"
+        nfw=$(find "$WORK/rootfs/System/Library/Extensions/$b/Contents/Resources/firmware" -type f 2>/dev/null | wc -l | tr -d ' ')
+        echo "    installed $b ($(du -sh "$WORK/rootfs/System/Library/Extensions/$b" | cut -f1), $nfw firmware files)"
     done
+    rm -rf "$kextstage"
 else
-    echo "==> NOTE: no driver kext artifact — /System/Library/Extensions not populated"
+    echo "==> NOTE: no driver kext tarball — /System/Library/Extensions not populated"
 fi
 
 #

--- a/build.sh
+++ b/build.sh
@@ -653,6 +653,11 @@ else
     chroot "$WORK/rootfs" kldxref /boot/kernel 2>/dev/null || true
 fi
 
+# Reclaim the modules obj tree now its *.ko are installed — frees several GB of
+# *.ko.full/*.ko.debug byproducts before the kext extraction below, so a large
+# bundled-firmware kext has room to stage.
+rm -rf "$NEXTBSD_MODULES_ARTIFACT"
+
 #
 # 3b3. install bundled driver kexts (IntelWiFi.kext, ...) from the
 #      nextbsd-kernel-modules `continuous` asset into /System/Library/Extensions.
@@ -670,12 +675,18 @@ if [ -d "$NEXTBSD_KEXT_DL" ] && \
    [ -n "$(find "$NEXTBSD_KEXT_DL" -maxdepth 1 -name '*.tar.gz' 2>/dev/null | head -1)" ]; then
     echo "==> installing driver kexts into /System/Library/Extensions"
     mkdir -p "$WORK/rootfs/System/Library/Extensions"
-    kextstage=$(mktemp -d)
+    # Stage on the build work filesystem, NOT mktemp's /tmp (which on a FreeBSD
+    # VM is often a small tmpfs that would silently truncate the ~268MB extract).
+    kextstage="$WORK/kext-stage"
+    rm -rf "$kextstage"; mkdir -p "$kextstage"
+    echo "    work fs: $(df -h "$WORK" | tail -1)"
     for tb in "$NEXTBSD_KEXT_DL"/*.tar.gz; do
         [ -e "$tb" ] || continue
-        echo "    extracting $(basename "$tb")"
+        echo "    extracting $(basename "$tb") ($(ls -lh "$tb" | awk '{print $5}'))"
         tar -C "$kextstage" -xzf "$tb"
     done
+    echo "    staged: $(du -sh "$kextstage" | cut -f1)"
+    ls -la "$kextstage"/*.kext/Contents/Resources/firmware/ 2>/dev/null | head -4
     find "$kextstage" -maxdepth 1 -type d -name '*.kext' | while IFS= read -r kext; do
         b=$(basename "$kext")
         rm -rf "$WORK/rootfs/System/Library/Extensions/$b"

--- a/build.sh
+++ b/build.sh
@@ -674,29 +674,24 @@ NEXTBSD_KEXT_DL="${NEXTBSD_KEXT_DL:-$ROOT/kext-dl}"
 if [ -d "$NEXTBSD_KEXT_DL" ] && \
    [ -n "$(find "$NEXTBSD_KEXT_DL" -maxdepth 1 -name '*.tar.gz' 2>/dev/null | head -1)" ]; then
     echo "==> installing driver kexts into /System/Library/Extensions"
-    mkdir -p "$WORK/rootfs/System/Library/Extensions"
-    # Stage on the build work filesystem, NOT mktemp's /tmp (which on a FreeBSD
-    # VM is often a small tmpfs that would silently truncate the ~268MB extract).
-    kextstage="$WORK/kext-stage"
-    rm -rf "$kextstage"; mkdir -p "$kextstage"
-    echo "    work fs: $(df -h "$WORK" | tail -1)"
+    sle="$WORK/rootfs/System/Library/Extensions"
+    mkdir -p "$sle"
+    echo "    rootfs fs: $(df -h "$WORK/rootfs" | tail -1)"
+    # Extract the kext tarball DIRECTLY into the rootfs (no intermediate cp -R,
+    # which was silently producing truncated files). tar restores the bundle in
+    # place; we then fix ownership/perms for OSKext authentication.
     for tb in "$NEXTBSD_KEXT_DL"/*.tar.gz; do
         [ -e "$tb" ] || continue
-        echo "    extracting $(basename "$tb") ($(ls -lh "$tb" | awk '{print $5}'))"
-        tar -C "$kextstage" -xzf "$tb"
+        echo "    extracting $(basename "$tb") ($(ls -lh "$tb" | awk '{print $5}')) into SLE"
+        tar -C "$sle" -xzf "$tb"
     done
-    echo "    staged: $(du -sh "$kextstage" | cut -f1)"
-    ls -la "$kextstage"/*.kext/Contents/Resources/firmware/ 2>/dev/null | head -4
-    find "$kextstage" -maxdepth 1 -type d -name '*.kext' | while IFS= read -r kext; do
-        b=$(basename "$kext")
-        rm -rf "$WORK/rootfs/System/Library/Extensions/$b"
-        cp -R "$kext" "$WORK/rootfs/System/Library/Extensions/"
-        chown -R 0:0 "$WORK/rootfs/System/Library/Extensions/$b"
-        chmod -R go-w "$WORK/rootfs/System/Library/Extensions/$b"
-        nfw=$(find "$WORK/rootfs/System/Library/Extensions/$b/Contents/Resources/firmware" -type f 2>/dev/null | wc -l | tr -d ' ')
-        echo "    installed $b ($(du -sh "$WORK/rootfs/System/Library/Extensions/$b" | cut -f1), $nfw firmware files)"
+    find "$sle" -maxdepth 1 -type d -name '*.kext' | while IFS= read -r kext; do
+        chown -R 0:0 "$kext"
+        chmod -R go-w "$kext"
+        nfw=$(find "$kext/Contents/Resources/firmware" -type f 2>/dev/null | wc -l | tr -d ' ')
+        echo "    installed $(basename "$kext") ($(du -sh "$kext" | cut -f1), $nfw firmware files)"
+        ls -la "$kext/Contents/Resources/firmware/" 2>/dev/null | sed -n '2,4p'
     done
-    rm -rf "$kextstage"
 else
     echo "==> NOTE: no driver kext tarball — /System/Library/Extensions not populated"
 fi

--- a/build.sh
+++ b/build.sh
@@ -654,6 +654,32 @@ else
 fi
 
 #
+# 3b3. install bundled driver kexts (IntelWiFi.kext, ...) from the
+#      nextbsd-kernel-modules `continuous` asset into /System/Library/Extensions.
+#      Each kext ships its firmware under Contents/Resources/firmware; firmware(9)
+#      locates it via the firmware_path kenv (see overlays/boot/loader.conf.d —
+#      a Tier-0 stopgap until kextload registers it dynamically, nextbsd#205).
+#      OSKext authenticates kexts, so every bundle component must be root:wheel
+#      and non-group/other-writable. Optional: absent artifact => none shipped.
+#
+NEXTBSD_KEXT_ARTIFACT="${NEXTBSD_KEXT_ARTIFACT:-$ROOT/kext-artifact}"
+if [ -d "$NEXTBSD_KEXT_ARTIFACT" ] && \
+   [ -n "$(find "$NEXTBSD_KEXT_ARTIFACT" -maxdepth 1 -type d -name '*.kext' 2>/dev/null | head -1)" ]; then
+    echo "==> installing driver kexts into /System/Library/Extensions"
+    mkdir -p "$WORK/rootfs/System/Library/Extensions"
+    find "$NEXTBSD_KEXT_ARTIFACT" -maxdepth 1 -type d -name '*.kext' | while IFS= read -r kext; do
+        b=$(basename "$kext")
+        rm -rf "$WORK/rootfs/System/Library/Extensions/$b"
+        cp -R "$kext" "$WORK/rootfs/System/Library/Extensions/"
+        chown -R 0:0 "$WORK/rootfs/System/Library/Extensions/$b"
+        chmod -R go-w "$WORK/rootfs/System/Library/Extensions/$b"
+        echo "    installed $b ($(du -sh "$WORK/rootfs/System/Library/Extensions/$b" | cut -f1))"
+    done
+else
+    echo "==> NOTE: no driver kext artifact — /System/Library/Extensions not populated"
+fi
+
+#
 # 3c. build libsystem_kernel (formerly libmach) on the host and install
 #     it into the chroot under the spike's chosen Apple-Libsystem layout:
 #       /usr/lib/system/libsystem_kernel.so + .so.0 sonname symlink

--- a/overlays/boot/loader.conf.d/freebsd-launchd-mach.conf
+++ b/overlays/boot/loader.conf.d/freebsd-launchd-mach.conf
@@ -36,3 +36,10 @@ autoboot_delay="2"
 # nvidia-drm.ko reads this kenv at kmod-init time; harmless on systems
 # without Nvidia hardware (kmodloader won't load nvidia-drm anyway).
 hw.nvidiadrm.modeset="1"
+
+# TEMPORARY (nextbsd#205): firmware(9) searches this ';'-separated list for raw
+# firmware images (nextbsd-kernel patch 0004). Point it at IntelWiFi.kext's
+# bundled firmware so if_iwlwifi finds iwlwifi-*.ucode inside the kext. This
+# hardcoded line is a Tier-0 stopgap — once kextload registers a kext's own
+# firmware dir dynamically at load (nextbsd#205), delete this line.
+firmware_path="/boot/firmware/;/System/Library/Extensions/IntelWiFi.kext/Contents/Resources/firmware/"


### PR DESCRIPTION
Phase C2 — completes the firmware-in-kext chain (A kernel firmware_path / B bundle / C1 nbkm publishes / **C2 ISO installs**).

- Download `intelwifi-kext.tar.gz` from nextbsd-kernel-modules `continuous` (full-firmware IntelWiFi.kext, 190 files ~257MB).
- Install the .kext into the image's `/System/Library/Extensions` (build.sh step 3b3), root:wheel + non-group/other-writable for OSKext auth.
- TEMPORARY `firmware_path` loader.conf line so firmware(9) finds the bundled firmware — stopgap, removed by nextbsd#205 (kextload registers it dynamically).

Verify on t420 (8260): boot → `kextload /System/Library/Extensions/IntelWiFi.kext` → dmesg shows iwlwifi loading iwlwifi-8000C-36.ucode + attach. Adds ~257MB to the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)