### PR TITLE
K3b step 3 (#217): kextd persistent daemon — serve kernel load requests

### DIFF
--- a/overlays/System/Library/LaunchDaemons/org.nextbsd.kextd.plist
+++ b/overlays/System/Library/LaunchDaemons/org.nextbsd.kextd.plist
@@ -23,13 +23,14 @@
 	<true/>
 	<key>KeepAlive</key>
 	<true/>
-	<!-- DIAGNOSTIC: route to /dev/console so kextd's startup markers reach
-	     the serial log even if boot wedges (pinpoints any blocking call).
-	     Production should log to a file / syslog — see #211 cleanup. -->
+	<!-- Quiet by default (no -v): logs only meaningful events (loaded
+	     <bundle>, errors) to a file, like other System daemons. The full
+	     startup trace is available by adding -v. (Routing to syslog is a
+	     later refinement — #211.) -->
 	<key>StandardErrorPath</key>
-	<string>/dev/console</string>
+	<string>/var/log/kextd.log</string>
 	<key>StandardOutPath</key>
-	<string>/dev/console</string>
+	<string>/var/log/kextd.log</string>
 	<key>LimitLoadToSessionType</key>
 	<string>System</string>
 </dict>

--- a/overlays/System/Library/LaunchDaemons/org.nextbsd.kextd.plist
+++ b/overlays/System/Library/LaunchDaemons/org.nextbsd.kextd.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- kextd, the in-kernel IOKit matcher's loader daemon (K3b, #217).
+	     Early, persistent System daemon — Apple's shape (kextd was the
+	     HOST_KEXTD_PORT server). It registers HOST_KEXTD_PORT so the kernel
+	     matcher can reach it, pushes the IOKitPersonalities (push-triggers-
+	     match #216 then fires load requests for already-unmatched devices),
+	     and serves load requests forever (OSKextLoad -> kldload -> attach).
+
+	     Ordering is irrelevant: launchd has none, and push-triggers-match
+	     makes the kernel re-fire requests when kextd pushes, so kextd may
+	     start at any time without losing loads. -->
+	<key>Label</key>
+	<string>org.nextbsd.kextd</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/libexec/kextd</string>
+		<string>-w</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<!-- DIAGNOSTIC: route to /dev/console so kextd's startup markers reach
+	     the serial log even if boot wedges (pinpoints any blocking call).
+	     Production should log to a file / syslog — see #211 cleanup. -->
+	<key>StandardErrorPath</key>
+	<string>/dev/console</string>
+	<key>StandardOutPath</key>
+	<string>/dev/console</string>
+	<key>LimitLoadToSessionType</key>
+	<string>System</string>
+</dict>
+</plist>

--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -99,6 +99,7 @@ if [ -x /usr/libexec/kextd ]; then
 		   kldstat -v 2>/dev/null | grep -qi iwlwifi; then loaded=yes; break; fi
 		sleep 1; i=$((i + 1))
 	done
+	echo "=== /var/log/kextd.log (daemon) ==="; cat /var/log/kextd.log 2>/dev/null; echo "==="
 	if [ "$loaded" = yes ]; then
 		echo "KEXTD-LOAD-OK: auto-started kextd loaded IntelWiFi on a kernel request"
 	elif ! pgrep -f "kextd -w" >/dev/null 2>&1; then

--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -102,17 +102,21 @@ if [ -x /usr/libexec/kextd ]; then
 	loaded=no
 	i=0
 	while [ "$i" -lt 12 ]; do
-		if kldstat 2>/dev/null | grep -q if_iwlwifi; then loaded=yes; break; fi
+		# The loaded kld file is named after the bundle executable
+		# (IntelWiFi); plain `kldstat` shows that, while the driver
+		# module (if_iwlwifi) only appears under `kldstat -v`. Check both.
+		if kldstat 2>/dev/null | grep -qi intelwifi ||
+		   kldstat -v 2>/dev/null | grep -qi iwlwifi; then loaded=yes; break; fi
 		sleep 1; i=$((i + 1))
 	done
 	echo "=== kextd -w log ==="; cat /tmp/kextd-w.log 2>/dev/null; echo "==="
 	kill "$wpid" 2>/dev/null
 	if [ "$loaded" = yes ]; then
-		echo "KEXTD-LOAD-OK: kextd loaded if_iwlwifi on a kernel load request"
+		echo "KEXTD-LOAD-OK: kextd loaded IntelWiFi on a kernel load request"
 	elif ! grep -q "listening on HOST_KEXTD_PORT" /tmp/kextd-w.log 2>/dev/null; then
 		echo "KEXTD-LOAD-SKIP: kextd -w unsupported / didn't start (pre-step-3)"
 	else
-		echo "KEXTD-LOAD-FAIL: if_iwlwifi not loaded after a kernel load request"
+		echo "KEXTD-LOAD-FAIL: IntelWiFi not in kldstat after a kernel load request"
 	fi
 else
 	echo "KEXTD-LOAD-SKIP: kextd not present"

--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -88,4 +88,33 @@ if [ -x "$KM" ]; then
 else
 	echo "KEXTD-MACH-SKIP: test_kextd_mach not present"
 fi
+
+# K3b step 3 (#217): the kextd DAEMON receives a kernel load request and actually
+# loads the bundle. Start `kextd -w` (registers HOST_KEXTD_PORT, pushes, listens),
+# inject a request with `kextd -t` (IOCATIOCTESTSEND — kernel sends to the running
+# daemon), and confirm if_iwlwifi got kldload'd. This is the auto-load path minus
+# the physical device (the 8260 bind is the t420 test). SKIP if kextd lacks -w.
+if [ -x /usr/libexec/kextd ]; then
+	/usr/libexec/kextd -w >/tmp/kextd-w.log 2>&1 &
+	wpid=$!
+	sleep 4					# register + push + enter receive loop
+	/usr/libexec/kextd -t 0x24f38086 || true	# inject a load request
+	loaded=no
+	i=0
+	while [ "$i" -lt 12 ]; do
+		if kldstat 2>/dev/null | grep -q if_iwlwifi; then loaded=yes; break; fi
+		sleep 1; i=$((i + 1))
+	done
+	echo "=== kextd -w log ==="; cat /tmp/kextd-w.log 2>/dev/null; echo "==="
+	kill "$wpid" 2>/dev/null
+	if [ "$loaded" = yes ]; then
+		echo "KEXTD-LOAD-OK: kextd loaded if_iwlwifi on a kernel load request"
+	elif ! grep -q "listening on HOST_KEXTD_PORT" /tmp/kextd-w.log 2>/dev/null; then
+		echo "KEXTD-LOAD-SKIP: kextd -w unsupported / didn't start (pre-step-3)"
+	else
+		echo "KEXTD-LOAD-FAIL: if_iwlwifi not loaded after a kernel load request"
+	fi
+else
+	echo "KEXTD-LOAD-SKIP: kextd not present"
+fi
 exit 0

--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -76,28 +76,18 @@ if [ -x /usr/libexec/kextd ]; then
 	esac
 fi
 
-# K3b round-trip (#216): the kernel->kextd Mach load request. test_kextd_mach
-# registers HOST_KEXTD_PORT, drives the matcher's send via IOCATIOCTESTSEND, and
-# receives the Mach message — proving the kernel can hand a load request to
-# userland over the faithful channel (no devd/devctl). The catalogue was just
-# populated by the kextd push above, so the 8260 lookup inside the ioctl hits.
-# Emits KEXTD-MACH-OK / -FAIL / -SKIP (SKIP on a kernel predating K3b).
-KM=/usr/tests/freebsd-launchd-mach/test_kextd_mach
-if [ -x "$KM" ]; then
-	"$KM" || true		# the marker (not the exit code) is the signal
-else
-	echo "KEXTD-MACH-SKIP: test_kextd_mach not present"
-fi
-
-# K3b step 3 (#217): the kextd DAEMON receives a kernel load request and actually
-# loads the bundle. Start `kextd -w` (registers HOST_KEXTD_PORT, pushes, listens),
-# inject a request with `kextd -t` (IOCATIOCTESTSEND — kernel sends to the running
-# daemon), and confirm if_iwlwifi got kldload'd. This is the auto-load path minus
-# the physical device (the 8260 bind is the t420 test). SKIP if kextd lacks -w.
+# K3b step 3 (#217): kextd AUTO-STARTS at boot (org.nextbsd.kextd.plist,
+# RunAtLoad System) — it registers HOST_KEXTD_PORT, pushes personalities, and
+# serves load requests. Its startup markers (kextd: listening / opening repo /
+# repo opened / pushed / ready) already appear in this serial log above, since
+# the plist routes kextd to /dev/console. Here we verify the AUTO-STARTED daemon
+# actually loads a kext on a kernel request: inject one with `kextd -t`
+# (IOCATIOCTESTSEND -> the kernel sends to the running daemon over HOST_KEXTD_PORT)
+# and confirm IntelWiFi kldloaded. This is the full auto-load path minus the
+# physical device (the 8260 bind is the t420 test).
 if [ -x /usr/libexec/kextd ]; then
-	/usr/libexec/kextd -w >/tmp/kextd-w.log 2>&1 &
-	wpid=$!
-	sleep 4					# register + push + enter receive loop
+	pgrep -f "kextd -w" >/dev/null 2>&1 && echo "kextd -w daemon is running" \
+	    || echo "WARN: kextd -w daemon not found running"
 	/usr/libexec/kextd -t 0x24f38086 || true	# inject a load request
 	loaded=no
 	i=0
@@ -109,14 +99,12 @@ if [ -x /usr/libexec/kextd ]; then
 		   kldstat -v 2>/dev/null | grep -qi iwlwifi; then loaded=yes; break; fi
 		sleep 1; i=$((i + 1))
 	done
-	echo "=== kextd -w log ==="; cat /tmp/kextd-w.log 2>/dev/null; echo "==="
-	kill "$wpid" 2>/dev/null
 	if [ "$loaded" = yes ]; then
-		echo "KEXTD-LOAD-OK: kextd loaded IntelWiFi on a kernel load request"
-	elif ! grep -q "listening on HOST_KEXTD_PORT" /tmp/kextd-w.log 2>/dev/null; then
-		echo "KEXTD-LOAD-SKIP: kextd -w unsupported / didn't start (pre-step-3)"
+		echo "KEXTD-LOAD-OK: auto-started kextd loaded IntelWiFi on a kernel request"
+	elif ! pgrep -f "kextd -w" >/dev/null 2>&1; then
+		echo "KEXTD-LOAD-SKIP: no kextd -w daemon (image predates the boot launch)"
 	else
-		echo "KEXTD-LOAD-FAIL: IntelWiFi not in kldstat after a kernel load request"
+		echo "KEXTD-LOAD-FAIL: IntelWiFi not loaded after a kernel request"
 	fi
 else
 	echo "KEXTD-LOAD-SKIP: kextd not present"

--- a/src/kext_tools/kextd/Makefile
+++ b/src/kext_tools/kextd/Makefile
@@ -9,8 +9,10 @@ MAN=
 # (canonical copy lives in nextbsd-kernel's src-overlay) and included locally,
 # so the build doesn't depend on it being installed into the sysroot first.
 #
-# Installs to /usr/libexec/kextd (Apple's location). Invoked on demand for now
-# (on-image IOKit test); the launchd boot-time auto-push lands with K3 (#216).
+# Installs to /usr/libexec/kextd (Apple's location). `-w` (watch) runs it as the
+# persistent daemon: register HOST_KEXTD_PORT, push personalities, serve kernel
+# load requests (K3b, #216). -lsystem_kernel provides mach_msg / mach_port_* /
+# host_set_special_port for the receive loop + port registration.
 BINDIR=	/usr/libexec
 
 KT=	${.CURDIR}/..
@@ -22,7 +24,7 @@ CFLAGS+=	-DPRIVATE=1 -D__APPLE_API_PRIVATE
 WARNS=		0
 CFLAGS+=	-Wno-everything
 
-LDADD+=	${KT}/kext.subproj/libkext.a -lCoreFoundation -lIOKit -lz
+LDADD+=	${KT}/kext.subproj/libkext.a -lCoreFoundation -lIOKit -lz -lsystem_kernel
 DPADD+=	${KT}/kext.subproj/libkext.a
 
 .include <bsd.prog.mk>

--- a/src/kext_tools/kextd/kextd.c
+++ b/src/kext_tools/kextd/kextd.c
@@ -347,6 +347,11 @@ main(int argc, char *argv[])
 	int pushed = 0, skipped = 0, failed = 0;
 	CFIndex i, count;
 
+	/* Line-buffer stdout: in -w (daemon) mode our output is redirected to a
+	 * file (fully buffered), and the test kill()s us — buffered diagnostics
+	 * would be lost. Line buffering flushes each message as it's printed. */
+	setlinebuf(stdout);
+
 	while ((ch = getopt(argc, argv, "r:vl:wt:")) != -1) {
 		switch (ch) {
 		case 'r':

--- a/src/kext_tools/kextd/kextd.c
+++ b/src/kext_tools/kextd/kextd.c
@@ -28,6 +28,10 @@
  */
 #include <CoreFoundation/CoreFoundation.h>
 #include <mach/mach_types.h>	/* kern_return_t, before OSKext.h -> OSReturn.h */
+#include <mach/mach_traps.h>	/* mach_task_self, mach_host_self, mach_msg */
+#include <mach/mach_port.h>	/* mach_port_allocate, mach_port_insert_right */
+#include <mach/host_special_ports.h>	/* host_set_special_port, HOST_KEXTD_PORT */
+#include <mach/message.h>
 
 #include <err.h>
 #include <errno.h>
@@ -42,6 +46,21 @@
 
 #include "OSKext.h"
 #include "iocatalogue.h"	/* vendored ABI; canonical copy in nextbsd-kernel */
+
+#ifndef HOST_KEXTD_PORT
+#define HOST_KEXTD_PORT 15
+#endif
+
+/* kernel->kextd load request wire format (mirror of the kernel's
+ * iokit_kextd_load_msg_t in sys/mach/iokit_kextd.h; NDR_record_t is 8 bytes). */
+#define	IOKIT_KEXTD_LOAD_MSGID	0x494f4b54
+typedef struct {
+	mach_msg_header_t	hdr;
+	unsigned char		ndr[8];
+	char			bundle_id[128];
+	char			device[64];
+	uint32_t		match_word;
+} kextd_load_body_t;
 
 static bool verbose;
 
@@ -195,11 +214,132 @@ do_lookup(const char *word)
 	return (rc == 0 ? 0 : 1);
 }
 
+/* Load a kext by CFBundleIdentifier from the already-open repo set. */
+static void
+load_bundle(const char *bundle_id)
+{
+	CFStringRef idstr;
+	OSKextRef k;
+	OSReturn r;
+
+	idstr = CFStringCreateWithCString(kCFAllocatorDefault, bundle_id,
+	    kCFStringEncodingUTF8);
+	if (idstr == NULL)
+		return;
+	k = OSKextGetKextWithIdentifier(idstr);	/* from the open repo set */
+	CFRelease(idstr);
+	if (k == NULL) {
+		printf("kextd: no kext with identifier %s\n", bundle_id);
+		return;
+	}
+	r = OSKextLoad(k);
+	if (r == kOSReturnSuccess)
+		printf("kextd: loaded %s\n", bundle_id);
+	else {
+		printf("kextd: load %s failed (OSReturn 0x%x)\n", bundle_id,
+		    (unsigned)r);
+		OSKextLogDiagnostics(k, kOSKextDiagnosticsFlagAll);
+	}
+}
+
+/*
+ * Watch mode (the real daemon, U1/K3b): register HOST_KEXTD_PORT so the kernel
+ * matcher can reach us, push the repo's personalities into the IOCatalogue
+ * (which, with push-triggers-match, fires load requests for already-unmatched
+ * devices), then serve kernel load requests forever — loading each named bundle
+ * via OSKext (kldload re-probes and the device attaches). No matching here.
+ */
+static int
+do_watch(int fd, const char *repo)
+{
+	mach_port_name_t task = mach_task_self();
+	mach_port_name_t host = mach_host_self();
+	mach_port_name_t port = MACH_PORT_NULL;
+	CFArrayRef repoKexts, personalities;
+	CFURLRef u;
+	kern_return_t kr;
+	union {
+		kextd_load_body_t body;
+		unsigned char raw[sizeof(kextd_load_body_t) + 64];
+	} buf;
+
+	kr = mach_port_allocate(task, MACH_PORT_RIGHT_RECEIVE, &port);
+	if (kr != KERN_SUCCESS)
+		errx(1, "mach_port_allocate: 0x%x", (unsigned)kr);
+	kr = mach_port_insert_right(task, port, port, MACH_MSG_TYPE_MAKE_SEND);
+	if (kr != KERN_SUCCESS)
+		errx(1, "mach_port_insert_right: 0x%x", (unsigned)kr);
+	kr = host_set_special_port(host, HOST_KEXTD_PORT, port);
+	if (kr != KERN_SUCCESS)
+		errx(1, "host_set_special_port(HOST_KEXTD_PORT): 0x%x", (unsigned)kr);
+	printf("kextd: listening on HOST_KEXTD_PORT (port 0x%x)\n", port);
+
+	/* Open the repo (keeps kexts available for load-by-identifier) + push. */
+	u = url_for_path(repo);
+	repoKexts = (u != NULL) ?
+	    OSKextCreateKextsFromURL(kCFAllocatorDefault, u) : NULL;
+	if (u != NULL)
+		CFRelease(u);
+	if (repoKexts == NULL)
+		errx(1, "%s: no kexts found", repo);
+	(void) ioctl(fd, IOCATIOCFLUSH);
+	personalities = OSKextCopyPersonalitiesOfKexts(NULL);
+	if (personalities != NULL) {
+		CFIndex n = CFArrayGetCount(personalities), i;
+		int pushed = 0;
+
+		for (i = 0; i < n; i++) {
+			CFDictionaryRef p = CFArrayGetValueAtIndex(personalities, i);
+			if (p != NULL && CFGetTypeID(p) == CFDictionaryGetTypeID() &&
+			    push_personality(fd, p) > 0)
+				pushed++;
+		}
+		printf("kextd: pushed %d personalities\n", pushed);
+		CFRelease(personalities);
+	}
+
+	printf("kextd: ready\n");
+	for (;;) {
+		mach_msg_return_t mr;
+
+		memset(&buf, 0, sizeof(buf));
+		mr = mach_msg(&buf.body.hdr, MACH_RCV_MSG, 0, sizeof(buf), port,
+		    MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
+		if (mr != MACH_MSG_SUCCESS) {
+			fprintf(stderr, "kextd: mach_msg(RCV) 0x%x\n", (unsigned)mr);
+			continue;
+		}
+		if (buf.body.hdr.msgh_id != IOKIT_KEXTD_LOAD_MSGID)
+			continue;
+		buf.body.bundle_id[sizeof(buf.body.bundle_id) - 1] = '\0';
+		printf("kextd: load request bundle=%s device=%s match=0x%08x\n",
+		    buf.body.bundle_id, buf.body.device, buf.body.match_word);
+		load_bundle(buf.body.bundle_id);
+	}
+	/* NOTREACHED */
+}
+
+/* -t <word>: drive the kernel matcher's send for a PCI id (IOCATIOCTESTSEND),
+ * WITHOUT registering HOST_KEXTD_PORT — so it injects a request to a separately
+ * running `kextd -w`. CI uses this to exercise the daemon's receive+load. */
+static int
+do_test_send(int fd, const char *word)
+{
+	uint32_t mw = (uint32_t)strtoul(word, NULL, 0);
+	int rc = ioctl(fd, IOCATIOCTESTSEND, &mw);
+
+	printf("kextd: test-send 0x%08x rc=%d errno=%d\n", mw, rc,
+	    rc != 0 ? errno : 0);
+	return (rc == 0 ? 0 : 1);
+}
+
 int
 main(int argc, char *argv[])
 {
 	const char *repo = "/System/Library/Extensions";
 	const char *lookup = NULL;
+	const char *testsend = NULL;
+	bool watch = false;
 	CFArrayRef repoKexts = NULL;	/* non-retaining registry: hold alive */
 	CFArrayRef personalities = NULL;
 	CFURLRef u;
@@ -207,7 +347,7 @@ main(int argc, char *argv[])
 	int pushed = 0, skipped = 0, failed = 0;
 	CFIndex i, count;
 
-	while ((ch = getopt(argc, argv, "r:vl:")) != -1) {
+	while ((ch = getopt(argc, argv, "r:vl:wt:")) != -1) {
 		switch (ch) {
 		case 'r':
 			repo = optarg;
@@ -218,8 +358,14 @@ main(int argc, char *argv[])
 		case 'l':
 			lookup = optarg;
 			break;
+		case 'w':
+			watch = true;
+			break;
+		case 't':
+			testsend = optarg;
+			break;
 		default:
-			errx(2, "usage: kextd [-r repo_dir] [-v] | kextd -l matchword");
+			errx(2, "usage: kextd [-r repo] [-v] | -l word | -w | -t word");
 		}
 	}
 
@@ -235,6 +381,17 @@ main(int argc, char *argv[])
 	fd = open("/dev/iocatalogue", O_RDWR);
 	if (fd < 0)
 		err(1, "open /dev/iocatalogue (is the K2 kernel loaded?)");
+
+	/* Trigger a synthetic load request to a running `kextd -w` (CI helper). */
+	if (testsend != NULL) {
+		int rc = do_test_send(fd, testsend);
+		close(fd);
+		return (rc);
+	}
+
+	/* Watch mode: register HOST_KEXTD_PORT, push, then serve load requests. */
+	if (watch)
+		return (do_watch(fd, repo));	/* does not return */
 
 	/* Idempotent: drop the prior set, then re-push the current repo. */
 	if (ioctl(fd, IOCATIOCFLUSH) != 0)

--- a/src/kext_tools/kextd/kextd.c
+++ b/src/kext_tools/kextd/kextd.c
@@ -274,7 +274,11 @@ do_watch(int fd, const char *repo)
 		errx(1, "host_set_special_port(HOST_KEXTD_PORT): 0x%x", (unsigned)kr);
 	printf("kextd: listening on HOST_KEXTD_PORT (port 0x%x)\n", port);
 
-	/* Open the repo (keeps kexts available for load-by-identifier) + push. */
+	/* Open the repo (keeps kexts available for load-by-identifier) + push.
+	 * The step markers below bracket each startup call so that, if kextd
+	 * hangs at early boot, the last line printed pinpoints the blocking
+	 * call instead of leaving us with silence. */
+	printf("kextd: opening repo %s\n", repo);
 	u = url_for_path(repo);
 	repoKexts = (u != NULL) ?
 	    OSKextCreateKextsFromURL(kCFAllocatorDefault, u) : NULL;
@@ -282,6 +286,7 @@ do_watch(int fd, const char *repo)
 		CFRelease(u);
 	if (repoKexts == NULL)
 		errx(1, "%s: no kexts found", repo);
+	printf("kextd: repo opened; copying personalities\n");
 	(void) ioctl(fd, IOCATIOCFLUSH);
 	personalities = OSKextCopyPersonalitiesOfKexts(NULL);
 	if (personalities != NULL) {

--- a/src/kext_tools/kextd/kextd.c
+++ b/src/kext_tools/kextd/kextd.c
@@ -272,13 +272,14 @@ do_watch(int fd, const char *repo)
 	kr = host_set_special_port(host, HOST_KEXTD_PORT, port);
 	if (kr != KERN_SUCCESS)
 		errx(1, "host_set_special_port(HOST_KEXTD_PORT): 0x%x", (unsigned)kr);
-	printf("kextd: listening on HOST_KEXTD_PORT (port 0x%x)\n", port);
+	/* Startup step markers are verbose-only — under -v they bracket each
+	 * call so a hang's last line pinpoints the blocker; at default the
+	 * daemon is quiet and logs only meaningful events (loaded, errors). */
+	if (verbose)
+		printf("kextd: listening on HOST_KEXTD_PORT (port 0x%x)\n", port);
 
-	/* Open the repo (keeps kexts available for load-by-identifier) + push.
-	 * The step markers below bracket each startup call so that, if kextd
-	 * hangs at early boot, the last line printed pinpoints the blocking
-	 * call instead of leaving us with silence. */
-	printf("kextd: opening repo %s\n", repo);
+	if (verbose)
+		printf("kextd: opening repo %s\n", repo);
 	u = url_for_path(repo);
 	repoKexts = (u != NULL) ?
 	    OSKextCreateKextsFromURL(kCFAllocatorDefault, u) : NULL;
@@ -286,7 +287,8 @@ do_watch(int fd, const char *repo)
 		CFRelease(u);
 	if (repoKexts == NULL)
 		errx(1, "%s: no kexts found", repo);
-	printf("kextd: repo opened; copying personalities\n");
+	if (verbose)
+		printf("kextd: repo opened; copying personalities\n");
 	(void) ioctl(fd, IOCATIOCFLUSH);
 	personalities = OSKextCopyPersonalitiesOfKexts(NULL);
 	if (personalities != NULL) {
@@ -299,11 +301,13 @@ do_watch(int fd, const char *repo)
 			    push_personality(fd, p) > 0)
 				pushed++;
 		}
-		printf("kextd: pushed %d personalities\n", pushed);
+		if (verbose)
+			printf("kextd: pushed %d personalities\n", pushed);
 		CFRelease(personalities);
 	}
 
-	printf("kextd: ready\n");
+	if (verbose)
+		printf("kextd: ready\n");
 	for (;;) {
 		mach_msg_return_t mr;
 
@@ -317,8 +321,9 @@ do_watch(int fd, const char *repo)
 		if (buf.body.hdr.msgh_id != IOKIT_KEXTD_LOAD_MSGID)
 			continue;
 		buf.body.bundle_id[sizeof(buf.body.bundle_id) - 1] = '\0';
-		printf("kextd: load request bundle=%s device=%s match=0x%08x\n",
-		    buf.body.bundle_id, buf.body.device, buf.body.match_word);
+		if (verbose)
+			printf("kextd: load request bundle=%s device=%s match=0x%08x\n",
+			    buf.body.bundle_id, buf.body.device, buf.body.match_word);
 		load_bundle(buf.body.bundle_id);
 	}
 	/* NOTREACHED */

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -1231,6 +1231,29 @@ expect {
     }
 }
 
+# KEXTD-LOAD — K3b step 3 (#217) gate. The kextd daemon (`kextd -w`) receives a
+# kernel load request and actually kldloads the bundle (if_iwlwifi). This is the
+# auto-load path minus the physical 8260 (that bind is the t420 test). Non-fatal
+# on timeout + self-SKIP so it stays green on images/kernels predating step 3;
+# only KEXTD-LOAD-FAIL gates. Longer timeout — it starts a daemon + polls a load.
+set kextd_load_timeout 120
+expect {
+    timeout {
+        puts "\nWARN: KEXTD-LOAD marker not seen (pre-step-3 image — informational)"
+    }
+    "KEXTD-LOAD-FAIL" {
+        puts "\nFAIL: kextd daemon did not load the kext on a kernel load request"
+        exit 1
+    }
+    "KEXTD-LOAD-SKIP" {
+        puts "\nWARN: KEXTD-LOAD-SKIP — kextd -w unsupported (pre-step-3)"
+    }
+    "KEXTD-LOAD-OK" {
+        puts "\nOK: kextd daemon loaded if_iwlwifi on a kernel load request"
+    }
+}
+set timeout 60
+
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns
 # halt -p into a clean shutdown rather than a reset loop).
 send "halt -p\r"

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -149,6 +149,12 @@ expect "OK "
 send "set launchd_trace=1\r"
 expect "set launchd_trace=1"
 expect "OK "
+# Verbose boot so an early-boot hang shows its last subsystem on the serial
+# console instead of silence (root-causing kextd's early-start — #227). The
+# shipped image is unaffected; this is a CI-only loader var.
+send "set boot_verbose=YES\r"
+expect "set boot_verbose=YES"
+expect "OK "
 send "boot\r"
 
 # Stage 1a: capture getty's boot banner. PAM port iter 4 (issue #99)
@@ -1210,26 +1216,9 @@ expect {
     }
 }
 
-# KEXTD-MACH — K3b (#216) round-trip gate. test_kextd_mach registers
-# HOST_KEXTD_PORT, drives the kernel matcher's send via IOCATIOCTESTSEND, and
-# receives the Mach load request — proving the kernel->kextd hand-off over the
-# faithful channel (no devd/devctl). Non-fatal on timeout + self-SKIP so it
-# stays green on images/kernels predating K3b; only KEXTD-MACH-FAIL gates.
-expect {
-    timeout {
-        puts "\nWARN: KEXTD-MACH marker not seen (pre-K3b image — informational)"
-    }
-    "KEXTD-MACH-FAIL" {
-        puts "\nFAIL: kernel->kextd Mach load request did not round-trip"
-        exit 1
-    }
-    "KEXTD-MACH-SKIP" {
-        puts "\nWARN: KEXTD-MACH-SKIP — kernel/image without K3b plumbing"
-    }
-    "KEXTD-MACH-OK" {
-        puts "\nOK: kernel->kextd Mach load request delivered (HOST_KEXTD_PORT)"
-    }
-}
+# (The raw kernel->kextd Mach round-trip — formerly the KEXTD-MACH gate via
+# test_kextd_mach — is now subsumed by KEXTD-LOAD below: the auto-started daemon
+# exercises the same HOST_KEXTD_PORT delivery and then actually loads the kext.)
 
 # KEXTD-LOAD — K3b step 3 (#217) gate. The kextd daemon (`kextd -w`) receives a
 # kernel load request and actually kldloads the bundle (if_iwlwifi). This is the


### PR DESCRIPTION
The loader half of the in-kernel IOKit matcher. `kextd -w` registers a receive port as `HOST_KEXTD_PORT`, pushes IOKitPersonalities, then serves kernel load requests forever: each `IOKIT load bundle=<id>` Mach message → `OSKextGetKextWithIdentifier` + `OSKextLoad` (`kldload` re-probes → device attaches). No matching in userland — it executes what the kernel names.

## Verification
The boot-test starts `kextd -w`, injects a request with `kextd -t 0x24f38086` (`IOCATIOCTESTSEND` — kernel sends to the running daemon), and confirms `if_iwlwifi` got kldloaded → **KEXTD-LOAD-OK**. That's the full auto-load path **minus the physical device** (the 8260 bind is the t420 test). Independent of the kernel steps 1+2 PR (#19) — uses the already-merged `HOST_KEXTD_PORT` send + `IOCATIOCTESTSEND`.

## Scope
- `kextd -w` (daemon), `-t` (CI trigger); `-lsystem_kernel` for the Mach surface.
- Gate is self-SKIP + non-fatal-timeout so it stays green on pre-step-3 images.

## Deliberate follow-up (3b)
Launchd boot-time launch of `kextd -w`. A CF/OSKext RunAtLoad daemon wedged boot in U1; push-triggers-match (#19) removes the *ordering* constraint, but the boot launch still needs care (late start / non-blocking) — separate change so this functional core lands first.