### PR TITLE
DIAGNOSTIC: isolate the early-daemon boot wedge (do not merge)

### DIFF
--- a/overlays/System/Library/LaunchDaemons/org.nextbsd.diagboot.plist
+++ b/overlays/System/Library/LaunchDaemons/org.nextbsd.diagboot.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- DIAGNOSTIC ONLY (do not merge): a trivial persistent RunAtLoad
+	     System daemon (/bin/sleep), to isolate the U1 boot-wedge. If boot
+	     wedges with THIS present, the conflict is launchd bringing up an
+	     extra early System daemon (a launchd-port bug) — independent of
+	     kextd's code. If boot is fine, kextd's own startup is the culprit.
+	     Mirrors the launchd shape kextd -w needs (early, System, persistent). -->
+	<key>Label</key>
+	<string>org.nextbsd.diagboot</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sleep</string>
+		<string>100000</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/var/log/diagboot.stderr</string>
+	<key>StandardOutPath</key>
+	<string>/var/log/diagboot.stderr</string>
+	<key>LimitLoadToSessionType</key>
+	<string>System</string>
+</dict>
+</plist>

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -149,6 +149,11 @@ expect "OK "
 send "set launchd_trace=1\r"
 expect "set launchd_trace=1"
 expect "OK "
+# DIAGNOSTIC (diag-runatload): verbose kernel boot so a hang shows its last
+# subsystem instead of silence — root-causing the early-daemon boot wedge.
+send "set boot_verbose=YES\r"
+expect "set boot_verbose=YES"
+expect "OK "
 send "boot\r"
 
 # Stage 1a: capture getty's boot banner. PAM port iter 4 (issue #99)


### PR DESCRIPTION
Diagnostic-only (will be closed, not merged). Tests whether a trivial persistent RunAtLoad System daemon (`/bin/sleep`) wedges boot — isolating launchd-fragility from kextd-specific startup — with `boot_verbose=YES` so a hang shows where instead of silence. Root-causes #227.