### PR TITLE
mDNSResponder iter 4: SCDS-driven reactive interface watcher (#62)

### DIFF
--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -1252,9 +1252,41 @@ if [ -f /var/log/mDNSResponder.stderr ]; then
         sleep 1
         i=$((i+1))
     done
+    # MDNS-IFWATCH — iter 4 reactive interface watcher. mDNSConfigStore.c
+    # subscribes to State:/Network/Global/IPv4 + State:/Network/Service/
+    # .+/IPv4; when ipconfigd publishes (DHCP bind) or removes (lease
+    # loss) a service IPv4, the SCDS callback wakes the mDNS main thread
+    # (self-pipe) to re-walk the interface list via
+    # mDNSPlatformPosixRefreshInterfaceList, logging MDNS-IFWATCH-OK to
+    # this stderr. By the time we get here the iter-3 DHCP BOUND publish
+    # and the iter-5b RENEW re-publish (both checked above) have already
+    # fired, so the marker should be present. Wait a little longer for
+    # it in case the publish raced the subscriber's startup.
+    i=0
+    while [ $i -lt 15 ]; do
+        if grep -q 'MDNS-IFWATCH-OK' \
+            /var/log/mDNSResponder.stderr 2>/dev/null; then
+            break
+        fi
+        sleep 1
+        i=$((i+1))
+    done
     echo "--- /var/log/mDNSResponder.stderr ---"
     cat /var/log/mDNSResponder.stderr
     echo "--- end mDNSResponder.stderr ---"
+    # Informational/non-fatal gate. If the SCDS-driven re-walk is absent
+    # (e.g. the IPv4 publish raced subscriber startup), emit -SKIP rather
+    # than failing: the routing-socket watcher in mDNSPosix.c remains the
+    # parallel trigger, so interface state is still tracked either way.
+    if grep -q 'MDNS-IFWATCH-OK' /var/log/mDNSResponder.stderr 2>/dev/null; then
+        echo "MDNS-IFWATCH-OK: SCDS interface/service IPv4 change drove a" \
+            "mDNSResponder interface re-walk"
+    else
+        echo "MDNS-IFWATCH-SKIP: no SCDS-driven interface re-walk observed" \
+            "(routing-socket watcher still active)"
+    fi
+else
+    echo "MDNS-IFWATCH-SKIP: /var/log/mDNSResponder.stderr missing"
 fi
 
 # MDNS-DNSSD — iter 3 end-to-end round-trip via libdns_sd:

--- a/src/mDNSResponder/mDNSPosix/mDNSConfigStore.c
+++ b/src/mDNSResponder/mDNSPosix/mDNSConfigStore.c
@@ -28,14 +28,47 @@
  *     new primary service / interface. mDNSResponder should re-pick
  *     its default-route interface for unicast DNS-SD fallback.
  *
- * iter 1 (this commit): registers the subscriptions and logs every
- * callback. The actual interface-walk + record-republish actions are
- * follow-up iters — landing the subscriber surface first proves the
- * Apple-shape wire-up under our libSystemConfiguration, on the same
- * dispatch infrastructure mDNSResponder already uses for AF_UNIX
- * client requests, without changing the existing routing-socket
- * fallback path. The CI markers MDNS-BOOT-OK / MDNS-ENGINE-OK /
- * MDNS-DNSSD-OK keep working unchanged.
+ * iter 1: registered the subscriptions and logged every callback,
+ * plus the HostNames -> mDNS_SetFQDN re-announce path (the debounced
+ * Recompute below). It proved the Apple-shape wire-up under our
+ * libSystemConfiguration, on the same dispatch infrastructure
+ * mDNSResponder already uses for AF_UNIX client requests, without
+ * changing the existing routing-socket fallback path. The CI markers
+ * MDNS-BOOT-OK / MDNS-ENGINE-OK / MDNS-DNSSD-OK keep working unchanged.
+ *
+ * iter 4 (this commit): wires the Global/IPv4 and Service/.+/IPv4
+ * subscriptions into the actual interface-list re-walk. When ipconfigd
+ * publishes (DHCP bind) or removes (lease loss) a service's IPv4, the
+ * SCDS callback now re-walks mDNSResponder's interface list and
+ * re-announces Bonjour records by calling
+ * mDNSPlatformPosixRefreshInterfaceList — the same heavyweight
+ * ClearInterfaceList + SetupInterfaceList the routing-socket watcher
+ * (InterfaceChangeCallback in mDNSPosix.c) already drives. Both
+ * triggers firing in parallel stays fine — the interface walk is
+ * idempotent.
+ *
+ * THREADING. The mDNS core runs single-threaded on the daemon's MAIN
+ * thread (PosixDaemon.c's mDNSPosixRunEventLoopOnce select loop). The
+ * Posix mDNSPlatformLock/Unlock are no-ops — there is no real mutex —
+ * so the only safe way to mutate core state is from the main thread.
+ * Our SCDS callback, by contrast, runs on g_queue (a dedicated
+ * dispatch queue). Calling mDNSPlatformPosixRefreshInterfaceList
+ * straight from g_queue would tear down and rebuild the very socket
+ * set the select loop is iterating, racing it. So we use a self-pipe:
+ * the SCDS path (on g_queue) writes one wake byte to g_wake_wr; the
+ * read end g_wake_rd is registered in the mDNS event loop via
+ * mDNSPosixAddFDToEventLoop, so mDNSConfigStoreWake runs on the MAIN
+ * thread, drains the pipe, and does the refresh there — matching where
+ * InterfaceChangeCallback already runs (no mDNS_Lock).
+ *
+ * The HostNames path keeps its iter-1 shape: the SCDS callback arms a
+ * 25ms debounce timer on g_queue whose handler (mDNSConfigStoreRecompute)
+ * reads the labels and calls mDNS_SetFQDN. That call is technically
+ * cross-thread too (a latent iter-1 race), but rerouting it through the
+ * pipe would entangle the proven hostname path with the new interface
+ * path for no functional gain here, so iter 4 leaves it as-is and only
+ * adds the interface path on the main thread. See the PR for the
+ * tradeoff.
  *
  * The notify_register_dispatch("com.apple.system.hostname") hook the
  * plan describes is intentionally deferred until the libnotify
@@ -43,16 +76,19 @@
  * memory + the same workaround skipping notify_register_dispatch in
  * hostnamed's vendored set-hostname.c).
  *
- * The routing-socket watcher in mDNSPosix.c stays the authoritative
- * trigger for interface state until iter 2 wires the SCDS callback
- * into the actual interface-list re-walk. Both signals firing in
- * parallel is fine — the interface walk is idempotent.
+ * The routing-socket watcher in mDNSPosix.c remains as a parallel
+ * trigger for interface state; the SCDS callback is now an additional,
+ * Apple-shape trigger that fires off the same SystemConfiguration
+ * publishes ipconfigd already emits. Both signals firing in parallel
+ * is fine — the interface walk is idempotent.
  */
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <SystemConfiguration/SCDynamicStore.h>
 #include <SystemConfiguration/SCSchemaDefinitions.h>
 #include <dispatch/dispatch.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -60,6 +96,9 @@
 /* mDNSResponder core API for the re-announce path. */
 #include "mDNSEmbeddedAPI.h"		/* mDNS, mDNS_SetFQDN, domainlabel */
 #include "DNSCommon.h"			/* mDNS_Lock / mDNS_Unlock macros */
+#include "mDNSPosix.h"			/* mDNSPlatformPosixRefreshInterfaceList,
+					 * mDNSPosixAddFDToEventLoop — the
+					 * mDNS-core event-loop FD registration */
 
 /* PosixDaemon.c's global mDNS instance — the SCDS callback drives
  * a re-announce on it whenever Setup:/Network/HostNames or
@@ -83,6 +122,21 @@ static dispatch_queue_t		g_queue;
  * triggering N separate re-announces. */
 #define DEBOUNCE_MS	25
 static dispatch_source_t	g_debounce_timer;
+
+/* Self-pipe used to hop interface-refresh requests from the SCDS
+ * dispatch queue (g_queue) onto the mDNS-core MAIN thread. The SCDS
+ * callback writes one wake byte to g_wake_wr; mDNSConfigStoreWake,
+ * registered on the mDNS event loop's read set, runs on the main
+ * thread, drains the pipe, and re-walks the interface list there. See
+ * the THREADING note at the top of the file. -1 = not yet created. */
+static int	g_wake_rd = -1;
+static int	g_wake_wr = -1;
+
+/* Cached State:/Network/HostNames key string (UTF-8). Used to tell the
+ * hostname-only path (debounce -> Recompute -> mDNS_SetFQDN) from the
+ * interface path (pipe wake -> RefreshInterfaceList) when classifying a
+ * changed key in the SCDS callback. Empty if it couldn't be cached. */
+static char	g_hostnames_key[256];
 
 static const char *
 key_kind(CFStringRef key)
@@ -251,13 +305,67 @@ mDNSConfigStoreDebounce(void)
 	    DEBOUNCE_MS * (uint64_t)NSEC_PER_MSEC / 10);
 }
 
