### PR TITLE
test: native EVFILT_MACHPORT delivery probe (#249) + concurrency stress (#251)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -785,6 +785,19 @@ cc -I"$WORK/rootfs/usr/include" \
    -lsystem_kernel
 ls -lh "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_mach_port"
 
+# test_evfilt_machport — #168 gate: proves the NATIVE kernel EVFILT_MACHPORT
+# kqueue filter (mach.ko filt_machport, patch 0003 slot -16) actually delivers a
+# wakeup + inline-receives a Mach message arriving on a port set. Raw kevent(2),
+# no libdispatch/libmach bridge. Marker EVFILT-MACHPORT-OK / -FAIL / -SKIP.
+echo "==> building test_evfilt_machport"
+cc -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_evfilt_machport" \
+   "$ROOT/src/mach_kmod/tests/test_evfilt_machport.c" \
+   -lsystem_kernel
+ls -lh "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_evfilt_machport"
+
 # test_task_special_port — exercises task_get_special_port /
 # task_set_special_port traps (Phase G prerequisite for the bootstrap
 # server's port discovery). Failure surfaces as TASK-SPECIAL-PORT-FAIL.

--- a/build.sh
+++ b/build.sh
@@ -798,6 +798,21 @@ cc -I"$WORK/rootfs/usr/include" \
    -lsystem_kernel
 ls -lh "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_evfilt_machport"
 
+# test_evfilt_machport_concurrent — #168 Stage 0 / #251: concurrency stress for
+# the native EVFILT_MACHPORT filter. Raw pthreads (no per-thread Mach init)
+# hammer concurrent knote attach/detach + port-set teardown + mach_port_move_member
+# churn on a shared set — the races behind the PR #250 boot panics (#253 UAF,
+# #252 NULL td_machdata, #148 thread-exit kmsg destroy). A regression panics the
+# kernel (CI catches it). Marker EVFILT-MACHPORT-CONCURRENT-OK / -FAIL / -SKIP.
+echo "==> building test_evfilt_machport_concurrent"
+cc -I"$WORK/rootfs/usr/include" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_evfilt_machport_concurrent" \
+   "$ROOT/src/mach_kmod/tests/test_evfilt_machport_concurrent.c" \
+   -lsystem_kernel -lpthread
+ls -lh "$WORK/rootfs/usr/tests/freebsd-launchd-mach/test_evfilt_machport_concurrent"
+
 # test_task_special_port — exercises task_get_special_port /
 # task_set_special_port traps (Phase G prerequisite for the bootstrap
 # server's port discovery). Failure surfaces as TASK-SPECIAL-PORT-FAIL.

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -80,6 +80,19 @@ else
     echo "EVFILT-MACHPORT-SKIP: test_evfilt_machport binary not installed"
 fi
 
+# 2b''. EVFILT_MACHPORT concurrency stress (#168 Stage 0 / #251). Raw pthreads
+# hammer concurrent knote attach/detach + port-set teardown + mach_port_move_member
+# churn on a shared set — the races behind the PR #250 boot panics (#253 UAF in
+# filt_machportattach, #252 NULL td_machdata on non-mach-init threads, #148
+# kmsg-destroy on thread exit). A regression panics the kernel and the boot test's
+# panic detection fails CI; a clean run prints EVFILT-MACHPORT-CONCURRENT-OK. The
+# gate WARNs on SKIP (filter unavailable) and FAILs CI on -FAIL.
+if [ -x /usr/tests/freebsd-launchd-mach/test_evfilt_machport_concurrent ]; then
+    /usr/tests/freebsd-launchd-mach/test_evfilt_machport_concurrent || true
+else
+    echo "EVFILT-MACHPORT-CONCURRENT-SKIP: binary not installed"
+fi
+
 # 2c. userland: task_get_special_port / task_set_special_port. Phase G
 # prerequisite — the bootstrap server uses task_set_bootstrap_port on
 # each client task to publish its receive port, and clients read it

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -68,6 +68,18 @@ else
     exit 1
 fi
 
+# 2b'. EVFILT_MACHPORT native-filter probe (#168 Phase A). Does the kernel's
+# native kqueue Mach-port filter (mach.ko filt_machport, slot -16) actually
+# deliver a wakeup + inline-receive a message on a port set? The test prints its
+# own EVFILT-MACHPORT-OK/-FAIL/-SKIP marker. NON-FATAL here (the boot-test gate
+# is a WARN): this is a discovery probe gating the configd KEM-in-process rework
+# (#168) — we want the result reported, not the suite aborted, until we know it.
+if [ -x /usr/tests/freebsd-launchd-mach/test_evfilt_machport ]; then
+    /usr/tests/freebsd-launchd-mach/test_evfilt_machport || true
+else
+    echo "EVFILT-MACHPORT-SKIP: test_evfilt_machport binary not installed"
+fi
+
 # 2c. userland: task_get_special_port / task_set_special_port. Phase G
 # prerequisite — the bootstrap server uses task_set_bootstrap_port on
 # each client task to publish its receive port, and clients read it

--- a/src/mach_kmod/tests/test_evfilt_machport.c
+++ b/src/mach_kmod/tests/test_evfilt_machport.c
@@ -1,0 +1,172 @@
+/*
+ * test_evfilt_machport — prove the NATIVE kernel EVFILT_MACHPORT filter
+ * delivers a kqueue wakeup (and the message) when a Mach message arrives on a
+ * port in a registered port set. #168 gate.
+ *
+ * Background: mach.ko registers a real kqueue filter at EVFILT_MACHPORT (-16,
+ * reserved by nextbsd-kernel patch 0003) — filt_machport in
+ * compat/mach/ipc/ipc_pset.c. It attaches a knote to the port set's ips_note;
+ * ipc_pset_signal() (called when a message is enqueued onto a port in the set)
+ * wakes the knote, and filt_machport then receives the message inline into the
+ * caller's buffer (kev.ext[0]/ext[1]), Apple-style. NOTHING in the tree
+ * exercises this native path: libdispatch's EVFILT_MACHPORT goes through
+ * libmach's kevent_qos() shim, which intercepts a DIFFERENT sentinel (-22) and
+ * routes it through the register_event_bell pipe-bridge (task #39 Path B).
+ * Whether the native filter actually delivers has been an open question
+ * (task #41 — every daemon avoids the dispatch MACH_RECV path with a
+ * pthread+mach_msg loop). This test answers it directly.
+ *
+ * Deliberately uses the raw FreeBSD kevent(2) with the native filter number
+ * (-16) and does NOT include <mach/mach.h> / <mach/dispatch_kevent.h> (which
+ * would redefine EVFILT_MACHPORT to the libmach -22 bridge sentinel). FreeBSD's
+ * struct kevent carries ext[4]; filt_machport reads ext[0] (recv buffer addr)
+ * and ext[1] (size) and fflags (MACH_RCV_MSG).
+ *
+ * Markers (greppable by tests/boot-test.sh):
+ *   EVFILT-MACHPORT-OK    — kevent registered, fired on send, and the message
+ *                           was received inline with the expected msgh_id
+ *   EVFILT-MACHPORT-FAIL  — registration rejected, no wakeup (timeout), or the
+ *                           delivered message was wrong
+ */
+#include <sys/types.h>
+#include <sys/event.h>		/* kqueue(2), struct kevent (ext[4] on FreeBSD) */
+#include <sys/time.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <mach/mach_traps.h>	/* mach_task_self */
+#include <mach/mach_port.h>	/* mach_port_allocate / _insert_right / _move_member */
+#include <mach/message.h>	/* mach_msg, MACH_RCV_MSG, MACH_MSG_TYPE_* */
+
+/*
+ * The NATIVE kernel filter number (nextbsd-kernel patch 0003 +
+ * mach_module.c kqueue_add_filteropts(EVFILT_MACHPORT, &machport_filtops)).
+ * Hardcoded because the stock userland <sys/event.h> predates the bump and
+ * <mach/dispatch_kevent.h> defines a different (-22) bridge sentinel.
+ */
+#define	EVFILT_MACHPORT_NATIVE	(-16)
+
+#define	TEST_MSG_ID	0x45564d50	/* "EVMP" */
+
+int
+main(void)
+{
+	mach_port_name_t task = mach_task_self();
+	mach_port_name_t port = MACH_PORT_NULL;
+	mach_port_name_t pset = MACH_PORT_NULL;
+	kern_return_t kr;
+	int kq, n;
+
+	/* Inline-receive buffer the kernel filter fills (ext[0]/ext[1]). */
+	static struct {
+		mach_msg_header_t	hdr;
+		uint8_t			body[1024];
+	} rcv;
+	struct kevent kev, out;
+	struct timespec ts;
+	mach_msg_header_t send_hdr;
+	mach_msg_return_t mr;
+
+	if (task == MACH_PORT_NULL) {
+		printf("EVFILT-MACHPORT-FAIL: mach_task_self == NULL\n");
+		return (1);
+	}
+
+	/* A receive port + a send right onto it (so we can send to ourselves). */
+	kr = mach_port_allocate(task, MACH_PORT_RIGHT_RECEIVE, &port);
+	if (kr != KERN_SUCCESS) {
+		printf("EVFILT-MACHPORT-FAIL: port allocate kr=0x%x\n", (unsigned)kr);
+		return (1);
+	}
+	kr = mach_port_insert_right(task, port, port, MACH_MSG_TYPE_MAKE_SEND);
+	if (kr != KERN_SUCCESS) {
+		printf("EVFILT-MACHPORT-FAIL: insert_right kr=0x%x\n", (unsigned)kr);
+		return (1);
+	}
+
+	/* A port set, with our receive port as a member. EVFILT_MACHPORT
+	 * attaches to the SET (filt_machportattach translates the ident as a
+	 * PORT_SET right and hangs the knote on pset->ips_note). */
+	kr = mach_port_allocate(task, MACH_PORT_RIGHT_PORT_SET, &pset);
+	if (kr != KERN_SUCCESS) {
+		printf("EVFILT-MACHPORT-FAIL: pset allocate kr=0x%x\n", (unsigned)kr);
+		return (1);
+	}
+	kr = mach_port_move_member(task, port, pset);
+	if (kr != KERN_SUCCESS) {
+		printf("EVFILT-MACHPORT-FAIL: move_member kr=0x%x\n", (unsigned)kr);
+		return (1);
+	}
+
+	kq = kqueue();
+	if (kq < 0) {
+		printf("EVFILT-MACHPORT-FAIL: kqueue()\n");
+		return (1);
+	}
+
+	/* Register EVFILT_MACHPORT on the port set, asking the filter to
+	 * inline-receive into rcv (ext[0]=addr, ext[1]=size, fflags=MACH_RCV_MSG). */
+	(void)memset(&rcv, 0, sizeof(rcv));
+	(void)memset(&kev, 0, sizeof(kev));
+	kev.ident = pset;
+	kev.filter = EVFILT_MACHPORT_NATIVE;
+	kev.flags = EV_ADD | EV_ENABLE;
+	kev.fflags = MACH_RCV_MSG;
+	kev.ext[0] = (uint64_t)(uintptr_t)&rcv;
+	kev.ext[1] = (uint64_t)sizeof(rcv);
+	if (kevent(kq, &kev, 1, NULL, 0, NULL) < 0) {
+		/* EINVAL here = the kernel rejected filter -16 (patch/registration
+		 * not effective on this image). Self-SKIP rather than hard-fail so
+		 * the gate stays green on a kernel predating the filter. */
+		printf("EVFILT-MACHPORT-SKIP: kevent EV_ADD rejected "
+		    "(native filter unavailable on this kernel)\n");
+		return (0);
+	}
+
+	/* Send a message to our port (enqueues on a member of the set). */
+	(void)memset(&send_hdr, 0, sizeof(send_hdr));
+	send_hdr.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_MAKE_SEND_ONCE, 0);
+	send_hdr.msgh_size = sizeof(send_hdr);
+	send_hdr.msgh_remote_port = port;
+	send_hdr.msgh_local_port = MACH_PORT_NULL;
+	send_hdr.msgh_id = TEST_MSG_ID;
+	mr = mach_msg(&send_hdr, MACH_SEND_MSG | MACH_SEND_TIMEOUT,
+	    sizeof(send_hdr), 0, MACH_PORT_NULL, 100, MACH_PORT_NULL);
+	if (mr != MACH_MSG_SUCCESS) {
+		printf("EVFILT-MACHPORT-FAIL: mach_msg(SEND) 0x%x\n", (unsigned)mr);
+		return (1);
+	}
+
+	/* Wait for the kqueue to wake. If the native filter delivers, this
+	 * returns one event AND rcv holds the message (filt_machport received
+	 * it inline). A timeout means the wakeup chain is broken. */
+	ts.tv_sec = 5;
+	ts.tv_nsec = 0;
+	(void)memset(&out, 0, sizeof(out));
+	n = kevent(kq, NULL, 0, &out, 1, &ts);
+	if (n < 0) {
+		printf("EVFILT-MACHPORT-FAIL: kevent(wait) error\n");
+		return (1);
+	}
+	if (n == 0) {
+		printf("EVFILT-MACHPORT-FAIL: no wakeup in 5s — native filter did "
+		    "not deliver (knote wakeup chain broken)\n");
+		return (1);
+	}
+	if (out.filter != EVFILT_MACHPORT_NATIVE) {
+		printf("EVFILT-MACHPORT-FAIL: woke on wrong filter %d\n", out.filter);
+		return (1);
+	}
+	if (rcv.hdr.msgh_id != TEST_MSG_ID) {
+		printf("EVFILT-MACHPORT-FAIL: woke but msgh_id=0x%x (expected 0x%x) "
+		    "— event fired without inline receive\n",
+		    (unsigned)rcv.hdr.msgh_id, TEST_MSG_ID);
+		return (1);
+	}
+
+	printf("EVFILT-MACHPORT-OK: kqueue woke on Mach message + received it "
+	    "inline (msgh_id=0x%x)\n", (unsigned)rcv.hdr.msgh_id);
+	return (0);
+}

