### PR TITLE
K3b round-trip (#216): userland receives the kernel→kextd Mach load request

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1947,6 +1947,19 @@ install -m 0644 "$ROOT/src/kext_tools/kextd/iocatalogue.h" \
     "$WORK/rootfs/usr/include/sys/iocatalogue.h"
 echo "==> kextd built + installed; sys/iocatalogue.h installed"
 
+# test_kextd_mach — K3b round-trip (#216): register HOST_KEXTD_PORT, drive the
+# kernel matcher's send via IOCATIOCTESTSEND, and receive the Mach load request.
+# Built here (not with the other mach tests at ~3p) because it needs
+# <sys/iocatalogue.h>, installed just above by the kext_tools step.
+echo "==> building test_kextd_mach"
+cc -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_kextd_mach" \
+   "$ROOT/src/mach_kmod/tests/test_kextd_mach.c" \
+   -lsystem_kernel
+ls -lh "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_kextd_mach"
+
 # Runtime smoke: resolve a 2-kext graph (Leaf -> Base via OSBundleLibraries)
 # and assert kextdeps emits Base BEFORE Leaf in the load order.
 echo "==> kextdeps dependency-resolution smoke"

--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -75,4 +75,17 @@ if [ -x /usr/libexec/kextd ]; then
 		;;
 	esac
 fi
+
+# K3b round-trip (#216): the kernel->kextd Mach load request. test_kextd_mach
+# registers HOST_KEXTD_PORT, drives the matcher's send via IOCATIOCTESTSEND, and
+# receives the Mach message — proving the kernel can hand a load request to
+# userland over the faithful channel (no devd/devctl). The catalogue was just
+# populated by the kextd push above, so the 8260 lookup inside the ioctl hits.
+# Emits KEXTD-MACH-OK / -FAIL / -SKIP (SKIP on a kernel predating K3b).
+KM=/usr/tests/freebsd-launchd-mach/test_kextd_mach
+if [ -x "$KM" ]; then
+	"$KM" || true		# the marker (not the exit code) is the signal
+else
+	echo "KEXTD-MACH-SKIP: test_kextd_mach not present"
+fi
 exit 0

--- a/src/kext_tools/kextd/iocatalogue.h
+++ b/src/kext_tools/kextd/iocatalogue.h
@@ -56,6 +56,14 @@ struct iocat_lookup {
 #define	IOCATIOCADD	_IOW('K', 1, struct iocat_add)		/* add a personality */
 #define	IOCATIOCFLUSH	_IO('K', 2)				/* drop all (re-push) */
 #define	IOCATIOCLOOKUP	_IOWR('K', 3, struct iocat_lookup)	/* match a PCI word */
+/*
+ * K3b PoC (#216): look up a PCI match word and, on a hit, fire the kernel->kextd
+ * Mach load request (HOST_KEXTD_PORT) for the winning bundle — the de-risk test
+ * for the matcher's real send. Throwaway: the production matcher sends from its
+ * device_nomatch taskqueue, not via an ioctl. Returns 0 / ENOENT (no match) /
+ * ENXIO (no kextd registered) / ENOSYS (kernel built without COMPAT_MACH).
+ */
+#define	IOCATIOCTESTSEND	_IOW('K', 4, uint32_t)
 
 #ifdef _KERNEL
 #include <sys/queue.h>

--- a/src/libmach/include/mach/host_special_ports.h
+++ b/src/libmach/include/mach/host_special_ports.h
@@ -35,6 +35,7 @@ extern "C" {
 #define HOST_PRIV_PORT			2
 #define HOST_IO_MASTER_PORT		3
 #define HOST_BOOTSTRAP_PORT		13	/* freebsd-launchd-mach */
+#define HOST_KEXTD_PORT			15	/* kextd load-request port (K3b, #216) */
 
 /*
  * Upper bound on a host-special-port `which` value. launchd uses it

--- a/src/mach_kmod/tests/test_kextd_mach.c
+++ b/src/mach_kmod/tests/test_kextd_mach.c
@@ -1,0 +1,131 @@
+/*
+ * test_kextd_mach — K3b round-trip: prove the kernel can send a Mach
+ * load-request to a userland receive right registered as HOST_KEXTD_PORT.
+ *
+ * This is the de-risk for the in-kernel IOKit matcher's kextd hand-off (#216).
+ * It mimics exactly what kextd will do, minus the actual load:
+ *
+ *   1. Allocate a port (RECEIVE + MAKE_SEND) and register it host-wide as
+ *      HOST_KEXTD_PORT (the slot the kernel matcher sends to).
+ *   2. ioctl(/dev/iocatalogue, IOCATIOCTESTSEND, 0x24f38086) — ask the kernel
+ *      to look up the Intel 8260 and fire iokit_kextd_send() for the winning
+ *      bundle to HOST_KEXTD_PORT. (Requires kextd to have pushed the IntelWiFi
+ *      personality first — run.sh does that.)
+ *   3. mach_msg(MACH_RCV) on our port and confirm the message carries
+ *      bundle_id "org.nextbsd.kext.intelwifi" and match 0x24f38086.
+ *
+ * Prints KEXTD-MACH-OK / KEXTD-MACH-FAIL / KEXTD-MACH-SKIP for the boot test.
+ * SKIP when /dev/iocatalogue or the IOCATIOCTESTSEND/HOST_KEXTD_PORT plumbing
+ * is absent (a kernel predating K3b).
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/ioctl.h>
+
+#include <mach/mach_traps.h>
+#include <mach/mach_port.h>
+#include <mach/host_special_ports.h>
+#include <mach/message.h>
+
+#include <sys/iocatalogue.h>	/* IOCATIOCTESTSEND */
+
+#ifndef HOST_KEXTD_PORT
+#define HOST_KEXTD_PORT 15
+#endif
+
+#define	IWL_8260_MATCH	0x24f38086u
+#define	WANT_BUNDLE	"org.nextbsd.kext.intelwifi"
+
+/* Mirror of the kernel's iokit_kextd_load_msg_t body (sys/mach/iokit_kextd.h),
+ * minus the trailer the kernel appends on receive. NDR_record_t is 8 bytes. */
+typedef struct {
+	mach_msg_header_t	hdr;
+	unsigned char		ndr[8];
+	char			bundle_id[128];
+	char			device[64];
+	uint32_t		match_word;
+} kextd_load_body_t;
+
+int
+main(void)
+{
+	mach_port_name_t task = mach_task_self();
+	mach_port_name_t host = mach_host_self();
+	mach_port_name_t port = MACH_PORT_NULL;
+	kern_return_t kr;
+	uint32_t mw = IWL_8260_MATCH;
+	int fd, rc;
+	union {
+		kextd_load_body_t body;
+		unsigned char raw[sizeof(kextd_load_body_t) + 64]; /* trailer slack */
+	} buf;
+	mach_msg_return_t mr;
+
+	fd = open("/dev/iocatalogue", O_RDWR);
+	if (fd < 0) {
+		printf("KEXTD-MACH-SKIP: no /dev/iocatalogue (pre-K2 kernel)\n");
+		return (0);
+	}
+
+	kr = mach_port_allocate(task, MACH_PORT_RIGHT_RECEIVE, &port);
+	if (kr != KERN_SUCCESS) {
+		printf("KEXTD-MACH-FAIL: mach_port_allocate 0x%x\n", (unsigned)kr);
+		return (1);
+	}
+	kr = mach_port_insert_right(task, port, port, MACH_MSG_TYPE_MAKE_SEND);
+	if (kr != KERN_SUCCESS) {
+		printf("KEXTD-MACH-FAIL: mach_port_insert_right 0x%x\n", (unsigned)kr);
+		return (1);
+	}
+	kr = host_set_special_port(host, HOST_KEXTD_PORT, port);
+	if (kr != KERN_SUCCESS) {
+		printf("KEXTD-MACH-FAIL: host_set_special_port(HOST_KEXTD_PORT) 0x%x\n",
+		    (unsigned)kr);
+		return (1);
+	}
+	printf("registered HOST_KEXTD_PORT = 0x%x\n", port);
+
+	/* Ask the kernel to match the 8260 and send the load request to us. */
+	rc = ioctl(fd, IOCATIOCTESTSEND, &mw);
+	if (rc != 0) {
+		if (errno == ENOTTY) {
+			printf("KEXTD-MACH-SKIP: no IOCATIOCTESTSEND (pre-K3b kernel)\n");
+			(void) host_set_special_port(host, HOST_KEXTD_PORT, MACH_PORT_NULL);
+			return (0);
+		}
+		printf("KEXTD-MACH-FAIL: IOCATIOCTESTSEND errno=%d (%s)\n",
+		    errno, errno == ENOENT ? "8260 not in catalogue — kextd push first" :
+		    errno == ENXIO ? "kernel saw no kextd port" : "?");
+		(void) host_set_special_port(host, HOST_KEXTD_PORT, MACH_PORT_NULL);
+		return (1);
+	}
+
+	/* The send is synchronous in the ioctl, so the message is already
+	 * queued; receive it (short timeout as a guard). */
+	memset(&buf, 0, sizeof(buf));
+	mr = mach_msg(&buf.body.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT,
+	    0, sizeof(buf), port, 5000 /* ms */, MACH_PORT_NULL);
+	(void) host_set_special_port(host, HOST_KEXTD_PORT, MACH_PORT_NULL);
+
+	if (mr != MACH_MSG_SUCCESS) {
+		printf("KEXTD-MACH-FAIL: mach_msg(RCV) 0x%x\n", (unsigned)mr);
+		return (1);
+	}
+
+	buf.body.bundle_id[sizeof(buf.body.bundle_id) - 1] = '\0';
+	printf("received: id=0x%x bundle='%s' match=0x%08x\n",
+	    buf.body.hdr.msgh_id, buf.body.bundle_id, buf.body.match_word);
+
+	if (strcmp(buf.body.bundle_id, WANT_BUNDLE) == 0 &&
+	    buf.body.match_word == IWL_8260_MATCH) {
+		printf("KEXTD-MACH-OK: kernel->kextd Mach load request delivered "
+		    "(%s for 0x%08x)\n", WANT_BUNDLE, IWL_8260_MATCH);
+		return (0);
+	}
+	printf("KEXTD-MACH-FAIL: message contents mismatch\n");
+	return (1);
+}

--- a/src/mach_kmod/tests/test_kextd_mach.c
+++ b/src/mach_kmod/tests/test_kextd_mach.c
@@ -89,43 +89,51 @@ main(void)
 	}
 	printf("registered HOST_KEXTD_PORT = 0x%x\n", port);
 
-	/* Ask the kernel to match the 8260 and send the load request to us. */
+	/* Ask the kernel to match the 8260 and send the load request to us.
+	 * NOTE: the serial console splits long lines and the boot test matches
+	 * the marker token as soon as it appears, so always print the diagnostic
+	 * on its OWN line first, then a bare KEXTD-MACH-{OK,FAIL,SKIP} marker. */
 	rc = ioctl(fd, IOCATIOCTESTSEND, &mw);
+	printf("IOCATIOCTESTSEND rc=%d errno=%d\n", rc, rc != 0 ? errno : 0);
 	if (rc != 0) {
+		(void) host_set_special_port(host, HOST_KEXTD_PORT, MACH_PORT_NULL);
 		if (errno == ENOTTY) {
-			printf("KEXTD-MACH-SKIP: no IOCATIOCTESTSEND (pre-K3b kernel)\n");
-			(void) host_set_special_port(host, HOST_KEXTD_PORT, MACH_PORT_NULL);
+			printf("(no IOCATIOCTESTSEND — pre-K3b kernel)\n");
+			printf("KEXTD-MACH-SKIP\n");
 			return (0);
 		}
-		printf("KEXTD-MACH-FAIL: IOCATIOCTESTSEND errno=%d (%s)\n",
-		    errno, errno == ENOENT ? "8260 not in catalogue — kextd push first" :
+		printf("(errno %d: %s)\n", errno,
+		    errno == ENOENT ? "8260 not in catalogue" :
 		    errno == ENXIO ? "kernel saw no kextd port" : "?");
-		(void) host_set_special_port(host, HOST_KEXTD_PORT, MACH_PORT_NULL);
+		printf("KEXTD-MACH-FAIL\n");
 		return (1);
 	}
 
 	/* The send is synchronous in the ioctl, so the message is already
-	 * queued; receive it (short timeout as a guard). */
+	 * queued; receive it (timeout as a guard). */
 	memset(&buf, 0, sizeof(buf));
 	mr = mach_msg(&buf.body.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT,
 	    0, sizeof(buf), port, 5000 /* ms */, MACH_PORT_NULL);
 	(void) host_set_special_port(host, HOST_KEXTD_PORT, MACH_PORT_NULL);
+	printf("mach_msg(RCV) = 0x%x\n", (unsigned)mr);
 
 	if (mr != MACH_MSG_SUCCESS) {
-		printf("KEXTD-MACH-FAIL: mach_msg(RCV) 0x%x\n", (unsigned)mr);
+		printf("(receive failed)\n");
+		printf("KEXTD-MACH-FAIL\n");
 		return (1);
 	}
 
 	buf.body.bundle_id[sizeof(buf.body.bundle_id) - 1] = '\0';
-	printf("received: id=0x%x bundle='%s' match=0x%08x\n",
-	    buf.body.hdr.msgh_id, buf.body.bundle_id, buf.body.match_word);
+	printf("received: msgid=0x%x size=%u bundle='%s' match=0x%08x\n",
+	    buf.body.hdr.msgh_id, (unsigned)buf.body.hdr.msgh_size,
+	    buf.body.bundle_id, buf.body.match_word);
 
 	if (strcmp(buf.body.bundle_id, WANT_BUNDLE) == 0 &&
 	    buf.body.match_word == IWL_8260_MATCH) {
-		printf("KEXTD-MACH-OK: kernel->kextd Mach load request delivered "
-		    "(%s for 0x%08x)\n", WANT_BUNDLE, IWL_8260_MATCH);
+		printf("KEXTD-MACH-OK\n");
 		return (0);
 	}
-	printf("KEXTD-MACH-FAIL: message contents mismatch\n");
+	printf("(contents mismatch — want '%s'/0x%08x)\n", WANT_BUNDLE, IWL_8260_MATCH);
+	printf("KEXTD-MACH-FAIL\n");
 	return (1);
 }

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -1210,6 +1210,27 @@ expect {
     }
 }
 
+# KEXTD-MACH — K3b (#216) round-trip gate. test_kextd_mach registers
+# HOST_KEXTD_PORT, drives the kernel matcher's send via IOCATIOCTESTSEND, and
+# receives the Mach load request — proving the kernel->kextd hand-off over the
+# faithful channel (no devd/devctl). Non-fatal on timeout + self-SKIP so it
+# stays green on images/kernels predating K3b; only KEXTD-MACH-FAIL gates.
+expect {
+    timeout {
+        puts "\nWARN: KEXTD-MACH marker not seen (pre-K3b image — informational)"
+    }
+    "KEXTD-MACH-FAIL" {
+        puts "\nFAIL: kernel->kextd Mach load request did not round-trip"
+        exit 1
+    }
+    "KEXTD-MACH-SKIP" {
+        puts "\nWARN: KEXTD-MACH-SKIP — kernel/image without K3b plumbing"
+    }
+    "KEXTD-MACH-OK" {
+        puts "\nOK: kernel->kextd Mach load request delivered (HOST_KEXTD_PORT)"
+    }
+}
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"


### PR DESCRIPTION
The K3b de-risk — proves the kernel-side Mach send (nextbsd-kernel #17, merged + in continuous) actually reaches userland over `HOST_KEXTD_PORT`, the faithful channel (no devd/devctl).

## What
`test_kextd_mach` does exactly what kextd will do, minus the load:
1. register a receive port as `HOST_KEXTD_PORT`;
2. `ioctl(/dev/iocatalogue, IOCATIOCTESTSEND, 0x24f38086)` → kernel matcher looks up the 8260 and fires `iokit_kextd_send()` to us;
3. `mach_msg(RCV)` and assert the message carries `org.nextbsd.kext.intelwifi` + `0x24f38086`.

Plus: `HOST_KEXTD_PORT=15` in userland `host_special_ports.h`; build wired after the kext_tools step (needs the installed `<sys/iocatalogue.h>`); `run.sh` runs it after the kextd push so the in-ioctl lookup hits; a non-fatal/self-SKIP `KEXTD-MACH` boot-test gate.

## Verification
CI boots the image (continuous kernel has `IOCATIOCTESTSEND`) and runs the real **kernel→userland Mach round-trip** — no Intel NIC. `KEXTD-MACH-OK` means the faithful hand-off works.

## After this
Wire `iokit_kextd_send()` into the `device_nomatch` matcher (replacing the K3a `devctl_notify` placeholder) + add push-triggers-match + kextd's persistent receive loop. The actual 8260 auto-load is the **t420** test.