### PR TITLE
ci: ingest IntelEthernet.kext from modules continuous (Step 2 of #219)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,17 +181,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
-          # ~100MB tarball, extracted + installed inside the VM by build.sh.
-          # Non-fatal if absent (ISO just ships without the driver kexts).
+          # Driver-kext tarballs, extracted + installed inside the VM by build.sh
+          # (the build.sh loop installs every kext-dl/*.tar.gz it finds). Each is
+          # non-fatal if absent (ISO just ships without that driver kext).
           mkdir -p kext-dl
-          if gh release download continuous \
-               -R nextbsd-redux/nextbsd-kernel-modules \
-               --pattern "intelwifi-kext.tar.gz" \
-               --output kext-dl/intelwifi-kext.tar.gz --clobber; then
-            echo "kext tarball: $(ls -lh kext-dl/intelwifi-kext.tar.gz | awk '{print $5}')"
-          else
-            echo "WARN: no intelwifi-kext asset; ISO ships without IntelWiFi.kext"
-          fi
+          for k in intelwifi intelethernet; do
+            if gh release download continuous \
+                 -R nextbsd-redux/nextbsd-kernel-modules \
+                 --pattern "${k}-kext.tar.gz" \
+                 --output "kext-dl/${k}-kext.tar.gz" --clobber; then
+              echo "kext tarball: $(ls -lh kext-dl/${k}-kext.tar.gz | awk '{print $5}')"
+            else
+              echo "WARN: no ${k}-kext asset; ISO ships without ${k} kext"
+            fi
+          done
 
       - name: build ISO inside FreeBSD VM
         uses: vmactions/freebsd-vm@v1

--- a/build.sh
+++ b/build.sh
@@ -681,8 +681,13 @@ done
 echo "    confirmed: kld* CLIs removed; kld*(2) syscalls + linker.hints intact"
 
 #
-# 3b3. install bundled driver kexts (IntelWiFi.kext, ...) from the
-#      nextbsd-kernel-modules `continuous` asset into /System/Library/Extensions.
+# 3b3. install bundled driver kexts (IntelWiFi.kext, IntelEthernet.kext, ...)
+#      from the nextbsd-kernel-modules `continuous` asset into
+#      /System/Library/Extensions. NB: IntelEthernet.kext (if_em, #219) ships
+#      here but stays INERT until the kernel drops `device em` (nodevice em in
+#      config/NEXTBSD) — until then the built-in em driver claims the e1000 and
+#      the matcher never fires a load for it. The loop below installs every
+#      kext-dl/*.tar.gz the workflow fetched, so no per-kext logic is needed.
 #      Each kext ships its firmware under Contents/Resources/firmware; firmware(9)
 #      locates it via the firmware_path kenv (see overlays/boot/loader.conf.d —
 #      a Tier-0 stopgap until kextload registers it dynamically, nextbsd#205).


### PR DESCRIPTION
Step 2 of #219 (D1: em → IntelEthernet.kext). Follows nextbsd-kernel-modules#10 (merged), which now ships **`intelethernet-kext.tar.gz`** (if_em / Intel GbE family) on the modules `continuous` release.

## Change
- The kext-download step now loops over `{intelwifi,intelethernet}-kext.tar.gz` (each non-fatal if absent).
- `build.sh`'s install loop already extracts every `kext-dl/*.tar.gz`, so no install-logic change — just a clarifying comment.

## Inert for now (by design)
`IntelEthernet.kext` ships into `/System/Library/Extensions` but stays **inert**: the kernel still has `device em` built in, so the in-kernel driver claims the qemu e1000 and the matcher never fires a load for it. Zero risk to networking.

**Step 3** (separate nextbsd-kernel PR) adds `nodevice em` to `config/NEXTBSD`; the e1000 then hits `device_nomatch` → kextd auto-loads this kext → `em0`. That's where the full cycle proves in CI (qemu emulates the e1000).

## Merge ordering
Merge only **after** the modules `continuous` release has `intelethernet-kext.tar.gz` live (so the post-merge main build actually ships it). The download step is non-fatal if it's not there yet, so this is safe either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)