### PR TITLE
ipconfigd: onboard NICs that arrive after startup (unblocks #219)

### DIFF
--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -40,7 +40,7 @@
  * sc_link_watch.c watches State:/Network/Interface/<if>/Link, which
  * the standalone KernelEventMonitor daemon publishes from PF_ROUTE
  * link-state changes; when an interface goes Active the watch invokes
- * on_link_active(), which runs DHCP on it. This is the Apple-shaped
+ * on_link_event(), which admin-ups it (link down) or runs DHCP (link up) on it. This is the Apple-shaped
  * trigger (KernelEventMonitor -> SCDynamicStore -> IPConfiguration);
  * it replaced the earlier hwregd attach subscription (removed with
  * hwregd in PR #167). At startup we bring the candidate NIC IFF_UP so
@@ -219,11 +219,11 @@ read_lease_cap_env(void)
 /*
  * dhcp_run_on_interface — full DHCPv4 INIT → BOUND → publish → RA →
  * lease loop on `ifname`. Driven by the link-watch callback
- * (on_link_active) when KernelEventMonitor reports the link Active.
+ * (on_link_event) when KernelEventMonitor reports the link Active.
  *
  * Blocks in lease_loop_run until SIGTERM; never returns from a fully
  * successful path. On any failure the function returns cleanly and
- * on_link_active re-arms so a later link-up event can retry.
+ * on_link_event re-arms so a later link-up event can retry.
  */
 static void
 dhcp_run_on_interface(const char *ifname, uint32_t lease_cap_secs)
@@ -334,26 +334,48 @@ dhcp_run_on_interface(const char *ifname, uint32_t lease_cap_secs)
 }
 
 /*
- * link-watch callback — invoked on a libdispatch worker thread when
- * KernelEventMonitor reports an interface's link went Active
- * (State:/Network/Interface/<if>/Link = {Active:true}). This is the
- * Apple-shaped trigger that replaced the hwregd attach subscription.
+ * link-watch callback — invoked on a libdispatch worker thread for every
+ * change to an interface's Link entity (State:/Network/Interface/<if>/Link),
+ * published by KernelEventMonitor from PF_ROUTE. `active` reflects the current
+ * link state. This is the Apple-shaped trigger that replaced the hwregd attach
+ * subscription.
  *
- * Run DHCP on the just-linked interface, guarding against concurrent /
- * duplicate fires: skip if a run is already in flight (g_dhcp_started)
- * or if we are already bound. The single-NIC focus is unchanged;
- * multi-NIC fan-out is a later iter. dhcp_run_on_interface blocks in
- * lease_loop_run on this worker thread once bound — fine, libdispatch
- * services other work on other threads.
+ * Two cases:
+ *   - link DOWN (active == 0): the interface is present but its link has not
+ *     come up. Bring it administratively up so its link can negotiate. This is
+ *     the critical path for a NIC that ARRIVES after startup — e.g. an
+ *     auto-loaded driver kext (#219): ipconfigd's startup scan never saw it, so
+ *     nothing else admin-ups it, and without IFF_UP the link stays down forever
+ *     and it is never DHCP'd. iface_bring_up is idempotent (no-op if already
+ *     up), so re-fires for an interface we already brought up are harmless. The
+ *     resulting link-up generates a fresh Active:true event that lands us in the
+ *     DHCP case below.
+ *   - link UP (active != 0): run DHCP on the just-linked interface, guarding
+ *     against concurrent / duplicate fires (skip if a run is in flight or we are
+ *     already bound). Single-NIC focus is unchanged; multi-NIC fan-out is a
+ *     later iter. dhcp_run_on_interface blocks in lease_loop_run on this worker
+ *     thread once bound — fine, libdispatch services other work on other threads.
  */
 static void
-on_link_active(const char *ifname, uint32_t lease_cap_secs)
+on_link_event(const char *ifname, int active, uint32_t lease_cap_secs)
 {
 	char already[IFNAMSIZ] = "";
 
-	/* loopback never carries a DHCP service; KEM filters lo0 too. */
+	/* loopback never carries a DHCP service; the watcher filters lo0 too. */
 	if (strncmp(ifname, "lo", 2) == 0)
 		return;
+
+	if (!active) {
+		/* Present but link down — admin-up so the link can negotiate
+		 * (the late-arriving-NIC onboarding path, #219). */
+		if (iface_bring_up(ifname) == 0)
+			xlog("link-seen(%s) — brought admin-up; awaiting "
+			    "link-active to DHCP", ifname);
+		else
+			xlog("link-seen(%s) — could not bring up: %s", ifname,
+			    strerror(errno));
+		return;
+	}
 
 	pthread_mutex_lock(&g_dhcp_lock);
 	if (g_dhcp_started || bound_state_any(already, sizeof(already))) {
@@ -455,7 +477,7 @@ main(int argc, char **argv)
 		xlog("no Ethernet at startup; will DHCP when one links up");
 	}
 
-	if (sc_link_watch_start(on_link_active, lease_cap_secs) != 0)
+	if (sc_link_watch_start(on_link_event, lease_cap_secs) != 0)
 		xlog("IPCFG-BOUND-FAIL: link watch unavailable — DHCP will "
 		    "not be triggered");
 

--- a/src/IPConfiguration/sc_link_watch.c
+++ b/src/IPConfiguration/sc_link_watch.c
@@ -61,41 +61,46 @@ mkstr(const char *s)
 }
 
 /* Trampoline payload — heap-allocated, freed by the trampoline. */
-struct dhcp_req {
+struct link_event {
 	char		ifname[IFNAMSIZ];
+	int		active;
 	uint32_t	lease_cap_secs;
 };
 
 static void
-run_dhcp_trampoline(void *arg)
+run_link_trampoline(void *arg)
 {
-	struct dhcp_req *req = arg;
+	struct link_event *ev = arg;
 
 	if (g_cb != NULL)
-		g_cb(req->ifname, req->lease_cap_secs);
-	free(req);
+		g_cb(ev->ifname, ev->active, ev->lease_cap_secs);
+	free(ev);
 }
 
-/* Schedule the caller's DHCP callback for `ifname` on the global queue. */
+/* Schedule the caller's link-event callback for `ifname` on the global queue. */
 static void
-schedule_dhcp(const char *ifname)
+schedule_link_event(const char *ifname, int active)
 {
-	struct dhcp_req *req;
+	struct link_event *ev;
 
-	req = calloc(1, sizeof(*req));
-	if (req == NULL)
+	ev = calloc(1, sizeof(*ev));
+	if (ev == NULL)
 		return;
-	(void)strlcpy(req->ifname, ifname, sizeof(req->ifname));
-	req->lease_cap_secs = g_lease_cap_secs;
+	(void)strlcpy(ev->ifname, ifname, sizeof(ev->ifname));
+	ev->active = active;
+	ev->lease_cap_secs = g_lease_cap_secs;
 	dispatch_async_f(dispatch_get_global_queue(
-	    DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), req, run_dhcp_trampoline);
+	    DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ev, run_link_trampoline);
 }
 
 /*
- * Pull "State:/Network/Interface/<if>/Link"'s Active flag out of the
- * store and, if true, schedule DHCP on <if>. Extracts the ifname from
- * the key text rather than the dict, so it works for both the change
- * callout and the initial scan.
+ * Pull "State:/Network/Interface/<if>/Link"'s Active flag out of the store
+ * and schedule the caller's callback for <if>, passing the link state.
+ * Fired for BOTH up and down so the callback can admin-up a newly-seen
+ * interface whose link is still down (the late-arriving-NIC case, #219) and
+ * DHCP it once it links. Extracts the ifname from the key text rather than the
+ * dict, so it works for both the change callout and the initial scan. lo0 is
+ * filtered here so the callback never sees loopback.
  */
 static void
 handle_link_key(SCDynamicStoreRef store, CFStringRef key)
@@ -107,6 +112,7 @@ handle_link_key(SCDynamicStoreRef store, CFStringRef key)
 	size_t n;
 	CFDictionaryRef dict;
 	CFBooleanRef active;
+	int is_active;
 
 	if (!CFStringGetCString(key, keybuf, sizeof(keybuf),
 	    kCFStringEncodingUTF8))
@@ -123,6 +129,9 @@ handle_link_key(SCDynamicStoreRef store, CFStringRef key)
 	(void)memcpy(ifname, p, n);
 	ifname[n] = '\0';
 
+	if (strncmp(ifname, "lo", 2) == 0)	/* loopback never DHCPs */
+		return;
+
 	dict = SCDynamicStoreCopyValue(store, key);
 	if (dict == NULL)
 		return;
@@ -131,11 +140,15 @@ handle_link_key(SCDynamicStoreRef store, CFStringRef key)
 		return;
 	}
 	active = CFDictionaryGetValue(dict, CFSTR("Active"));