+/* Post an interface-refresh request from the SCDS dispatch queue to the
+ * mDNS-core main thread by writing one wake byte to the self-pipe. Runs
+ * on g_queue. Coalescing happens naturally on the read side: the main
+ * thread drains every queued byte in one RefreshInterfaceList. EINTR is
+ * retried; EAGAIN (pipe already full of pending wakes) is benign — a
+ * refresh is already pending, so dropping this byte loses nothing. */
+static void
+mDNSConfigStorePostInterfaceRefresh(void)
+{
+	const char byte = 'i';
+	ssize_t n;
+
+	if (g_wake_wr < 0)
+		return;
+	do {
+		n = write(g_wake_wr, &byte, 1);
+	} while (n < 0 && errno == EINTR);
+	if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+		(void)fprintf(stderr, "mDNSResponder mDNSConfigStore: "
+		    "wake-pipe write failed: %s\n", strerror(errno));
+}
+
+/* mDNS event-loop read callback for the self-pipe read end. Runs on the
+ * MAIN thread (mDNSPosixRunEventLoopOnce's select loop), so it may
+ * mutate mDNS-core state directly. Drains every queued wake byte, then
+ * re-walks the interface list once — matching InterfaceChangeCallback
+ * in mDNSPosix.c, which also calls RefreshInterfaceList from the event
+ * loop without mDNS_Lock (the Posix lock is a no-op). */
+static void
+mDNSConfigStoreWake(int fd, void *context)
+{
+	char drain[64];
+	ssize_t n;
+
+	(void)context;
+
+	/* Drain the pipe — coalesce a burst of wakes into one refresh. */
+	do {
+		n = read(fd, drain, sizeof(drain));
+	} while (n > 0 || (n < 0 && errno == EINTR));
+
+	(void)fprintf(stderr, "mDNSResponder mDNSConfigStore: "
+	    "MDNS-IFWATCH-OK: interface/service IPv4 change -> "
+	    "re-walking interface list (RefreshInterfaceList)\n");
+	(void)fflush(stderr);
+
+	(void)mDNSPlatformPosixRefreshInterfaceList(&mDNSStorage);
+}
+
 /* SCDS callback — every registered key + pattern routes here. We log
- * the change(s) and schedule the debounced recompute. */
+ * the change(s) and dispatch: HostNames changes arm the debounced
+ * hostname recompute (mDNS_SetFQDN); interface / service IPv4 changes
+ * wake the main thread to re-walk the interface list. A single callback
+ * can carry both kinds, so we track them independently. */
 static void
 mDNSConfigStoreCallback(SCDynamicStoreRef store, CFArrayRef changedKeys,
     void *info)
 {
 	CFIndex i, count;
+	Boolean hostname_changed = FALSE;
+	Boolean interface_changed = FALSE;
 
 	(void)store;
 	(void)info;
@@ -266,12 +374,28 @@ mDNSConfigStoreCallback(SCDynamicStoreRef store, CFArrayRef changedKeys,
 	count = CFArrayGetCount(changedKeys);
 	for (i = 0; i < count; i++) {
 		CFStringRef key = CFArrayGetValueAtIndex(changedKeys, i);
+		const char *kk = key_kind(key);
 
 		(void)fprintf(stderr, "mDNSResponder mDNSConfigStore: "
-		    "key changed -> %s\n", key_kind(key));
+		    "key changed -> %s\n", kk);
+
+		/* Classify: the exact HostNames key drives the hostname
+		 * recompute; everything else we subscribe to is interface /
+		 * service IPv4 (State:/Network/Global/IPv4 or the
+		 * State:/Network/Service/.+/IPv4 pattern) and drives the
+		 * interface re-walk. */
+		if (g_hostnames_key[0] != '\0' &&
+		    strcmp(kk, g_hostnames_key) == 0)
+			hostname_changed = TRUE;
+		else
+			interface_changed = TRUE;
 	}
 	(void)fflush(stderr);
-	mDNSConfigStoreDebounce();
+
+	if (hostname_changed)
+		mDNSConfigStoreDebounce();
+	if (interface_changed)
+		mDNSConfigStorePostInterfaceRefresh();
 }
 
 /* Build the watch lists per SCDynamicStoreSetNotificationKeys's
@@ -293,10 +417,14 @@ mDNSConfigStoreSubscribe(SCDynamicStoreRef store)
 		return (FALSE);
 	}
 
-	/* State:/Network/HostNames — Bonjour LocalHostName surface. */
+	/* State:/Network/HostNames — Bonjour LocalHostName surface. Cache
+	 * its string form so the callback can tell the hostname path from
+	 * the interface path (see g_hostnames_key). */
 	key = SCDynamicStoreKeyCreateNetworkGlobalEntity(NULL,
 	    kSCDynamicStoreDomainState, CFSTR("HostNames"));
 	if (key != NULL) {
+		(void)CFStringGetCString(key, g_hostnames_key,
+		    sizeof(g_hostnames_key), kCFStringEncodingUTF8);
 		CFArrayAppendValue(keys, key);
 		CFRelease(key);
 	}
