### PR TITLE
libIOKit: migrate IOKitNotify onto the kernel notify channel (C1.2, #218)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2104,6 +2104,28 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/iokitnotifytest" \
     || { echo "FAIL: iokitnotifytest not built"; exit 1; }
 echo "==> iokitnotifytest built"
 
+# iokitnotifyrt — libIOKit notification ROUND-TRIP test (C1.2, #218). Registers
+# a matching notification through libIOKit (-> IOREGIOCWATCH on /dev/ioregistry)
+# then fires the IOREGIOCTESTEVENT inject ioctl to synthesize a matching device
+# event and confirms the registered callback fires — the deterministic proof of
+# the kernel notify channel migration. SELF-SKIPs when /dev/ioregistry or
+# IOREGIOCTESTEVENT is absent, so it is green on continuous images built before
+# the Part A kernel ingests. -I src/libIOKit for the vendored ioregistry.h
+# (IOREGIOCTESTEVENT / struct ioreg_test_event).
+echo "==> building iokitnotifyrt"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -I"$ROOT/src/libIOKit" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/iokitnotifyrt" \
+   "$ROOT/src/libIOKit/iokitnotifyrt.c" \
+   -lIOKit -lCoreFoundation -ldispatch -lBlocksRuntime \
+   -lsystem_kernel -llaunch -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/iokitnotifyrt" \
+    || { echo "FAIL: iokitnotifyrt not built"; exit 1; }
+echo "==> iokitnotifyrt built"
+
 #
 # 3s. Phase J1 iter 1 — generate libnotify MIG stubs + build libnotify.
 #     Apple's libnotify client library (src/Libnotify/). Vendored at

--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -82,6 +82,52 @@ ioreg_gate()
 }
 ioreg_gate
 
+# IOKITNOTIFY — C1.2 (#218) IOKitNotify migration round-trip gate. The
+# iokitnotifyrt client registers a matching notification through libIOKit (which
+# now registers the recv port via IOREGIOCWATCH on the in-kernel registry, #225)
+# and fires the IOREGIOCTESTEVENT inject ioctl to synthesize a matching device
+# event, then confirms the registered callback received it. This is the
+# deterministic proof of the kernel notify channel without a physical device.
+#
+#   IOKITNOTIFY-OK    — injected event round-tripped to the callback
+#   IOKITNOTIFY-FAIL  — channel present but the callback never fired
+#   IOKITNOTIFY-SKIP  — no /dev/ioregistry, no IOREGIOCTESTEVENT, or no client
+#
+# CRITICAL (MDNS-IFWATCH lesson): the client ALWAYS prints exactly one definite
+# marker — including a SELF-SKIP when the round-trip can't be staged (a kernel
+# predating the Part A inject ioctl, i.e. a continuous image built before the
+# kernel PR ingests). Run it as a function that emits one marker and RETURNS
+# (never exits) so the IOCATALOGUE / IOKIT-LOOKUP / KEXTD-LOAD checks below still
+# run. The boot test gates on the IOKITNOTIFY-FAIL *string*, not this script's
+# exit code.
+iokitnotify_gate()
+{
+	rt=/usr/tests/freebsd-launchd-mach/iokitnotifyrt
+
+	if [ ! -x "$rt" ]; then
+		echo "IOKITNOTIFY-SKIP: iokitnotifyrt client not present"
+		return 0
+	fi
+	# iokitnotifyrt prints exactly one IOKITNOTIFY-{OK,FAIL,SKIP} line and
+	# self-skips on a kernel without /dev/ioregistry or IOREGIOCTESTEVENT. It
+	# is self-bounding (a ~5s callback budget; its receive thread joins on a
+	# 500ms mach_msg timeout) so it cannot stall the boot test. If it somehow
+	# produces no marker at all (crash / signal), synthesize a SKIP so the
+	# expect stream always advances on a definite line.
+	out=$("$rt" 2>&1)
+	rc=$?
+	echo "=== iokitnotifyrt (rc=${rc}) ==="
+	echo "${out}"
+	echo "==="
+	if echo "${out}" | grep -q '^IOKITNOTIFY-'; then
+		:	# the client already emitted its definite marker
+	else
+		echo "IOKITNOTIFY-SKIP: iokitnotifyrt produced no marker (rc=${rc})"
+	fi
+	return 0
+}
+iokitnotify_gate
+
 
 if [ ! -c /dev/iocatalogue ]; then
 	echo "IOCATALOGUE-SKIP: no /dev/iocatalogue (kernel without the K2 IOCatalogue)"

--- a/src/libIOKit/IOKitInternal.h
+++ b/src/libIOKit/IOKitInternal.h
@@ -112,15 +112,17 @@ kern_return_t	__io_pack_criteria(const struct io_criteria *c,
 		    uint8_t *blob, uint32_t *out_size);
 
 /*
- * Pack a criteria struct into the FreeBSD KERNEL libnv wire format, for the
- * /dev/ioregistry IOREGIOC{WATCH,LOOKUP} ioctls whose handlers unpack with the
- * base system's sys/contrib/libnv nvlist_unpack(). That layout differs from
- * this repo's libxpc nvlist (an extra nvlh_type header byte and a trailing
- * nvph_nitems per pair), so the libxpc-packed blob from __io_pack_criteria()
- * fails to unpack in the kernel (#218). Use this for the kernel ioctl paths;
- * keep __io_pack_criteria() for the hwregd RPC fallback (libxpc on both ends).
+ * Fill a flat kernel `struct ioreg_criteria` from an io_criteria for the
+ * /dev/ioregistry IOREGIOC{WATCH,LOOKUP} ioctls (#218). These ioctls now carry
+ * the criteria as a fixed by-value struct instead of a packed nvlist: there is
+ * no serialization, so the former libxpc-vs-libnv wire-format mismatch that
+ * broke the #218 round-trip simply cannot happen. Non-empty string fields and
+ * non-zero numeric fields constrain the match (zero-as-wildcard); the hwregd RPC
+ * fallback still uses __io_pack_criteria() (libxpc nvlist over MIG, both ends).
+ * Declared with a forward struct ref so this header pulls in no kernel ABI.
  */
-kern_return_t	__io_pack_criteria_libnv(const struct io_criteria *c,
-		    uint8_t *blob, uint32_t *out_size);
+struct ioreg_criteria;
+void	__io_fill_criteria(const struct io_criteria *c,
+		    struct ioreg_criteria *out);
 
 #endif /* _IOKIT_INTERNAL_H_ */

