### PR TITLE
ci: revert loader handshake to pre-#226 + skip build on tests-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,66 @@ permissions:
   contents: read
 
 jobs:
+  # Decide whether the heavy ISO build is needed. Deny-by-default: the build
+  # runs UNLESS every changed file is under tests/ (the boot harness). Any
+  # non-tests/ file (src/, overlays/, build.sh, config/, pkglists, ...) forces
+  # a full build, so a mixed harness+code change is never boot-tested against a
+  # stale image. A tests-only change skips the ~17-min build and boots the
+  # latest published continuous ISO instead. workflow_dispatch /
+  # repository_dispatch / force-push always build.
+  changes:
+    name: changes (decide whether to rebuild)
+    runs-on: ubuntu-latest
+    outputs:
+      build_needed: ${{ steps.detect.outputs.build_needed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: detect changed paths
+        id: detect
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          set -eu
+          force() { echo "==> forcing full build ($1)"; echo "build_needed=true" >> "$GITHUB_OUTPUT"; exit 0; }
+          case "$EVENT" in
+            pull_request)
+              [ -n "${BASE_SHA:-}" ] || force "no base sha"
+              git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
+              changed=$(git diff --name-only "$BASE_SHA" HEAD) || force "diff failed"
+              ;;
+            push)
+              case "${BEFORE:-}" in
+                ""|0000000000000000000000000000000000000000) force "new/force push" ;;
+              esac
+              changed=$(git diff --name-only "$BEFORE" "$AFTER") || force "diff failed"
+              ;;
+            *)
+              force "$EVENT" ;;
+          esac
+          echo "changed files:"; printf '%s\n' "$changed"
+          # List the changed files that are NOT under tests/. Capture (not
+          # `grep -q`): grep -q exits on first match and SIGPIPEs the feeding
+          # printf, which under bash pipefail would falsely fail the pipeline
+          # and mis-skip a mixed change. grep -v reads all input; || true
+          # absorbs "no matches".
+          nontests=$(printf '%s\n' "$changed" | grep -vE '^tests/' || true)
+          if [ -z "$changed" ] || [ -n "$nontests" ]; then
+            need=true   # empty diff (safe default) or a non-tests/ file -> full build
+          else
+            need=false  # tests/ only -> skip build, boot the continuous ISO
+          fi
+          echo "build_needed=$need" >> "$GITHUB_OUTPUT"
+          echo "==> build_needed=$need"
+
   build:
     name: build (FreeBSD ${{ matrix.variant }} ${{ matrix.arch }})
+    needs: changes
+    if: needs.changes.outputs.build_needed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -190,7 +248,11 @@ jobs:
 
   test:
     name: test (FreeBSD ${{ matrix.variant }} ${{ matrix.arch }})
-    needs: build
+    needs: [changes, build]
+    # Run after a real build, OR when the build was skipped for a tests-only
+    # change (then we boot the latest published continuous ISO). Do NOT run if
+    # the build actually failed.
+    if: "!cancelled() && needs.changes.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -203,13 +265,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Download whatever the build job produced (the dated diskimg
-      # artifact) and locate the image by glob — avoids threading the
-      # datestamp across jobs.
-      - uses: actions/download-artifact@v4
+      # Image source depends on whether the build ran:
+      #  - build ran: download whatever the build job produced (the dated
+      #    diskimg artifact), located by glob (avoids threading the datestamp).
+      #  - build skipped (tests-only change): pull the latest published
+      #    continuous ISO so the harness change is validated against the
+      #    current known-good image.
+      - name: download built image (artifact)
+        if: needs.changes.outputs.build_needed == 'true'
+        uses: actions/download-artifact@v4
         with:
           path: out/
           merge-multiple: true
+
+      - name: download latest continuous ISO (build skipped)
+        if: needs.changes.outputs.build_needed != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p out
+          gh release download continuous \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'NextBSD-*.img.zip' \
+            --dir out/ --clobber
+          ls -lh out/
 
       - name: install qemu + expect
         run: |

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -116,61 +116,40 @@ expect {
     "OK " { puts "\n==> at loader prompt; setting serial console vars" }
 }
 
-# The loader OK-prompt handshake is serial-console-fragile in two ways,
-# both of which have wedged CI:
-#   1. Stale-OK race: a bare `expect "OK "` can match the OK from the
-#      PRIOR command before the loader consumes this send (run 26070245676
-#      ate `boot_multicons=YES`). Mitigation: match the echoed command
-#      BEFORE matching "OK ".
-#   2. Dropped characters: qemu's stdio serial + the loader's line
-#      discipline drop chars when expect blasts a whole line at once (send
-#      is effectively instantaneous). A dropped char means the echo never
-#      matches and expect hangs to the global 480s timeout. This grew worse
-#      as the handshake gained `set`s — #226 added boot_verbose, a 7th, and
-#      CI started hanging here. Mitigation: type one char at a time
-#      (send -s / send_slow).
+# Match the echoed command BEFORE matching "OK " to avoid expect races
+# where a stale OK from a prior `set` is matched before the loader has
+# consumed the current send. Without this, run 26070245676 ate
+# `boot_multicons=YES` and merged the next `set` into the partial line.
 #