--- a/src/mach_kmod/tests/test_evfilt_machport_concurrent.c
+++ b/src/mach_kmod/tests/test_evfilt_machport_concurrent.c
@@ -1,0 +1,272 @@
+/*
+ * test_evfilt_machport_concurrent — concurrency stress for the native kernel
+ * EVFILT_MACHPORT filter. Companion to test_evfilt_machport (the single-
+ * threaded delivery probe, #249). #168 Stage 0 / #251.
+ *
+ * Purpose: pound the kernel paths that the single-threaded probe never
+ * touches — concurrent knote attach/detach, port-set teardown with a live
+ * knote, and mach_port_move_member churning a set's membership while another
+ * thread is mid-filt_machportattach. These are exactly the races behind the
+ * PR #250 boot panics:
+ *
+ *   - #253: UAF in filt_machportattach — it dropped the pset lock before
+ *     taking a reference, so a concurrent move_member could free the pset out
+ *     from under the attaching knote. Reproduced here by attacher threads and
+ *     mover threads hammering one SHARED port set at once.
+ *   - #252: NULL td_machdata deref in filt_machport / filt_machportattach on
+ *     threads that never went through mach.ko's per-thread init. Every worker
+ *     here is a raw pthread (libdispatch-style worker), so its td_machdata is
+ *     NULL on first Mach touch — the lazy-init path is exercised by every
+ *     attach.
+ *   - #148: page fault in ipc_kmsg_destroy when such a pthread EXITS and the
+ *     kernel walks its fd table closing Mach ports. Each worker allocates and
+ *     drops Mach rights, then exits, so thread teardown runs the kmsg-destroy
+ *     path repeatedly.
+ *
+ * If any of those regress, the kernel panics and CI's boot test catches it.
+ * If they hold, every worker completes and we print EVFILT-MACHPORT-CONCURRENT-OK.
+ *
+ * NOTE on coverage: CI boots qemu with a single vcpu (and TCG thread=single),
+ * so true parallelism is limited — this is a strong path/teardown exerciser
+ * there and a genuine race detector on KVM / multi-core hardware. It is
+ * written to be safe and terminating either way (bounded iterations, short
+ * timeouts, all threads joined).
+ *
+ * Raw FreeBSD kevent(2) with the native filter number (-16); deliberately does
+ * NOT include <mach/dispatch_kevent.h> (which would redefine EVFILT_MACHPORT to
+ * the libmach -22 bridge sentinel). See test_evfilt_machport.c for the rationale.
+ *
+ * Markers (greppable by tests/boot-test.sh):
+ *   EVFILT-MACHPORT-CONCURRENT-OK    — all workers finished, no panic
+ *   EVFILT-MACHPORT-CONCURRENT-FAIL  — a worker hit an unexpected hard error
+ *   EVFILT-MACHPORT-CONCURRENT-SKIP  — native filter unavailable on this kernel
+ */
+#include <sys/types.h>
+#include <sys/event.h>		/* kqueue(2), struct kevent (ext[4] on FreeBSD) */
+#include <sys/time.h>
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <mach/mach_traps.h>	/* mach_task_self */
+#include <mach/mach_port.h>	/* mach_port_allocate / _insert_right / _move_member / _mod_refs */
+#include <mach/message.h>	/* mach_msg, MACH_RCV_MSG, MACH_MSG_TYPE_* */
+
+#define	EVFILT_MACHPORT_NATIVE	(-16)
+#define	TEST_MSG_ID		0x45564d50	/* "EVMP" */
+
+#define	N_ATTACH		6	/* threads registering/dropping knotes */
+#define	N_MOVE			4	/* threads churning set membership + sending */
+#define	N_SHARED_PORTS		8	/* ports moved in/out of the shared set */
+#define	ITERS			300	/* per-thread iterations */
+
+#ifndef MACH_PORT_RIGHT_PORT_SET
+#define	MACH_PORT_RIGHT_PORT_SET	3
+#endif
+
+/* The shared port set every worker contends on (the #253 race surface). */
+static mach_port_name_t	g_pset = MACH_PORT_NULL;
+/* Ports the mover threads shuffle in and out of g_pset. */
+static mach_port_name_t	g_ports[N_SHARED_PORTS];
+
+/* SKIP/FAIL signalling out of the worker threads. */
+static atomic_int	g_skip;		/* native filter rejected — nothing to test */
+static atomic_int	g_fail;		/* an unexpected hard error */
+
+/*
+ * Attacher worker: repeatedly register an EVFILT_MACHPORT knote on the shared
+ * set, let it sit briefly (so a mover thread can race membership against the
+ * live attach), then tear it down. Every other iteration also spins up a
+ * throwaway private port set, attaches a knote, and destroys the set while the
+ * knote is still live — exercising ipc_pset_destroy's knote-eviction path
+ * (#29) under contention.
+ */
+static void *
+attach_worker(void *arg)
+{
+	mach_port_name_t task = mach_task_self();
+	int id = (int)(intptr_t)arg;
+	int i;
+
+	for (i = 0; i < ITERS; i++) {
+		struct kevent kev;
+		int kq;
+
+		if (atomic_load(&g_skip) || atomic_load(&g_fail))
+			return (NULL);
+
+		kq = kqueue();
+		if (kq < 0) {
+			atomic_store(&g_fail, 1);
+			return (NULL);
+		}
+
+		(void)memset(&kev, 0, sizeof(kev));
+		kev.ident = g_pset;
+		kev.filter = EVFILT_MACHPORT_NATIVE;
+		kev.flags = EV_ADD | EV_ENABLE;
+		kev.fflags = MACH_RCV_MSG;	/* notify mode, no recv buffer */
+		if (kevent(kq, &kev, 1, NULL, 0, NULL) < 0) {
+			/* Filter -16 unavailable on this kernel — discovery SKIP. */
+			atomic_store(&g_skip, 1);
+			(void)close(kq);
+			return (NULL);
+		}
+
+		/* Give a mover thread a window to race membership vs this attach. */
+		usleep(50);
+
+		(void)memset(&kev, 0, sizeof(kev));
+		kev.ident = g_pset;
+		kev.filter = EVFILT_MACHPORT_NATIVE;
+		kev.flags = EV_DELETE;
+		(void)kevent(kq, &kev, 1, NULL, 0, NULL);
+
+		/*
+		 * Half the time, also create + destroy a private set with a live
+		 * knote attached (knote still registered when the set is torn
+		 * down — the #29 ipc_pset_destroy eviction path).
+		 */
+		if ((i & 1) == 0) {
+			mach_port_name_t ps = MACH_PORT_NULL;
+
+			if (mach_port_allocate(task, MACH_PORT_RIGHT_PORT_SET,
+			    &ps) == KERN_SUCCESS) {
+				(void)memset(&kev, 0, sizeof(kev));
+				kev.ident = ps;
+				kev.filter = EVFILT_MACHPORT_NATIVE;
+				kev.flags = EV_ADD | EV_ENABLE;
+				kev.fflags = MACH_RCV_MSG;
+				(void)kevent(kq, &kev, 1, NULL, 0, NULL);
+				/* Destroy the set out from under the live knote. */
+				(void)mach_port_mod_refs(task, ps,
+				    MACH_PORT_RIGHT_PORT_SET, -1);
+			}
+		}
+
+		(void)close(kq);	/* detaches any remaining knote */
+		(void)id;
+	}
+	return (NULL);
+}
+
+/*
+ * Mover worker: churn the shared set's membership while attachers are mid-
+ * attach, and send messages to ports as they pass through the set so the
+ * filter's inline-receive / signal path runs against changing membership.
+ */
+static void *
+move_worker(void *arg)
+{
+	mach_port_name_t task = mach_task_self();
+	int id = (int)(intptr_t)arg;
+	int i;
+
+	for (i = 0; i < ITERS; i++) {
+		int p;
+
+		if (atomic_load(&g_skip) || atomic_load(&g_fail))
+			return (NULL);
+
+		for (p = 0; p < N_SHARED_PORTS; p++) {
+			mach_port_name_t port = g_ports[p];
+			mach_msg_header_t hdr;
+
+			if (port == MACH_PORT_NULL)
+				continue;
+
+			/* Into the shared set (races filt_machportattach). */
+			(void)mach_port_move_member(task, port, g_pset);
+
+			/* Enqueue a message so ipc_pset_signal wakes any knote. */
+			(void)memset(&hdr, 0, sizeof(hdr));
+			hdr.msgh_bits =
+			    MACH_MSGH_BITS(MACH_MSG_TYPE_MAKE_SEND_ONCE, 0);
+			hdr.msgh_size = sizeof(hdr);
+			hdr.msgh_remote_port = port;
+			hdr.msgh_local_port = MACH_PORT_NULL;
+			hdr.msgh_id = TEST_MSG_ID;
+			(void)mach_msg(&hdr, MACH_SEND_MSG | MACH_SEND_TIMEOUT,
+			    sizeof(hdr), 0, MACH_PORT_NULL, 0, MACH_PORT_NULL);
+
+			/* Back out of the set (move to the null set = remove). */
+			(void)mach_port_move_member(task, port, MACH_PORT_NULL);
+		}
+		(void)id;
+	}
+	return (NULL);
+}
+
+int
+main(void)
+{
+	mach_port_name_t task = mach_task_self();
+	pthread_t at[N_ATTACH], mt[N_MOVE];
+	int i;
+
+	if (task == MACH_PORT_NULL) {
+		printf("EVFILT-MACHPORT-CONCURRENT-FAIL: mach_task_self == NULL\n");
+		return (1);
+	}
+
+	/* The shared contended set. */
+	if (mach_port_allocate(task, MACH_PORT_RIGHT_PORT_SET, &g_pset)
+	    != KERN_SUCCESS) {
+		printf("EVFILT-MACHPORT-CONCURRENT-FAIL: shared pset allocate\n");
+		return (1);
+	}
+
+	/* The pool of receive ports (with self-send rights) the movers shuffle. */
+	for (i = 0; i < N_SHARED_PORTS; i++) {
+		mach_port_name_t port = MACH_PORT_NULL;
+
+		if (mach_port_allocate(task, MACH_PORT_RIGHT_RECEIVE, &port)
+		    != KERN_SUCCESS) {
+			printf("EVFILT-MACHPORT-CONCURRENT-FAIL: port allocate\n");
+			return (1);
+		}
+		(void)mach_port_insert_right(task, port, port,
+		    MACH_MSG_TYPE_MAKE_SEND);
+		g_ports[i] = port;
+	}
+
+	for (i = 0; i < N_ATTACH; i++) {
+		if (pthread_create(&at[i], NULL, attach_worker,
+		    (void *)(intptr_t)i) != 0) {
+			printf("EVFILT-MACHPORT-CONCURRENT-FAIL: pthread_create\n");
+			return (1);
+		}
+	}
+	for (i = 0; i < N_MOVE; i++) {
+		if (pthread_create(&mt[i], NULL, move_worker,
+		    (void *)(intptr_t)i) != 0) {
+			printf("EVFILT-MACHPORT-CONCURRENT-FAIL: pthread_create\n");
+			return (1);
+		}
+	}
+
+	for (i = 0; i < N_ATTACH; i++)
+		(void)pthread_join(at[i], NULL);
+	for (i = 0; i < N_MOVE; i++)
+		(void)pthread_join(mt[i], NULL);
+
+	if (atomic_load(&g_skip)) {
+		printf("EVFILT-MACHPORT-CONCURRENT-SKIP: native filter unavailable "
+		    "on this kernel\n");
+		return (0);
+	}
+	if (atomic_load(&g_fail)) {
+		printf("EVFILT-MACHPORT-CONCURRENT-FAIL: a worker hit an "
+		    "unexpected error\n");
+		return (1);
+	}
+
+	printf("EVFILT-MACHPORT-CONCURRENT-OK: %d attach + %d move workers x %d "
+	    "iters, no panic under concurrent attach/detach/destroy + "
+	    "move_member churn\n", N_ATTACH, N_MOVE, ITERS);
+	return (0);
+}

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -277,6 +277,27 @@ expect {
         puts "\nOK: native EVFILT_MACHPORT delivers (kqueue wakeup + inline receive) — #168 can use it directly"
     }
 }
