### PR TITLE
DiskArbitration: migrate device-arrival subscription onto the kernel notify channel (C1.3, #218)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2480,13 +2480,16 @@ test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/dnssdtest" \
 echo "==> mDNSResponder + mdnstest + libdns_sd + dnssdtest built"
 
 #
-# 3w. Phase K DiskArbitration iter 1 — daemon skeleton.
-#     Apple's DiskArbitration daemon. iter 1 is the bootstrap_check_in
-#     shell (no hwregd subscription yet, no libgeom enrichment, no
-#     DA framework). Mirrors hwregd / ipconfigd / mDNSResponder iter 1
-#     shape: prove the Mach plumbing + launchd plist + build infra
-#     first, then layer real subsystem code. iter 2 subscribes to
-#     hwregd's storage device class events.
+# 3w. Phase K DiskArbitration — daemon + storage subscription.
+#     Apple's DiskArbitration daemon. It claims com.apple.DiskArbitration via
+#     bootstrap_check_in, then subscribes to storage device arrival/removal.
+#     C1.3 (#218): the subscription now prefers the kernel notify channel via
+#     libIOKit's IOServiceAddMatchingNotification (recv port registered with the
+#     in-kernel registry via IOREGIOCWATCH on /dev/ioregistry, #225), keeping the
+#     legacy org.freebsd.hwregd raw pub/sub as a fallback when /dev/ioregistry is
+#     absent. This step runs AFTER step 3r4 (libIOKit build + install), so the
+#     Makefile's -lIOKit resolves against the installed /usr/lib/system/libIOKit.so
+#     and <IOKit/IOKitLib.h> against the installed /usr/include/IOKit header.
 #     Plan: pkgdemon.github.io/freebsd-disk-arbitration-plan.html
 #
 echo "==> Phase K: building diskarbitrationd (src/DiskArbitration)"
@@ -2496,6 +2499,12 @@ make -C "$ROOT/src/DiskArbitration" \
      all install
 test -x "$WORK/rootfs/usr/sbin/diskarbitrationd" \
     || { echo "FAIL: /usr/sbin/diskarbitrationd not installed or not executable"; exit 1; }
+# C1.3 (#218): the kernel-notify subscription path links libIOKit. Verify the
+# dynamic dependency resolves to the installed facade (a regression in the
+# Makefile -lIOKit / SYSROOT lib path would otherwise only surface at runtime).
+chroot "$WORK/rootfs" ldd /usr/sbin/diskarbitrationd \
+    | grep -q "libIOKit.so.* => /usr/lib/system/" \
+    || { echo "FAIL: diskarbitrationd doesn't resolve libIOKit from /usr/lib/system"; exit 1; }
 
 # datest — iter 1 liveness probe. bootstrap_look_up for
 # com.apple.DiskArbitration; prints DA-BOOT-OK on success. run.sh

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -1337,6 +1337,76 @@ else
     "$datest" || true	# marker gates in boot-test.sh
 fi
 
+# DA-IOKIT — C1.3 (#218) DiskArbitration kernel-notify migration gate.
+# diskarbitrationd now learns of storage arrival/removal from the kernel notify
+# channel via libIOKit's IOServiceAddMatchingNotification (recv port registered
+# with the in-kernel registry via IOREGIOCWATCH on /dev/ioregistry, #225), with
+# the legacy org.freebsd.hwregd pub/sub kept as a fallback when /dev/ioregistry
+# is absent. The daemon logs to /var/log/diskarbitrationd.stderr (its own lines
+# use DISTINCT spellings — DA-IOKIT-ARMED / DA-IOKIT-REGFAIL / "DA-IOKIT: storage"
+# — that deliberately do NOT collide with the canonical DA-IOKIT-OK/SKIP/FAIL
+# tokens this gate emits, so dumping the daemon log below cannot trip the
+# boot-test expect block early):
+#   DA-IOKIT-ARMED        — daemon registered the kernel arrival + departure watches
+#   "DA-IOKIT: storage X" — daemon saw storage device X (qemu vtblk/ahci boot
+#                            disk) arrive through the kernel channel
+#   DA-IOKIT-REGFAIL      — a kernel watch registration failed outright
+#
+# This run.sh gate emits EXACTLY ONE definite marker and RETURNS (never exits),
+# folding the optional daemon-side lines into one decision so it can never sit
+# blocking while a later required marker scrolls past (the MDNS-IFWATCH lesson):
+#   DA-IOKIT-OK    — daemon registered the kernel watches + saw a storage device
+#   DA-IOKIT-FAIL  — daemon logged DA-IOKIT-FAIL (a watch registration failed)
+#   DA-IOKIT-SKIP  — no /dev/ioregistry, the daemon took the hwregd fallback, or
+#                    no storage device surfaced through the kernel channel
+# SKIP keeps this green on a continuous image whose kernel predates K1 (DA falls
+# back to hwregd) — only DA-IOKIT-FAIL gates in boot-test.sh.
+da_iokit_gate()
+{
+    log=/var/log/diskarbitrationd.stderr
+
+    if [ ! -f "$log" ]; then
+        echo "DA-IOKIT-SKIP: $log missing"
+        return 0
+    fi
+    echo "=== diskarbitrationd.stderr (tail -40) ==="
+    tail -40 "$log" 2>/dev/null
+    echo "==="
+
+    # A hard registration failure gates regardless of anything else.
+    if grep -q 'DA-IOKIT-REGFAIL' "$log" 2>/dev/null; then
+        echo "DA-IOKIT-FAIL: diskarbitrationd failed to register kernel watches"
+        return 0
+    fi
+    # No /dev/ioregistry on this kernel — DA took the hwregd fallback path.
+    if [ ! -c /dev/ioregistry ]; then
+        echo "DA-IOKIT-SKIP: no /dev/ioregistry (kernel predating K1); DA used the hwregd fallback"
+        return 0
+    fi
+    # The daemon itself self-reported the hwregd fallback (e.g. registration
+    # bailed before the kernel path armed). Treat as SKIP, not FAIL — the
+    # fallback subscription still works.
+    if grep -q 'using hwregd pub/sub fallback' "$log" 2>/dev/null; then
+        echo "DA-IOKIT-SKIP: diskarbitrationd took the hwregd pub/sub fallback"
+        return 0
+    fi
+    # Definite success: a storage device arrived through the kernel channel.
+    if grep -q 'DA-IOKIT: storage ' "$log" 2>/dev/null; then
+        echo "DA-IOKIT-OK: diskarbitrationd saw a storage device via /dev/ioregistry"
+        return 0
+    fi
+    # Kernel path armed (DA-IOKIT-ARMED subscription line) but no storage device
+    # surfaced — e.g. the qemu disk's class isn't visible as a storage *name* to
+    # the registry yet. Non-fatal: the channel works; nothing storage to report.
+    if grep -q 'DA-IOKIT-ARMED' "$log" 2>/dev/null; then
+        echo "DA-IOKIT-SKIP: kernel watches registered but no storage device arrival observed"
+        return 0
+    fi
+    echo "DA-IOKIT-SKIP: no DA kernel-notify activity in $log"
+    return 0
+}
+da_iokit_gate
+
 ipconfig_cli=/usr/sbin/ipconfig
 if [ ! -x "$ipconfig_cli" ]; then
     echo "IPCFG-IPCONFIG-FAIL: $ipconfig_cli missing"

--- a/src/DiskArbitration/Makefile
+++ b/src/DiskArbitration/Makefile
@@ -13,14 +13,29 @@
 
 PROG=		diskarbitrationd
 MAN=
-SRCS=		diskarbitrationd.c hwreg_subscribe.c
+SRCS=		diskarbitrationd.c da_iokit_subscribe.c hwreg_subscribe.c
 
 NO_MAN=		yes
-WARNS=		6
+
+# WARNS=0: da_iokit_subscribe.c pulls <IOKit/IOKitLib.h>, which drags in the
+# whole CoreFoundation + dispatch public header tree (the IONotificationPort /
+# IOServiceMatchingCallback / CFDictionary surface). At WARNS>0 the FreeBSD
+# warning machinery adds -Wsystem-headers -Werror, which promotes warnings
+# *inside* the vendored CF headers (CFLocking.h's "CF is not thread-safe"
+# #warning, -Wexpansion-to-defined) into hard errors. libIOKit + its test
+# clients + kext_tools all build at WARNS=0 for exactly this reason. The other
+# two DA sources (diskarbitrationd.c, hwreg_subscribe.c) still get the explicit
+# warning set below.
+WARNS=		0
 
 CFLAGS+=	-O2 -pipe
 CFLAGS+=	-Wall -Wextra -Wshadow -Wstrict-prototypes
 CFLAGS+=	-Wmissing-prototypes -Wpointer-arith
+
+# -fblocks: <IOKit/IOKitLib.h> pulls CoreFoundation + <dispatch/dispatch.h>,
+# whose headers carry block-typed function pointers that need -fblocks even
+# where DA itself uses no blocks. Same flag libIOKit + its clients carry.
+CFLAGS+=	-fblocks
 
 # <servers/bootstrap.h> (bootstrap_check_in + bootstrap_port global)
 # comes from liblaunch; its bootstrap.h pulls in Apple shim headers
@@ -40,7 +55,13 @@ LDFLAGS+=	-Wl,--allow-shlib-undefined
 # -llaunch: bootstrap_check_in + the bootstrap_port global.
 # -lsystem_kernel: mach_msg + the Mach port syscalls behind it.
 # -lpthread: the hwregd subscription receive-loop runs on its own thread.
+# -lIOKit: the IONotificationPort / IOServiceAddMatchingNotification kernel-
+#   notify path (C1.3, #218). -lCoreFoundation: the CFDictionary matching-dict
+#   object model libIOKit's API consumes. -ldispatch + -lBlocksRuntime: the
+#   dispatch queue DA delivers notification callbacks on
+#   (IONotificationPortSetDispatchQueue) + the -fblocks runtime CF/dispatch pull.
 LDADD+=		-llaunch -lsystem_kernel -lpthread
+LDADD+=		-lIOKit -lCoreFoundation -ldispatch -lBlocksRuntime
 
 BINDIR=		/usr/sbin
 

--- a/src/DiskArbitration/Makefile
+++ b/src/DiskArbitration/Makefile
@@ -37,6 +37,18 @@ CFLAGS+=	-Wmissing-prototypes -Wpointer-arith
 # where DA itself uses no blocks. Same flag libIOKit + its clients carry.
 CFLAGS+=	-fblocks
 
+# ${SYSROOT}/usr/include MUST precede freebsd-shims: <IOKit/IOKitLib.h> has
+# to resolve to libIOKit's REAL installed header (IONotificationPortRef /
+# io_iterator_t / io_name_t / IOServiceAddMatchingNotification, which
+# da_iokit_subscribe.c needs) and NOT the freebsd-shims IOKit stub
+# (IOKitWaitQuiet-only, for launchctl). IOKitLib.h is the only header present
+# in both trees; AvailabilityMacros.h / NSSystemDirectories.h etc. are
+# Apple-only and still resolve from freebsd-shims regardless of order.
+SYSROOT?=
+.if !empty(SYSROOT)
+CFLAGS+=	-I${SYSROOT}/usr/include
+.endif
+
 # <servers/bootstrap.h> (bootstrap_check_in + bootstrap_port global)
 # comes from liblaunch; its bootstrap.h pulls in Apple shim headers
 # (AvailabilityMacros.h, ...) from launchd/freebsd-shims. Same -I
@@ -44,9 +56,7 @@ CFLAGS+=	-fblocks
 CFLAGS+=	-I${.CURDIR}/../launchd/liblaunch
 CFLAGS+=	-I${.CURDIR}/../launchd/freebsd-shims
 
-SYSROOT?=
 .if !empty(SYSROOT)
-CFLAGS+=	-I${SYSROOT}/usr/include
 LDFLAGS+=	-L${SYSROOT}/usr/lib/system
 LDFLAGS+=	-Wl,-rpath,/usr/lib/system
 LDFLAGS+=	-Wl,--allow-shlib-undefined

--- a/src/DiskArbitration/da_iokit_subscribe.c
+++ b/src/DiskArbitration/da_iokit_subscribe.c
@@ -1,0 +1,346 @@
+/*
+ * da_iokit_subscribe.c — DiskArbitration kernel-notify subscription (C1.3, #218).
+ *
+ * Migrates DA's device-arrival/removal subscription off hwregd's raw pub/sub
+ * onto the kernel notify channel, reusing libIOKit's now-proven
+ * IOServiceAddMatchingNotification path (#241, IOKITNOTIFY-OK): an
+ * IONotificationPort whose recv port libIOKit registers with the in-kernel
+ * registry via IOREGIOCWATCH on /dev/ioregistry, the kernel pushing a binary
+ * ioreg_event_msg per matching event into libIOKit's receive thread, which fires
+ * our IOServiceMatchingCallback (delivered on DA's dispatch queue via
+ * IONotificationPortSetDispatchQueue).
+ *
+ * DA cares about MANY storage classes (da/ada/nvd/nda/cd/mmcsd), but the kernel
+ * watch criteria is a single flat by-value struct that matches ONE class or a
+ * wildcard. So DA registers a MATCH-ALL notification (empty matching dictionary
+ * leaves every kernel criteria field zeroed, which the kernel ABI treats as a
+ * wildcard) for both arrival (kIOFirstMatchNotification) and departure
+ * (kIOTerminatedNotification), and keeps the is_storage_name() filter
+ * client-side in the callback — exactly the receive-all-then-filter shape
+ * hwreg_subscribe.c uses today.
+ *
+ * FALLBACK: this path needs /dev/ioregistry. If it is absent (a kernel image
+ * predating the K1 in-kernel registry), da_iokit_subscribe_start() returns -1
+ * (without a failure marker) and diskarbitrationd falls back to the legacy
+ * hwreg_subscribe_start() pub/sub path, which stays compiled (PR7/#218 removes
+ * it). libIOKit itself also has an internal hwregd fallback inside
+ * IONotificationPortCreate, but DA gates on /dev/ioregistry up front so a
+ * fallback run takes the SAME hwregd subscription DA used before this change,
+ * and so the DA-IOKIT gate can self-SKIP cleanly (rather than double-subscribing
+ * via two different hwregd clients).
+ */
+#include "da_iokit_subscribe.h"
+
+#include <IOKit/IOKitLib.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <dispatch/dispatch.h>
+
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/*
+ * One IONotificationPort serves both the arrival and the departure watch; the
+ * dispatch queue delivers their callbacks. Kept process-global (the daemon owns
+ * exactly one subscription for its lifetime) so the receive thread + queue
+ * outlive da_iokit_subscribe_start(). There is no teardown path: the daemon
+ * holds the subscription until exit, same as hwreg_subscribe's recv thread.
+ */
+static IONotificationPortRef	g_notify;
+static dispatch_queue_t		g_queue;
+
+static void
+xlog(const char *fmt, ...)
+{
+	va_list ap;
+
+	(void)fprintf(stderr, "diskarbitrationd[iokit] ");
+	va_start(ap, fmt);
+	(void)vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	(void)fputc('\n', stderr);
+	(void)fflush(stderr);
+}
+
+/*
+ * True if `name` looks like a CAM storage peripheral DA cares about: ada*
+ * (AHCI/CAM ATA), da* (SCSI / USB), nvd* / nda* (NVMe), cd* (optical), mmcsd*
+ * (SD/eMMC). Same rule (and same prefix list) as hwreg_subscribe.c's
+ * is_storage_name — kept in sync so both paths filter CAM peripheral names
+ * identically. These are the disk-layer names hwregd's pub/sub events carry.
+ */
+static int
+is_storage_name(const char *name)
+{
+	static const char *prefixes[] = {
+		"ada", "da", "nvd", "nda", "cd", "mmcsd"
+	};
+	size_t i;
+
+	for (i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
+		size_t plen = strlen(prefixes[i]);
+		if (strncmp(name, prefixes[i], plen) != 0)
+			continue;
+		if (name[plen] >= '0' && name[plen] <= '9')
+			return (1);
+	}
+	return (0);
+}
+
+/*
+ * The in-kernel registry (#225) exposes newbus nodes by device_get_name() /
+ * devclass — i.e. the BUS-LEVEL storage driver name (vtblk, ahci, ahcich,
+ * nvme), NOT the CAM peripheral name (da0, ada0) that hwregd's higher-level
+ * pub/sub events carry. is_storage_name above never matches a bus-driver name
+ * (no trailing unit digit, not in its prefix list), so this companion check
+ * recognizes the storage CONTROLLER/DISK driver names the registry actually
+ * reports. Both the name and the class are tested against this set (the registry
+ * fills both fields, and under qemu the virtio-blk disk shows up as name/class
+ * "vtblk"; AHCI as "ahci"/"ahcich"). Matching here is exact-or-prefix on the
+ * known storage driver tokens so a non-storage driver can't false-positive.
+ */
+static int
+is_storage_driver(const char *s)
+{
+	static const char *drivers[] = {
+		"vtblk",	/* virtio-blk (qemu default disk) */
+		"virtio_blk",	/* alternate virtio-blk devclass spelling */
+		"ahcich",	/* per-channel AHCI (the disk-bearing node) */
+		"ahci",		/* AHCI controller */
+		"nvme",		/* NVMe controller */
+		"mmc",		/* SD/eMMC host */
+		"umass"		/* USB mass storage */
+	};
+	size_t i;
+
+	if (s == NULL || s[0] == '\0')
+		return (0);
+	for (i = 0; i < sizeof(drivers) / sizeof(drivers[0]); i++)
+		if (strncmp(s, drivers[i], strlen(drivers[i])) == 0)
+			return (1);
+	return (0);
+}
+
+/*
+ * Storage decision for one registry node: true if either the CAM peripheral
+ * name rule (is_storage_name) or the bus-level storage driver rule
+ * (is_storage_driver, on name OR class) matches. This is what lets the qemu
+ * vtblk boot disk — which the registry reports as name/class "vtblk", not
+ * "da0" — drive DA's storage path through the kernel channel.
+ */
+static int
+node_is_storage(const char *name, const char *klass)
+{
+	if (name[0] != '\0' && is_storage_name(name))
+		return (1);
+	if (is_storage_driver(name) || is_storage_driver(klass))
+		return (1);
+	return (0);
+}
+
+/*
+ * Drive DA's arrival/departure path for one matched storage device. iter 2's
+ * surface is a log line (the same observable hwreg_subscribe emits) plus the
+ * distinct DA-IOKIT marker the boot test greps to prove the event came through
+ * /dev/ioregistry. Later iters hang libgeom enrichment + the DiskArbitration
+ * framework callbacks off this point, exactly where the hwregd path fed them.
+ */
+static void
+da_handle_storage(const char *verb, const char *name, const char *klass)
+{
+	xlog("STORAGE %s name=%s class=%s (via /dev/ioregistry)",
+	    verb, name, klass[0] != '\0' ? klass : "?");
+	/*
+	 * One-shot, unambiguous marker for the CI boot-test gate: storage
+	 * arrival seen through the kernel notify channel. Emitting it on the
+	 * ARRIVAL verb (the common qemu vtblk/ahci case) keeps the gate
+	 * deterministic; departures still log above but do not re-fire the
+	 * marker so the gate's expect block stays single-shot.
+	 */
+	if (strcmp(verb, "arrival") == 0)
+		xlog("DA-IOKIT: storage %s %s via /dev/ioregistry", name,
+		    klass[0] != '\0' ? klass : "");
+}
+
+/*
+ * Drain the iterator libIOKit handed us, reading each node's name + class via
+ * libIOKit and applying the storage filter. The facade owns the iterator (it
+ * tears it down when we return), so we MUST NOT release it; we DO release each
+ * io_object_t IOIteratorNext hands back. `verb` distinguishes the arrival watch
+ * from the departure watch (the two share this drain).
+ */
+static void
+drain_iterator(io_iterator_t it, const char *verb)
+{
+	io_object_t obj;
+
+	while ((obj = IOIteratorNext(it)) != IO_OBJECT_NULL) {
+		io_name_t name;
+		io_name_t klass;
+
+		name[0] = '\0';
+		klass[0] = '\0';
+		(void)IORegistryEntryGetName(obj, name);
+		(void)IOObjectGetClass(obj, klass);
+
+		if (node_is_storage(name, klass))
+			da_handle_storage(verb, name, klass);
+		else
+			xlog("event %s name=%s class=%s (non-storage, ignored)",
+			    verb, name[0] != '\0' ? name : "?",
+			    klass[0] != '\0' ? klass : "?");
+
+		IOObjectRelease(obj);
+	}
+}
+
+static void
+arrival_callback(void *refcon __unused, io_iterator_t it)
+{
+	drain_iterator(it, "arrival");
+}
+
+static void
+departure_callback(void *refcon __unused, io_iterator_t it)
+{
+	drain_iterator(it, "departure");
+}
+
+/*
+ * Build a MATCH-ALL matching dictionary: an empty CFDictionary. libIOKit's
+ * __io_extract_criteria leaves every io_criteria field empty, __io_fill_criteria
+ * then zeroes the kernel struct, and the kernel ABI treats an all-zero criteria
+ * as "match every node" — so the watch fires for every storage class without
+ * enumerating them. (IOServiceAddMatchingNotification consumes one reference of
+ * the dictionary, so each watch gets its own fresh copy.)
+ */
+static CFMutableDictionaryRef
+match_all_dict(void)
+{
+	return (CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+	    &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+}
+
+int
+da_iokit_subscribe_start(void)
+{
+	CFMutableDictionaryRef arrive_match, depart_match;
+	io_iterator_t arrive_it = IO_OBJECT_NULL;
+	io_iterator_t depart_it = IO_OBJECT_NULL;
+	io_object_t obj;
+	kern_return_t kr;
+
+	/*
+	 * Gate on /dev/ioregistry up front. If it is absent, the kernel notify
+	 * channel does not exist on this image; return -1 (no failure marker)
+	 * so the caller takes the legacy hwregd fallback. (libIOKit would itself
+	 * fall back to hwregd internally, but DA prefers a single explicit
+	 * decision here so the fallback uses DA's own hwreg_subscribe client and
+	 * the DA-IOKIT gate can self-SKIP rather than report a half-kernel path.)
+	 */
+	{
+		int fd = open("/dev/ioregistry", O_RDONLY | O_CLOEXEC);
+
+		if (fd < 0) {
+			xlog("no /dev/ioregistry — kernel notify channel "
+			    "unavailable; falling back to hwregd pub/sub");
+			return (-1);
+		}
+		(void)close(fd);
+	}
+
+	g_notify = IONotificationPortCreate(kIOMainPortDefault);
+	if (g_notify == NULL) {
+		xlog("DA-IOKIT-REGFAIL: IONotificationPortCreate failed");
+		return (-1);
+	}
+
+	/*
+	 * Deliver callbacks on a serial DA dispatch queue, mirroring how DA
+	 * consumes events (libdispatch). The receive thread inside libIOKit
+	 * dispatch_async_f's each callback onto this queue, so device events
+	 * are serialized w.r.t. each other on DA's own queue rather than
+	 * running on libIOKit's private receive thread.
+	 */
+	g_queue = dispatch_queue_create("com.apple.DiskArbitration.iokit", NULL);
+	if (g_queue == NULL) {
+		xlog("DA-IOKIT-REGFAIL: dispatch_queue_create failed");
+		IONotificationPortDestroy(g_notify);
+		g_notify = NULL;
+		return (-1);
+	}
+	IONotificationPortSetDispatchQueue(g_notify, g_queue);
+
+	/* Arrival watch (match-all; storage filtered client-side). */
+	arrive_match = match_all_dict();
+	if (arrive_match == NULL) {
+		xlog("DA-IOKIT-REGFAIL: match dict alloc (arrival)");
+		goto fail;
+	}
+	kr = IOServiceAddMatchingNotification(g_notify,
+	    kIOFirstMatchNotification, arrive_match, arrival_callback, NULL,
+	    &arrive_it);
+	if (kr != KERN_SUCCESS) {
+		xlog("DA-IOKIT-REGFAIL: AddMatchingNotification(arrival) kr=0x%x",
+		    (unsigned)kr);
+		goto fail;
+	}
+
+	/* Departure watch. */
+	depart_match = match_all_dict();
+	if (depart_match == NULL) {
+		xlog("DA-IOKIT-REGFAIL: match dict alloc (departure)");
+		goto fail;
+	}
+	kr = IOServiceAddMatchingNotification(g_notify,
+	    kIOTerminatedNotification, depart_match, departure_callback, NULL,
+	    &depart_it);
+	if (kr != KERN_SUCCESS) {
+		xlog("DA-IOKIT-REGFAIL: AddMatchingNotification(departure) kr=0x%x",
+		    (unsigned)kr);
+		goto fail;
+	}
+
+	xlog("DA-IOKIT-ARMED: subscribed to kernel device notifications via "
+	    "/dev/ioregistry (match-all arrival + departure, storage filtered "
+	    "client-side)");
+
+	/*
+	 * Initial arming: each watch handed back an iterator over the devices
+	 * that ALREADY match (Apple's contract). Drain them so storage devices
+	 * present at boot are reported through the SAME path as later arrivals —
+	 * this is what makes the qemu vtblk disk, attached before DA starts,
+	 * fire the DA-IOKIT marker. Departure's initial set is also drained
+	 * (logged, but it does not re-fire the marker). The facade does NOT tear
+	 * these iterators down (they are the caller-owned arming iterators, not
+	 * the per-event ones), so we release them ourselves.
+	 */
+	drain_iterator(arrive_it, "arrival");
+	drain_iterator(depart_it, "departure");
+	IOObjectRelease(arrive_it);
+	IOObjectRelease(depart_it);
+
+	return (0);
+
+fail:
+	if (arrive_it != IO_OBJECT_NULL) {
+		while ((obj = IOIteratorNext(arrive_it)) != IO_OBJECT_NULL)
+			IOObjectRelease(obj);
+		IOObjectRelease(arrive_it);
+	}
+	if (depart_it != IO_OBJECT_NULL) {
+		while ((obj = IOIteratorNext(depart_it)) != IO_OBJECT_NULL)
+			IOObjectRelease(obj);
+		IOObjectRelease(depart_it);
+	}
+	IONotificationPortDestroy(g_notify);
+	g_notify = NULL;
+	if (g_queue != NULL) {
+		dispatch_release(g_queue);
+		g_queue = NULL;
+	}
+	return (-1);
+}

--- a/src/DiskArbitration/da_iokit_subscribe.h
+++ b/src/DiskArbitration/da_iokit_subscribe.h
@@ -1,0 +1,34 @@
+/*
+ * da_iokit_subscribe.h — DiskArbitration kernel-notify subscription (C1.3, #218).
+ *
+ * Learns of storage-device arrival/removal from the kernel notify channel via
+ * libIOKit's IOServiceAddMatchingNotification, which (when /dev/ioregistry is
+ * present) registers the recv port via IOREGIOCWATCH on the in-kernel registry
+ * (#225) and the kernel pushes a binary ioreg_event_msg per matching event. The
+ * proven path libIOKit's iokitnotifyrt round-trip exercises (#241, IOKITNOTIFY-OK).
+ *
+ * DA registers a MATCH-ALL notification (empty matching dictionary) for both
+ * arrival (kIOFirstMatchNotification) and departure (kIOTerminatedNotification),
+ * then filters storage device names client-side in the callback with the same
+ * is_storage_name() rule hwreg_subscribe uses today (da*, ada*, nvd*, nda*, cd*,
+ * mmcsd*). This mirrors how hwreg_subscribe receives all events and tags storage.
+ *
+ * FALLBACK: this path requires /dev/ioregistry. If it is absent (a kernel image
+ * predating K1), da_iokit_subscribe_start() returns -1 WITHOUT logging a failure
+ * marker, and the caller falls back to the legacy hwreg_subscribe_start() pub/sub
+ * path. hwreg_subscribe.c stays compiled as that fallback (PR7/#218 removes it).
+ */
+#ifndef DISKARBITRATION_DA_IOKIT_SUBSCRIBE_H
+#define DISKARBITRATION_DA_IOKIT_SUBSCRIBE_H
+
+/*
+ * Start the kernel-notify storage subscription via libIOKit. Returns 0 when the
+ * kernel notify channel is present and both arrival + departure notifications
+ * registered (the receive thread + dispatch delivery are up). Returns -1 when
+ * the kernel path is unavailable (no /dev/ioregistry) or registration failed —
+ * the caller should fall back to hwreg_subscribe_start(). Non-fatal either way:
+ * the daemon keeps its Mach service registered regardless.
+ */
+int da_iokit_subscribe_start(void);
+
+#endif /* DISKARBITRATION_DA_IOKIT_SUBSCRIBE_H */

--- a/src/DiskArbitration/diskarbitrationd.c
+++ b/src/DiskArbitration/diskarbitrationd.c
@@ -25,6 +25,7 @@
  *             DADiskUnmount / DADiskEject.
  *   iter 5+ — mount-policy arbitration, per-user agent.
  */
+#include "da_iokit_subscribe.h"
 #include "hwreg_subscribe.h"
 
 #include <mach/mach.h>
@@ -105,13 +106,26 @@ main(int argc, char **argv)
 	    "(receive right=0x%x)", (unsigned)svc);
 
 	/*
-	 * iter 2: subscribe to org.freebsd.hwregd's pub/sub bus and log
-	 * incoming device events. Tag storage names (ada*, da*, nvd*,
-	 * cd*, mmcsd*) with STORAGE; emit DA-WATCH-OK on subscription
-	 * ack. Non-fatal — if hwregd isn't up yet, the daemon stays
-	 * alive without storage events.
+	 * Subscribe to storage device arrival/removal. Prefer the kernel
+	 * notify channel (C1.3, #218): libIOKit's IOServiceAddMatchingNotification
+	 * registers DA's recv port with the in-kernel registry via IOREGIOCWATCH
+	 * on /dev/ioregistry (#225), and the kernel pushes a binary event per
+	 * matching device. DA registers a match-all arrival + departure watch and
+	 * filters storage names (ada*, da*, nvd*, nda*, cd*, mmcsd*) client-side.
+	 *
+	 * FALLBACK: if /dev/ioregistry is absent (a kernel image predating K1) or
+	 * registration fails, da_iokit_subscribe_start returns -1 and we fall
+	 * back to the legacy org.freebsd.hwregd raw pub/sub path
+	 * (hwreg_subscribe_start), which tags the same storage names and emits
+	 * DA-WATCH-OK on its subscription ack. Both paths are non-fatal — if
+	 * neither backend is up yet, the daemon stays alive without storage
+	 * events and KeepAlive respawns / relookups happen as services appear.
 	 */
-	(void)hwreg_subscribe_start();
+	if (da_iokit_subscribe_start() != 0) {
+		xlog("storage subscription: kernel notify channel unavailable, "
+		    "using hwregd pub/sub fallback");
+		(void)hwreg_subscribe_start();
+	}
 
 	/*
 	 * iter-1 hold-alive loop. Spin on sleep(60) — SIGTERM/SIGHUP

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -1005,6 +1005,37 @@ expect {
     }
 }
 
+# DA-IOKIT — C1.3 (#218) DiskArbitration kernel-notify migration gate. run.sh's
+# da_iokit_gate inspects /var/log/diskarbitrationd.stderr: the daemon now learns
+# of storage arrival/removal from the kernel notify channel via libIOKit's
+# IOServiceAddMatchingNotification (recv port registered via IOREGIOCWATCH on
+# /dev/ioregistry, #225), keeping the legacy org.freebsd.hwregd pub/sub as a
+# fallback. DA-IOKIT-OK means it registered the kernel watches AND saw a storage
+# device (the qemu vtblk/ahci boot disk) arrive through that channel.
+#
+# CRITICAL (MDNS-IFWATCH lesson): OK/SKIP are folded into ONE block that ends
+# only on OK/FAIL/SKIP, with a NON-FATAL timeout, so an absent/optional marker
+# can never sit blocking while a later required marker scrolls past. The gate
+# SELF-SKIPs when /dev/ioregistry is absent (kernel predating K1 — DA used the
+# hwregd fallback) or when no storage device surfaced through the kernel
+# channel, so this stays green on pre-K1 continuous images. Only DA-IOKIT-FAIL
+# gates (a kernel watch registration failed outright).
+expect {
+    timeout {
+        puts "\nWARN: DA-IOKIT marker not seen (pre-C1.3 run.sh — informational)"
+    }
+    "DA-IOKIT-FAIL" {
+        puts "\nFAIL: diskarbitrationd failed to register kernel device notifications"
+        exit 1
+    }
+    "DA-IOKIT-SKIP" {
+        puts "\nWARN: DA-IOKIT-SKIP — no /dev/ioregistry, hwregd fallback, or no storage arrival"
+    }
+    "DA-IOKIT-OK" {
+        puts "\nOK: diskarbitrationd saw a storage device via the kernel notify channel (/dev/ioregistry)"
+    }
+}
+
 # IPCFG-IPCONFIG — iter 8 Apple-shape CLI. Same MIG round-trip
 # ipconfigrpctest exercises, but driven through /usr/sbin/ipconfig.
 # Validates that the Apple-canonical CLI parses argv, looks up


### PR DESCRIPTION
## What

Migrates DiskArbitration's storage device-arrival/removal subscription off hwregd's raw pub/sub onto the **kernel notify channel**, reusing the now-proven libIOKit `IOServiceAddMatchingNotification` path (PR4 / #241, merged — IOKITNOTIFY-OK in CI). KEEPS the hwregd subscription as a fallback so nothing breaks if `/dev/ioregistry` is absent.

Userland-only: the kernel support is already merged and in continuous, so there is no cross-repo timing dependency.

## Kernel path + fallback

- New `src/DiskArbitration/da_iokit_subscribe.c/.h`: creates an `IONotificationPort`, registers a **match-all** notification (empty matching dict → all-zero kernel criteria → wildcard) for arrival (`kIOFirstMatchNotification`) and departure (`kIOTerminatedNotification`). libIOKit registers the recv port via `IOREGIOCWATCH` on `/dev/ioregistry` (#225); the kernel pushes a binary event per matching device into libIOKit's receive thread, which fires the callback on a DA dispatch queue (`IONotificationPortSetDispatchQueue`).
- The callback drains the `io_iterator_t`, reads each node's name/class (`IORegistryEntryGetName` / `IOObjectGetClass`), applies the storage filter, and drives the same storage path hwreg_subscribe drives. Because the registry exposes **bus-level driver names** (`vtblk`/`ahcich`/`nvme`), not CAM peripheral names (`da0`), the filter matches both: `is_storage_name` (kept in sync with hwreg_subscribe's `da*/ada*/nvd*/nda*/cd*/mmcsd*`) and `is_storage_driver` (vtblk/virtio_blk/ahci/ahcich/nvme/mmc/umass).
- Initial arming iterators are drained at startup so the qemu boot disk (present before DA starts) fires the marker deterministically.
- **Fallback**: `da_iokit_subscribe_start()` gates on `/dev/ioregistry` up front; if absent or registration fails it returns -1 (no failure marker) and `diskarbitrationd` calls the existing `hwreg_subscribe_start()`. `hwreg_subscribe.c` stays compiled (its removal is PR7/#218).
- `diskarbitrationd.c`: try kernel path, fall back to hwregd. `Makefile`: adds the new source, `-lIOKit -lCoreFoundation -ldispatch -lBlocksRuntime`, `-fblocks`, and WARNS=0 (CF header tree, same as libIOKit). `build.sh`: comment + an `ldd` check that diskarbitrationd resolves libIOKit (DA builds after libIOKit at step 3r4).

## Test gate

New **DA-IOKIT** boot-test gate. The daemon logs `DA-IOKIT: storage <name> via /dev/ioregistry` when it sees storage via the kernel channel. `run.sh`'s `da_iokit_gate` folds the daemon log into exactly one `DA-IOKIT-OK/SKIP/FAIL` line; `boot-test.sh` gates only on `DA-IOKIT-FAIL` (self-SKIP when `/dev/ioregistry` is absent or DA took the hwregd fallback). The daemon's own log spellings (`DA-IOKIT-ARMED` / `DA-IOKIT-REGFAIL` / `DA-IOKIT: storage`) deliberately do **not** collide with the canonical gate tokens, so dumping the log cannot trip the expect block early (the MDNS-IFWATCH stream-swallowing lesson). The gate is exp_continue-safe and mirrors the IOREG / IOKITNOTIFY gates.

## Risks

- If the registry node names/classes for the qemu disk differ from the recognized set, the gate self-SKIPs (still green) rather than failing — the channel-armed case is a SKIP, only an outright watch-registration failure gates.
- PR boot tests can still hit the rare loader char-drop flake (bare "banner not seen" with no panic).

Refs #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)