-	if (active != NULL && CFGetTypeID(active) == CFBooleanGetTypeID() &&
-	    CFBooleanGetValue(active)) {
+	is_active = (active != NULL &&
+	    CFGetTypeID(active) == CFBooleanGetTypeID() &&
+	    CFBooleanGetValue(active));
+	if (is_active)
 		xlog("IPCFG-LINK-UP: %s link Active — scheduling DHCP", ifname);
-		schedule_dhcp(ifname);
-	}
+	else
+		xlog("IPCFG-LINK-SEEN: %s present, link down — scheduling "
+		    "admin-up", ifname);
+	schedule_link_event(ifname, is_active);
 	CFRelease(dict);
 }
 

--- a/src/IPConfiguration/sc_link_watch.h
+++ b/src/IPConfiguration/sc_link_watch.h
@@ -3,9 +3,11 @@
  *
  * Replaces hwreg_subscribe (the removed hwregd attach trigger) with a
  * watch on State:/Network/Interface/<if>/Link, which the standalone
- * KernelEventMonitor publishes from PF_ROUTE link-state changes. On a
- * link going Active the watcher invokes the caller's callback so
- * ipconfigd can start DHCP on the freshly-linked interface.
+ * KernelEventMonitor publishes from PF_ROUTE link-state changes. The
+ * watcher invokes the caller's callback whenever an interface's Link
+ * entity appears or changes — carrying the current Active state — so
+ * ipconfigd can both admin-up a newly-seen interface (whose link is
+ * still down) and start DHCP once the link is Active.
  */
 #ifndef SC_LINK_WATCH_H
 #define SC_LINK_WATCH_H