@@ -322,6 +450,62 @@ mDNSConfigStoreSubscribe(SCDynamicStoreRef store)
 	CFRelease(keys);
 	CFRelease(patterns);
 	return (ok);
+}
+
+/* Mark a descriptor non-blocking + close-on-exec. We want the write end
+ * non-blocking so a wake from g_queue can never stall the dispatch
+ * queue, and both ends close-on-exec so they don't leak into children.
+ * Returns TRUE on success. */
+static Boolean
+set_nonblock_cloexec(int fd)
+{
+	int fl;
+
+	fl = fcntl(fd, F_GETFL, 0);
+	if (fl < 0 || fcntl(fd, F_SETFL, fl | O_NONBLOCK) < 0)
+		return (FALSE);
+	fl = fcntl(fd, F_GETFD, 0);
+	if (fl < 0 || fcntl(fd, F_SETFD, fl | FD_CLOEXEC) < 0)
+		return (FALSE);
+	return (TRUE);
+}
+
+/* Create the cross-thread wake pipe and register its read end on the
+ * mDNS event loop so mDNSConfigStoreWake fires on the main thread. On
+ * any failure we tear the pipe back down and return FALSE; the caller
+ * treats that as non-fatal (interface refresh then relies solely on the
+ * routing-socket watcher, exactly as before iter 4). */
+static Boolean
+mDNSConfigStoreSetupWakePipe(void)
+{
+	int fds[2];
+
+	if (pipe(fds) != 0) {
+		(void)fprintf(stderr, "mDNSResponder mDNSConfigStore: "
+		    "wake-pipe pipe() failed: %s\n", strerror(errno));
+		return (FALSE);
+	}
+	if (!set_nonblock_cloexec(fds[0]) || !set_nonblock_cloexec(fds[1])) {
+		(void)fprintf(stderr, "mDNSResponder mDNSConfigStore: "
+		    "wake-pipe fcntl() failed: %s\n", strerror(errno));
+		(void)close(fds[0]);
+		(void)close(fds[1]);
+		return (FALSE);
+	}
+	g_wake_rd = fds[0];
+	g_wake_wr = fds[1];
+
+	if (mDNSPosixAddFDToEventLoop(g_wake_rd, mDNSConfigStoreWake, NULL)
+	    != mStatus_NoError) {
+		(void)fprintf(stderr, "mDNSResponder mDNSConfigStore: "
+		    "mDNSPosixAddFDToEventLoop(wake) failed\n");
+		(void)close(g_wake_rd);
+		(void)close(g_wake_wr);
+		g_wake_rd = -1;
+		g_wake_wr = -1;
+		return (FALSE);
+	}
+	return (TRUE);
 }
 
 /* Entry point called from PosixDaemon.c main() AFTER mDNS_Init has
@@ -359,6 +543,17 @@ mDNSConfigStoreInit(void)
 	    DISPATCH_TIME_FOREVER, 0);
 	dispatch_activate(g_debounce_timer);
 
+	/* Cross-thread wake pipe for the interface re-walk. Set up BEFORE
+	 * the SCDS dispatch queue starts delivering callbacks, so the read
+	 * end is already on the main-thread event loop the first time the
+	 * callback writes to it. Non-fatal on failure: the routing-socket
+	 * watcher in mDNSPosix.c still drives interface changes, and the
+	 * write side guards on g_wake_wr < 0. */
+	if (!mDNSConfigStoreSetupWakePipe())
+		(void)fprintf(stderr, "mDNSResponder mDNSConfigStore: "
+		    "wake pipe unavailable — interface refresh falls back to "
+		    "the routing-socket watcher only\n");
+
 	g_store = SCDynamicStoreCreate(NULL,
 	    CFSTR("com.apple.mDNSResponder.config"),
 	    mDNSConfigStoreCallback, &ctx);
