### PR TITLE
loader.conf: drop the firmware_path stopgap (#205)

### DIFF
--- a/overlays/boot/loader.conf.d/freebsd-launchd-mach.conf
+++ b/overlays/boot/loader.conf.d/freebsd-launchd-mach.conf
@@ -37,9 +37,8 @@ autoboot_delay="2"
 # without Nvidia hardware (kmodloader won't load nvidia-drm anyway).
 hw.nvidiadrm.modeset="1"
 
-# TEMPORARY (nextbsd#205): firmware(9) searches this ';'-separated list for raw
-# firmware images (nextbsd-kernel patch 0004). Point it at IntelWiFi.kext's
-# bundled firmware so if_iwlwifi finds iwlwifi-*.ucode inside the kext. This
-# hardcoded line is a Tier-0 stopgap — once kextload registers a kext's own
-# firmware dir dynamically at load (nextbsd#205), delete this line.
-firmware_path="/boot/firmware/;/System/Library/Extensions/IntelWiFi.kext/Contents/Resources/firmware/"
+# No firmware_path here: firmware(9) (nextbsd-kernel patch 0004) auto-searches
+# each loaded kext bundle's Contents/Resources/firmware, so a driver kext's
+# bundled firmware (e.g. IntelWiFi.kext's iwlwifi-*.ucode) is found with no
+# configuration. /boot/firmware/ remains the built-in default for base firmware.
+# (nextbsd#205)


### PR DESCRIPTION
Part 2 of #205. firmware(9) now auto-searches each loaded kext bundle's `Contents/Resources/firmware` (nextbsd-kernel #13, merged + in `continuous`), so the hardcoded `firmware_path` loader.conf line is no longer needed.

- IntelWiFi.kext's bundled iwlwifi firmware is found with **zero configuration**.
- Scales to any future firmware-bearing kext (no per-module path; the `kenv` route was impossible — `KENV_MVALLEN=128`).
- `/boot/firmware/` remains the built-in default for base firmware.

Verify on t420 (8260): `kenv firmware_path` unset, `kextload IntelWiFi.kext` still loads `iwlwifi-8000C-36.ucode` + attaches. **Closes #205.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)