### PR TITLE
login.conf: add /usr/libexec to the default PATH (kextd et al.)

### DIFF
--- a/overlays/etc/login.conf
+++ b/overlays/etc/login.conf
@@ -27,7 +27,7 @@ default:\
 	:welcome=/var/run/motd:\
 	:setenv=BLOCKSIZE=K:\
 	:mail=/var/mail/$:\
-	:path=/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin ~/bin:\
+	:path=/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin /usr/libexec ~/bin:\
 	:nologin=/var/run/nologin:\
 	:cputime=unlimited:\
 	:datasize=unlimited:\
@@ -67,7 +67,7 @@ staff:\
 # may not include /usr/local/sbin and /usr/local/bin when starting services or
 # jobs.
 daemon:\
-	:path=/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin:\
+	:path=/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin /usr/libexec:\
 	:mail@:\
 	:memorylocked=128M:\
 	:tc=default:


### PR DESCRIPTION
Adds `/usr/libexec` to the `default` and `daemon` class PATH in `/etc/login.conf`, so `/usr/libexec/kextd` (and other libexec helpers) run without a full path. login(1) reads `login.conf.db`, which build.sh regenerates from this overlay via `cap_mkdb`, so it applies on the next image.

Verified on the t420: `/usr/libexec/kextd -v` + `-l 0x24f38086` work — this just makes them reachable as `kextd`.

Note: `/System` has no executable directory yet (only `Library/Extensions` + `Library/LaunchDaemons`), so nothing there to add to PATH; happy to wire one in if you have a target location in mind.