--- a/src/libIOKit/IOKitInternal.h
+++ b/src/libIOKit/IOKitInternal.h
@@ -111,4 +111,16 @@ void	__io_extract_criteria(CFDictionaryRef matching,
 kern_return_t	__io_pack_criteria(const struct io_criteria *c,
 		    uint8_t *blob, uint32_t *out_size);
 
+/*
+ * Pack a criteria struct into the FreeBSD KERNEL libnv wire format, for the
+ * /dev/ioregistry IOREGIOC{WATCH,LOOKUP} ioctls whose handlers unpack with the
+ * base system's sys/contrib/libnv nvlist_unpack(). That layout differs from
+ * this repo's libxpc nvlist (an extra nvlh_type header byte and a trailing
+ * nvph_nitems per pair), so the libxpc-packed blob from __io_pack_criteria()
+ * fails to unpack in the kernel (#218). Use this for the kernel ioctl paths;
+ * keep __io_pack_criteria() for the hwregd RPC fallback (libxpc on both ends).
+ */
+kern_return_t	__io_pack_criteria_libnv(const struct io_criteria *c,
+		    uint8_t *blob, uint32_t *out_size);
+
 #endif /* _IOKIT_INTERNAL_H_ */

--- a/src/libIOKit/IOKitMatching.c
+++ b/src/libIOKit/IOKitMatching.c
@@ -324,110 +324,32 @@ __io_pack_criteria(const struct io_criteria *c, uint8_t *blob,
 }
 
 /*
- * Pack a criteria struct into the FreeBSD KERNEL libnv wire format (#218).
+ * Fill a flat kernel `struct ioreg_criteria` from an io_criteria (#218).
  *
- * The kernel /dev/ioregistry IOREGIOC{WATCH,LOOKUP} handlers unpack the
- * criteria blob with the base system's sys/contrib/libnv nvlist_unpack(), whose
- * on-the-wire layout is NOT the same as this repo's libxpc nvlist (used by
- * __io_pack_criteria above and by the hwregd RPCs). Two concrete differences
- * make a libxpc-packed blob fail to unpack in the kernel:
+ * The kernel /dev/ioregistry IOREGIOC{WATCH,LOOKUP} handlers no longer unpack a
+ * packed-nvlist criteria bag — they read this fixed by-value struct directly.
+ * That removes the libxpc-vs-libnv wire-format mismatch (libxpc's packer added
+ * an extra nvlh_type header byte and omitted the trailing nvph_nitems the
+ * kernel's libnv reader expects) which made every kernel nvlist_unpack() return
+ * NULL, so IOREGIOCWATCH returned EINVAL and no watch ever registered — the #218
+ * round-trip break. There is no serialization here, so nothing can mismatch.
  *
- *   - nvlist header: libxpc's struct nvlist_header has an extra uint8_t
- *     nvlh_type at offset 3 (a libxpc dictionary/array extension); the kernel's
- *     has none. So every following field is shifted one byte and the kernel's
- *     "nvlh_size == left - sizeof(header)" check fails (header sizes 20 vs 19).
- *   - nvpair header: the kernel's struct nvpair_header carries a trailing
- *     uint64_t nvph_nitems that libxpc's omits, shifting each pair by 8 bytes.
- *
- * Either mismatch makes the kernel nvlist_unpack() return NULL, so IOREGIOCWATCH
- * returns EINVAL and the watch is never registered (the #218 round-trip break).
- * The criteria are only ever a flat set of NV_TYPE_STRING pairs (name/class/
- * driver), so we serialize them directly in the kernel format here rather than
- * teach libxpc a second wire format.
- *
- * Kernel wire format (little-endian, __packed; mirrors sys/contrib/libnv):
- *   nvlist_header (19 bytes): u8 magic=0x6c, u8 version=0, u8 flags=0,
- *       u64 descriptors=0, u64 size=<bytes after this header>
- *   per pair (19 bytes + namesize + datasize): u8 type=3 (NV_TYPE_STRING),
- *       u16 namesize=strlen(key)+1, u64 datasize=strlen(val)+1, u64 nitems=0,
- *       key bytes (incl NUL), value bytes (incl NUL)
+ * Mapping: io_criteria name/klass/driver -> the kernel criteria name/classname/
+ * driver. Empty source strings are left zeroed (the kernel treats a zero field
+ * as a wildcard). The pci_* numeric criteria are unused by the current Apple
+ * matching keys and stay zero (also wildcard). The hwregd RPC fallback still
+ * uses __io_pack_criteria() (libxpc nvlist over MIG — a working transport).
  */
-#define	NV_HDR_MAGIC		0x6cu
-#define	NVPAIR_TYPE_STRING	3u	/* sys/contrib/libnv NV_TYPE_STRING */
-
-static void
-le_put16(uint8_t *p, uint16_t v)
+void
+__io_fill_criteria(const struct io_criteria *c, struct ioreg_criteria *out)
 {
-	p[0] = (uint8_t)(v & 0xff);
-	p[1] = (uint8_t)((v >> 8) & 0xff);
-}
-
-static void
-le_put64(uint8_t *p, uint64_t v)
-{
-	int i;
-
-	for (i = 0; i < 8; i++)
-		p[i] = (uint8_t)((v >> (8 * i)) & 0xff);
-}
-
-/* Append one NV_TYPE_STRING pair to `blob` at *off (bounded by cap). Returns
- * KERN_SUCCESS or kIOReturnError on overflow. */
-static kern_return_t
-libnv_append_string(uint8_t *blob, size_t cap, size_t *off,
-    const char *key, const char *val)
-{
-	size_t namesz = strlen(key) + 1;
-	size_t datasz = strlen(val) + 1;
-	size_t need = 1 + 2 + 8 + 8 + namesz + datasz;	/* nvpair_header + name + data */
-
-	if (*off + need > cap)
-		return (kIOReturnError);
-	blob[*off + 0] = (uint8_t)NVPAIR_TYPE_STRING;
-	le_put16(&blob[*off + 1], (uint16_t)namesz);
-	le_put64(&blob[*off + 3], (uint64_t)datasz);
-	le_put64(&blob[*off + 11], 0);			/* nvph_nitems == 0 for a string */
-	*off += 19;
-	(void)memcpy(&blob[*off], key, namesz);
-	*off += namesz;
-	(void)memcpy(&blob[*off], val, datasz);
-	*off += datasz;
-	return (KERN_SUCCESS);
-}
-
-kern_return_t
-__io_pack_criteria_libnv(const struct io_criteria *c, uint8_t *blob,
-    uint32_t *out_size)
-{
-	const size_t cap = sizeof(hwreg_blob_t);
-	size_t off = 19;	/* leave room for the nvlist_header, filled last */
-	kern_return_t kr;
-
-	if (cap < 19)
-		return (kIOReturnError);
-
-	if (c->klass[0] != '\0' &&
-	    (kr = libnv_append_string(blob, cap, &off, "class", c->klass))
-	    != KERN_SUCCESS)
-		return (kr);
-	if (c->name[0] != '\0' &&
-	    (kr = libnv_append_string(blob, cap, &off, "name", c->name))
-	    != KERN_SUCCESS)
-		return (kr);
-	if (c->driver[0] != '\0' &&
-	    (kr = libnv_append_string(blob, cap, &off, "driver", c->driver))
-	    != KERN_SUCCESS)
-		return (kr);
-
-	/* nvlist_header: magic, version 0, flags 0, descriptors 0, size = body. */
-	blob[0] = (uint8_t)NV_HDR_MAGIC;
-	blob[1] = 0;			/* version */
-	blob[2] = 0;			/* flags (must be 0: unpack(...,flags=0)) */
-	le_put64(&blob[3], 0);		/* descriptors */
-	le_put64(&blob[11], (uint64_t)(off - 19));	/* size after the header */
-
-	*out_size = (uint32_t)off;
-	return (KERN_SUCCESS);
+	(void)memset(out, 0, sizeof(*out));
+	if (c->name[0] != '\0')
+		(void)strlcpy(out->name, c->name, sizeof(out->name));
+	if (c->klass[0] != '\0')
+		(void)strlcpy(out->classname, c->klass, sizeof(out->classname));
+	if (c->driver[0] != '\0')
+		(void)strlcpy(out->driver, c->driver, sizeof(out->driver));
 }
 
 /*
@@ -444,23 +366,11 @@ lookup_matches(CFDictionaryRef matching, uint64_t **ids_out,
 {
 	int fd = __io_ioregistry_fd();
 	struct io_criteria c;
-	hwreg_blob_t critblob;	/* packed criteria nvlist; same wire format
-				 * for both /dev/ioregistry and hwregd */
-	uint32_t psz = 0;
 	uint64_t *ids;
 	uint32_t cap = IOKIT_MAX_MATCHES;
 	kern_return_t kr;
 
 	__io_extract_criteria(matching, &c);
-	/* Pack in the chosen backend's wire format: base-system libnv for the
-	 * kernel /dev/ioregistry IOREGIOCLOOKUP handler, libxpc for the hwregd
-	 * RPC fallback. The libxpc-vs-libnv mismatch is the #218 root cause (see
-	 * __io_pack_criteria_libnv); the same fix applies to LOOKUP and WATCH. */
-	kr = (fd >= 0)
-	    ? __io_pack_criteria_libnv(&c, critblob, &psz)
-	    : __io_pack_criteria(&c, critblob, &psz);
-	if (kr != KERN_SUCCESS)
-		return (kr);
 	ids = calloc(cap, sizeof(*ids));
 	if (ids == NULL)
 		return (KERN_RESOURCE_SHORTAGE);
@@ -468,11 +378,11 @@ lookup_matches(CFDictionaryRef matching, uint64_t **ids_out,
 	if (fd >= 0) {
 		struct ioreg_lookup lk;
 
+		/* Flat by-value criteria (#218): no nvlist packing, so nothing to
+		 * mismatch. An all-zero criteria (no key survived extraction)
+		 * matches every live node — the kernel ABI's documented default. */
 		(void)memset(&lk, 0, sizeof(lk));
-		/* crit_len 0 (no criteria survived extraction) matches every
-		 * live node — same semantics as the kernel ABI documents. */
-		lk.buf_criteria = (uint64_t)(uintptr_t)critblob;
-		lk.crit_len = psz;
+		__io_fill_criteria(&c, &lk.criteria);
 		lk.max = cap;
 		lk.matches = (uint64_t)(uintptr_t)ids;
 		if (ioctl(fd, IOREGIOCLOOKUP, &lk) != 0) {
@@ -486,14 +396,22 @@ lookup_matches(CFDictionaryRef matching, uint64_t **ids_out,
 		return (KERN_SUCCESS);
 	}
 
-	/* Fallback: hwregd MIG. */
+	/* Fallback: hwregd MIG — libxpc-packed nvlist criteria over the RPC (a
+	 * working transport: libxpc on both ends). */
 	{
 		mach_port_t svc = __io_hwregd_port();
+		hwreg_blob_t critblob;
+		uint32_t psz = 0;
 		mach_msg_type_number_t nids = cap;
 
 		if (svc == MACH_PORT_NULL) {
 			free(ids);
 			return (kIOReturnNoDevice);
+		}
+		kr = __io_pack_criteria(&c, critblob, &psz);
+		if (kr != KERN_SUCCESS) {
+			free(ids);
+			return (kr);
 		}
 		kr = hwreg_lookup(svc, critblob, (mach_msg_type_number_t)psz,
 		    ids, &nids);

--- a/src/libIOKit/IOKitMatching.c
+++ b/src/libIOKit/IOKitMatching.c
@@ -324,6 +324,113 @@ __io_pack_criteria(const struct io_criteria *c, uint8_t *blob,
 }
 
 /*
+ * Pack a criteria struct into the FreeBSD KERNEL libnv wire format (#218).
+ *
+ * The kernel /dev/ioregistry IOREGIOC{WATCH,LOOKUP} handlers unpack the
+ * criteria blob with the base system's sys/contrib/libnv nvlist_unpack(), whose
+ * on-the-wire layout is NOT the same as this repo's libxpc nvlist (used by
+ * __io_pack_criteria above and by the hwregd RPCs). Two concrete differences
+ * make a libxpc-packed blob fail to unpack in the kernel:
+ *
+ *   - nvlist header: libxpc's struct nvlist_header has an extra uint8_t
+ *     nvlh_type at offset 3 (a libxpc dictionary/array extension); the kernel's
+ *     has none. So every following field is shifted one byte and the kernel's
+ *     "nvlh_size == left - sizeof(header)" check fails (header sizes 20 vs 19).
+ *   - nvpair header: the kernel's struct nvpair_header carries a trailing
+ *     uint64_t nvph_nitems that libxpc's omits, shifting each pair by 8 bytes.
+ *
+ * Either mismatch makes the kernel nvlist_unpack() return NULL, so IOREGIOCWATCH
+ * returns EINVAL and the watch is never registered (the #218 round-trip break).
+ * The criteria are only ever a flat set of NV_TYPE_STRING pairs (name/class/
+ * driver), so we serialize them directly in the kernel format here rather than
+ * teach libxpc a second wire format.
+ *
+ * Kernel wire format (little-endian, __packed; mirrors sys/contrib/libnv):
+ *   nvlist_header (19 bytes): u8 magic=0x6c, u8 version=0, u8 flags=0,
+ *       u64 descriptors=0, u64 size=<bytes after this header>
+ *   per pair (19 bytes + namesize + datasize): u8 type=3 (NV_TYPE_STRING),
+ *       u16 namesize=strlen(key)+1, u64 datasize=strlen(val)+1, u64 nitems=0,
+ *       key bytes (incl NUL), value bytes (incl NUL)
+ */
+#define	NV_HDR_MAGIC		0x6cu
+#define	NVPAIR_TYPE_STRING	3u	/* sys/contrib/libnv NV_TYPE_STRING */
+
+static void
+le_put16(uint8_t *p, uint16_t v)
+{
+	p[0] = (uint8_t)(v & 0xff);
+	p[1] = (uint8_t)((v >> 8) & 0xff);
+}
+
+static void
+le_put64(uint8_t *p, uint64_t v)
+{
+	int i;
+
+	for (i = 0; i < 8; i++)
+		p[i] = (uint8_t)((v >> (8 * i)) & 0xff);
+}
+
+/* Append one NV_TYPE_STRING pair to `blob` at *off (bounded by cap). Returns
+ * KERN_SUCCESS or kIOReturnError on overflow. */
+static kern_return_t
+libnv_append_string(uint8_t *blob, size_t cap, size_t *off,
+    const char *key, const char *val)
+{
+	size_t namesz = strlen(key) + 1;
+	size_t datasz = strlen(val) + 1;
+	size_t need = 1 + 2 + 8 + 8 + namesz + datasz;	/* nvpair_header + name + data */
+
+	if (*off + need > cap)
+		return (kIOReturnError);
+	blob[*off + 0] = (uint8_t)NVPAIR_TYPE_STRING;
+	le_put16(&blob[*off + 1], (uint16_t)namesz);
+	le_put64(&blob[*off + 3], (uint64_t)datasz);
+	le_put64(&blob[*off + 11], 0);			/* nvph_nitems == 0 for a string */
+	*off += 19;
+	(void)memcpy(&blob[*off], key, namesz);
+	*off += namesz;
+	(void)memcpy(&blob[*off], val, datasz);
+	*off += datasz;
+	return (KERN_SUCCESS);
+}
+
+kern_return_t
+__io_pack_criteria_libnv(const struct io_criteria *c, uint8_t *blob,
+    uint32_t *out_size)
+{
+	const size_t cap = sizeof(hwreg_blob_t);
+	size_t off = 19;	/* leave room for the nvlist_header, filled last */
+	kern_return_t kr;
+
+	if (cap < 19)
+		return (kIOReturnError);
+
+	if (c->klass[0] != '\0' &&
+	    (kr = libnv_append_string(blob, cap, &off, "class", c->klass))
+	    != KERN_SUCCESS)
+		return (kr);
+	if (c->name[0] != '\0' &&
+	    (kr = libnv_append_string(blob, cap, &off, "name", c->name))
+	    != KERN_SUCCESS)
+		return (kr);
+	if (c->driver[0] != '\0' &&
+	    (kr = libnv_append_string(blob, cap, &off, "driver", c->driver))
+	    != KERN_SUCCESS)
+		return (kr);
+
+	/* nvlist_header: magic, version 0, flags 0, descriptors 0, size = body. */
+	blob[0] = (uint8_t)NV_HDR_MAGIC;
+	blob[1] = 0;			/* version */
+	blob[2] = 0;			/* flags (must be 0: unpack(...,flags=0)) */
+	le_put64(&blob[3], 0);		/* descriptors */
+	le_put64(&blob[11], (uint64_t)(off - 19));	/* size after the header */
+
+	*out_size = (uint32_t)off;
+	return (KERN_SUCCESS);
+}
+
+/*
  * Translate `matching` to a hwreg_lookup criteria nvlist, pack it,
  * fire the RPC, return the malloc'd id array + count. Caller frees
  * `ids_out`. KERN_SUCCESS even when 0 matches — the result is
@@ -345,7 +452,13 @@ lookup_matches(CFDictionaryRef matching, uint64_t **ids_out,
 	kern_return_t kr;
 
 	__io_extract_criteria(matching, &c);
-	kr = __io_pack_criteria(&c, critblob, &psz);
+	/* Pack in the chosen backend's wire format: base-system libnv for the
+	 * kernel /dev/ioregistry IOREGIOCLOOKUP handler, libxpc for the hwregd
+	 * RPC fallback. The libxpc-vs-libnv mismatch is the #218 root cause (see
+	 * __io_pack_criteria_libnv); the same fix applies to LOOKUP and WATCH. */
+	kr = (fd >= 0)
+	    ? __io_pack_criteria_libnv(&c, critblob, &psz)
+	    : __io_pack_criteria(&c, critblob, &psz);
 	if (kr != KERN_SUCCESS)
 		return (kr);
 	ids = calloc(cap, sizeof(*ids));

--- a/src/libIOKit/IOKitNotify.c
+++ b/src/libIOKit/IOKitNotify.c
@@ -450,15 +450,17 @@ IONotificationPortDestroy(IONotificationPortRef port)
 
 /*
  * Register the watch on the kernel notify channel: ioctl(/dev/ioregistry,
- * IOREGIOCWATCH) with this port's recv-right name, the packed-nvlist criteria
- * (same wire format IOREGIOCLOOKUP uses), and the IOREG_EVENT_* mask. The kernel
- * copies a send right to the port and emits ioreg_event_msg on each matching
- * event. Returns KERN_SUCCESS on success, a kIOReturn* error otherwise. The
- * HWREG_EVT_* arrive/depart bits are value-identical to IOREG_EVENT_*.
+ * IOREGIOCWATCH) with this port's recv-right name, the flat by-value criteria
+ * struct (#218; same fixed struct IOREGIOCLOOKUP uses) and the IOREG_EVENT_*
+ * mask. The kernel copies a send right to the port and emits ioreg_event_msg on
+ * each matching event. Returns KERN_SUCCESS on success, a kIOReturn* error
+ * otherwise. The HWREG_EVT_* arrive/depart bits are value-identical to
+ * IOREG_EVENT_*. No nvlist packing is involved, so the libxpc-vs-libnv mismatch
+ * that broke the #218 round-trip cannot recur.
  */
 static kern_return_t
 kernel_watch_register(struct IONotificationPort *port,
-    const hwreg_blob_t critblob, uint32_t crit_sz, uint32_t mask)
+    const struct io_criteria *c, uint32_t mask)
 {
 	struct ioreg_watch_reg reg;
 	int fd = __io_ioregistry_fd();
@@ -467,8 +469,7 @@ kernel_watch_register(struct IONotificationPort *port,
 		return (kIOReturnNoDevice);
 
 	memset(&reg, 0, sizeof(reg));
-	reg.buf_criteria = (crit_sz > 0) ? (uint64_t)(uintptr_t)critblob : 0;
-	reg.crit_len = crit_sz;
+	__io_fill_criteria(c, &reg.criteria);
 	reg.event_mask = mask;	/* IOREG_EVENT_ARRIVE/DEPART == HWREG_EVT_* */
 	reg.notify_port = (uint32_t)port->recv_port;	/* recv right name */
 
@@ -519,22 +520,12 @@ IOServiceAddMatchingNotification(IONotificationPortRef port,
 		mask = HWREG_EVT_ARRIVED;
 
 	__io_extract_criteria(matching, &c);
-	/* Pack the criteria in the wire format the chosen backend's UNPACKER
-	 * expects: the kernel /dev/ioregistry IOREGIOCWATCH handler uses the base
-	 * system libnv (__io_pack_criteria_libnv), while the hwregd RPC fallback
-	 * uses this repo's libxpc nvlist on both ends (__io_pack_criteria). Packing
-	 * the libxpc format for the kernel path is exactly the #218 break: the
-	 * kernel nvlist_unpack returns NULL -> IOREGIOCWATCH EINVAL -> no watch. */
-	kr = port->use_kernel
-	    ? __io_pack_criteria_libnv(&c, critblob, &crit_sz)
-	    : __io_pack_criteria(&c, critblob, &crit_sz);
-	if (kr != KERN_SUCCESS) {
-		CFRelease(matching);
-		return (kr);
-	}
 
 	if (port->use_kernel) {
-		kr = kernel_watch_register(port, critblob, crit_sz, mask);
+		/* Kernel notify channel: the criteria travel as a flat by-value
+		 * struct (#218), so there is no nvlist packing and nothing to
+		 * mismatch — kernel_watch_register fills it from `c` directly. */
+		kr = kernel_watch_register(port, &c, mask);
 		if (kr != KERN_SUCCESS) {
 			CFRelease(matching);
 			return (kr);
@@ -542,6 +533,13 @@ IOServiceAddMatchingNotification(IONotificationPortRef port,
 		/* watcher_id stays 0: the kernel has no per-watch handle and
 		 * retires the watch when the recv right is dropped. */
 	} else {
+		/* hwregd RPC fallback: libxpc-packed nvlist criteria over MIG (a
+		 * working transport, libxpc on both ends). */
+		kr = __io_pack_criteria(&c, critblob, &crit_sz);
+		if (kr != KERN_SUCCESS) {
+			CFRelease(matching);
+			return (kr);
+		}
 		kr = hwreg_watch(svc, critblob, (mach_msg_type_number_t)crit_sz,
 		    mask, port->recv_port, &watcher_id);
 		if (kr != KERN_SUCCESS || watcher_id == 0) {

--- a/src/libIOKit/IOKitNotify.c
+++ b/src/libIOKit/IOKitNotify.c
@@ -40,7 +40,6 @@
 
 #include <pthread.h>
 #include <stdatomic.h>
-#include <errno.h>		/* temp diag: errno from the IOREGIOCWATCH ioctl */
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -474,21 +473,8 @@ kernel_watch_register(struct IONotificationPort *port,
 	reg.event_mask = mask;	/* IOREG_EVENT_ARRIVE/DEPART == HWREG_EVT_* */
 	reg.notify_port = (uint32_t)port->recv_port;	/* recv right name */
 
-	/* TEMP diag (#218): the kernel copyin print never surfaces though analysis
-	 * says it should — dump exactly what we send + the raw ioctl errno. */
-	(void)fprintf(stderr, "libIOKit/kwr: use_kernel=%d fd=%d notify_port=0x%x "
-	    "event_mask=0x%x sizeof_reg=%zu\n", port->use_kernel, fd,
-	    reg.notify_port, reg.event_mask, sizeof(reg));
-	(void)fflush(stderr);
-
-	if (ioctl(fd, IOREGIOCWATCH, &reg) != 0) {
-		(void)fprintf(stderr, "libIOKit/kwr: IOREGIOCWATCH ioctl errno=%d (%s)\n",
-		    errno, strerror(errno));
-		(void)fflush(stderr);
+	if (ioctl(fd, IOREGIOCWATCH, &reg) != 0)
 		return (kIOReturnError);
-	}
-	(void)fprintf(stderr, "libIOKit/kwr: IOREGIOCWATCH ioctl OK\n");
-	(void)fflush(stderr);
 	return (KERN_SUCCESS);
 }
 

--- a/src/libIOKit/IOKitNotify.c
+++ b/src/libIOKit/IOKitNotify.c
@@ -331,8 +331,33 @@ IONotificationPortCreate(mach_port_t mainPort __unused)
 	    MACH_PORT_RIGHT_RECEIVE, &mp) != KERN_SUCCESS)
 		return (NULL);
 
+	/*
+	 * Insert a send right into our own name space for `mp` (MAKE_SEND).
+	 * Both backends resolve this port by *name* and need that name to
+	 * carry a send right:
+	 *   - the kernel notify channel passes the name to IOREGIOCWATCH, where
+	 *     iokit_notify_copyin_port does ipc_object_copyin(...,
+	 *     MACH_MSG_TYPE_COPY_SEND, ...) on the calling task's IPC space.
+	 *     COPY_SEND requires the name to already hold a send right
+	 *     (ipc_right_copyin rejects a name with no MACH_PORT_TYPE_SEND_RIGHTS
+	 *     as KERN_INVALID_RIGHT); a bare receive-right name fails, the watch
+	 *     never registers, and no event is ever delivered.
+	 *   - the hwregd fallback sends the name as the message's local port with
+	 *     MAKE_SEND, which likewise needs the receive right (still held here).
+	 * This mirrors the proven hwregd subscribe pattern in
+	 * src/hwregd/hwregtest.c (allocate RECEIVE, then insert MAKE_SEND).
+	 */
+	if (mach_port_insert_right(mach_task_self(), mp, mp,
+	    MACH_MSG_TYPE_MAKE_SEND) != KERN_SUCCESS) {
+		(void)mach_port_mod_refs(mach_task_self(), mp,
+		    MACH_PORT_RIGHT_RECEIVE, -1);
+		return (NULL);
+	}
+
 	p = calloc(1, sizeof(*p));
 	if (p == NULL) {
+		(void)mach_port_mod_refs(mach_task_self(), mp,
+		    MACH_PORT_RIGHT_SEND, -1);
 		(void)mach_port_mod_refs(mach_task_self(), mp,
 		    MACH_PORT_RIGHT_RECEIVE, -1);
 		return (NULL);
@@ -347,6 +372,8 @@ IONotificationPortCreate(mach_port_t mainPort __unused)
 	(void)pthread_mutex_init(&p->lock, NULL);
 	if (pthread_create(&p->thread, NULL, receive_thread, p) != 0) {
 		(void)pthread_mutex_destroy(&p->lock);
+		(void)mach_port_mod_refs(mach_task_self(), mp,
+		    MACH_PORT_RIGHT_SEND, -1);
 		(void)mach_port_mod_refs(mach_task_self(), mp,
 		    MACH_PORT_RIGHT_RECEIVE, -1);
 		free(p);
@@ -407,7 +434,12 @@ IONotificationPortDestroy(IONotificationPortRef port)
 
 	/* Dropping the recv right both stops the legacy hwregd sends AND signals
 	 * the kernel notify channel to prune this port's watches on its next
-	 * emission (iokit_notify_port_dead). */
+	 * emission (iokit_notify_port_dead). The local send right inserted at
+	 * create time (MAKE_SEND) is released too so the name is fully reclaimed;
+	 * the kernel/hwregd each hold their own copied send ref independent of
+	 * ours, so this does not race their pending sends. */
+	(void)mach_port_mod_refs(mach_task_self(), port->recv_port,
+	    MACH_PORT_RIGHT_SEND, -1);
 	(void)mach_port_mod_refs(mach_task_self(), port->recv_port,
 	    MACH_PORT_RIGHT_RECEIVE, -1);
 	if (port->queue != NULL)

--- a/src/libIOKit/IOKitNotify.c
+++ b/src/libIOKit/IOKitNotify.c
@@ -40,6 +40,7 @@
 
 #include <pthread.h>
 #include <stdatomic.h>
+#include <errno.h>		/* temp diag: errno from the IOREGIOCWATCH ioctl */
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -473,8 +474,21 @@ kernel_watch_register(struct IONotificationPort *port,
 	reg.event_mask = mask;	/* IOREG_EVENT_ARRIVE/DEPART == HWREG_EVT_* */
 	reg.notify_port = (uint32_t)port->recv_port;	/* recv right name */
 
-	if (ioctl(fd, IOREGIOCWATCH, &reg) != 0)
+	/* TEMP diag (#218): the kernel copyin print never surfaces though analysis
+	 * says it should — dump exactly what we send + the raw ioctl errno. */
+	(void)fprintf(stderr, "libIOKit/kwr: use_kernel=%d fd=%d notify_port=0x%x "
+	    "event_mask=0x%x sizeof_reg=%zu\n", port->use_kernel, fd,
+	    reg.notify_port, reg.event_mask, sizeof(reg));
+	(void)fflush(stderr);
+
+	if (ioctl(fd, IOREGIOCWATCH, &reg) != 0) {
+		(void)fprintf(stderr, "libIOKit/kwr: IOREGIOCWATCH ioctl errno=%d (%s)\n",
+		    errno, strerror(errno));
+		(void)fflush(stderr);
 		return (kIOReturnError);
+	}
+	(void)fprintf(stderr, "libIOKit/kwr: IOREGIOCWATCH ioctl OK\n");
+	(void)fflush(stderr);
 	return (KERN_SUCCESS);
 }
 

--- a/src/libIOKit/IOKitNotify.c
+++ b/src/libIOKit/IOKitNotify.c
@@ -519,7 +519,15 @@ IOServiceAddMatchingNotification(IONotificationPortRef port,
 		mask = HWREG_EVT_ARRIVED;
 
 	__io_extract_criteria(matching, &c);
-	kr = __io_pack_criteria(&c, critblob, &crit_sz);
+	/* Pack the criteria in the wire format the chosen backend's UNPACKER
+	 * expects: the kernel /dev/ioregistry IOREGIOCWATCH handler uses the base
+	 * system libnv (__io_pack_criteria_libnv), while the hwregd RPC fallback
+	 * uses this repo's libxpc nvlist on both ends (__io_pack_criteria). Packing
+	 * the libxpc format for the kernel path is exactly the #218 break: the
+	 * kernel nvlist_unpack returns NULL -> IOREGIOCWATCH EINVAL -> no watch. */
+	kr = port->use_kernel
+	    ? __io_pack_criteria_libnv(&c, critblob, &crit_sz)
+	    : __io_pack_criteria(&c, critblob, &crit_sz);
 	if (kr != KERN_SUCCESS) {
 		CFRelease(matching);
 		return (kr);

--- a/src/libIOKit/IOKitNotify.c
+++ b/src/libIOKit/IOKitNotify.c
@@ -1,31 +1,42 @@
 /*
- * IOKitNotify.c — libIOKit iter 4: K2 device-arrival / departure
- * notifications.
+ * IOKitNotify.c — libIOKit: K2 device-arrival / departure notifications.
  *
- * Each IONotificationPort owns one Mach receive right and one
- * private pthread that drives a raw mach_msg(MACH_RCV_MSG|MACH_RCV_
- * TIMEOUT, 500ms) loop on it. Watch registrations go through
- * hwreg_watch (which targets the IONotificationPort's recv port);
- * events fan in on the one port and the receive thread re-matches
- * each event's device fields against the per-watch criteria stored
- * client-side, then fires each matching IOServiceMatchingCallback
- * (via dispatch_async_f if a queue is set, inline on the receive
- * thread otherwise).
+ * Each IONotificationPort owns one Mach receive right and one private pthread
+ * that drives a raw mach_msg(MACH_RCV_MSG|MACH_RCV_TIMEOUT, 500ms) loop on it.
+ * Events fan in on the one port and the receive thread re-matches each event's
+ * device fields against the per-watch criteria stored client-side, then fires
+ * each matching IOServiceMatchingCallback (via dispatch_async_f if a queue is
+ * set, inline on the receive thread otherwise).
  *
- * Why raw mach_msg and not a libdispatch MACH_RECV source: task
- * #41 + the libSystemConfiguration iter-2 / hwregd-Phase-0 notes
- * confirm DISPATCH_SOURCE_TYPE_MACH_RECV does not reliably deliver
- * in this repo. hwregd, libSystemConfiguration's SCNotify and now
- * this facade all use the same pthread+timed-mach_msg pattern.
+ * Backend (C1.2, #218): watch registration prefers the kernel notify channel —
+ * ioctl(/dev/ioregistry, IOREGIOCWATCH) registers the recv port directly with
+ * the in-kernel registry (#225), and the kernel pushes a binary ioreg_event_msg
+ * (msgid IOKIT_NOTIFY_EVENT_MSGID) from its device_attach/device_detach
+ * eventhandlers. If /dev/ioregistry is absent (a kernel image predating K1), it
+ * FALLS BACK to hwreg_watch on hwregd, whose events arrive as the legacy
+ * "arrived id=N name=Y class=Z" text wire format (msgid HWREG_MSG_EVENT). This
+ * is the same dual-path pattern IOKitLib.c uses for the read-only walk. The
+ * receive thread handles BOTH wire formats (dispatched by msgh_id) so the path
+ * choice is transparent to the rest of the facade.
+ *
+ * Why raw mach_msg and not a libdispatch MACH_RECV source: task #41 + the
+ * libSystemConfiguration iter-2 / hwregd-Phase-0 notes confirm
+ * DISPATCH_SOURCE_TYPE_MACH_RECV does not reliably deliver in this repo. hwregd,
+ * libSystemConfiguration's SCNotify and this facade all use the same
+ * pthread+timed-mach_msg pattern.
  */
 #include <IOKit/IOKitLib.h>
 #include "IOKitInternal.h"
 
 #include "hwreg.h"
 #include "hwreg_mig_types.h"
+#include "ioregistry.h"		/* vendored: IOREGIOCWATCH, ioreg_watch_reg */
+#include "iokit_notify.h"	/* vendored: ioreg_event_msg + msgid */
 
 #include <dispatch/dispatch.h>
 #include <mach/mach.h>
+
+#include <sys/ioctl.h>		/* ioctl(2) on /dev/ioregistry */
 
 #include <pthread.h>
 #include <stdatomic.h>
@@ -35,15 +46,21 @@
 #include <string.h>
 
 /*
- * The hwregd-side watch carried as one IOServiceAddMatching
- * Notification. The criteria fields are kept client-side so that
- * when multiple watches share one IONotificationPort, the receive
- * thread can re-match each event against them and fire the right
- * callback(s).
+ * One watch carried as an IOServiceAddMatchingNotification. The criteria
+ * fields are kept client-side so that when multiple watches share one
+ * IONotificationPort, the receive thread can re-match each event against them
+ * and fire the right callback(s). `watcher_id` is the hwregd server-side watcher
+ * id (fallback path only); for the kernel notify channel there is no per-watch
+ * id — the kernel retires the watch when the recv right is dropped — so it is 0.
+ *
+ * `event_mask` uses the HWREG_EVT_* bits as the client-side canonical mask; the
+ * kernel IOREG_EVENT_* / IOKIT_NOTIFY_KIND_* bits are value-identical to the
+ * arrive/depart ones (0x1 / 0x2), so the same mask drives both backends and the
+ * re-match in event_matches_watch is backend-agnostic.
  */
 struct __io_watch {
 	struct __io_watch		*next;
-	uint64_t			 watcher_id;
+	uint64_t			 watcher_id;	/* hwregd id; 0 for kernel */
 	uint32_t			 event_mask;	/* HWREG_EVT_* */
 	struct io_criteria		 criteria;
 	IOServiceMatchingCallback	 callback;
@@ -52,6 +69,7 @@ struct __io_watch {
 
 struct IONotificationPort {
 	mach_port_t		 recv_port;	/* receive right we own */
+	int			 use_kernel;	/* 1: IOREGIOCWATCH; 0: hwregd */
 	pthread_t		 thread;
 	atomic_int		 stop;
 	pthread_mutex_t		 lock;		/* guards `watches` + queue */
@@ -187,16 +205,83 @@ event_matches_watch(struct __io_watch *w, uint32_t evt_bit,
 	return (true);
 }
 
+/*
+ * One mach_msg receive buffer big enough for either wire format plus the
+ * largest trailer the kernel might append: the legacy hwregd text event
+ * (struct hwreg_event_msg, msgid HWREG_MSG_EVENT) or the kernel notify channel's
+ * binary event (ioreg_event_msg, msgid IOKIT_NOTIFY_EVENT_MSGID). The receive
+ * thread dispatches on msgh_id, so a single port can serve either backend.
+ */
+union event_rcv_buf {
+	mach_msg_header_t	hdr;
+	struct {
+		struct hwreg_event_msg	msg;
+		mach_msg_max_trailer_t	trailer;
+	} hw;
+	struct {
+		ioreg_event_msg		msg;
+		mach_msg_max_trailer_t	trailer;
+	} k;
+};
+
+/*
+ * Decode one received message into (evt, id, name, class). Returns true if the
+ * message was a recognized event (either wire format) and was decoded; false
+ * for an unknown msgid or a malformed body (caller drops it). `evt` is the
+ * client-side HWREG_EVT_* bit (arrive/depart) used by event_matches_watch.
+ */
+static bool
+decode_event(const union event_rcv_buf *buf, uint32_t *evt, uint64_t *id,
+    char *name, size_t name_sz, char *klass, size_t klass_sz)
+{
+	switch (buf->hdr.msgh_id) {
+	case IOKIT_NOTIFY_EVENT_MSGID: {
+		const ioreg_event_msg *m = &buf->k.msg;
+		char tmp_name[IOKIT_NOTIFY_NAME_MAX];
+		char tmp_klass[IOKIT_NOTIFY_NAME_MAX];
+
+		/* The kernel re-bounds these, but treat them as untrusted wire
+		 * data: copy into a local, force-terminate, then hand out. */
+		memcpy(tmp_name, m->name, sizeof(tmp_name));
+		memcpy(tmp_klass, m->classname, sizeof(tmp_klass));
+		tmp_name[sizeof(tmp_name) - 1] = '\0';
+		tmp_klass[sizeof(tmp_klass) - 1] = '\0';
+
+		*id = m->id;
+		if (name != NULL && name_sz > 0) {
+			strncpy(name, tmp_name, name_sz - 1);
+			name[name_sz - 1] = '\0';
+		}
+		if (klass != NULL && klass_sz > 0) {
+			strncpy(klass, tmp_klass, klass_sz - 1);
+			klass[klass_sz - 1] = '\0';
+		}
+		/* DEPART maps to departed; ARRIVE and MATCHED both map to
+		 * arrived (hwregd has no Publish/Matched distinction, and the
+		 * client-side mask only carries arrive/depart). */
+		*evt = (m->kind == IOKIT_NOTIFY_KIND_DEPART) ? HWREG_EVT_DEPARTED
+		    : HWREG_EVT_ARRIVED;
+		return (true);
+	}
+	case HWREG_MSG_EVENT:
+		if (!parse_event_text(buf->hw.msg.text, id, name, name_sz,
+		    klass, klass_sz))
+			return (false);
+		*evt = (buf->hw.msg.kind == '+') ? HWREG_EVT_ARRIVED
+		    : HWREG_EVT_DEPARTED;
+		return (true);
+	default:
+		return (false);
+	}
+}
+
 static void *
 receive_thread(void *arg)
 {
 	struct IONotificationPort *port = arg;
 
 	while (atomic_load(&port->stop) == 0) {
-		struct {
-			struct hwreg_event_msg msg;
-			mach_msg_max_trailer_t trailer;
-		} buf;
+		union event_rcv_buf buf;
 		mach_msg_return_t mr;
 		uint64_t id;
 		uint32_t evt;
@@ -204,7 +289,7 @@ receive_thread(void *arg)
 		struct __io_watch *w, *snap[16];
 		int n_snap = 0, i;
 
-		mr = mach_msg(&buf.msg.hdr,
+		mr = mach_msg(&buf.hdr,
 		    MACH_RCV_MSG | MACH_RCV_TIMEOUT,
 		    0, sizeof(buf), port->recv_port,
 		    500, MACH_PORT_NULL);
@@ -212,14 +297,9 @@ receive_thread(void *arg)
 			continue;
 		if (mr != MACH_MSG_SUCCESS)
 			continue;	/* transient — keep looping */
-		if (buf.msg.hdr.msgh_id != HWREG_MSG_EVENT)
-			continue;
-		if (!parse_event_text(buf.msg.text, &id, name, sizeof(name),
+		if (!decode_event(&buf, &evt, &id, name, sizeof(name),
 		    klass, sizeof(klass)))
 			continue;
-
-		evt = (buf.msg.kind == '+') ? HWREG_EVT_ARRIVED
-		    : HWREG_EVT_DEPARTED;
 
 		/* Snapshot the matching watches under the lock into a
 		 * small array, then fire outside the lock so a user
@@ -258,6 +338,11 @@ IONotificationPortCreate(mach_port_t mainPort __unused)
 		return (NULL);
 	}
 	p->recv_port = mp;
+	/* Prefer the kernel notify channel when /dev/ioregistry is present;
+	 * fall back to hwregd otherwise (same dual-path as IOKitLib.c). The
+	 * decision is fixed at port-create time and applies to every watch the
+	 * port registers, so the receive thread's backend stays consistent. */
+	p->use_kernel = (__io_ioregistry_fd() >= 0);
 	atomic_store(&p->stop, 0);
 	(void)pthread_mutex_init(&p->lock, NULL);
 	if (pthread_create(&p->thread, NULL, receive_thread, p) != 0) {
@@ -307,16 +392,22 @@ IONotificationPortDestroy(IONotificationPortRef port)
 	atomic_store(&port->stop, 1);
 	(void)pthread_join(port->thread, NULL);
 
-	/* Unwatch each registered watch on hwregd so the daemon
-	 * reclaims its watcher table slot. */
-	svc = __io_hwregd_port();
+	/* Retire each registered watch. Kernel-channel watches (watcher_id == 0)
+	 * need no explicit teardown — the kernel prunes the watch when the recv
+	 * right is dropped below — so only the hwregd fallback watches are
+	 * unwatched here, freeing the daemon's watcher-table slots. */
+	svc = port->use_kernel ? MACH_PORT_NULL : __io_hwregd_port();
 	for (w = port->watches; w != NULL; w = next) {
 		next = w->next;
-		if (svc != MACH_PORT_NULL)
+		if (!port->use_kernel && w->watcher_id != 0 &&
+		    svc != MACH_PORT_NULL)
 			(void)hwreg_unwatch(svc, w->watcher_id);
 		free(w);
 	}
 
+	/* Dropping the recv right both stops the legacy hwregd sends AND signals
+	 * the kernel notify channel to prune this port's watches on its next
+	 * emission (iokit_notify_port_dead). */
 	(void)mach_port_mod_refs(mach_task_self(), port->recv_port,
 	    MACH_PORT_RIGHT_RECEIVE, -1);
 	if (port->queue != NULL)
@@ -325,19 +416,48 @@ IONotificationPortDestroy(IONotificationPortRef port)
 	free(port);
 }
 
+/*
+ * Register the watch on the kernel notify channel: ioctl(/dev/ioregistry,
+ * IOREGIOCWATCH) with this port's recv-right name, the packed-nvlist criteria
+ * (same wire format IOREGIOCLOOKUP uses), and the IOREG_EVENT_* mask. The kernel
+ * copies a send right to the port and emits ioreg_event_msg on each matching
+ * event. Returns KERN_SUCCESS on success, a kIOReturn* error otherwise. The
+ * HWREG_EVT_* arrive/depart bits are value-identical to IOREG_EVENT_*.
+ */
+static kern_return_t
+kernel_watch_register(struct IONotificationPort *port,
+    const hwreg_blob_t critblob, uint32_t crit_sz, uint32_t mask)
+{
+	struct ioreg_watch_reg reg;
+	int fd = __io_ioregistry_fd();
+
+	if (fd < 0)
+		return (kIOReturnNoDevice);
+
+	memset(&reg, 0, sizeof(reg));
+	reg.buf_criteria = (crit_sz > 0) ? (uint64_t)(uintptr_t)critblob : 0;
+	reg.crit_len = crit_sz;
+	reg.event_mask = mask;	/* IOREG_EVENT_ARRIVE/DEPART == HWREG_EVT_* */
+	reg.notify_port = (uint32_t)port->recv_port;	/* recv right name */
+
+	if (ioctl(fd, IOREGIOCWATCH, &reg) != 0)
+		return (kIOReturnError);
+	return (KERN_SUCCESS);
+}
+
 kern_return_t
 IOServiceAddMatchingNotification(IONotificationPortRef port,
     const io_name_t notification_type, CFDictionaryRef matching,
     IOServiceMatchingCallback callback, void *refcon,
     io_iterator_t *out_iterator)
 {
-	mach_port_t svc = __io_hwregd_port();
 	struct __io_watch *w;
 	struct io_criteria c;
 	hwreg_blob_t critblob;
 	uint32_t crit_sz = 0;
 	uint32_t mask;
 	uint64_t watcher_id = 0;
+	mach_port_t svc = MACH_PORT_NULL;
 	kern_return_t kr;
 
 	if (port == NULL || notification_type == NULL || matching == NULL ||
@@ -346,14 +466,21 @@ IOServiceAddMatchingNotification(IONotificationPortRef port,
 			CFRelease(matching);
 		return (KERN_INVALID_ARGUMENT);
 	}
-	if (svc == MACH_PORT_NULL) {
-		CFRelease(matching);
-		return (kIOReturnNoDevice);
+
+	/* The fallback path needs hwregd; the kernel path needs nothing extra
+	 * here (the fd was resolved at port-create). Bail early if neither
+	 * backend is reachable. */
+	if (!port->use_kernel) {
+		svc = __io_hwregd_port();
+		if (svc == MACH_PORT_NULL) {
+			CFRelease(matching);
+			return (kIOReturnNoDevice);
+		}
 	}
 
-	/* Notification type → hwregd event mask. The three "device
-	 * arrived" flavours map to HWREG_EVT_ARRIVED (hwregd has no
-	 * internal Publish/FirstMatch/Matched distinction). */
+	/* Notification type → event mask. The three "device arrived" flavours
+	 * map to HWREG_EVT_ARRIVED / IOREG_EVENT_ARRIVE (no internal
+	 * Publish/FirstMatch/Matched distinction in either backend). */
 	if (strcmp(notification_type, kIOTerminatedNotification) == 0)
 		mask = HWREG_EVT_DEPARTED;
 	else
@@ -366,16 +493,28 @@ IOServiceAddMatchingNotification(IONotificationPortRef port,
 		return (kr);
 	}
 
-	kr = hwreg_watch(svc, critblob, (mach_msg_type_number_t)crit_sz,
-	    mask, port->recv_port, &watcher_id);
-	if (kr != KERN_SUCCESS || watcher_id == 0) {
-		CFRelease(matching);
-		return (kr != KERN_SUCCESS ? kr : kIOReturnError);
+	if (port->use_kernel) {
+		kr = kernel_watch_register(port, critblob, crit_sz, mask);
+		if (kr != KERN_SUCCESS) {
+			CFRelease(matching);
+			return (kr);
+		}
+		/* watcher_id stays 0: the kernel has no per-watch handle and
+		 * retires the watch when the recv right is dropped. */
+	} else {
+		kr = hwreg_watch(svc, critblob, (mach_msg_type_number_t)crit_sz,
+		    mask, port->recv_port, &watcher_id);
+		if (kr != KERN_SUCCESS || watcher_id == 0) {
+			CFRelease(matching);
+			return (kr != KERN_SUCCESS ? kr : kIOReturnError);
+		}
 	}
 
 	w = calloc(1, sizeof(*w));
 	if (w == NULL) {
-		(void)hwreg_unwatch(svc, watcher_id);
+		if (!port->use_kernel && watcher_id != 0 &&
+		    svc != MACH_PORT_NULL)
+			(void)hwreg_unwatch(svc, watcher_id);
 		CFRelease(matching);
 		return (KERN_RESOURCE_SHORTAGE);
 	}

--- a/src/libIOKit/iokit_notify.h
+++ b/src/libIOKit/iokit_notify.h
@@ -1,0 +1,72 @@
+/*
+ * VENDORED COPY — keep in sync with the kernel canonical.
+ *
+ * Canonical: nextbsd-kernel src-overlay/sys/sys/mach/iokit_notify.h (installed
+ * as <sys/mach/iokit_notify.h> in the kernel sysroot). Userland in this repo
+ * cannot include the kernel src-overlay directly, so libIOKit carries a copy of
+ * the K-PR2 (#225) device-event Mach message ABI here — the same convention
+ * kextd uses for its vendored kernel wire structs (see kextd.c's
+ * kextd_load_body_t / src/kext_tools/kextd/iocatalogue.h). This copy keeps ONLY
+ * the userland-relevant on-the-wire pieces (the message struct + the msgid +
+ * the kind constants); the kernel-only send-side decls under #ifdef _KERNEL in
+ * the canonical header are deliberately omitted. The ABI is frozen once
+ * shipped, so this mirror should rarely move; if the canonical struct/msgid
+ * ever changes, update this file to match.
+ *
+ * --- canonical contents below (userland-relevant subset), verbatim ---
+ *
+ * iokit_notify.h — kernel->userland IORegistry device-event Mach message
+ * (K-PR2, nextbsd#225, part of #211/#218).
+ *
+ * The Apple-faithful device-arrival/departure notification channel. A userland
+ * client (DiskArbitration, the IOKitNotify migration) creates a Mach receive
+ * right and registers it via IOREGIOCWATCH on /dev/ioregistry (see
+ * <sys/ioregistry.h>) together with a packed-nvlist match bag and an event
+ * mask. The kernel copies a send right to that port and, from the newbus
+ * device_attach / device_detach eventhandlers, pushes one ioreg_event_msg per
+ * matching event to the client's port.
+ */
+#ifndef _SYS_MACH_IOKIT_NOTIFY_H_
+#define _SYS_MACH_IOKIT_NOTIFY_H_
+
+#include <mach/message.h>
+#include <mach/ndr.h>
+
+/*
+ * msgh_id for a device-event notification — "IONT", chosen outside the
+ * MACH_NOTIFY_* range (0x0100..) and distinct from IOKIT_KEXTD_LOAD_MSGID
+ * ("IOKT", 0x494f4b54). The userland receivers (the PR4/PR5 IOKitNotify /
+ * DiskArbitration migration) MUST match on this id.
+ */
+#define	IOKIT_NOTIFY_EVENT_MSGID	0x494f4e54	/* 'I','O','N','T' */
+
+/* Event kinds carried in ioreg_event_msg.kind — value-identical to the
+ * IOREG_EVENT_* mask bits in <sys/ioregistry.h>. Re-stated here so a userland
+ * receiver of this message need only include this one header. */
+#define	IOKIT_NOTIFY_KIND_ARRIVE	0x00000001	/* device attached */
+#define	IOKIT_NOTIFY_KIND_DEPART	0x00000002	/* device detached */
+#define	IOKIT_NOTIFY_KIND_MATCHED	0x00000004	/* device bound driver */
+
+#define	IOKIT_NOTIFY_NAME_MAX		32		/* == IOREG_NAME_MAX */
+
+/*
+ * Wire format. Fixed-size, inline (no out-of-line/complex descriptors) so the
+ * kernel send is trivial and the client reads it with a plain mach_msg. The
+ * body identifies the device by its stable registry id (see <sys/ioregistry.h>)
+ * plus its newbus name/class and PCI ids (0 if not a PCI nub), enough for a
+ * client to act or to issue follow-up IOREGIOC* queries.
+ */
+typedef struct {
+	mach_msg_header_t		hdr;
+	NDR_record_t			NDR;
+	uint32_t			kind;		/* IOKIT_NOTIFY_KIND_* */
+	uint32_t			_pad;		/* keep id 8-byte aligned */
+	uint64_t			id;		/* stable registry node id */
+	char				name[IOKIT_NOTIFY_NAME_MAX];	/* device_get_name() */
+	char				classname[IOKIT_NOTIFY_NAME_MAX]; /* devclass name */
+	uint32_t			pci_vendor;	/* 0 if not a PCI nub */
+	uint32_t			pci_device;	/* 0 if not a PCI nub */
+	mach_msg_format_0_trailer_t	trailer;	/* appended on receive */
+} ioreg_event_msg;
+
+#endif /* _SYS_MACH_IOKIT_NOTIFY_H_ */

--- a/src/libIOKit/iokitnotifyrt.c
+++ b/src/libIOKit/iokitnotifyrt.c
@@ -1,0 +1,168 @@
+/*
+ * iokitnotifyrt — libIOKit notification round-trip test (C1.2, #218).
+ *
+ * Proves the FULL device-event path the C1.2 migration moved onto the kernel
+ * notify channel: register an IOServiceAddMatchingNotification through libIOKit
+ * (which, when /dev/ioregistry is present, registers the recv port via
+ * IOREGIOCWATCH on the in-kernel registry, #225), then SYNTHESIZE a matching
+ * device-arrival event with the IOREGIOCTESTEVENT inject ioctl (kernel PR,
+ * #225/#218) and confirm the registered callback actually fires. This exercises
+ * the kernel match + ioreg_event_msg Mach send + the receive thread's binary
+ * decode end-to-end, deterministically, with no physical device.
+ *
+ * SELF-SKIP (never a hard failure) when the round-trip cannot be staged:
+ *   - no /dev/ioregistry            -> kernel predating K1 (libIOKit on hwregd)
+ *   - IOREGIOCTESTEVENT == ENOTTY   -> kernel predating the Part A inject ioctl
+ *   - IOREGIOCTESTEVENT == ENOSYS   -> kernel built without COMPAT_MACH
+ * This keeps the gate CI-greenable on a continuous image built before the Part A
+ * kernel reaches continuous (the kernel PR must merge + ingest first).
+ *
+ * Emits EXACTLY ONE marker (gated in tests/boot-test.sh):
+ *   IOKITNOTIFY-OK    — injected event arrived at the registered callback
+ *   IOKITNOTIFY-FAIL  — channel present but the callback never fired
+ *   IOKITNOTIFY-SKIP  — round-trip not stageable on this kernel (see above)
+ */
+#include <IOKit/IOKitLib.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <mach/mach.h>
+
+#include "ioregistry.h"		/* vendored ABI: IOREGIOCTESTEVENT etc. */
+
+#include <sys/ioctl.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* A class string no real newbus device carries, so the only event that can ever
+ * match this watch is the one we inject — no false positives from real attaches
+ * racing the test. */
+#define	RT_TEST_NAME	"nbiokit_rt_probe"
+
+static atomic_int g_fired;
+
+static void
+rt_callback(void *refcon __unused, io_iterator_t iterator)
+{
+	io_object_t obj;
+
+	/* Drain the iterator the facade handed us (it owns the synthetic id). */
+	while ((obj = IOIteratorNext(iterator)) != IO_OBJECT_NULL)
+		IOObjectRelease(obj);
+	atomic_store(&g_fired, 1);
+}
+
+int
+main(void)
+{
+	IONotificationPortRef	notify;
+	CFMutableDictionaryRef	matching;
+	io_iterator_t		it = IO_OBJECT_NULL;
+	io_object_t		obj;
+	struct ioreg_test_event	te;
+	int			fd, i;
+
+	fd = open("/dev/ioregistry", O_RDONLY | O_CLOEXEC);
+	if (fd < 0) {
+		printf("IOKITNOTIFY-SKIP: no /dev/ioregistry "
+		    "(kernel without the K1 in-kernel registry)\n");
+		return (0);
+	}
+
+	/* Probe IOREGIOCTESTEVENT before staging the watch: a kind of 0 is
+	 * rejected with EINVAL by a kernel that HAS the ioctl, and with ENOTTY
+	 * by one that lacks it (the cdev's default case). ENOSYS means the
+	 * kernel has the ioctl but no COMPAT_MACH channel. Either absence -> a
+	 * non-fatal SKIP so this gate is green on pre-Part-A continuous images. */
+	memset(&te, 0, sizeof(te));
+	te.kind = 0;
+	if (ioctl(fd, IOREGIOCTESTEVENT, &te) != 0 &&
+	    (errno == ENOTTY || errno == ENOSYS)) {
+		printf("IOKITNOTIFY-SKIP: IOREGIOCTESTEVENT absent (errno=%d) "
+		    "— kernel predating the notify test-inject ioctl\n", errno);
+		(void)close(fd);
+		return (0);
+	}
+
+	atomic_store(&g_fired, 0);
+
+	notify = IONotificationPortCreate(kIOMainPortDefault);
+	if (notify == NULL) {
+		printf("IOKITNOTIFY-FAIL: IONotificationPortCreate\n");
+		(void)close(fd);
+		return (1);
+	}
+
+	/* Match on a unique name only we will inject (IONameMatch -> the kernel
+	 * criteria "name" key, AND-matched against the injected node's name). */
+	matching = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+	    &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	if (matching == NULL) {
+		printf("IOKITNOTIFY-FAIL: CFDictionaryCreateMutable\n");
+		IONotificationPortDestroy(notify);
+		(void)close(fd);
+		return (1);
+	}
+	{
+		CFStringRef v = CFStringCreateWithCString(kCFAllocatorDefault,
+		    RT_TEST_NAME, kCFStringEncodingUTF8);
+
+		CFDictionarySetValue(matching, CFSTR(kIONameMatchKey), v);
+		CFRelease(v);
+	}
+
+	if (IOServiceAddMatchingNotification(notify, kIOFirstMatchNotification,
+	    matching, rt_callback, NULL, &it) != KERN_SUCCESS) {
+		printf("IOKITNOTIFY-FAIL: AddMatchingNotification\n");
+		IONotificationPortDestroy(notify);
+		(void)close(fd);
+		return (1);
+	}
+	/* `matching` consumed by the facade. Drain the (expected empty) initial
+	 * arming — no real device carries RT_TEST_NAME. */
+	if (it != IO_OBJECT_NULL) {
+		while ((obj = IOIteratorNext(it)) != IO_OBJECT_NULL)
+			IOObjectRelease(obj);
+		IOObjectRelease(it);
+	}
+
+	/* Inject the matching arrival event through the same match+send path a
+	 * real device_attach takes. The receive thread should decode the
+	 * binary ioreg_event_msg, re-match RT_TEST_NAME, and fire rt_callback. */
+	memset(&te, 0, sizeof(te));
+	te.kind = IOREG_EVENT_ARRIVE;
+	te.id = 0x6e62696fULL;	/* arbitrary synthetic registry id */
+	strlcpy(te.name, RT_TEST_NAME, sizeof(te.name));
+	te.classname[0] = '\0';
+	te.pci_vendor = 0;
+	te.pci_device = 0;
+	if (ioctl(fd, IOREGIOCTESTEVENT, &te) != 0) {
+		/* The probe above already ruled out absence; a failure here is a
+		 * real channel error. */
+		printf("IOKITNOTIFY-FAIL: IOREGIOCTESTEVENT inject failed "
+		    "(errno=%d)\n", errno);
+		IONotificationPortDestroy(notify);
+		(void)close(fd);
+		return (1);
+	}
+
+	/* Wait for the callback. The receive thread polls on a 500ms mach_msg
+	 * timeout, so allow comfortably more than one cycle. */
+	for (i = 0; i < 50 && atomic_load(&g_fired) == 0; i++)
+		usleep(100 * 1000);	/* 100ms * 50 = 5s budget */
+
+	IONotificationPortDestroy(notify);
+	(void)close(fd);
+
+	if (atomic_load(&g_fired) != 0) {
+		printf("IOKITNOTIFY-OK: injected device event round-tripped "
+		    "through IOREGIOCWATCH to the registered callback\n");
+		return (0);
+	}
+	printf("IOKITNOTIFY-FAIL: injected event never reached the callback\n");
+	return (1);
+}

--- a/src/libIOKit/iokitnotifyrt.c
+++ b/src/libIOKit/iokitnotifyrt.c
@@ -66,7 +66,15 @@ main(void)
 	struct ioreg_test_event	te;
 	int			fd, i;
 
+	/* Unbuffer stdout so every step line below reaches the serial console
+	 * even if the process is killed or exits abnormally before an implicit
+	 * flush (#218 observability: the prior pass's stderr diagnostics never
+	 * surfaced). run.sh runs us as `iokitnotifyrt 2>&1` and echoes the lot. */
+	setvbuf(stdout, NULL, _IONBF, 0);
+
 	fd = open("/dev/ioregistry", O_RDONLY | O_CLOEXEC);
+	printf("iokitnotifyrt: opened /dev/ioregistry fd=%d (errno=%d)\n",
+	    fd, fd < 0 ? errno : 0);
 	if (fd < 0) {
 		printf("IOKITNOTIFY-SKIP: no /dev/ioregistry "
 		    "(kernel without the K1 in-kernel registry)\n");
@@ -80,12 +88,21 @@ main(void)
 	 * non-fatal SKIP so this gate is green on pre-Part-A continuous images. */
 	memset(&te, 0, sizeof(te));
 	te.kind = 0;
-	if (ioctl(fd, IOREGIOCTESTEVENT, &te) != 0 &&
-	    (errno == ENOTTY || errno == ENOSYS)) {
-		printf("IOKITNOTIFY-SKIP: IOREGIOCTESTEVENT absent (errno=%d) "
-		    "— kernel predating the notify test-inject ioctl\n", errno);
-		(void)close(fd);
-		return (0);
+	{
+		int probe_rc = ioctl(fd, IOREGIOCTESTEVENT, &te);
+		int probe_errno = errno;
+
+		printf("iokitnotifyrt: IOREGIOCTESTEVENT probe rc=%d errno=%d "
+		    "(EINVAL=%d expected on a kernel that HAS the ioctl)\n",
+		    probe_rc, probe_rc != 0 ? probe_errno : 0, EINVAL);
+		if (probe_rc != 0 &&
+		    (probe_errno == ENOTTY || probe_errno == ENOSYS)) {
+			printf("IOKITNOTIFY-SKIP: IOREGIOCTESTEVENT absent "
+			    "(errno=%d) — kernel predating the notify "
+			    "test-inject ioctl\n", probe_errno);
+			(void)close(fd);
+			return (0);
+		}
 	}
 
 	atomic_store(&g_fired, 0);
@@ -96,6 +113,8 @@ main(void)
 		(void)close(fd);
 		return (1);
 	}
+	printf("iokitnotifyrt: created notify port name=%u\n",
+	    (unsigned)IONotificationPortGetMachPort(notify));
 
 	/* Match on a unique name only we will inject (IONameMatch -> the kernel
 	 * criteria "name" key, AND-matched against the injected node's name). */
@@ -115,18 +134,29 @@ main(void)
 		CFRelease(v);
 	}
 
-	if (IOServiceAddMatchingNotification(notify, kIOFirstMatchNotification,
-	    matching, rt_callback, NULL, &it) != KERN_SUCCESS) {
-		printf("IOKITNOTIFY-FAIL: AddMatchingNotification\n");
-		IONotificationPortDestroy(notify);
-		(void)close(fd);
-		return (1);
+	{
+		kern_return_t akr = IOServiceAddMatchingNotification(notify,
+		    kIOFirstMatchNotification, matching, rt_callback, NULL, &it);
+
+		printf("iokitnotifyrt: IOREGIOCWATCH (via "
+		    "IOServiceAddMatchingNotification) kr=0x%x\n",
+		    (unsigned)akr);
+		if (akr != KERN_SUCCESS) {
+			printf("IOKITNOTIFY-FAIL: AddMatchingNotification "
+			    "(kr=0x%x) — watch registration failed; see the "
+			    "kernel 'iokit: IOREGIOCWATCH ...' line for the "
+			    "exact cause (nvlist_unpack / copyin_port)\n",
+			    (unsigned)akr);
+			IONotificationPortDestroy(notify);
+			(void)close(fd);
+			return (1);
+		}
 	}
-	/* Diagnostic (stderr, gate-safe — never an IOKITNOTIFY- marker): the watch
-	 * registered (IOREGIOCWATCH resolved our recv-port send right and added the
-	 * watch). If this prints but the callback never fires, the break is on the
-	 * kernel emit/match/send side, not registration. */
-	fprintf(stderr, "iokitnotifyrt: watch registered on '%s' (recv port %u)\n",
+	/* The watch registered: IOREGIOCWATCH resolved our recv-port send right,
+	 * unpacked the criteria and added the watch. If this prints but the
+	 * callback never fires, the break is on the kernel emit/match/send side
+	 * or the userland receive side, not registration. */
+	printf("iokitnotifyrt: watch registered on '%s' (recv port %u)\n",
 	    RT_TEST_NAME, (unsigned)IONotificationPortGetMachPort(notify));
 	/* `matching` consumed by the facade. Drain the (expected empty) initial
 	 * arming — no real device carries RT_TEST_NAME. */
@@ -146,23 +176,35 @@ main(void)
 	te.classname[0] = '\0';
 	te.pci_vendor = 0;
 	te.pci_device = 0;
-	if (ioctl(fd, IOREGIOCTESTEVENT, &te) != 0) {
-		/* The probe above already ruled out absence; a failure here is a
-		 * real channel error. */
-		printf("IOKITNOTIFY-FAIL: IOREGIOCTESTEVENT inject failed "
-		    "(errno=%d)\n", errno);
-		IONotificationPortDestroy(notify);
-		(void)close(fd);
-		return (1);
+	{
+		int inj_rc = ioctl(fd, IOREGIOCTESTEVENT, &te);
+		int inj_errno = errno;
+
+		printf("iokitnotifyrt: IOREGIOCTESTEVENT inject "
+		    "(kind=ARRIVE name='%s') rc=%d errno=%d\n",
+		    RT_TEST_NAME, inj_rc, inj_rc != 0 ? inj_errno : 0);
+		if (inj_rc != 0) {
+			/* The probe above already ruled out absence; a failure
+			 * here is a real channel error. */
+			printf("IOKITNOTIFY-FAIL: IOREGIOCTESTEVENT inject "
+			    "failed (errno=%d)\n", inj_errno);
+			IONotificationPortDestroy(notify);
+			(void)close(fd);
+			return (1);
+		}
 	}
-	fprintf(stderr, "iokitnotifyrt: IOREGIOCTESTEVENT inject ok "
-	    "(kind=ARRIVE name='%s'); waiting up to 5s for callback\n",
-	    RT_TEST_NAME);
+	printf("iokitnotifyrt: inject ok; waiting up to 5s for callback\n");
 
 	/* Wait for the callback. The receive thread polls on a 500ms mach_msg
 	 * timeout, so allow comfortably more than one cycle. */
 	for (i = 0; i < 50 && atomic_load(&g_fired) == 0; i++)
 		usleep(100 * 1000);	/* 100ms * 50 = 5s budget */
+
+	if (atomic_load(&g_fired) != 0)
+		printf("iokitnotifyrt: callback fired (received the injected "
+		    "event)\n");
+	else
+		printf("iokitnotifyrt: no callback after 5s\n");
 
 	IONotificationPortDestroy(notify);
 	(void)close(fd);

--- a/src/libIOKit/iokitnotifyrt.c
+++ b/src/libIOKit/iokitnotifyrt.c
@@ -143,9 +143,10 @@ main(void)
 		    (unsigned)akr);
 		if (akr != KERN_SUCCESS) {
 			printf("IOKITNOTIFY-FAIL: AddMatchingNotification "
-			    "(kr=0x%x) — watch registration failed; see the "
-			    "kernel 'iokit: IOREGIOCWATCH ...' line for the "
-			    "exact cause (nvlist_unpack / copyin_port)\n",
+			    "(kr=0x%x) — watch registration failed; the most "
+			    "likely cause is the IOREGIOCWATCH copyin_port (the "
+			    "recv-port send right) since the criteria now travel "
+			    "as a flat by-value struct (#218, no nvlist unpack)\n",
 			    (unsigned)akr);
 			IONotificationPortDestroy(notify);
 			(void)close(fd);
@@ -153,9 +154,9 @@ main(void)
 		}
 	}
 	/* The watch registered: IOREGIOCWATCH resolved our recv-port send right,
-	 * unpacked the criteria and added the watch. If this prints but the
-	 * callback never fires, the break is on the kernel emit/match/send side
-	 * or the userland receive side, not registration. */
+	 * read the flat by-value criteria (#218) and added the watch. If this
+	 * prints but the callback never fires, the break is on the kernel
+	 * emit/match/send side or the userland receive side, not registration. */
 	printf("iokitnotifyrt: watch registered on '%s' (recv port %u)\n",
 	    RT_TEST_NAME, (unsigned)IONotificationPortGetMachPort(notify));
 	/* `matching` consumed by the facade. Drain the (expected empty) initial

--- a/src/libIOKit/iokitnotifyrt.c
+++ b/src/libIOKit/iokitnotifyrt.c
@@ -122,6 +122,12 @@ main(void)
 		(void)close(fd);
 		return (1);
 	}
+	/* Diagnostic (stderr, gate-safe — never an IOKITNOTIFY- marker): the watch
+	 * registered (IOREGIOCWATCH resolved our recv-port send right and added the
+	 * watch). If this prints but the callback never fires, the break is on the
+	 * kernel emit/match/send side, not registration. */
+	fprintf(stderr, "iokitnotifyrt: watch registered on '%s' (recv port %u)\n",
+	    RT_TEST_NAME, (unsigned)IONotificationPortGetMachPort(notify));
 	/* `matching` consumed by the facade. Drain the (expected empty) initial
 	 * arming — no real device carries RT_TEST_NAME. */
 	if (it != IO_OBJECT_NULL) {
@@ -149,6 +155,9 @@ main(void)
 		(void)close(fd);
 		return (1);
 	}
+	fprintf(stderr, "iokitnotifyrt: IOREGIOCTESTEVENT inject ok "
+	    "(kind=ARRIVE name='%s'); waiting up to 5s for callback\n",
+	    RT_TEST_NAME);
 
 	/* Wait for the callback. The receive thread polls on a 500ms mach_msg
 	 * timeout, so allow comfortably more than one cycle. */

--- a/src/libIOKit/ioregistry.h
+++ b/src/libIOKit/ioregistry.h
@@ -35,7 +35,32 @@
 
 #define	IOREG_NAME_MAX		32	/* device name / class / driver field */
 #define	IOREG_PATH_MAX		256	/* full newbus path, incl. NUL */
-#define	IOREG_CRIT_MAX		65536	/* max packed criteria nvlist (bytes) */
+
+/*
+ * Flat, fixed-size device match criteria (nextbsd#218). Replaces the former
+ * packed-nvlist criteria bag that IOREGIOCLOOKUP / IOREGIOCWATCH carried: the
+ * userland packer (libxpc's nvlist) and the kernel reader (base libnv) use
+ * incompatible wire formats, so a packed bag round-tripped through the ioctl
+ * never unpacked. A flat struct has NO serialization, so there is nothing to
+ * mismatch — both sides simply read the same fixed fields.
+ *
+ * Match semantics: a field that is the empty string (for the char[] fields) or
+ * zero (for the numeric fields) is a WILDCARD and does not constrain the match;
+ * any non-empty / non-zero field MUST equal the candidate node's corresponding
+ * value (strcmp for strings, == for numerics). All set fields are AND-ed; an
+ * all-zero criteria therefore matches every node. Self-contained / fixed-size,
+ * so the ABI is identical for 32- and 64-bit userland.
+ */
+struct ioreg_criteria {
+	char		name[IOREG_NAME_MAX];	/* device_get_name(); "" = any */
+	char		classname[IOREG_NAME_MAX]; /* devclass name; "" = any */
+	char		driver[IOREG_NAME_MAX];	/* bound driver name; "" = any */
+	uint32_t	pci_vendor;		/* PCI vendor id; 0 = any */
+	uint32_t	pci_device;		/* PCI device id; 0 = any */
+	uint32_t	pci_subvendor;		/* PCI subsystem vendor; 0 = any */
+	uint32_t	pci_class;		/* PCI base class (low 8 bits); 0 = any */
+	uint32_t	match_flags;		/* reserved; 0 (zero-as-wildcard) */
+};
 
 /*
  * Node lifecycle state (ioreg_node.state). Distinct from the newbus
@@ -98,19 +123,17 @@ struct ioreg_props {
 };
 
 /*
- * Look up nodes matching a packed-nvlist criteria bag (e.g. {"name":"pci"} or
- * {"pci_vendor":0x8086}). Userland sets `buf_criteria`/`crit_len` (a packed
- * nvlist of scalar keys, AND-matched against each node) and `max` (capacity of
- * the `matches` array, user ptr to uint64_t[max]); the kernel writes up to
+ * Look up nodes matching a flat criteria struct (e.g. {.name = "pci"} or
+ * {.pci_vendor = 0x8086}). Userland fills `criteria` (zero-as-wildcard,
+ * AND-matched against each node; see struct ioreg_criteria) and `max` (capacity
+ * of the `matches` array, user ptr to uint64_t[max]); the kernel writes up to
  * `max` matching ids and sets `count` to the total number of matches. count >
- * max means truncation. crit_len == 0 matches every live node.
+ * max means truncation. An all-zero criteria matches every live node.
  */
 struct ioreg_lookup {
-	uint64_t	buf_criteria;	/* in: user ptr to packed nvlist criteria */
-	uint32_t	crit_len;	/* in: length of criteria bag, 0 = match all */
+	struct ioreg_criteria criteria;	/* in: flat match criteria */
 	uint32_t	max;		/* in: capacity of matches[] */
 	uint32_t	count;		/* out: total number of matches */
-	uint32_t	_pad;
 	uint64_t	matches;	/* in: user ptr to uint64_t[max] */
 };
 
@@ -137,20 +160,18 @@ struct ioreg_lookup {
 #define	IOREG_EVENT_MATCHED	0x00000004	/* device bound a driver */
 
 /*
- * IOREGIOCWATCH argument. `buf_criteria`/`crit_len` is the same packed-nvlist
- * AND-match bag used by IOREGIOCLOOKUP (scalar keys name/class/driver/pci_*;
- * crit_len == 0 means "match every device"). `event_mask` is the OR of the
+ * IOREGIOCWATCH argument. `criteria` is the same flat AND-match struct used by
+ * IOREGIOCLOOKUP (fields name/class/driver/pci_*; zero-as-wildcard, an all-zero
+ * criteria means "match every device"). `event_mask` is the OR of the
  * IOREG_EVENT_* kinds to deliver. `notify_port` is the *name*, in the calling
  * task's IPC space, of the receive right whose send right the kernel copies and
  * keeps; the client keeps the receive right and reads ioreg_event_msg from it.
  * Self-contained / fixed-size for 32- and 64-bit ABI parity.
  */
 struct ioreg_watch_reg {
-	uint64_t	buf_criteria;	/* in: user ptr to packed nvlist criteria */
-	uint32_t	crit_len;	/* in: length of criteria bag, 0 = all */
+	struct ioreg_criteria criteria;	/* in: flat match criteria */
 	uint32_t	event_mask;	/* in: OR of IOREG_EVENT_* to deliver */
 	uint32_t	notify_port;	/* in: mach_port_name_t (recv right name) */
-	uint32_t	_pad;
 };
 
 /*

--- a/src/libIOKit/ioregistry.h
+++ b/src/libIOKit/ioregistry.h
@@ -114,10 +114,78 @@ struct ioreg_lookup {
 	uint64_t	matches;	/* in: user ptr to uint64_t[max] */
 };
 
+/*
+ * Device-event notification (K-PR2, nextbsd#225). A userland client (e.g.
+ * DiskArbitration, the IOKitNotify migration) creates a Mach receive right,
+ * then registers it here so the kernel pushes a message to that port whenever a
+ * device whose newbus identity matches `criteria` arrives or departs. This is
+ * the kernel-served replacement for hwregd watching /dev/devctl: the kernel
+ * emits the events itself from the device_attach / device_detach eventhandlers.
+ *
+ * The faithful IOKit shape: the client owns the receive right; the kernel holds
+ * a copied send right and sends the on-the-wire event message (struct
+ * ioreg_event_msg, defined in <sys/mach/iokit_notify.h> with the wire msgid) on
+ * each matching event whose kind is in `event_mask`. The send right is dropped
+ * (and the watch retired) when the client's port goes dead.
+ */
+
+/* event_mask bits and ioreg_event_msg.kind values (faithful to IOKit's notion
+ * of matched/published vs. terminated). A watch with event_mask == 0 receives
+ * nothing; the common case is IOREG_EVENT_ARRIVE | IOREG_EVENT_DEPART. */
+#define	IOREG_EVENT_ARRIVE	0x00000001	/* device attached (published) */
+#define	IOREG_EVENT_DEPART	0x00000002	/* device detached (terminated) */
+#define	IOREG_EVENT_MATCHED	0x00000004	/* device bound a driver */
+
+/*
+ * IOREGIOCWATCH argument. `buf_criteria`/`crit_len` is the same packed-nvlist
+ * AND-match bag used by IOREGIOCLOOKUP (scalar keys name/class/driver/pci_*;
+ * crit_len == 0 means "match every device"). `event_mask` is the OR of the
+ * IOREG_EVENT_* kinds to deliver. `notify_port` is the *name*, in the calling
+ * task's IPC space, of the receive right whose send right the kernel copies and
+ * keeps; the client keeps the receive right and reads ioreg_event_msg from it.
+ * Self-contained / fixed-size for 32- and 64-bit ABI parity.
+ */
+struct ioreg_watch_reg {
+	uint64_t	buf_criteria;	/* in: user ptr to packed nvlist criteria */
+	uint32_t	crit_len;	/* in: length of criteria bag, 0 = all */
+	uint32_t	event_mask;	/* in: OR of IOREG_EVENT_* to deliver */
+	uint32_t	notify_port;	/* in: mach_port_name_t (recv right name) */
+	uint32_t	_pad;
+};
+
+/*
+ * IOREGIOCTESTEVENT (PR4/C1.2, nextbsd#225/#218): deterministic test injection
+ * of a synthetic device event. The notify channel (IOREGIOCWATCH) normally
+ * pushes only on real device_attach / device_detach, which CI cannot easily
+ * synthesize without a physical device. This ioctl feeds a caller-supplied
+ * fake event {kind, id, name, classname, pci_vendor, pci_device} through the
+ * SAME watch match + ioreg_event_msg emission path a real device_attach takes,
+ * so any registered watch whose criteria match receives a genuine
+ * ioreg_event_msg. It exercises match + Mach send end-to-end with no device.
+ *
+ * `kind` is exactly ONE IOREG_EVENT_* bit (the event being injected). The
+ * string fields are NUL-terminated (the kernel re-bounds them). This mirrors
+ * the catalogue's IOCATIOCTESTSEND de-risk ioctl: a test affordance, inert in
+ * the build until a userland test fires it. Returns 0 on success, EINVAL for a
+ * malformed event, ENOSYS on a kernel built without COMPAT_MACH (no Mach
+ * channel). Self-contained / fixed-size for 32- and 64-bit ABI parity.
+ */
+struct ioreg_test_event {
+	uint32_t	kind;			/* in: exactly one IOREG_EVENT_* */
+	uint32_t	pci_vendor;		/* in: synthetic PCI vendor, 0 if n/a */
+	uint32_t	pci_device;		/* in: synthetic PCI device, 0 if n/a */
+	uint32_t	_pad;
+	uint64_t	id;			/* in: synthetic registry node id */
+	char		name[IOREG_NAME_MAX];	/* in: device name */
+	char		classname[IOREG_NAME_MAX]; /* in: devclass name */
+};
+
 #define	IOREGIOCROOT	_IOR('R', 1, uint64_t)		   /* get root node id */
 #define	IOREGIOCCHILDREN _IOWR('R', 2, struct ioreg_children) /* enum children */
 #define	IOREGIOCNODE	_IOWR('R', 3, struct ioreg_node)   /* node by id (in id) */
 #define	IOREGIOCPROPS	_IOWR('R', 4, struct ioreg_props)  /* node property bag */
 #define	IOREGIOCLOOKUP	_IOWR('R', 5, struct ioreg_lookup) /* match by criteria */
+#define	IOREGIOCWATCH	_IOW('R', 6, struct ioreg_watch_reg) /* register notify */
+#define	IOREGIOCTESTEVENT _IOW('R', 7, struct ioreg_test_event) /* inject event */
 
 #endif /* _SYS_IOREGISTRY_H_ */

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -1219,6 +1219,33 @@ expect {
         puts "\nOK: libIOKit walks /dev/ioregistry (root + boot device nubs)"
     }
 }
+# IOKITNOTIFY — C1.2 (#218) IOKitNotify migration round-trip gate. run.sh's
+# iokitnotifyrt registers a matching notification through libIOKit (now via
+# IOREGIOCWATCH on the in-kernel registry, #225) and fires IOREGIOCTESTEVENT to
+# synthesize a matching device event, confirming the registered callback fired —
+# the deterministic proof of the kernel notify channel with no physical device.
+#
+# CRITICAL (MDNS-IFWATCH lesson): OK/SKIP are folded into ONE block that ends
+# only on OK/FAIL/SKIP, with a NON-FATAL timeout, so an absent/optional marker
+# can never sit blocking while a later required marker (IOCATALOGUE/...) scrolls
+# past unmatched. The Part A inject ioctl must merge + reach continuous before
+# this can pass; until then iokitnotifyrt SELF-SKIPs (IOKITNOTIFY-SKIP), so this
+# gate is green on pre-Part-A continuous images. Only IOKITNOTIFY-FAIL gates.
+expect {
+    timeout {
+        puts "\nWARN: IOKITNOTIFY marker not seen (pre-C1.2 run.sh — informational)"
+    }
+    "IOKITNOTIFY-FAIL" {
+        puts "\nFAIL: libIOKit notify round-trip — injected event never reached the callback"
+        exit 1
+    }
+    "IOKITNOTIFY-SKIP" {
+        puts "\nWARN: IOKITNOTIFY-SKIP — no /dev/ioregistry or IOREGIOCTESTEVENT (pre-Part-A kernel)"
+    }
+    "IOKITNOTIFY-OK" {
+        puts "\nOK: libIOKit notify round-trip (IOREGIOCWATCH + IOREGIOCTESTEVENT -> callback)"
+    }
+}
 expect {
     timeout {
         puts "\nWARN: IOCATALOGUE marker not seen (pre-kextd/K2 image — informational)"


### PR DESCRIPTION
## What

Migrates `IOServiceAddMatchingNotification` off hwregd's `hwreg_watch` onto the **in-kernel IORegistry notify channel** (`IOREGIOCWATCH`, nextbsd-kernel #225), keeping hwregd as a **fallback** — the same dual-path C1.1 (#240) used for the read-only walk.

This is **PR4b of the in-kernel IOKit line (#218)**. It pairs with the kernel PR adding `IOREGIOCTESTEVENT` (the deterministic test-inject ioctl) — see that PR for Part A.

## Re-synced / vendored ABI

- **`src/libIOKit/ioregistry.h`** was vendored (C1.1) *before* #225 added the watch channel. Brought current with the kernel canonical: adds `IOREG_EVENT_*`, `struct ioreg_watch_reg` + `IOREGIOCWATCH`, and `struct ioreg_test_event` + `IOREGIOCTESTEVENT`.
- **new `src/libIOKit/iokit_notify.h`** — vendored userland subset of the kernel's `sys/mach/iokit_notify.h`: the `ioreg_event_msg` wire struct + `IOKIT_NOTIFY_EVENT_MSGID` + kind constants, so the receive thread can parse the binary event. Keep-in-sync notes mirror kextd's vendored `iocatalogue.h`.

## IOKitNotify.c

- `IONotificationPort` gains `use_kernel`, fixed at create time from `__io_ioregistry_fd()`.
- **Register**: `kernel_watch_register()` issues `ioctl(fd, IOREGIOCWATCH, &reg)` passing the recv-right name + the packed-nvlist criteria (same blob `__io_pack_criteria` builds for `IOREGIOCLOOKUP`) + the `IOREG_EVENT_*` mask (value-identical to the `HWREG_EVT_*` arrive/depart bits). `hwreg_watch` is the fallback. Kernel watches carry `watcher_id == 0` (kernel retires them when the recv right drops); only hwregd watches are `hwreg_unwatch`'d on destroy.
- **Receive**: a union receive buffer + `decode_event()` dispatch on `msgh_id` — `IOKIT_NOTIFY_EVENT_MSGID` parses the binary `ioreg_event_msg`; the legacy `HWREG_MSG_EVENT` keeps the `"arrived id=N ..."` text parse — both feed the existing client-side re-match + callback dispatch. One port serves either backend.

## Functional round-trip gate (heeds the MDNS-IFWATCH bug)

- **new `iokitnotifyrt`**: registers a name-matched notification via libIOKit, fires `IOREGIOCTESTEVENT` to synthesize a matching arrival, and confirms the callback fired → `IOKITNOTIFY-OK`. **SELF-SKIPs** when `/dev/ioregistry` or `IOREGIOCTESTEVENT` is absent (`ENOTTY`/`ENOSYS`), so it is **CI-green on continuous images built before the Part A kernel ingests**.
- `run.sh` runs it as a function that always emits exactly one definite `IOKITNOTIFY-{OK,FAIL,SKIP}` line and **returns** (never exits), reusing the IOREG gate's safe structure. `boot-test.sh` folds OK/SKIP as **non-terminating** (`exp_continue`-safe) with a **non-fatal timeout**; only `IOKITNOTIFY-FAIL` gates — so an optional/absent marker can never block a later required marker.

## Merge order

The Part A kernel PR (`IOREGIOCTESTEVENT`) must merge **and reach continuous** before the round-trip actually exercises end-to-end; until then `iokitnotifyrt` self-SKIPs, so this PR is greenable first.

## Risks

- ioctl on the `O_RDONLY` `/dev/ioregistry` fd: `IOREGIOCWATCH`/`TESTEVENT` are `_IOW`; the cdev doesn't gate on `fflag`, matching the already-shipped `_IOWR` `IOREGIOCLOOKUP`/`NODE` calls on the same fd.
- `mach_port_t` is `unsigned int` here, so `(uint32_t)recv_port` is exact (same name handed to `hwreg_watch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)