### PR TITLE
libmach: drop the dead register_event_bell pipe-bridge wrappers (#168 Stage 5, #256)

### DIFF
--- a/src/libmach/dispatch_kevent.c
+++ b/src/libmach/dispatch_kevent.c
@@ -42,7 +42,6 @@
 
 #include <sys/types.h>
 #include <sys/event.h>
-#include <sys/sysctl.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
@@ -206,63 +205,6 @@ reg_remove_locked(struct mach_kev_reg *target)
 			return;
 		}
 	}
-}
-
-/*
- * Resolve a named mach.ko syscall (lazy, cached per call site).
- * Returns the syscall number or -1 if mach.ko isn't loaded.
- */
-static int
-resolve_mach_syscall(const char *name)
-{
-	int tmp;
-	size_t len = sizeof(tmp);
-	char oid[64];
-
-	if (snprintf(oid, sizeof(oid), "mach.syscall.%s", name) >=
-	    (int)sizeof(oid))
-		return (-1);
-	if (sysctlbyname(oid, &tmp, &len, NULL, 0) != 0)
-		return (-1);
-	return (tmp);
-}
-
-int
-mach_event_bell_register(mach_port_name_t pset_name, int pipe_w)
-{
-	static int num = -2;	/* -2 = unresolved, -1 = unavailable */
-	long ret;
-
-	if (num == -2)
-		num = resolve_mach_syscall("register_event_bell");
-	if (num < 0)
-		return (ENOSYS);
-	ret = syscall(num, (uint64_t)pset_name, (uint64_t)(unsigned)pipe_w);
-	if (ret != 0)
-		return ((int)ret);
-	return (0);
-}
-
-/*
- * mach_event_bell_unregister — dedicated unregister_event_bell syscall.
- * Tears down the bell registered by mach_event_bell_register so the
- * kernel stops writing wakeup bytes to a pipe whose read-end the
- * wrapper is about to close. Returns 0 on success, errno on failure.
- */
-int
-mach_event_bell_unregister(mach_port_name_t pset_name)
-{
-	static int num = -2;	/* -2 = unresolved, -1 = unavailable */
-	long ret;
-
-	if (num == -2)
-		num = resolve_mach_syscall("unregister_event_bell");
-	if (num < 0)
-		return (ENOSYS);
-	ret = syscall(num, (uint64_t)pset_name);
-	if (ret != 0)
-		return ((int)ret);
-	return (0);
 }
 
 /*

--- a/src/libmach/include/mach/dispatch_kevent.h
+++ b/src/libmach/include/mach/dispatch_kevent.h
@@ -180,24 +180,11 @@ int kevent_qos(int kq, const struct kevent_qos_s *changelist, int nchanges,
     void *data_out, size_t *data_available, unsigned int flags);
 
 /*
- * mach_event_bell_register — userland wrapper around the
- * register_event_bell syscall. Registers `pipe_w` as the wakeup file
- * descriptor for `pset_name`.
- * Returns 0 on success, errno on failure.
- *
- * Exposed in this header so other consumers (tests, future libxpc
- * runloop integration) can register additional psets without going
- * through libdispatch.
+ * The task#39 register_event_bell / unregister_event_bell pipe-bridge
+ * wrappers were removed in #168 Stage 5 (#256): EVFILT_MACHPORT is rerouted
+ * to the native kernel filter (filt_machport), so libdispatch no longer needs
+ * a userland pipe bridge.
  */
-int mach_event_bell_register(mach_port_name_t pset_name, int pipe_w);
-
-/*
- * mach_event_bell_unregister — the unregister_event_bell syscall. Drop
- * the bell register armed so the kernel stops writing wakeup bytes to
- * the pipe.
- * Returns 0 on success, errno on failure.
- */
-int mach_event_bell_unregister(mach_port_name_t pset_name);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Stage 5 (final, userland half) of the [native EVFILT_MACHPORT migration](https://pkgdemon.github.io/nextbsd-evfilt-machport-native-plan.html) (#256, #168)

Since #250 rerouted `EVFILT_MACHPORT` to the native kernel filter, libmach's `mach_event_bell_register` / `mach_event_bell_unregister` wrappers — and the `resolve_mach_syscall` helper that looked up the `register_event_bell` / `unregister_event_bell` syscall numbers via the `mach.syscall.*` sysctls — have had **no callers**.

Removes the dead wrappers + their header declarations + the `<sys/sysctl.h>` include that only `resolve_mach_syscall` used. The native reroute (`kevent_qos` + `EVFILT_MACHPORT_NATIVE` registration) is unchanged. libIOKit's own independent `resolve_mach_syscall` (for `mach_wait_quiet`) is untouched.

Pairs with **nextbsd-kernel PR #33** (kernel half: deletes `mach_event_bridge.{c,h}`, the syscalls/sysctls/sysents, and the `ipc_pset_signal` weak hook).

Part of #168 (Stage 5, final).

🤖 Generated with [Claude Code](https://claude.com/claude-code)