@@ -385,7 +580,8 @@ mDNSConfigStoreInit(void)
 	}
 
 	(void)fprintf(stderr, "mDNSResponder MDNS-SCDS-OK: SCDynamicStore "
-	    "subscriber up (HostNames + Global/IPv4 + Service/.+/IPv4)\n");
+	    "subscriber up (HostNames + Global/IPv4 + Service/.+/IPv4)%s\n",
+	    g_wake_wr >= 0 ? "; iter-4 interface watcher armed" : "");
 	(void)fflush(stderr);
 	return (0);
 }

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -947,6 +947,27 @@ expect {
     }
 }
 
+# MDNS-IFWATCH — iter 4 reactive interface watcher. mDNSConfigStore.c's
+# SCDS subscriber now wakes the mDNS main thread (via a self-pipe onto
+# the event loop) to re-walk the interface list when ipconfigd publishes
+# / removes a service IPv4 (State:/Network/Global/IPv4 or
+# State:/Network/Service/.+/IPv4), logging MDNS-IFWATCH-OK. run.sh emits
+# a definite -OK or -SKIP line (it never relies on a bare timeout), so
+# this block always matches. Non-fatal by design: the routing-socket
+# watcher in mDNSPosix.c stays a parallel trigger, so -SKIP is not a
+# regression — keep this informational, not a hard gate.
+expect {
+    timeout {
+        puts "\nSKIP: MDNS-IFWATCH marker not seen (treated as non-fatal)"
+    }
+    "MDNS-IFWATCH-SKIP" {
+        puts "\nSKIP: no SCDS-driven interface re-walk observed (routing-socket watcher still active)"
+    }
+    "MDNS-IFWATCH-OK" {
+        puts "\nOK: SCDS interface/service IPv4 change drove a mDNSResponder interface re-walk (iter 4)"
+    }
+}
+
 # MDNS-DNSSD — iter 3 end-to-end DNS-SD round-trip via libdns_sd.
 # dnssdtest registers "_iter3._tcp" / "freebsd-launchd-mach-iter3"
 # through libdns_sd's AF_UNIX channel to the daemon, then browses


