### PR TITLE
Retire the kld* user-space CLIs; keep the kld*(2) syscalls (#193)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -386,7 +386,10 @@ tar -xJf "$DIST/src.txz" -C "$WORK/freebsd-src"
 #      accidentally-disabled overlay and an incomplete compat artifact.
 #
 echo "==> verifying from-source base overlay provided the FreeBSD-only userland"
-for KEY_BIN in /sbin/kldload /sbin/mount /bin/kenv \
+# Probe kept FreeBSD-only tools. (The kld* CLIs the artifact also ships are
+# RETIRED from the image at step 3b2 below, #193 — macOS ships kextload/
+# kextstat, not kldload — so don't probe them here.)
+for KEY_BIN in /sbin/umount /sbin/mount /bin/kenv \
                /usr/bin/ldd /usr/sbin/pciconf; do
     if [ ! -x "$WORK/rootfs$KEY_BIN" ]; then
         echo "ERROR: from-source base overlay did not provide $KEY_BIN" >&2
@@ -395,7 +398,7 @@ for KEY_BIN in /sbin/kldload /sbin/mount /bin/kenv \
         exit 1
     fi
 done
-ls -lh "$WORK/rootfs/sbin/kldload" "$WORK/rootfs/sbin/mount" \
+ls -lh "$WORK/rootfs/sbin/umount" "$WORK/rootfs/sbin/mount" \
        "$WORK/rootfs/bin/kenv" "$WORK/rootfs/usr/bin/ldd" \
        "$WORK/rootfs/usr/sbin/pciconf"
 
@@ -630,6 +633,9 @@ fi
 #      still has a linker.hints (mach is built into the kernel, not a module).
 #
 echo "==> /boot/kernel: kernel only (no .ko module tree)"
+# kldxref runs HERE (build time, in the chroot) to generate the loader's
+# linker.hints. The kldxref BINARY itself is then retired from the image at
+# 3b2a below — only the hints file it produces needs to ship.
 chroot "$WORK/rootfs" kldxref /boot/kernel 2>/dev/null || true
 if ls "$WORK/rootfs/boot/kernel"/*.ko >/dev/null 2>&1; then
     echo "    WARN: unexpected .ko present in /boot/kernel:"
@@ -637,6 +643,42 @@ if ls "$WORK/rootfs/boot/kernel"/*.ko >/dev/null 2>&1; then
 else
     echo "    confirmed: no .ko modules in /boot/kernel"
 fi
+
+#
+# 3b2a. Retire the FreeBSD kld* USER-SPACE CLIs (#193). macOS ships
+#       kextload/kextunload/kextstat, NOT kldload/kldunload/kldstat — so
+#       NextBSD does the same. These CLI front-ends arrive from the
+#       nextbsd-freebsd-compat from-source base artifact (overlaid at the
+#       top of this script); that artifact is built in a separate repo, so
+#       they can't be dropped at the source from here — strip them from the
+#       rootfs instead, now that build-time kldxref (above) has run.
+#
+#       KEPT, deliberately NOT touched: the kld*(2) SYSCALLS (kldload(2)/
+#       kldunload(2)/kldstat(2)/kldnext(2)/modfind(2)/... — the libc stubs
+#       and kernel ABI), libkldelf / libprivatekldelf, and /boot/kernel/
+#       linker.hints. kextload/kextd/OSKext and our kextstat (src/kext_tools)
+#       ride those syscalls; removing the CLIs leaves them intact.
+#
+echo "==> retiring kld* user-space CLIs (#193 — kextload/kextstat replace them)"
+for kldbin in sbin/kldload sbin/kldunload sbin/kldstat sbin/kldconfig \
+              usr/sbin/kldxref; do
+    rm -f "$WORK/rootfs/$kldbin"
+done
+# man pages for the retired CLIs (section 8 — user-space tools). The kld*(2)
+# section-2 syscall man pages are LEFT in place (they document the kept ABI).
+rm -f "$WORK/rootfs"/usr/share/man/man8/kldload.8.gz \
+      "$WORK/rootfs"/usr/share/man/man8/kldunload.8.gz \
+      "$WORK/rootfs"/usr/share/man/man8/kldstat.8.gz \
+      "$WORK/rootfs"/usr/share/man/man8/kldconfig.8.gz \
+      "$WORK/rootfs"/usr/share/man/man8/kldxref.8.gz 2>/dev/null || true
+for kldbin in sbin/kldload sbin/kldunload sbin/kldstat sbin/kldconfig \
+              usr/sbin/kldxref; do
+    if [ -e "$WORK/rootfs/$kldbin" ]; then
+        echo "    ERROR: failed to retire /$kldbin" >&2
+        exit 1
+    fi
+done
+echo "    confirmed: kld* CLIs removed; kld*(2) syscalls + linker.hints intact"
 
 #
 # 3b3. install bundled driver kexts (IntelWiFi.kext, ...) from the
@@ -1909,7 +1951,9 @@ echo "==> libIOKit built + installed"
 #       (+ libIOKit, for IORegistryEntryCreateCFProperty), so the whole subdir
 #       builds here. kextload = dependency-ordered load, kextunload =
 #       bundle-aware unload, kextdeps = dependency resolution; kextstat stays
-#       kld-only. Install: /usr/sbin/{kextload,kextunload,kextstat,kextdeps}.
+#       kld-syscall-backed (kldnext/kldstat/modfind — the KEPT ABI) and now
+#       also serves `kextstat -m <module>`, the stand-in for the retired
+#       `kldstat -m` (#193). Install: /usr/sbin/{kextload,kextunload,kextstat,kextdeps}.
 #       A runtime smoke then proves the OSBundleLibraries dependency sort works
 #       on the real image (possible now that CF runs, #195).
 #

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -14,14 +14,17 @@
 
 set -u
 
-# 1. kernel-side: mach.ko loaded.
-if kldstat -m mach >/dev/null 2>&1; then
-    echo "MACH-SMOKE-OK: mach.ko is loaded"
-    kldstat -v 2>/dev/null | grep -i mach || true
+# 1. kernel-side: mach module registered. mach is compiled INTO the kernel
+# (#181), so it's a kernel module rather than a separate .ko. The kld* CLIs
+# were retired (#193); kextstat -m queries the module by name via modfind(2)
+# (a kept syscall), which finds it whether it's a .ko or in-kernel.
+if kextstat -m mach >/dev/null 2>&1; then
+    echo "MACH-SMOKE-OK: mach module is registered"
+    kextstat 2>/dev/null | grep -i mach || true
 else
-    echo "MACH-SMOKE-FAIL: mach.ko is NOT loaded"
-    echo "kldstat output:"
-    kldstat
+    echo "MACH-SMOKE-FAIL: mach module is NOT registered"
+    echo "kextstat output:"
+    kextstat
     exit 1
 fi
 
@@ -276,9 +279,12 @@ fi
 # Plan: https://pkgdemon.github.io/freebsd-srclist-build-plan.html
 FBSDGLUE_FAIL=0
 # bin/ + sbin/ (kernel-bound + UFS):
+# NOTE: the kld* CLIs (kldload/kldunload/kldstat/kldconfig/kldxref) were
+# RETIRED (#193) — macOS ships kextload/kextstat, not kldload. The kld*(2)
+# SYSCALLS stay; kextload/kextstat (src/kext_tools) drive them. They are
+# asserted ABSENT below.
 for fbin in /bin/freebsd-version /bin/kenv \
             /sbin/devfs /sbin/fsck /sbin/fsck_ffs \
-            /sbin/kldconfig /sbin/kldload /sbin/kldstat /sbin/kldunload \
             /sbin/ldconfig /sbin/mount /sbin/newfs /sbin/tunefs /sbin/umount; do
     if [ ! -x "$fbin" ]; then
         echo "FBSDGLUE-FAIL: $fbin missing or not executable"
@@ -293,9 +299,11 @@ if [ ! -x /usr/bin/ldd ]; then
     FBSDGLUE_FAIL=1
 fi
 # usr.sbin/ FreeBSD HW/FS introspection + user mgmt + libexec.
+# (kldxref retired with the rest of the kld* CLIs, #193 — linker.hints is
+# generated at build time, not on the image.)
 for fbin in /usr/sbin/devctl /usr/sbin/diskinfo \
             /usr/sbin/fstyp /usr/sbin/gstat \
-            /usr/sbin/kldxref /usr/sbin/pciconf /usr/sbin/pw \
+            /usr/sbin/pciconf /usr/sbin/pw \
             /usr/libexec/save-entropy; do
     if [ ! -x "$fbin" ]; then
         echo "FBSDGLUE-FAIL: $fbin missing or not executable"
@@ -322,12 +330,31 @@ if [ -d /rescue ]; then
     ls -la /rescue 2>&1 | head -5 || true
     FBSDGLUE_FAIL=1
 fi
+# Verify the kld* CLIs are ABSENT (#193) — macOS ships kextload/kextstat,
+# not kldload. The kld*(2) SYSCALLS stay (kextstat uses them); only the
+# user-space CLI front-ends are retired.
+for kldcli in /sbin/kldload /sbin/kldunload /sbin/kldstat \
+              /sbin/kldconfig /usr/sbin/kldxref; do
+    if [ -e "$kldcli" ]; then
+        echo "FBSDGLUE-FAIL: $kldcli still present; kld* CLIs should be retired (#193)"
+        ls -la "$kldcli" 2>&1 || true
+        FBSDGLUE_FAIL=1
+    fi
+done
+# Verify the kext* replacements ARE present.
+for kextcli in /usr/sbin/kextload /usr/sbin/kextunload /usr/sbin/kextstat; do
+    if [ ! -x "$kextcli" ]; then
+        echo "FBSDGLUE-FAIL: $kextcli missing; should replace the retired kld* CLI"
+        ls -la "$kextcli" 2>&1 || true
+        FBSDGLUE_FAIL=1
+    fi
+done
 if [ $FBSDGLUE_FAIL -eq 0 ]; then
-    # Sanity-probe a few: their --version/-h paths exit 0 quickly.
-    kldstat_count=$(kldstat 2>/dev/null | wc -l | tr -d ' ')
+    # Sanity-probe a few: their output paths exit 0 quickly.
+    kextstat_count=$(kextstat 2>/dev/null | wc -l | tr -d ' ')
     kenv_count=$(kenv 2>/dev/null | wc -l | tr -d ' ')
     mount_count=$(mount 2>/dev/null | wc -l | tr -d ' ')
-    echo "FBSDGLUE-OK: 25/25 fbsdglue binaries present + executable; BSD-debug toolkit deferred; kldstat=${kldstat_count} kenv=${kenv_count} mount=${mount_count}; /rescue/ absent"
+    echo "FBSDGLUE-OK: fbsdglue binaries present + executable; kld* CLIs retired (kext* present); BSD-debug toolkit deferred; kextstat=${kextstat_count} kenv=${kenv_count} mount=${mount_count}; /rescue/ absent"
 else
     exit 1
 fi

--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -93,10 +93,12 @@ if [ -x /usr/libexec/kextd ]; then
 	i=0
 	while [ "$i" -lt 12 ]; do
 		# The loaded kld file is named after the bundle executable
-		# (IntelWiFi); plain `kldstat` shows that, while the driver
-		# module (if_iwlwifi) only appears under `kldstat -v`. Check both.
-		if kldstat 2>/dev/null | grep -qi intelwifi ||
-		   kldstat -v 2>/dev/null | grep -qi iwlwifi; then loaded=yes; break; fi
+		# (IntelWiFi); `kextstat` lists loaded files, so it shows that.
+		# The driver module inside (if_iwlwifi) is found by module name
+		# via `kextstat -m` (modfind(2)). The kld* CLIs were retired
+		# (#193); kextstat rides the same kld*(2) syscalls. Check both.
+		if kextstat 2>/dev/null | grep -qi intelwifi ||
+		   kextstat -m if_iwlwifi >/dev/null 2>&1; then loaded=yes; break; fi
 		sleep 1; i=$((i + 1))
 	done
 	echo "=== /var/log/kextd.log (daemon) ==="; cat /var/log/kextd.log 2>/dev/null; echo "==="

--- a/src/kext_tools/kextstat/kextstat.c
+++ b/src/kext_tools/kextstat/kextstat.c
@@ -6,16 +6,25 @@
  * with kldnext(2)/kldstat(2). No OSKext. This is the proof-of-concept trio
  * (nextbsd#183); the faithful kext_tools/OSKext port is tracked in
  * nextbsd#182.
+ *
+ * It also accepts `-m <module>` (mirroring the retired kldstat(1) flag):
+ * exit 0 if a kernel MODULE of that name is registered (modfind(2)), else
+ * exit 1. This lets kextstat stand in for `kldstat -m` after the kld* CLIs
+ * were retired (nextbsd#193). modfind(2)/kldnext(2)/kldstat(2) are all KEPT
+ * syscalls, so it works the same whether the module is a separate .ko or
+ * compiled into the kernel.
  */
 #include <sys/param.h>
 #include <sys/linker.h>
+#include <sys/module.h>
 
 #include <err.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <unistd.h>
 
-int
-main(void)
+static void
+list_loaded(void)
 {
 	int fileid;
 
@@ -32,5 +41,32 @@ main(void)
 		    stat.id, stat.refs, (uintmax_t)(uintptr_t)stat.address,
 		    stat.size, stat.name);
 	}
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *module = NULL;
+	int ch;
+
+	while ((ch = getopt(argc, argv, "m:")) != -1) {
+		switch (ch) {
+		case 'm':
+			module = optarg;
+			break;
+		default:
+			fprintf(stderr, "usage: kextstat [-m module]\n");
+			return (2);
+		}
+	}
+
+	if (module != NULL) {
+		/* Module-presence query (replaces `kldstat -m <module>`). */
+		if (modfind(module) < 0)
+			return (1);
+		return (0);
+	}
+
+	list_loaded();
 	return (0);
 }

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -220,7 +220,7 @@ expect {
 # Stage 3: invoke the on-ISO mach smoke test. Test scripts live under
 # /usr/tests/<component>/ following the FreeBSD convention. The script
 # emits two markers in sequence:
-#   MACH-SMOKE-OK / MACH-SMOKE-FAIL          — kernel-side kldstat -m mach
+#   MACH-SMOKE-OK / MACH-SMOKE-FAIL          — kernel-side kextstat -m mach
 #   LIBSYSTEM-KERNEL-OK / LIBSYSTEM-KERNEL-FAIL — userland test_libmach
 # Both must pass.
 send "/usr/tests/freebsd-launchd-mach/run.sh\r"
@@ -376,7 +376,7 @@ expect {
         puts "\nFAIL: fbsdglue full set missing or non-functional"
         exit 1
     }
-    "FBSDGLUE-OK" { puts "\nOK: srclist-fbsdglue.txt minimal 25-entry set present + /rescue/ absent (#109)" }
+    "FBSDGLUE-OK" { puts "\nOK: fbsdglue set present, kld* CLIs retired (kext* present), /rescue/ absent (#109/#193)" }
 }
 expect {
     timeout {


### PR DESCRIPTION
## What

Removes the FreeBSD **kld\* user-space CLI utilities** — `kldload`, `kldunload`, `kldstat`, `kldconfig`, `kldxref` — from the NextBSD image, and migrates the in-repo consumers to the `kext*` equivalents. Apple-faithfulness: macOS ships `kextload`/`kextstat`, not `kldload`.

The **kld\*(2) SYSCALLS are NOT touched** — `kldload(2)`/`kldunload(2)`/`kldstat(2)`/`kldnext(2)`/`modfind(2)`, their libc stubs, the kernel ABI, `libkldelf`/`libprivatekldelf`, and `/boot/kernel/linker.hints` all stay. `kextload`/`kextd`/OSKext and `kextstat` ride those syscalls.

## Audit findings

- **How the CLIs enter the image:** they come from the `nextbsd-freebsd-compat` from-source base artifact (built in a separate repo, overlaid at the top of `build.sh`). They are **not** built from a srclist in this repo (the old `srclist-fbsdglue.txt` build was already removed). So they can't be dropped at the source from here — they're stripped from `$WORK/rootfs` in `build.sh`.
- **Build-time dependency:** `build.sh` runs `kldxref /boot/kernel` in the chroot to generate the loader's `linker.hints`. The strip step (new **3b2a**) runs *after* that, so the hints file still ships; only the binary is removed.
- **Consumers in this repo:** the CI boot test (`overlays/usr/tests/freebsd-launchd-mach/run.sh` and `overlays/usr/tests/nextbsd-iokit/run.sh`) used `kldstat`/`kldstat -m`/`kldstat -v`.

## Changes

- **`kextstat` gains `-m <module>`** (`modfind(2)`, a kept syscall) — the stand-in for the retired `kldstat -m`. Works whether the module is a `.ko` or compiled into the kernel.
- **`build.sh`:** new step 3b2a strips the kld\* CLI binaries + their man8 pages from the rootfs (with a verify-removed guard); the from-source-base verify probe switches off `/sbin/kldload`.
- **`freebsd-launchd-mach/run.sh`:** `kldstat -m mach` -> `kextstat -m mach`; diagnostics `kldstat` -> `kextstat`; the FBSDGLUE presence check no longer requires the kld\* CLIs and now asserts they are **absent** and the kext\* CLIs are **present**.
- **`nextbsd-iokit/run.sh`:** `kldstat | grep intelwifi` -> `kextstat | grep intelwifi`; `kldstat -v | grep iwlwifi` -> `kextstat -m if_iwlwifi`.
- **`boot-test.sh`:** marker comments updated.

## Verification

- `kextstat.c` syntax-checked with `-Wall -Wextra` against stub headers (clean).
- Cannot fully build locally; CI compiles + boot-tests. Consumers were migrated **before** removal so the boot test should stay green.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)