### PR TITLE
loader: rename fragment to nextbsd.conf + stop preloading hostid/entropy

### DIFF
--- a/overlays/boot/loader.conf.d/nextbsd.conf
+++ b/overlays/boot/loader.conf.d/nextbsd.conf
@@ -1,4 +1,4 @@
-# freebsd-launchd-mach — loader settings for the GPT disk image.
+# nextbsd.conf — NextBSD loader settings for the GPT disk image.
 #
 # A loader.conf.d fragment: the loader reads /boot/loader.conf then
 # every /boot/loader.conf.d/*.conf, so this layers cleanly on top of
@@ -42,3 +42,13 @@ hw.nvidiadrm.modeset="1"
 # bundled firmware (e.g. IntelWiFi.kext's iwlwifi-*.ucode) is found with no
 # configuration. /boot/firmware/ remains the built-in default for base firmware.
 # (nextbsd#205)
+
+# Don't preload /etc/hostid or /boot/entropy. The base FreeBSD
+# /boot/defaults/loader.conf sets hostuuid_load + entropy_cache_load="YES",
+# but this image ships neither file (on stock FreeBSD they're created by
+# rc.d/hostid + rc.d/entropy; NextBSD runs launchd, not rc.d), so the loader
+# printed "can't find '/etc/hostid'" / "can't find '/boot/entropy'" on every
+# boot. Neither is needed here: kern.hostuuid is unused, and early entropy
+# still comes from the UEFI firmware RNG (entropy_efi_seed stays "YES").
+hostuuid_load="NO"
+entropy_cache_load="NO"


### PR DESCRIPTION
## What
- **Rename** `overlays/boot/loader.conf.d/freebsd-launchd-mach.conf` → **`nextbsd.conf`**. The old name is misleading: it's NextBSD's own loader config (not FreeBSD's), and the launchd-as-PID1 + Mach mechanisms it once named are now **baked into the kernel**, not configured here. Nothing references the file by name (`loader.conf.d/*.conf` is auto-read), so the rename is self-contained. (The other `freebsd-launchd-mach` strings in the tree are the legacy *project* name and the `/usr/tests/freebsd-launchd-mach/` test dir — unrelated, left alone.)
- **Stop the two "can't find" loader warnings** by adding:
  ```
  hostuuid_load="NO"
  entropy_cache_load="NO"
  ```

## Why the warnings happened
Base FreeBSD `/boot/defaults/loader.conf` preloads `/etc/hostid` (`hostuuid_load`) and `/boot/entropy` (`entropy_cache_load`). This image ships neither — on stock FreeBSD they're created by `rc.d/hostid` + `rc.d/entropy`, and NextBSD runs launchd, not rc.d — so the loader printed `can't find '/etc/hostid'` and `can't find '/boot/entropy'` every boot (benign, but noisy).

Neither is needed here: `kern.hostuuid` is unused, and early entropy still comes from the **UEFI firmware RNG** (`entropy_efi_seed` stays `"YES"`). If we later want a stable hostid or a disk entropy cache, the proper path is generating those files (e.g. a launchd job using `/usr/libexec/save-entropy`), not the absent rc.d.

## Validation
Touches `overlays/` → full build+test runs; the booted loader no longer emits the two `can't find` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)