### PR DESCRIPTION
## Summary

When a network interface arrives or changes (DHCP bind / lease loss), mDNSResponder must re-walk its interface list and re-announce its Bonjour records. Until now only the routing-socket watcher (`InterfaceChangeCallback` in `mDNSPosix.c`) drove that re-walk; the iter-1 SCDynamicStore subscriber (`mDNSConfigStore.c`) logged `Global/IPv4` + `Service/.+/IPv4` changes but took no action on them.

This PR wires those SCDS subscriptions into the actual interface re-walk (`mDNSPlatformPosixRefreshInterfaceList`), driven reactively by the existing SCDS subscriber.

## What changed

- **Key classification.** The SCDS callback now classifies each changed key. The exact `State:/Network/HostNames` key keeps driving the existing debounced hostname recompute (`mDNS_SetFQDN`); everything else we subscribe to (`State:/Network/Global/IPv4` and the `State:/Network/Service/.+/IPv4` pattern) drives the new interface re-walk.

- **Cross-thread self-pipe (the core of the change).** The mDNS core runs single-threaded on the daemon MAIN thread (`mDNSPosixRunEventLoopOnce`), and the Posix `mDNSPlatformLock`/`Unlock` are no-ops — so core state may only be mutated from the main thread. The SCDS callback runs on a dedicated dispatch queue (`com.apple.mDNSResponder.scds`). Calling `mDNSPlatformPosixRefreshInterfaceList` from there would tear down and rebuild the very socket set the select loop is iterating, racing it. So we use a self-pipe:
  - SCDS path writes one wake byte (non-blocking, EINTR-retried, EAGAIN-benign).
  - Read end registered on the mDNS event loop via `mDNSPosixAddFDToEventLoop`, so the drain + `RefreshInterfaceList` run on the MAIN thread — exactly where `InterfaceChangeCallback` already runs (no `mDNS_Lock`).
  - Pipe fds are `O_NONBLOCK` + `FD_CLOEXEC`; setup failure is non-fatal (falls back to the routing-socket watcher).

