### PR TITLE
ci: harden loader-prompt handshake against serial char drops (fix CI hang)

### DIFF
--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -116,46 +116,61 @@ expect {
     "OK " { puts "\n==> at loader prompt; setting serial console vars" }
 }
 
-# Match the echoed command BEFORE matching "OK " to avoid expect races
-# where a stale OK from a prior `set` is matched before the loader has
-# consumed the current send. Without this, run 26070245676 ate
-# `boot_multicons=YES` and merged the next `set` into the partial line.
+# The loader OK-prompt handshake is serial-console-fragile in two ways,
+# both of which have wedged CI:
+#   1. Stale-OK race: a bare `expect "OK "` can match the OK from the
+#      PRIOR command before the loader consumes this send (run 26070245676
+#      ate `boot_multicons=YES`). Mitigation: match the echoed command
+#      BEFORE matching "OK ".
+#   2. Dropped characters: qemu's stdio serial + the loader's line
+#      discipline drop chars when expect blasts a whole line at once (send
+#      is effectively instantaneous). A dropped char means the echo never
+#      matches and expect hangs to the global 480s timeout. This grew worse
+#      as the handshake gained `set`s — #226 added boot_verbose, a 7th, and
+#      CI started hanging here. Mitigation: type one char at a time
+#      (send -s / send_slow).
 #
-# Also dropped vidconsole from console var: QEMU CI runs with
-# -display none, so vidconsole always fails to bind and the loader
-# prints "console vidconsole is unavailable" on every boot. comconsole
-# alone is sufficient for serial-only capture.
-send "set console=comconsole\r"
-expect "set console=comconsole"
-expect "OK "
-send "set boot_serial=YES\r"
-expect "set boot_serial=YES"
-expect "OK "
-send "set comconsole_speed=115200\r"
-expect "set comconsole_speed=115200"
-expect "OK "
-send "set boot_multicons=YES\r"
-expect "set boot_multicons=YES"
-expect "OK "
+# Also dropped vidconsole from the console var: QEMU CI runs with
+# -display none, so vidconsole never binds and the loader prints "console
+# vidconsole is unavailable" on every boot. comconsole alone suffices for
+# serial-only capture.
+set send_slow {1 .03}
+
+# loader_set — type one command at the OK prompt robustly, failing FAST
+# with the exact stuck command rather than hanging the whole global timeout.
+proc loader_set {cmd} {
+    send -s -- "$cmd\r"
+    expect {
+        timeout { puts "\nFAIL: loader did not echo '$cmd' (dropped char on serial?)"; exit 1 }
+        -ex $cmd
+    }
+    expect {
+        timeout { puts "\nFAIL: loader did not return to OK after '$cmd'"; exit 1 }
+        "OK "
+    }
+}
+
+# Each handshake step is sub-second; use a short timeout so a stuck step
+# reports in seconds. Restore the long boot timeout before kernel hand-off.
+set timeout 30
+loader_set "set console=comconsole"
+loader_set "set boot_serial=YES"
+loader_set "set comconsole_speed=115200"
+loader_set "set boot_multicons=YES"
 # Verbose diagnostic trace toggles. CI-only — the shipped ISO is
 # silent by default. The kernel reads mach.debug_enable as a tunable
 # (CTLFLAG_RWTUN) at boot; launchd PID 1 and libxpc both read kenv
 # "launchd_trace=1" once at startup. Together these gate the [T41-*]
 # / [T39-*] trace points; keeping them on for CI gives a paper trail
 # for the next regression.
-send "set mach.debug_enable=1\r"
-expect "set mach.debug_enable=1"
-expect "OK "
-send "set launchd_trace=1\r"
-expect "set launchd_trace=1"
-expect "OK "
+loader_set "set mach.debug_enable=1"
+loader_set "set launchd_trace=1"
 # Verbose boot so an early-boot hang shows its last subsystem on the serial
 # console instead of silence (root-causing kextd's early-start — #227). The
 # shipped image is unaffected; this is a CI-only loader var.
-send "set boot_verbose=YES\r"
-expect "set boot_verbose=YES"
-expect "OK "
-send "boot\r"
+loader_set "set boot_verbose=YES"
+set timeout 480
+send -s -- "boot\r"
 
 # Stage 1a: capture getty's boot banner. PAM port iter 4 (issue #99)
 # restored RunAtLoad on com.apple.hostnamed.plist so hostnamed runs


### PR DESCRIPTION
## Problem

Main CI started **hanging** at the boot test, even though the *identical image* passed in the PR run minutes earlier (same kernel, same code — `922bd2b` is the squash of the green PR run `27072665735`). So this is **not** a kernel/kextd regression — it's the boot-test expect harness.

The loader OK-prompt handshake sends each `set` as a whole line instantaneously. qemu's stdio serial + the loader's line discipline **drop characters** under that load. A dropped char means the echoed command never matches `expect`, and the script hangs to the **480s global timeout** — a silent multi-minute wedge that looks like a boot failure.

The window widened as the handshake grew: **#226 added a 7th `set` (`boot_verbose=YES`)**, and that's exactly where the hangs landed — the failing logs stop right at `set launchd_trace=1`, the line immediately before the new send.

## Fix (CI-only; shipped image unchanged)

- **Type one char at a time** (`send -s` + `send_slow {1 .03}`) so neither the loader nor the serial line drops input.
- Wrap each command in a `loader_set` proc that **fails fast with the exact stuck command** (e.g. `loader did not echo 'set boot_verbose=YES' (dropped char on serial?)`) instead of a silent global-timeout hang.
- Short `timeout 30` during the handshake; restored to `480` before kernel hand-off.

## Validation

- `sh -n tests/boot-test.sh` — OK
- tcl/expect body parses + runs clean under stubbed `spawn`/`expect`/`send`
- The real proof is this PR's own boot test going green (and reliably so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)