### PR TITLE
ipconfigd: recover dropped link-up notification for late NICs (fixes em0 CI flake)

### DIFF
--- a/src/IPConfiguration/ipconfigd.c
+++ b/src/IPConfiguration/ipconfigd.c
@@ -360,6 +360,7 @@ static void
 on_link_event(const char *ifname, int active, uint32_t lease_cap_secs)
 {
 	char already[IFNAMSIZ] = "";
+	int i;
 
 	/* loopback never carries a DHCP service; the watcher filters lo0 too. */
 	if (strncmp(ifname, "lo", 2) == 0)
@@ -367,13 +368,42 @@ on_link_event(const char *ifname, int active, uint32_t lease_cap_secs)
 
 	if (!active) {
 		/* Present but link down — admin-up so the link can negotiate
-		 * (the late-arriving-NIC onboarding path, #219). */
-		if (iface_bring_up(ifname) == 0)
-			xlog("link-seen(%s) — brought admin-up; awaiting "
-			    "link-active to DHCP", ifname);
-		else
+		 * (the late-arriving-NIC onboarding path, #219).
+		 *
+		 * Recovery for the lost-wakeup race (#250): KEM publishes Active:0
+		 * then Active:1 in quick succession for a late NIC. configd sends a
+		 * watcher wakeup only on the empty->non-empty edge, so if the
+		 * Active:1 _configset is demuxed by configd's single serve thread
+		 * between our wakeup and our notifychanges drain, no second wakeup
+		 * is sent and our callout reads the store one instant too early
+		 * (Active:0). The Active:1 value then sits in the store with no
+		 * pending notification and we would wait forever. The store *value*
+		 * is authoritative even when the *wakeup* is not, so poll it a few
+		 * times after admin-up and recover by re-driving the active path.
+		 * This also covers a configd full-queue silent send-drop and any
+		 * future transport change — it does not depend on the wakeup at all. */
+		if (iface_bring_up(ifname) != 0) {
 			xlog("link-seen(%s) — could not bring up: %s", ifname,
 			    strerror(errno));
+			return;
+		}
+		xlog("link-seen(%s) — brought admin-up; polling link state",
+		    ifname);
+		for (i = 0; i < 6; i++) {
+			struct timespec ts = { .tv_sec = 0,
+			    .tv_nsec = 500 * 1000 * 1000 };	/* 500ms */
+
+			(void)nanosleep(&ts, NULL);
+			if (link_active_in_store(ifname)) {
+				xlog("link-seen(%s) — store shows Active after "
+				    "admin-up; recovering missed wakeup, DHCP",
+				    ifname);
+				on_link_event(ifname, 1, lease_cap_secs);
+				return;
+			}
+		}
+		xlog("link-seen(%s) — still down after admin-up poll; "
+		    "awaiting Active wakeup", ifname);
 		return;
 	}
 

--- a/src/IPConfiguration/sc_link_watch.c
+++ b/src/IPConfiguration/sc_link_watch.c
@@ -60,6 +60,49 @@ mkstr(const char *s)
 	return (CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8));
 }
 
+/*
+ * Read State:/Network/Interface/<if>/Link {Active} straight from configd via a
+ * synchronous SCDynamicStoreCopyValue. Authoritative even when the change
+ * *wakeup* was lost (#250 recovery): configd sends a watcher notification only
+ * on the empty->non-empty edge, so for a late NIC's rapid Active:0 -> Active:1
+ * the second wakeup can be raced away — but the *value* is always committed to
+ * the store. ipconfigd polls this after admin-up so a dropped wakeup still
+ * recovers. Uses a private throwaway session (no notification registration) so
+ * it cannot perturb the linkwatch session's notify state. Returns 1 if Active.
+ */
+int
+link_active_in_store(const char *ifname)
+{
+	SCDynamicStoreRef store;
+	CFStringRef key;
+	CFDictionaryRef dict;
+	CFBooleanRef active;
+	int is_active = 0;
+
+	store = SCDynamicStoreCreate(NULL, CFSTR("ipconfigd-linkpoll"),
+	    NULL, NULL);
+	if (store == NULL)
+		return (0);
+	key = CFStringCreateWithFormat(NULL, NULL,
+	    CFSTR("State:/Network/Interface/%s/Link"), ifname);
+	if (key != NULL) {
+		dict = SCDynamicStoreCopyValue(store, key);
+		if (dict != NULL) {
+			if (CFGetTypeID(dict) == CFDictionaryGetTypeID()) {
+				active = CFDictionaryGetValue(dict,
+				    CFSTR("Active"));
+				is_active = (active != NULL &&
+				    CFGetTypeID(active) == CFBooleanGetTypeID() &&
+				    CFBooleanGetValue(active));
+			}
+			CFRelease(dict);
+		}
+		CFRelease(key);
+	}
+	CFRelease(store);
+	return (is_active);
+}
+
 /* Trampoline payload — heap-allocated, freed by the trampoline. */
 struct link_event {
 	char		ifname[IFNAMSIZ];

--- a/src/IPConfiguration/sc_link_watch.h
+++ b/src/IPConfiguration/sc_link_watch.h
@@ -37,4 +37,12 @@ typedef void (*sc_link_watch_cb)(const char *ifname, int active,
  */
 int sc_link_watch_start(sc_link_watch_cb cb, uint32_t lease_cap_secs);
 
+/*
+ * Synchronously read State:/Network/Interface/<if>/Link {Active} from configd.
+ * Returns non-zero if the interface's link is Active. The store *value* is
+ * authoritative even when the change *wakeup* was lost — ipconfigd polls this
+ * after admin-up to recover a dropped Active notification (#250).
+ */
+int link_active_in_store(const char *ifname);
+
 #endif /* SC_LINK_WATCH_H */


### PR DESCRIPTION
Fixes the intermittent (~50%) **em0 CI flake** (`ifcount=0`, no DHCP) that's been failing nearly every kernel/nextbsd boot test for hours — root-caused by a 4-agent review (see the [plan](https://pkgdemon.github.io/nextbsd-evfilt-machport-native-plan.html)).

### Root cause — a lost-wakeup race in configd's edge-triggered notification
configd sends a watcher wakeup **only on the empty→non-empty change-list edge** (`config_session.c`). For a late-arriving NIC, KernelEventMonitor publishes `Link Active:0` then `Active:1` in quick succession. configd is single-threaded, so if the `Active:1` `_configset` is demuxed **between** ipconfigd's wakeup and its `notifychanges` drain, no second wakeup is sent and ipconfigd's callout reads the store one instant too early (`Active:0`). The `Active:1` value then sits in the store with **no pending notification**, and ipconfigd — having only admin-upped the interface and "awaiting link-active" — waits forever. em0 never DHCPs.

Confirmed on **both** the pipe-bridge and native-`EVFILT_MACHPORT` transports → the loss is **above** the transport, in configd's edge-trigger bookkeeping (also rules out the libdispatch re-arm theory: ipconfigd's SCDS notify uses a raw `mach_msg` thread, not a dispatch source).

### Fix — ipconfigd resilience (the value is authoritative even when the wakeup isn't)
After bringing a late interface admin-up, **poll** `State:/Network/Interface/<if>/Link` a few times (6×500ms) via synchronous `SCDynamicStoreCopyValue` (new `link_active_in_store()` in `sc_link_watch.c`); if it shows `Active`, recover by re-driving `on_link_event(active=1)` → DHCP. Idempotency guards (`g_dhcp_lock`/`g_dhcp_started`/`bound_state_any`) prevent a double-start. Runs **only** on the late-arrival path (the common SLIRP-link-already-up path hits the initial scan and never reaches here). No configd/libdispatch/protocol change; survives a full-queue silent drop and any future transport swap.

### Validation
The existing `EM-AUTOLOAD` → `IPCFG-IPCONFIG-OK`/`IPCFG-RENEW-OK` gates require em0 to complete DHCP — today they flake ~50%. This makes them deterministic; the recovery log line `store shows Active after admin-up; recovering missed wakeup` appears on runs that hit the race.

A deeper configd edge-trigger hardening (defense-in-depth) is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)