- **Markers / tests.** The main-thread refresh logs `MDNS-IFWATCH-OK` to `/var/log/mDNSResponder.stderr`. `run.sh` waits for it after the DHCP BOUND / RENEW publishes (both already checked earlier in the run) and emits a definite `MDNS-IFWATCH-OK` or `-SKIP` line; `boot-test.sh` gains an informational, non-fatal expect block (SKIP, never FAIL).

## Risks / assumptions

- **Hostname path left cross-thread (deliberate tradeoff).** The iter-1 hostname recompute still calls `mDNS_SetFQDN` cross-thread from the dispatch queue (a pre-existing latent race). Rerouting it through the same pipe was considered but left as-is to avoid entangling the proven hostname path with the new interface path for no functional gain here.
- **Non-fatal gating.** `MDNS-IFWATCH-SKIP` is not a regression: the routing-socket watcher remains a parallel trigger, so interface state is still tracked even if the SCDS-driven re-walk isn't observed (e.g. an IPv4 publish racing subscriber startup).
- **Not built locally** (cross/VM build). The diff was re-read for C correctness (pipe fd lifecycle, EINTR/EAGAIN handling, no double-lock, includes). A host `-fsyntax-only` confirms the new code parses cleanly; the only remaining diagnostics are the pre-existing `SCDynamicStoreKeyCreate*` SDK-header mismatches that also fire on the unmodified iter-1 file and resolve in the target SDK at CI build time.
- The `notify_register_dispatch("com.apple.system.hostname")` fast-path hook remains **deferred** behind the libnotify `mig_get_special_reply_port` blocker and is out of scope here.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)