+# EVFILT-MACHPORT-CONCURRENT — #168 Stage 0 / #251 concurrency stress: pthreads
+# hammer concurrent knote attach/detach + port-set teardown + move_member churn
+# on a shared set (the PR #250 panic surface: #253 UAF, #252 NULL td_machdata,
+# #148 thread-exit kmsg destroy). A kernel regression panics here — caught by the
+# boot test's panic handling — so a clean OK proves the races stay fixed. WARN on
+# timeout (pre-#251 run.sh / image) and on SKIP (filter unavailable); FAIL on -FAIL.
+expect {
+    timeout {
+        puts "\nWARN: EVFILT-MACHPORT-CONCURRENT marker not seen (pre-#251 run.sh — informational)"
+    }
+    "EVFILT-MACHPORT-CONCURRENT-FAIL" {
+        puts "\nFAIL: EVFILT-MACHPORT-CONCURRENT-FAIL — a stress worker hit an unexpected error"
+        exit 1
+    }
+    "EVFILT-MACHPORT-CONCURRENT-SKIP" {
+        puts "\nWARN: EVFILT-MACHPORT-CONCURRENT-SKIP — native filter unavailable on this kernel image"
+    }
+    "EVFILT-MACHPORT-CONCURRENT-OK" {
+        puts "\nOK: native EVFILT_MACHPORT survives concurrent attach/detach/destroy + move_member churn (#251)"
+    }
+}
 expect {
     timeout {
         puts "\nFAIL: TASK-SPECIAL-PORT marker not seen"

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -257,6 +257,26 @@ expect {
     }
     "MACH-PORT-OK" { puts "\nOK: mach_port_* round-trip works" }
 }
+# EVFILT-MACHPORT — #168 Phase A discovery probe: does the kernel's NATIVE
+# kqueue Mach-port filter (mach.ko filt_machport, slot -16) deliver a wakeup +
+# inline-receive on a port set, via raw kevent(2) (no libdispatch/libmach
+# bridge)? NON-FATAL — every outcome is reported, none gates the build; the
+# result decides whether the configd KEM-in-process rework (#168) can use the
+# native filter directly or must fall back to the register_event_bell pipe-bridge.
+expect {
+    timeout {
+        puts "\nWARN: EVFILT-MACHPORT marker not seen (pre-#168 run.sh — informational)"
+    }
+    "EVFILT-MACHPORT-FAIL" {
+        puts "\nWARN: EVFILT-MACHPORT-FAIL — native kqueue Mach-port filter did NOT deliver (configd fold must use the pipe-bridge)"
+    }
+    "EVFILT-MACHPORT-SKIP" {
+        puts "\nWARN: EVFILT-MACHPORT-SKIP — native filter unavailable on this kernel image"
+    }
+    "EVFILT-MACHPORT-OK" {
+        puts "\nOK: native EVFILT_MACHPORT delivers (kqueue wakeup + inline receive) — #168 can use it directly"
+    }
+}
 expect {
     timeout {
         puts "\nFAIL: TASK-SPECIAL-PORT marker not seen"


### PR DESCRIPTION
Two on-image tests for mach.ko's native `EVFILT_MACHPORT` kqueue filter (slot -16), wired into `/usr/tests/freebsd-launchd-mach/` and gated in `tests/boot-test.sh`.

## `test_evfilt_machport` — delivery probe (#249, Phase A)
Raw `kevent(2)` on a port set with the native filter (-16), `fflags=MACH_RCV_MSG`, `ext[0]/ext[1]` receive buffer — no libdispatch/libmach bridge. Allocates a receive port + send right, adds it to a set, registers the filter, self-sends, asserts `kevent` wakes **and** the message was inline-received. **Already proven `EVFILT-MACHPORT-OK`** in CI — this is what justified the #250 native reroute. Gate is non-fatal (discovery probe).

## `test_evfilt_machport_concurrent` — concurrency stress (#251, Stage 0)
Raw pthreads (no per-thread Mach init, like libdispatch workers) hammer concurrent knote attach/detach + port-set teardown with a live knote + `mach_port_move_member` churn on a shared set — the PR #250 boot-panic surfaces:
- **#253** UAF in `filt_machportattach` (lock dropped before taking a ref),
- **#252** NULL `td_machdata` deref on non-mach-init threads,
- **#148** page fault in `ipc_kmsg_destroy` on thread exit.

A regression panics the kernel → boot test's panic handling fails CI. Clean run → `EVFILT-MACHPORT-CONCURRENT-OK`. Gate FAILs on `-FAIL`, WARNs on timeout/SKIP. (Single-vcpu CI limits true parallelism; full race detector on KVM/multi-core.)

Closes #249. Closes #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)