### PR TITLE
K3 verify (#216): kextd -l lookup + boot-test IOKIT-LOOKUP gate

### DIFF
--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -50,8 +50,29 @@ fi
 if echo "${dump}" | grep -q "org.nextbsd.kext.intelwifi" &&
    echo "${dump}" | grep -qi "24f38086"; then
 	echo "IOCATALOGUE-OK: IntelWiFi personalities (incl. 8260) in the catalogue"
-	exit 0
+else
+	echo "IOCATALOGUE-FAIL: IntelWiFi match table not found in the catalogue"
+	exit 1
 fi
 
-echo "IOCATALOGUE-FAIL: IntelWiFi match table not found in the catalogue"
-exit 1
+# K3 matcher (#216): ask the kernel which bundle claims the 8260 (0x24f38086),
+# via IOCATIOCLOOKUP — the same lookup the in-kernel device_nomatch matcher uses.
+# Proves the matcher resolves a real PCI id to its driver bundle without the
+# physical NIC. SKIP on a kernel that predates IOCATIOCLOOKUP (K3a).
+if [ -x /usr/libexec/kextd ]; then
+	lk=$(/usr/libexec/kextd -l 0x24f38086 2>/dev/null || true)
+	echo "matcher lookup: ${lk}"
+	case "${lk}" in
+	*org.nextbsd.kext.intelwifi*)
+		echo "IOKIT-LOOKUP-OK: kernel matcher resolves 0x24f38086 -> IntelWiFi"
+		;;
+	*unsupported*)
+		echo "IOKIT-LOOKUP-SKIP: kernel without IOCATIOCLOOKUP (pre-K3a)"
+		;;
+	*)
+		echo "IOKIT-LOOKUP-FAIL: matcher did not resolve the 8260 (catalogue has it)"
+		exit 1
+		;;
+	esac
+fi
+exit 0

--- a/src/kext_tools/kextd/iocatalogue.h
+++ b/src/kext_tools/kextd/iocatalogue.h
@@ -40,8 +40,22 @@ struct iocat_add {
 	uint64_t	match;			/* user ptr to uint32_t[nmatch] */
 };
 
-#define	IOCATIOCADD	_IOW('K', 1, struct iocat_add)	/* add one personality */
-#define	IOCATIOCFLUSH	_IO('K', 2)			/* drop all (re-push) */
+/*
+ * Look up the best driver bundle for a PCI match word (0x<device><vendor>).
+ * Userland sets `match`; the kernel fills `bundle_id` + `score` and returns 0,
+ * or ENOENT if nothing matches. This is the same lookup the in-kernel
+ * device_nomatch matcher (K3) uses — exposed so userland can verify it
+ * deterministically (e.g. is the 8260 bound to IntelWiFi?).
+ */
+struct iocat_lookup {
+	uint32_t	match;				/* in: 0x<device><vendor> */
+	int32_t		score;				/* out: winning IOProbeScore */
+	char		bundle_id[IOCAT_BUNDLE_ID_MAX];	/* out: winning bundle */
+};
+
+#define	IOCATIOCADD	_IOW('K', 1, struct iocat_add)		/* add a personality */
+#define	IOCATIOCFLUSH	_IO('K', 2)				/* drop all (re-push) */
+#define	IOCATIOCLOOKUP	_IOWR('K', 3, struct iocat_lookup)	/* match a PCI word */
 
 #ifdef _KERNEL
 #include <sys/queue.h>

--- a/src/kext_tools/kextd/kextd.c
+++ b/src/kext_tools/kextd/kextd.c
@@ -30,6 +30,7 @@
 #include <mach/mach_types.h>	/* kern_return_t, before OSKext.h -> OSReturn.h */
 
 #include <err.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -165,10 +166,40 @@ push_personality(int fd, CFDictionaryRef p)
 	return (1);
 }
 