@@ -13,13 +15,17 @@
 #include <stdint.h>
 
 /*
- * Invoked (on a libdispatch worker thread) when an interface's link
- * becomes Active. `ifname` is the BSD interface name; `lease_cap_secs`
+ * Invoked (on a libdispatch worker thread) for every change to a watched
+ * interface's Link entity, AND for each one found by the initial scan.
+ * `ifname` is the BSD interface name; `active` is non-zero when the link
+ * is up (Active:true), zero when it is present but down. `lease_cap_secs`
  * is forwarded verbatim from sc_link_watch_start. The callback decides
- * whether to DHCP (e.g. skip if already bound) and may block in the
- * DHCP + lease loop.
+ * what to do (e.g. admin-up the interface when down so its link can
+ * negotiate; DHCP when up, skipping if already bound) and may block in
+ * the DHCP + lease loop. lo0 is filtered by the watcher.
  */
-typedef void (*sc_link_watch_cb)(const char *ifname, uint32_t lease_cap_secs);
+typedef void (*sc_link_watch_cb)(const char *ifname, int active,
+	    uint32_t lease_cap_secs);
 
 /*
  * Open a configd session, watch State:/Network/Interface/<if>/Link,


### PR DESCRIPTION
Unblocks nextbsd-kernel#28 (`nodevice em`, #219). That PR's smoke test proved the auto-load chain **works** (em0 attaches via the kext) but went red on networking — and the diagnosis was an ipconfigd gap, not the auto-load:

```
ipconfigd starts → scans → only lo0 → "no Ethernet at startup; will DHCP when one links up"
em0 attaches ~0.3s later (kext loaded it — just after the scan)
KernelEventMonitor: em0 Active=0   (link DOWN)
→ ipconfigd never admin-ups em0 → link never negotiates → never DHCP'd → ifcount=0
```

ipconfigd only **admin-ups interfaces present at its startup scan**; a NIC that arrives later (an auto-loaded driver kext) is left down forever.

## Fix
ipconfigd already *learns* of the late interface — KEM publishes its `State:/Network/Interface/em0/Link` key on attach, and `sc_link_watch`'s wildcard catches it — it just ignored the `Active:false` state. Now:

- **`sc_link_watch.{h,c}`** — the callback gains an `int active` flag and fires for **both** up and down (lo0 filtered in the watcher).
- **`ipconfigd.c`** — `on_link_active` → `on_link_event(ifname, active, …)`: when **down**, bring the interface admin-up (`iface_bring_up`, idempotent) so its link can negotiate; when **up**, run DHCP via the existing path (guards unchanged).

The resulting link-up generates an `Active:true` event → DHCP. This is the Apple-faithful split — **KernelEventMonitor monitors, ipconfigd configures** — now extended to late arrivals, not just startup-present NICs. (It also makes real-hardware hot-plug work, not just kext auto-load.)

## Sequencing
Merge this → nextbsd `continuous` rebuilds with the fixed ipconfigd in the ISO → re-run nextbsd-kernel#28's smoke, which should then flip `EM-AUTOLOAD-SKIP` → **`EM-AUTOLOAD-OK`** and bring `em0` up via DHCP. Safe to merge now regardless of #28: on a built-in-`em` kernel the interface is present at startup, so the new down→admin-up path is a harmless idempotent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)