### PR TITLE
libIOKit: walk /dev/ioregistry (K1) with hwregd fallback (C1.1, #218)

### DIFF
--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -55,12 +55,16 @@ ioreg_gate()
 	# da) and the NIC is the configured model (em/e1000 in CI, or a
 	# virtio-net vtnet). Accept any of the common names so the gate tracks
 	# "the registry sees real hardware nubs" rather than one exact string.
+	# ioreg renders bare driver CLASS names without unit numbers, e.g.
+	# "+-o vtblk  <class vtblk>" / "+-o em  <class em>" — so match the
+	# "<class NAME>" token, not "name+digit". (virtio-blk is class "vtblk",
+	# NOT "vtbd"; the qemu e1000 NIC is class "em".)
 	disk_ok=no
-	if echo "${iorg}" | grep -Eqi 'vtbd|\bda[0-9]|\bnvd[0-9]|\bad[0-9]'; then
+	if echo "${iorg}" | grep -Eqi '<class (vtblk|ahcich|nvme|nvd|ada|da|mmcsd|cd)>'; then
 		disk_ok=yes
 	fi
 	nic_ok=no
-	if echo "${iorg}" | grep -Eqi 'vtnet|\bem[0-9]|\bigb[0-9]|\bre[0-9]'; then
+	if echo "${iorg}" | grep -Eqi '<class (em|vtnet|igb|ix|re|bge)>'; then
 		nic_ok=yes
 	fi
 	echo "ioreg: disk_ok=${disk_ok} nic_ok=${nic_ok}"

--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -12,6 +12,73 @@
 
 set -u
 
+# IOREG — libIOKit registry walk via the K1 /dev/ioregistry device (C1.1,
+# #218). libIOKit now prefers /dev/ioregistry (IOREGIOC* ioctls) and falls
+# back to hwregd; this gate exercises the live path with the `ioreg` tool and
+# asserts the registry root plus the boot disk/NIC nubs are visible. It is also
+# the deferred K1 functional proof (the kernel registry actually answers).
+#
+#   IOREG-OK    — /dev/ioregistry present; ioreg printed root + a disk/NIC nub
+#   IOREG-FAIL  — /dev/ioregistry present but the walk is empty / missing nodes
+#   IOREG-SKIP  — no /dev/ioregistry (old kernel predating K1) — nothing to test
+#
+# Run as a function that emits EXACTLY ONE marker and returns (never exits) so
+# the IOCATALOGUE/IOKIT-LOOKUP/KEXTD-LOAD checks below still run on a K1-but-
+# no-K2 kernel — and so a K1 SKIP here doesn't short-circuit the rest. The boot
+# test gates on the IOREG-FAIL *string*, not on this script's exit code, so a
+# FAIL marker + return still fails CI. SELF-SKIP on a pre-K1 kernel keeps this
+# green on continuous images built before #214 landed.
+ioreg_gate()
+{
+	if [ ! -c /dev/ioregistry ]; then
+		echo "IOREG-SKIP: no /dev/ioregistry (kernel without the K1 in-kernel registry)"
+		return 0
+	fi
+	if [ ! -x /usr/sbin/ioreg ]; then
+		echo "IOREG-SKIP: /usr/sbin/ioreg not present"
+		return 0
+	fi
+
+	iorg=$(/usr/sbin/ioreg 2>/dev/null || true)
+	echo "=== ioreg (via /dev/ioregistry) ==="
+	echo "${iorg}"
+	echo "==="
+
+	# Root: ioreg prints the tree top as "+-o <root> <class ...>"; an empty
+	# walk (no "+-o" lines at all) means the registry didn't answer.
+	if ! echo "${iorg}" | grep -q '+-o '; then
+		echo "IOREG-FAIL: ioreg produced no nodes from /dev/ioregistry"
+		return 0
+	fi
+
+	# Boot devices: under QEMU the root disk is a virtio block device (vtbd /
+	# da) and the NIC is the configured model (em/e1000 in CI, or a
+	# virtio-net vtnet). Accept any of the common names so the gate tracks
+	# "the registry sees real hardware nubs" rather than one exact string.
+	disk_ok=no
+	if echo "${iorg}" | grep -Eqi 'vtbd|\bda[0-9]|\bnvd[0-9]|\bad[0-9]'; then
+		disk_ok=yes
+	fi
+	nic_ok=no
+	if echo "${iorg}" | grep -Eqi 'vtnet|\bem[0-9]|\bigb[0-9]|\bre[0-9]'; then
+		nic_ok=yes
+	fi
+	echo "ioreg: disk_ok=${disk_ok} nic_ok=${nic_ok}"
+
+	if [ "${disk_ok}" = yes ] && [ "${nic_ok}" = yes ]; then
+		echo "IOREG-OK: /dev/ioregistry walk shows root + boot disk + NIC nubs"
+	elif [ "${disk_ok}" = yes ] || [ "${nic_ok}" = yes ]; then
+		# One nub class visible is enough to prove the live kernel walk
+		# works; the other may carry a name this matcher doesn't list.
+		echo "IOREG-OK: /dev/ioregistry walk shows root + a boot device nub"
+	else
+		echo "IOREG-FAIL: /dev/ioregistry walk found no disk or NIC nub"
+	fi
+	return 0
+}
+ioreg_gate
+
+
 if [ ! -c /dev/iocatalogue ]; then
 	echo "IOCATALOGUE-SKIP: no /dev/iocatalogue (kernel without the K2 IOCatalogue)"
 	exit 0

--- a/src/libIOKit/IOKitInternal.h
+++ b/src/libIOKit/IOKitInternal.h
@@ -45,6 +45,30 @@ struct __IOObject {
 mach_port_t	__io_hwregd_port(void);
 
 /*
+ * __io_ioregistry_fd — cached read-only fd to the kernel /dev/ioregistry
+ * device (the K1 in-kernel registry, nextbsd#214), opened with
+ * O_CLOEXEC on first call (pthread_once-guarded, shared with the
+ * hwregd-port lookup). Returns -1 if the device is absent (an
+ * old-kernel image predating K1) — every facade entry point then
+ * FALLS BACK to the hwregd MIG path. This dual-path is the safety net
+ * for the consumer migration (#218) until hwregd is retired (PR7).
+ */
+int	__io_ioregistry_fd(void);
+
+/*
+ * Shared per-op node accessor: prefers the /dev/ioregistry fast path
+ * (IOREGIOCNODE) and falls back to hwregd's hwreg_get_node. Both
+ * IOKitLib.c (name/path) and IOKitMatching.c (class) call it so the
+ * dual-path logic lives in one place. Out-params mirror
+ * hwreg_get_node's so call sites change minimally; any pointer may be
+ * NULL to skip that field. `state` is the IOREG_STATE_* / hwregd
+ * liveness value. Returns a kern_return_t (KERN_SUCCESS on success).
+ */
+kern_return_t	__io_node(uint64_t node_id, uint64_t *parent_id, int *state,
+		    char name[32], char classname[32], char driver[32],
+		    char path[256]);
+
+/*
  * Internal allocators. __io_alloc_iterator takes ownership of the
  * id array (it is freed by IOObjectRelease) — on calloc failure the
  * array is freed and IO_OBJECT_NULL returned.

--- a/src/libIOKit/IOKitLib.c
+++ b/src/libIOKit/IOKitLib.c
@@ -1,16 +1,26 @@
 /*
- * IOKitLib.c — libIOKit iter 1: read-only registry walk.
+ * IOKitLib.c — libIOKit: read-only registry walk.
  *
- * Each entry point is a thin wrapper over hwregd's MIG RPC
- * (src/hwregd/hwreg.defs). Handles are client-side structs with a
- * hwregd node id (or a captured id array for iterators) and an
- * atomic refcount. The hwregd service port is looked up lazily via
- * bootstrap_look_up on first use and cached process-wide.
+ * Each registry entry point first tries the kernel /dev/ioregistry
+ * device (the K1 in-kernel registry, nextbsd#214) via ioctl, and
+ * FALLS BACK to hwregd's MIG RPC (src/hwregd/hwreg.defs) when that
+ * device is absent — i.e. an old-kernel image predating K1. This
+ * dual-path is the consumer migration (#218): /dev/ioregistry walks
+ * the live newbus device_t tree directly, whereas hwregd is only a
+ * userland cache; the hwregd path stays compiled as the safety net
+ * until hwregd is retired (PR7).
+ *
+ * Handles are client-side structs with a node id (or a captured id
+ * array for iterators) and an atomic refcount. The /dev/ioregistry
+ * fd and the hwregd service port are both resolved lazily on first
+ * use under one pthread_once and cached process-wide.
  */
 #include <IOKit/IOKitLib.h>
 #include "IOKitInternal.h"
 
-#include "hwreg.h"		/* MIG hwreg.defs user-side stubs */
+#include "ioregistry.h"		/* vendored K1 ABI; canonical in nextbsd-kernel */
+
+#include "hwreg.h"		/* MIG hwreg.defs user-side stubs (fallback) */
 #include "hwreg_mig_types.h"	/* hwreg_id_array_t / hwreg_name_t / ... */
 
 #include <mach/mach.h>
@@ -20,8 +30,10 @@
 #ifndef NO_SYSCALL
 #define NO_SYSCALL (-1)	/* kernel sentinel; sysctl reports -1 when a trap is unwired */
 #endif
+#include <sys/ioctl.h>		/* ioctl(2) on /dev/ioregistry */
 #include <sys/sysctl.h>		/* sysctlbyname (mach.bus.busy / mach.syscall.*) */
 
+#include <fcntl.h>		/* open(2), O_RDONLY / O_CLOEXEC */
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdint.h>
@@ -29,23 +41,107 @@
 #include <string.h>
 #include <unistd.h>		/* syscall(2) */
 
-/* hwregd send right — cached after the first bootstrap_look_up. */
-static pthread_once_t	hwregd_once = PTHREAD_ONCE_INIT;
+/*
+ * Lazy registry-backend resolution, shared under one pthread_once:
+ *   - ioregistry_fd: fd to /dev/ioregistry, or -1 if the K1 device is
+ *     absent (then everything falls back to hwregd).
+ *   - hwregd_port:   send right to org.freebsd.hwregd (the fallback),
+ *     or MACH_PORT_NULL if that lookup also fails.
+ * The fd is process-lived and intentionally never closed (libIOKit is
+ * a long-lived facade); O_CLOEXEC keeps it from leaking across exec.
+ */
+static pthread_once_t	io_backend_once = PTHREAD_ONCE_INIT;
+static int		ioregistry_fd = -1;
 static mach_port_t	hwregd_port = MACH_PORT_NULL;
 
 static void
-hwregd_lookup(void)
+io_backend_init(void)
 {
+	ioregistry_fd = open("/dev/ioregistry", O_RDONLY | O_CLOEXEC);
+	/* hwregd is the fallback; resolve it too so a per-call miss on
+	 * /dev/ioregistry doesn't pay a bootstrap_look_up each time. */
 	if (bootstrap_look_up(bootstrap_port,
 	    "org.freebsd.hwregd", &hwregd_port) != KERN_SUCCESS)
 		hwregd_port = MACH_PORT_NULL;
 }
 
+int
+__io_ioregistry_fd(void)
+{
+	(void)pthread_once(&io_backend_once, io_backend_init);
+	return (ioregistry_fd);
+}
+
 mach_port_t
 __io_hwregd_port(void)
 {
-	(void)pthread_once(&hwregd_once, hwregd_lookup);
+	(void)pthread_once(&io_backend_once, io_backend_init);
 	return (hwregd_port);
+}
+
+/*
+ * __io_node — fetch one node's scalar fields. Prefers /dev/ioregistry
+ * (IOREGIOCNODE: fill struct ioreg_node.id, ioctl, copy out the
+ * fields, which are laid out to match hwreg_get_node's out-params);
+ * falls back to hwregd's hwreg_get_node. Any out-pointer may be NULL.
+ */
+kern_return_t
+__io_node(uint64_t node_id, uint64_t *parent_id, int *state,
+    char name[32], char classname[32], char driver[32], char path[256])
+{
+	int fd = __io_ioregistry_fd();
+
+	if (fd >= 0) {
+		struct ioreg_node n;
+
+		(void)memset(&n, 0, sizeof(n));
+		n.id = node_id;
+		if (ioctl(fd, IOREGIOCNODE, &n) != 0)
+			return (kIOReturnNotFound);
+		if (parent_id != NULL)
+			*parent_id = n.parent_id;
+		if (state != NULL)
+			*state = n.state;
+		if (name != NULL)
+			(void)memcpy(name, n.name, IOREG_NAME_MAX);
+		if (classname != NULL)
+			(void)memcpy(classname, n.classname, IOREG_NAME_MAX);
+		if (driver != NULL)
+			(void)memcpy(driver, n.driver, IOREG_NAME_MAX);
+		if (path != NULL)
+			(void)memcpy(path, n.path, IOREG_PATH_MAX);
+		return (KERN_SUCCESS);
+	}
+
+	/* Fallback: hwregd MIG. hwreg_get_node requires all out-params,
+	 * so supply local scratch for any the caller passed as NULL. */
+	{
+		mach_port_t svc = __io_hwregd_port();
+		uint64_t lparent;
+		int lstate;
+		char lname[32], lclass[32], ldriver[32], lpath[256];
+		kern_return_t kr;
+
+		if (svc == MACH_PORT_NULL)
+			return (kIOReturnNoDevice);
+		kr = hwreg_get_node(svc, node_id, &lparent, &lstate,
+		    lname, lclass, ldriver, lpath);
+		if (kr != KERN_SUCCESS)
+			return (kr);
+		if (parent_id != NULL)
+			*parent_id = lparent;
+		if (state != NULL)
+			*state = lstate;
+		if (name != NULL)
+			(void)strlcpy(name, lname, 32);
+		if (classname != NULL)
+			(void)strlcpy(classname, lclass, 32);
+		if (driver != NULL)
+			(void)strlcpy(driver, ldriver, 32);
+		if (path != NULL)
+			(void)strlcpy(path, lpath, 256);
+		return (KERN_SUCCESS);
+	}
 }
 
 io_object_t
@@ -81,19 +177,32 @@ __io_alloc_iterator(uint64_t *ids, uint32_t count)
 io_registry_entry_t
 IORegistryGetRootEntry(mach_port_t mainPort __unused)
 {
-	mach_port_t svc = __io_hwregd_port();
+	int fd = __io_ioregistry_fd();
 	uint64_t root = 0;
 
-	if (svc == MACH_PORT_NULL)
-		return (IO_OBJECT_NULL);
-	if (hwreg_get_root(svc, &root) != KERN_SUCCESS || root == 0)
-		return (IO_OBJECT_NULL);
-	return (__io_alloc_entry(root));
+	if (fd >= 0) {
+		if (ioctl(fd, IOREGIOCROOT, &root) != 0 || root == 0)
+			return (IO_OBJECT_NULL);
+		return (__io_alloc_entry(root));
+	}
+
+	/* Fallback: hwregd MIG. */
+	{
+		mach_port_t svc = __io_hwregd_port();
+
+		if (svc == MACH_PORT_NULL)
+			return (IO_OBJECT_NULL);
+		if (hwreg_get_root(svc, &root) != KERN_SUCCESS || root == 0)
+			return (IO_OBJECT_NULL);
+		return (__io_alloc_entry(root));
+	}
 }
 
 /*
- * hwreg.defs caps a single get_children reply at 128 ids — see the
- * hwreg_id_array_t bound. Mirror it here.
+ * Fixed capacity for a single get-children call. The hwregd fallback
+ * caps a get_children reply at 128 ids (the hwreg_id_array_t bound),
+ * so mirror it for the /dev/ioregistry path too — the kernel reports
+ * the true count via ioreg_children.count and we clamp to this.
  */
 #define IOKIT_MAX_CHILDREN	128
 
@@ -101,29 +210,58 @@ kern_return_t
 IORegistryEntryGetChildIterator(io_registry_entry_t entry,
     const io_name_t plane __unused, io_iterator_t *iterator)
 {
-	mach_port_t svc = __io_hwregd_port();
+	int fd = __io_ioregistry_fd();
 	uint64_t *ids;
-	mach_msg_type_number_t nids = IOKIT_MAX_CHILDREN;
-	kern_return_t kr;
+	uint32_t cap = IOKIT_MAX_CHILDREN;
 
 	if (entry == NULL || entry->kind != IOOBJ_KIND_ENTRY ||
 	    iterator == NULL)
 		return (KERN_INVALID_ARGUMENT);
-	if (svc == MACH_PORT_NULL)
-		return (kIOReturnNoDevice);
 
-	ids = calloc(nids, sizeof(*ids));
+	ids = calloc(cap, sizeof(*ids));
 	if (ids == NULL)
 		return (KERN_RESOURCE_SHORTAGE);
 
-	kr = hwreg_get_children(svc, entry->node_id, ids, &nids);
-	if (kr != KERN_SUCCESS) {
-		free(ids);
-		return (kr);
+	if (fd >= 0) {
+		struct ioreg_children c;
+
+		(void)memset(&c, 0, sizeof(c));
+		c.id = entry->node_id;
+		c.max = cap;
+		c.children = (uint64_t)(uintptr_t)ids;
+		if (ioctl(fd, IOREGIOCCHILDREN, &c) != 0) {
+			free(ids);
+			return (kIOReturnError);
+		}
+		/* Truncation: c.count > cap means more children than the
+		 * fixed array holds; clamp to what we captured (mirrors the
+		 * hwreg.defs 128-id reply bound the fallback path inherits). */
+		if (c.count > cap)
+			c.count = cap;
+		*iterator = __io_alloc_iterator(ids, c.count);
+		return (*iterator != IO_OBJECT_NULL ? KERN_SUCCESS
+		    : KERN_RESOURCE_SHORTAGE);
 	}
-	*iterator = __io_alloc_iterator(ids, nids);
-	return (*iterator != IO_OBJECT_NULL ? KERN_SUCCESS
-	    : KERN_RESOURCE_SHORTAGE);
+
+	/* Fallback: hwregd MIG. */
+	{
+		mach_port_t svc = __io_hwregd_port();
+		mach_msg_type_number_t nids = cap;
+		kern_return_t kr;
+
+		if (svc == MACH_PORT_NULL) {
+			free(ids);
+			return (kIOReturnNoDevice);
+		}
+		kr = hwreg_get_children(svc, entry->node_id, ids, &nids);
+		if (kr != KERN_SUCCESS) {
+			free(ids);
+			return (kr);
+		}
+		*iterator = __io_alloc_iterator(ids, nids);
+		return (*iterator != IO_OBJECT_NULL ? KERN_SUCCESS
+		    : KERN_RESOURCE_SHORTAGE);
+	}
 }
 
 io_object_t
@@ -139,21 +277,16 @@ IOIteratorNext(io_iterator_t iterator)
 kern_return_t
 IORegistryEntryGetName(io_registry_entry_t entry, io_name_t name)
 {
-	mach_port_t svc = __io_hwregd_port();
-	uint64_t parent_id;
-	int state;
-	/* hwreg.defs bounds: hwreg_name_t = c_string[32], hwreg_path_t
-	 * = c_string[256]. Mirror exactly so MIG fills them safely. */
-	char hwname[32], classname[32], driver[32], path[256];
+	char hwname[32];
 	kern_return_t kr;
 
 	if (entry == NULL || entry->kind != IOOBJ_KIND_ENTRY ||
 	    name == NULL)
 		return (KERN_INVALID_ARGUMENT);
-	if (svc == MACH_PORT_NULL)
-		return (kIOReturnNoDevice);
-	kr = hwreg_get_node(svc, entry->node_id, &parent_id, &state,
-	    hwname, classname, driver, path);
+	/* Only the name is wanted; __io_node fills just that field and
+	 * skips the rest (NULLs). The 32/256 buffers match both the K1
+	 * ioreg_node[name] and the hwreg.defs hwreg_name_t bound. */
+	kr = __io_node(entry->node_id, NULL, NULL, hwname, NULL, NULL, NULL);
 	if (kr != KERN_SUCCESS)
 		return (kr);
 	(void)strlcpy(name, hwname, sizeof(io_name_t));
@@ -164,19 +297,13 @@ kern_return_t
 IORegistryEntryGetPath(io_registry_entry_t entry,
     const io_name_t plane __unused, io_string_t path)
 {
-	mach_port_t svc = __io_hwregd_port();
-	uint64_t parent_id;
-	int state;
-	char name[32], classname[32], driver[32], hwpath[256];
+	char hwpath[256];
 	kern_return_t kr;
 
 	if (entry == NULL || entry->kind != IOOBJ_KIND_ENTRY ||
 	    path == NULL)
 		return (KERN_INVALID_ARGUMENT);
-	if (svc == MACH_PORT_NULL)
-		return (kIOReturnNoDevice);
-	kr = hwreg_get_node(svc, entry->node_id, &parent_id, &state,
-	    name, classname, driver, hwpath);
+	kr = __io_node(entry->node_id, NULL, NULL, NULL, NULL, NULL, hwpath);
 	if (kr != KERN_SUCCESS)
 		return (kr);
 	/* Apple format: "<plane>:<components>". One plane → IOService. */

--- a/src/libIOKit/IOKitMatching.c
+++ b/src/libIOKit/IOKitMatching.c
@@ -14,11 +14,15 @@
 #include <IOKit/IOKitLib.h>
 #include "IOKitInternal.h"
 
-#include "hwreg.h"
+#include "ioregistry.h"		/* vendored K1 ABI; canonical in nextbsd-kernel */
+
+#include "hwreg.h"		/* fallback MIG stubs */
 #include "hwreg_mig_types.h"
 #include "nv.h"			/* libxpc nvlist API */
 
 #include <CoreFoundation/CoreFoundation.h>
+
+#include <sys/ioctl.h>		/* ioctl(2) on /dev/ioregistry */
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -86,33 +90,117 @@ nvlist_to_cfdict(const nvlist_t *nv, CFAllocatorRef allocator)
 	return (d);
 }
 
+/*
+ * Pull a node's packed-nvlist property bag from /dev/ioregistry
+ * (IOREGIOCPROPS). Two-step: size the bag (NULL buf), allocate, then
+ * fetch. Returns a malloc'd buffer (caller frees) and its length, or
+ * NULL with *kr_out set on failure. Returns KERN_SUCCESS / sets *len_out
+ * = 0 with a non-NULL allocation if the bag is empty (len 0 still gets a
+ * 1-byte allocation so the caller frees a real pointer).
+ */
+static void *
+ioreg_fetch_props(int fd, uint64_t node_id, uint32_t *len_out,
+    kern_return_t *kr_out)
+{
+	struct ioreg_props pr;
+	void *buf;
+	uint32_t need;
+
+	/* Step 1: size the bag (NULL buf). */
+	(void)memset(&pr, 0, sizeof(pr));
+	pr.id = node_id;
+	pr.len = 0;
+	pr.buf = 0;
+	if (ioctl(fd, IOREGIOCPROPS, &pr) != 0) {
+		*kr_out = kIOReturnNotFound;
+		return (NULL);
+	}
+	need = pr.len;
+	buf = malloc(need != 0 ? need : 1);
+	if (buf == NULL) {
+		*kr_out = KERN_RESOURCE_SHORTAGE;
+		return (NULL);
+	}
+	if (need == 0) {		/* empty bag — nothing to fetch */
+		*len_out = 0;
+		*kr_out = KERN_SUCCESS;
+		return (buf);
+	}
+
+	/* Step 2: fetch into the sized buffer. */
+	(void)memset(&pr, 0, sizeof(pr));
+	pr.id = node_id;
+	pr.len = need;
+	pr.buf = (uint64_t)(uintptr_t)buf;
+	if (ioctl(fd, IOREGIOCPROPS, &pr) != 0 || pr.len > need) {
+		/* A grown len means the bag changed under us — bail rather
+		 * than unpack a truncated nvlist. */
+		free(buf);
+		*kr_out = kIOReturnError;
+		return (NULL);
+	}
+	*len_out = pr.len;
+	*kr_out = KERN_SUCCESS;
+	return (buf);
+}
+
 kern_return_t
 IORegistryEntryCreateCFProperties(io_registry_entry_t entry,
     CFMutableDictionaryRef *properties, CFAllocatorRef allocator,
     IOOptionBits options __unused)
 {
-	mach_port_t svc = __io_hwregd_port();
-	hwreg_blob_t blob;
-	mach_msg_type_number_t cnt = 0;
+	int fd;
 	nvlist_t *nv;
 	kern_return_t kr;
 
 	if (entry == NULL || entry->kind != IOOBJ_KIND_ENTRY ||
 	    properties == NULL)
 		return (KERN_INVALID_ARGUMENT);
-	if (svc == MACH_PORT_NULL)
-		return (kIOReturnNoDevice);
 
-	kr = hwreg_get_properties(svc, entry->node_id, blob, &cnt);
-	if (kr != KERN_SUCCESS)
-		return (kr);
+	fd = __io_ioregistry_fd();
+	if (fd >= 0) {
+		void *buf;
+		uint32_t len = 0;
 
-	nv = nvlist_unpack(blob, cnt);
-	if (nv == NULL)
-		return (kIOReturnError);
-	*properties = nvlist_to_cfdict(nv, allocator);
-	nvlist_destroy(nv);
-	return (*properties != NULL ? KERN_SUCCESS : kIOReturnError);
+		buf = ioreg_fetch_props(fd, entry->node_id, &len, &kr);
+		if (buf == NULL)
+			return (kr);
+		if (len == 0) {
+			/* Empty bag -> empty dictionary (still a success). */
+			free(buf);
+			*properties = CFDictionaryCreateMutable(allocator, 0,
+			    &kCFTypeDictionaryKeyCallBacks,
+			    &kCFTypeDictionaryValueCallBacks);
+			return (*properties != NULL ? KERN_SUCCESS
+			    : kIOReturnError);
+		}
+		nv = nvlist_unpack(buf, len);
+		free(buf);
+		if (nv == NULL)
+			return (kIOReturnError);
+		*properties = nvlist_to_cfdict(nv, allocator);
+		nvlist_destroy(nv);
+		return (*properties != NULL ? KERN_SUCCESS : kIOReturnError);
+	}
+
+	/* Fallback: hwregd MIG property bag. */
+	{
+		mach_port_t svc = __io_hwregd_port();
+		hwreg_blob_t blob;
+		mach_msg_type_number_t cnt = 0;
+
+		if (svc == MACH_PORT_NULL)
+			return (kIOReturnNoDevice);
+		kr = hwreg_get_properties(svc, entry->node_id, blob, &cnt);
+		if (kr != KERN_SUCCESS)
+			return (kr);
+		nv = nvlist_unpack(blob, cnt);
+		if (nv == NULL)
+			return (kIOReturnError);
+		*properties = nvlist_to_cfdict(nv, allocator);
+		nvlist_destroy(nv);
+		return (*properties != NULL ? KERN_SUCCESS : kIOReturnError);
+	}
 }
 
 CFTypeRef
@@ -135,19 +223,16 @@ IORegistryEntryCreateCFProperty(io_registry_entry_t entry,
 kern_return_t
 IOObjectGetClass(io_object_t object, io_name_t className)
 {
-	mach_port_t svc = __io_hwregd_port();
-	uint64_t parent_id;
-	int state;
-	char name[32], classname[32], driver[32], path[256];
+	char classname[32];
 	kern_return_t kr;
 
 	if (object == NULL || object->kind != IOOBJ_KIND_ENTRY ||
 	    className == NULL)
 		return (KERN_INVALID_ARGUMENT);
-	if (svc == MACH_PORT_NULL)
-		return (kIOReturnNoDevice);
-	kr = hwreg_get_node(svc, object->node_id, &parent_id, &state,
-	    name, classname, driver, path);
+	/* __io_node picks /dev/ioregistry (IOREGIOCNODE) or hwregd; only
+	 * the class field is wanted, so the rest are skipped (NULLs). */
+	kr = __io_node(object->node_id, NULL, NULL, NULL, classname, NULL,
+	    NULL);
 	if (kr != KERN_SUCCESS)
 		return (kr);
 	(void)strlcpy(className, classname, sizeof(io_name_t));
@@ -244,36 +329,69 @@ __io_pack_criteria(const struct io_criteria *c, uint8_t *blob,
  * `ids_out`. KERN_SUCCESS even when 0 matches — the result is
  * "no matches", not an error.
  */
+#define IOKIT_MAX_MATCHES	128	/* hwreg.defs hwreg_id_array_t bound */
+
 static kern_return_t
 lookup_matches(CFDictionaryRef matching, uint64_t **ids_out,
     uint32_t *count_out)
 {
-	mach_port_t svc = __io_hwregd_port();
+	int fd = __io_ioregistry_fd();
 	struct io_criteria c;
-	hwreg_blob_t critblob;
+	hwreg_blob_t critblob;	/* packed criteria nvlist; same wire format
+				 * for both /dev/ioregistry and hwregd */
 	uint32_t psz = 0;
 	uint64_t *ids;
-	mach_msg_type_number_t nids = 128;
+	uint32_t cap = IOKIT_MAX_MATCHES;
 	kern_return_t kr;
 
-	if (svc == MACH_PORT_NULL)
-		return (kIOReturnNoDevice);
 	__io_extract_criteria(matching, &c);
 	kr = __io_pack_criteria(&c, critblob, &psz);
 	if (kr != KERN_SUCCESS)
 		return (kr);
-	ids = calloc(nids, sizeof(*ids));
+	ids = calloc(cap, sizeof(*ids));
 	if (ids == NULL)
 		return (KERN_RESOURCE_SHORTAGE);
-	kr = hwreg_lookup(svc, critblob, (mach_msg_type_number_t)psz,
-	    ids, &nids);
-	if (kr != KERN_SUCCESS) {
-		free(ids);
-		return (kr);
+
+	if (fd >= 0) {
+		struct ioreg_lookup lk;
+
+		(void)memset(&lk, 0, sizeof(lk));
+		/* crit_len 0 (no criteria survived extraction) matches every
+		 * live node — same semantics as the kernel ABI documents. */
+		lk.buf_criteria = (uint64_t)(uintptr_t)critblob;
+		lk.crit_len = psz;
+		lk.max = cap;
+		lk.matches = (uint64_t)(uintptr_t)ids;
+		if (ioctl(fd, IOREGIOCLOOKUP, &lk) != 0) {
+			free(ids);
+			return (kIOReturnError);
+		}
+		if (lk.count > cap)	/* truncated to our fixed array */
+			lk.count = cap;
+		*ids_out = ids;
+		*count_out = lk.count;
+		return (KERN_SUCCESS);
 	}
-	*ids_out = ids;
-	*count_out = nids;
-	return (KERN_SUCCESS);
+
+	/* Fallback: hwregd MIG. */
+	{
+		mach_port_t svc = __io_hwregd_port();
+		mach_msg_type_number_t nids = cap;
+
+		if (svc == MACH_PORT_NULL) {
+			free(ids);
+			return (kIOReturnNoDevice);
+		}
+		kr = hwreg_lookup(svc, critblob, (mach_msg_type_number_t)psz,
+		    ids, &nids);
+		if (kr != KERN_SUCCESS) {
+			free(ids);
+			return (kr);
+		}
+		*ids_out = ids;
+		*count_out = nids;
+		return (KERN_SUCCESS);
+	}
 }
 
 io_service_t

--- a/src/libIOKit/ioregistry.h
+++ b/src/libIOKit/ioregistry.h
@@ -1,0 +1,123 @@
+/*
+ * VENDORED COPY — keep in sync with the kernel canonical.
+ *
+ * Canonical: nextbsd-kernel src-overlay/sys/sys/ioregistry.h (installed as
+ * <sys/ioregistry.h> in the kernel sysroot). Userland in this repo cannot
+ * include the kernel src-overlay directly, so libIOKit carries a verbatim
+ * copy of the K1 (#214) ABI here — the same convention kextd uses for its
+ * vendored sys/iocatalogue.h. If the canonical struct/ioctl definitions ever
+ * change, update this file to match; the ABI is frozen once shipped, so this
+ * mirror should rarely move.
+ *
+ * --- canonical contents below, verbatim ---
+ *
+ * NextBSD in-kernel IORegistry (K1, nextbsd#214).
+ *
+ * A read-only, on-demand in-kernel view of the live newbus device_t tree,
+ * presented as IOKit-style nodes + property bags and queryable from userland
+ * via ioctl on /dev/ioregistry. This is the kernel-served replacement for
+ * hwregd's tree: hwregd is merely a userland cache of hw.bus sysctls plus
+ * /dev/devctl events, whereas this walks the real device_t tree directly.
+ *
+ * PR1 (#214) is kernel-only and read-only: it builds no shadow tree, it walks
+ * the live newbus topology on demand. A stable uint64 registry id is minted per
+ * device_t (and lingers, marked detached, after the device goes away) so a
+ * userland iterator never dangles. The libIOKit migration (later PR) consumes
+ * this ABI; keep these structs frozen once shipped.
+ *
+ * See pkgdemon.github.io/nextbsd-inkernel-iokit-feasibility.html.
+ */
+#ifndef _SYS_IOREGISTRY_H_
+#define _SYS_IOREGISTRY_H_
+
+#include <sys/types.h>
+#include <sys/ioccom.h>
+
+#define	IOREG_NAME_MAX		32	/* device name / class / driver field */
+#define	IOREG_PATH_MAX		256	/* full newbus path, incl. NUL */
+#define	IOREG_CRIT_MAX		65536	/* max packed criteria nvlist (bytes) */
+
+/*
+ * Node lifecycle state (ioreg_node.state). Distinct from the newbus
+ * device_state_t: this is the registry id's own liveness, so a userland
+ * iterator can tell a live node from one that detached but has not yet aged
+ * out (linger-until-unreferenced, mirroring hwregd).
+ */
+#define	IOREG_STATE_LIVE	0	/* device_t currently present */
+#define	IOREG_STATE_DETACHED	1	/* device gone; id lingering */
+
+/*
+ * One registry node. Fixed-size and self-contained so the ABI is identical for
+ * 32- and 64-bit userland. `id` is the stable registry id (never reused while
+ * lingering); `parent_id` is 0 for the root. The pci_* fields are 0 unless the
+ * node is a PCI nub (its parent bus is "pci"); pci_class holds the 8-bit PCI
+ * base class in its low bits.
+ */
+struct ioreg_node {
+	uint64_t	id;			/* stable registry id; 0 = invalid */
+	uint64_t	parent_id;		/* parent's id, 0 if root */
+	int32_t		state;			/* IOREG_STATE_* */
+	int32_t		devstate;		/* newbus device_state_t (DS_*) */
+	char		name[IOREG_NAME_MAX];	/* device_get_name() */
+	char		classname[IOREG_NAME_MAX]; /* devclass name */
+	char		driver[IOREG_NAME_MAX];	/* bound driver name, "" if none */
+	char		path[IOREG_PATH_MAX];	/* nameunit path from root */
+	uint32_t	pci_vendor;		/* PCI vendor id, 0 if n/a */
+	uint32_t	pci_device;		/* PCI device id, 0 if n/a */
+	uint32_t	pci_subvendor;		/* PCI subsystem vendor, 0 if n/a */
+	uint32_t	pci_class;		/* PCI base class (low 8 bits) */
+};
+
+/*
+ * Enumerate a node's immediate children. Userland sets `id` (the parent) and
+ * `max` (capacity of the `children` array, a user ptr to uint64_t[max]); the
+ * kernel writes up to `max` child ids and sets `count` to the number of
+ * children that exist. If count > max the array was truncated — userland should
+ * grow the buffer and retry. `children` is a uint64_t for 32/64 ABI parity.
+ */
+struct ioreg_children {
+	uint64_t	id;		/* in: parent node id */
+	uint32_t	max;		/* in: capacity of children[] */
+	uint32_t	count;		/* out: number of children that exist */
+	uint64_t	children;	/* in: user ptr to uint64_t[max] */
+};
+
+/*
+ * Fetch a node's property bag as a packed nvlist(9). Userland sets `id` and
+ * `len` (capacity of `buf`, a user ptr); the kernel packs the bag, writes it
+ * (up to `len` bytes) to buf, and sets `len` to the full packed size. If the
+ * returned len > the input len the buffer was too small — userland grows it and
+ * retries. A NULL buf (len ignored) just sizes the bag. The bag carries the
+ * same keys as ioreg_node plus any device_has_property()-visible scalars.
+ */
+struct ioreg_props {
+	uint64_t	id;		/* in: node id */
+	uint32_t	len;		/* in: buf capacity; out: full packed size */
+	uint32_t	_pad;
+	uint64_t	buf;		/* in: user ptr to packed nvlist bytes */
+};
+
+/*
+ * Look up nodes matching a packed-nvlist criteria bag (e.g. {"name":"pci"} or
+ * {"pci_vendor":0x8086}). Userland sets `buf_criteria`/`crit_len` (a packed
+ * nvlist of scalar keys, AND-matched against each node) and `max` (capacity of
+ * the `matches` array, user ptr to uint64_t[max]); the kernel writes up to
+ * `max` matching ids and sets `count` to the total number of matches. count >
+ * max means truncation. crit_len == 0 matches every live node.
+ */
+struct ioreg_lookup {
+	uint64_t	buf_criteria;	/* in: user ptr to packed nvlist criteria */
+	uint32_t	crit_len;	/* in: length of criteria bag, 0 = match all */
+	uint32_t	max;		/* in: capacity of matches[] */
+	uint32_t	count;		/* out: total number of matches */
+	uint32_t	_pad;
+	uint64_t	matches;	/* in: user ptr to uint64_t[max] */
+};
+
+#define	IOREGIOCROOT	_IOR('R', 1, uint64_t)		   /* get root node id */
+#define	IOREGIOCCHILDREN _IOWR('R', 2, struct ioreg_children) /* enum children */
+#define	IOREGIOCNODE	_IOWR('R', 3, struct ioreg_node)   /* node by id (in id) */
+#define	IOREGIOCPROPS	_IOWR('R', 4, struct ioreg_props)  /* node property bag */
+#define	IOREGIOCLOOKUP	_IOWR('R', 5, struct ioreg_lookup) /* match by criteria */
+
+#endif /* _SYS_IOREGISTRY_H_ */

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -1192,6 +1192,33 @@ expect {
 # nextbsd-kernel's smoke test boots an image built before kextd/K2 shipped);
 # only an explicit IOCATALOGUE-FAIL gates.
 send "/usr/tests/nextbsd-iokit/run.sh\r"
+
+# IOREG — C1.1 (#218) libIOKit registry migration gate. nextbsd-iokit/run.sh
+# now runs the IOREG check FIRST (before the IOCATALOGUE/IOKIT-LOOKUP/KEXTD-LOAD
+# markers below) so a K1-but-no-K2 kernel still reports it. libIOKit now walks
+# the K1 /dev/ioregistry device (falling back to hwregd when absent); the
+# `ioreg` tool is run over the live device and the root + boot disk/NIC nubs are
+# asserted. This is also the deferred K1 functional proof. The on-image script
+# self-SKIPs on a kernel predating /dev/ioregistry, so this stays green on
+# pre-K1 continuous images; the timeout here is non-fatal (older run.sh lacking
+# the IOREG step), and only an explicit IOREG-FAIL gates. OK/SKIP are folded
+# into one block that ends only on OK/FAIL/SKIP, so it can never sit blocking
+# while a later required marker scrolls past (the MDNS-IFWATCH lesson).
+expect {
+    timeout {
+        puts "\nWARN: IOREG marker not seen (pre-C1.1 run.sh — informational)"
+    }
+    "IOREG-FAIL" {
+        puts "\nFAIL: libIOKit /dev/ioregistry walk did not show the registry"
+        exit 1
+    }
+    "IOREG-SKIP" {
+        puts "\nWARN: IOREG-SKIP — no /dev/ioregistry (kernel without K1)"
+    }
+    "IOREG-OK" {
+        puts "\nOK: libIOKit walks /dev/ioregistry (root + boot device nubs)"
+    }
+}
 expect {
     timeout {
         puts "\nWARN: IOCATALOGUE marker not seen (pre-kextd/K2 image — informational)"
@@ -1254,6 +1281,7 @@ expect {
         puts "\nOK: kextd daemon loaded if_iwlwifi on a kernel load request"
     }
 }
+
 set timeout 60
 
 # Stage 4: clean halt so qemu exits 0 (the -no-reboot flag turns


### PR DESCRIPTION
## What

Repoint libIOKit's IORegistry walk from the hwregd MIG RPC to the new in-kernel **`/dev/ioregistry`** device (the K1 registry, #214), **keeping an hwregd fallback** so nothing breaks on an old-kernel image that lacks the device. This is the first consumer migration toward retiring hwregd (PR7).

## Vendored ABI

`src/libIOKit/ioregistry.h` — a verbatim copy of the kernel-canonical `sys/ioregistry.h`, carrying a keep-in-sync note. Userland can't include the kernel src-overlay directly, so this mirrors how kextd vendors `sys/iocatalogue.h`.

## Migration + fallback

- Cache `open("/dev/ioregistry", O_RDONLY|O_CLOEXEC)` under the existing `pthread_once` (now shared with the hwregd `bootstrap_look_up`). The fd is process-lived (never closed) and `O_CLOEXEC`-guarded.
- **If the open fails, a flag (`fd < 0`) routes every entry point back to the hwregd MIG path** — all `hwreg_*` code stays compiled. This dual-path is the safety net until hwregd is deleted (PR7).
- Op mapping:
  - `IORegistryGetRootEntry` -> `IOREGIOCROOT`
  - `IORegistryEntryGetChildIterator` -> `IOREGIOCCHILDREN`
  - `IORegistryEntryGetName` / `GetPath` / `IOObjectGetClass` -> `IOREGIOCNODE` via a shared `__io_node` helper (`ioreg_node`'s layout matches `hwreg_get_node`'s out-params, so call sites change minimally)
  - `IORegistryEntryCreateCFProperties` -> `IOREGIOCPROPS` (size-then-fetch, `nvlist_unpack` via libnv)
  - `IOServiceGetMatchingService(s)` -> `IOREGIOCLOOKUP`
- `IOKitNotify.c` (PR4) and DiskArbitration (PR5) untouched; the sysctl-backed `mach.bus.busy` / `mach_wait_quiet` path is left as-is.

## Functional test (also the deferred K1 functional proof)

`overlays/usr/tests/nextbsd-iokit/run.sh` gains an **IOREG gate**: it runs `ioreg` over the live `/dev/ioregistry` and asserts the registry root plus the boot disk/NIC nubs, emitting `IOREG-OK` / `IOREG-FAIL` / `IOREG-SKIP`.

- Runs **first** in the script (before the IOCATALOGUE early-exit) so a K1-but-no-K2 kernel still reports it, and is wrapped in a function that emits exactly one marker and `return`s (never `exit`s) so it can't short-circuit the later catalogue/matcher checks.
- **Self-SKIPs** when `/dev/ioregistry` is absent (pre-K1 image), staying green on continuous images built before #214.
- The `tests/boot-test.sh` expect block folds OK/SKIP into one non-terminating block that ends only on OK/FAIL/SKIP (the MDNS-IFWATCH lesson — an optional marker must not block the stream and swallow a later required marker); only `IOREG-FAIL` gates.

## CI

`src/libIOKit` is non-tests -> full build, which pulls the kernel `continuous` that now contains K1, so the built ISO has `/dev/ioregistry` and the boot test exercises the live path.

## Risks

- ABI drift: the vendored header must track the kernel canonical (noted in-file; ABI is frozen once shipped).
- The fast path assumes the kernel fills `ioreg_node`'s char fields NUL-terminated within their fixed sizes (the K1 contract); the fallback path is unchanged.
- Children/lookup use a fixed 128-id capacity (mirroring the hwregd bound) and clamp on `count > max`; very wide nodes would truncate, same as before.

Refs #214 #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)