-# Also dropped vidconsole from the console var: QEMU CI runs with
-# -display none, so vidconsole never binds and the loader prints "console
-# vidconsole is unavailable" on every boot. comconsole alone suffices for
-# serial-only capture.
-set send_slow {1 .03}
-
-# loader_set — type one command at the OK prompt robustly, failing FAST
-# with the exact stuck command rather than hanging the whole global timeout.
-proc loader_set {cmd} {
-    send -s -- "$cmd\r"
-    expect {
-        timeout { puts "\nFAIL: loader did not echo '$cmd' (dropped char on serial?)"; exit 1 }
-        -ex $cmd
-    }
-    expect {
-        timeout { puts "\nFAIL: loader did not return to OK after '$cmd'"; exit 1 }
-        "OK "
-    }
-}
-
-# Each handshake step is sub-second; use a short timeout so a stuck step
-# reports in seconds. Restore the long boot timeout before kernel hand-off.
-set timeout 30
-loader_set "set console=comconsole"
-loader_set "set boot_serial=YES"
-loader_set "set comconsole_speed=115200"
-loader_set "set boot_multicons=YES"
+# Also dropped vidconsole from console var: QEMU CI runs with
+# -display none, so vidconsole always fails to bind and the loader
+# prints "console vidconsole is unavailable" on every boot. comconsole
+# alone is sufficient for serial-only capture.
+send "set console=comconsole\r"
+expect "set console=comconsole"
+expect "OK "
+send "set boot_serial=YES\r"
+expect "set boot_serial=YES"
+expect "OK "
+send "set comconsole_speed=115200\r"
+expect "set comconsole_speed=115200"
+expect "OK "
+send "set boot_multicons=YES\r"
+expect "set boot_multicons=YES"
+expect "OK "
 # Verbose diagnostic trace toggles. CI-only — the shipped ISO is
 # silent by default. The kernel reads mach.debug_enable as a tunable
 # (CTLFLAG_RWTUN) at boot; launchd PID 1 and libxpc both read kenv
 # "launchd_trace=1" once at startup. Together these gate the [T41-*]
 # / [T39-*] trace points; keeping them on for CI gives a paper trail
 # for the next regression.
-loader_set "set mach.debug_enable=1"
-loader_set "set launchd_trace=1"
-# Verbose boot so an early-boot hang shows its last subsystem on the serial
-# console instead of silence (root-causing kextd's early-start — #227). The
-# shipped image is unaffected; this is a CI-only loader var.
-loader_set "set boot_verbose=YES"
-set timeout 480
-send -s -- "boot\r"
+send "set mach.debug_enable=1\r"
+expect "set mach.debug_enable=1"
+expect "OK "
+send "set launchd_trace=1\r"
+expect "set launchd_trace=1"
+expect "OK "
+send "boot\r"
 
 # Stage 1a: capture getty's boot banner. PAM port iter 4 (issue #99)
 # restored RunAtLoad on com.apple.hostnamed.plist so hostnamed runs


### PR DESCRIPTION
Two CI-only changes. Fixes the recurring "passes as a PR, fails on merge" boot-test breakage and stops wasting a full ~17-min build on harness-only edits.

## 1. Revert the loader handshake to its exact pre-#226 form

The breakage traces to **#226**, which added `set boot_verbose=YES` — a **7th** `set` round-trip to the loader OK-prompt handshake. That handshake has a long-standing, probabilistic serial char-drop race (the file's own comment cites an earlier one-off, run `26070245676`); it was flaky-but-fine at 6 round-trips, and the 7th tipped it over so it started reddening `main` on merge. Image/kernel/KVM are identical PR-vs-merge — the only thing that moved was that extra round-trip.

- `boot_verbose=YES` was added to diagnose the kextd early-start wedge (**#227**), which is resolved — so it's no longer earning its keep, and it floods the serial console.
- My #230 `send-slow`/`loader_set` rework over-corrected (and #230 still dropped a char on merge); it's reverted too.

Net: `tests/boot-test.sh`'s handshake is now **byte-identical to the pre-#226 version** (6 commands, plain `send`/`expect`). The rest of the file (e.g. the KEXTD-LOAD gate) is unchanged.

## 2. Skip the build when only `tests/` changed

A new `changes` gate job decides `build_needed` **deny-by-default**:
- **Any** file outside `tests/` → full build (so a mixed harness+code change is *never* boot-tested against a stale image — the key safety property).
- **Only** `tests/` files → skip the build; the `test` job boots the **latest published `continuous` ISO** instead, which is exactly the right thing to validate a harness change against.

Subtlety worth noting: detection captures the non-`tests/` files rather than using `grep -q`. `grep -q` exits on first match and SIGPIPEs the feeding `printf`, which under **bash `pipefail`** (GitHub's default) would falsely fail the pipeline and **mis-skip a mixed change** — the dangerous direction. Verified across cases (tests-only, mixed both orderings, non-tests, empty) under `bash -euo pipefail`.

## Validation
- `sh -n` + tcl/expect parse clean; handshake confirmed `diff`-identical to `922bd2b^`.
- Workflow YAML validates; job graph: `changes → build (conditional) → test (runs on build success *or* skip) → release (main push, auto-skips when build skipped)`.
- This PR touches `build.yml` (non-`tests/`), so it runs a full build+test — end-to-end proof of the reverted handshake *and* the new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)