+/*
+ * -l <matchword>: ask the kernel which driver bundle claims a PCI id
+ * (0x<device><vendor>) via IOCATIOCLOOKUP — the same lookup the in-kernel
+ * device_nomatch matcher (K3) uses. Lets the matcher be verified deterministically
+ * (e.g. 0x24f38086 -> org.nextbsd.kext.intelwifi) without the physical device.
+ */
+static int
+do_lookup(const char *word)
+{
+	struct iocat_lookup lu;
+	int fd, rc;
+
+	memset(&lu, 0, sizeof(lu));
+	lu.match = (uint32_t)strtoul(word, NULL, 0);
+	fd = open("/dev/iocatalogue", O_RDWR);
+	if (fd < 0)
+		err(1, "open /dev/iocatalogue (is the K2 kernel loaded?)");
+	rc = ioctl(fd, IOCATIOCLOOKUP, &lu);
+	close(fd);
+	if (rc == 0)
+		printf("LOOKUP 0x%08x -> %s score %d\n", lu.match,
+		    lu.bundle_id, lu.score);
+	else if (errno == ENOTTY)	/* kernel without K3a's IOCATIOCLOOKUP */
+		printf("LOOKUP 0x%08x -> unsupported\n", lu.match);
+	else
+		printf("LOOKUP 0x%08x -> (none)\n", lu.match);
+	return (rc == 0 ? 0 : 1);
+}
+
 int
 main(int argc, char *argv[])
 {
 	const char *repo = "/System/Library/Extensions";
+	const char *lookup = NULL;
 	CFArrayRef repoKexts = NULL;	/* non-retaining registry: hold alive */
 	CFArrayRef personalities = NULL;
 	CFURLRef u;
@@ -176,7 +207,7 @@ main(int argc, char *argv[])
 	int pushed = 0, skipped = 0, failed = 0;
 	CFIndex i, count;
 
-	while ((ch = getopt(argc, argv, "r:v")) != -1) {
+	while ((ch = getopt(argc, argv, "r:vl:")) != -1) {
 		switch (ch) {
 		case 'r':
 			repo = optarg;
@@ -184,10 +215,17 @@ main(int argc, char *argv[])
 		case 'v':
 			verbose = true;
 			break;
+		case 'l':
+			lookup = optarg;
+			break;
 		default:
-			errx(2, "usage: kextd [-r repo_dir] [-v]");
+			errx(2, "usage: kextd [-r repo_dir] [-v] | kextd -l matchword");
 		}
 	}
+
+	/* Query mode: just resolve one PCI id against the catalogue and exit. */
+	if (lookup != NULL)
+		return (do_lookup(lookup));
 
 	OSKextSetLogOutputFunction(&tool_log);
 	if (verbose)

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -1189,6 +1189,27 @@ expect {
     }
 }
 
+# IOKIT-LOOKUP — K3 (#216) matcher gate. The same on-image script asks the
+# kernel (IOCATIOCLOOKUP) which bundle claims the 8260 (0x24f38086); it must
+# resolve to IntelWiFi. Proves the in-kernel matcher's lookup without the
+# physical NIC. SKIP on a kernel predating IOCATIOCLOOKUP; non-fatal on timeout
+# (older images whose run.sh lacks this step); only IOKIT-LOOKUP-FAIL gates.
+expect {
+    timeout {
+        puts "\nWARN: IOKIT-LOOKUP marker not seen (pre-K3a image — informational)"
+    }
+    "IOKIT-LOOKUP-FAIL" {
+        puts "\nFAIL: in-kernel matcher did not resolve the 8260 to IntelWiFi"
+        exit 1
+    }
+    "IOKIT-LOOKUP-SKIP" {
+        puts "\nWARN: IOKIT-LOOKUP-SKIP — kernel without IOCATIOCLOOKUP (pre-K3a)"
+    }
+    "IOKIT-LOOKUP-OK" {
+        puts "\nOK: in-kernel matcher resolves 0x24f38086 -> IntelWiFi"
+    }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
Userland verification of the K3a in-kernel matcher (nextbsd-kernel #16, merged + in continuous). Proves the matcher resolves a real PCI id to its driver bundle **deterministically, with no physical NIC**.

## What
- `kextd -l <matchword>`: `IOCATIOCLOOKUP` query mode — asks the kernel which bundle claims a PCI id (the same lookup the in-kernel `device_nomatch` matcher uses). Prints the winning bundle, `(none)`, or `unsupported` (kernel predating IOCATIOCLOOKUP).
- `iocatalogue.h` synced from nextbsd-kernel (adds `IOCATIOCLOOKUP` + `struct iocat_lookup`).
- `nextbsd-iokit/run.sh`: after the catalogue push, `kextd -l 0x24f38086` must resolve to `org.nextbsd.kext.intelwifi` → **IOKIT-LOOKUP-OK** (SKIP on a pre-K3a kernel; FAIL only if the catalogue has it but the matcher misses it).
- `boot-test.sh`: IOKIT-LOOKUP gate (non-fatal timeout + self-SKIP, like the IOCATALOGUE gate, so it stays green on older images).

## Verification
The PR builds the image (continuous kernel now has K3a + IOCATIOCLOOKUP) and boot-tests it: kextd pushes IntelWiFi → `kextd -l 0x24f38086` → matcher returns `org.nextbsd.kext.intelwifi` → IOKIT-LOOKUP-OK. End-to-end proof of the in-kernel matcher path **except** the physical bind.

## Boundary
The remaining K3 pieces — kextd's persistent `/dev/devctl` listener for the kernel's load requests + its launchd boot ordering, and the actual 8260 `device_nomatch` → load → bind — need the **t420 hardware**.