### PR TITLE
ci(experiment): boot with qemu e1000e to reproduce real-hardware autoload failure

### DIFF
--- a/overlays/System/Library/LaunchDaemons/com.apple.kextd.plist
+++ b/overlays/System/Library/LaunchDaemons/com.apple.kextd.plist
@@ -18,6 +18,10 @@
 	<array>
 		<string>/usr/libexec/kextd</string>
 		<string>-w</string>
+		<!-- -v: log the boot daemon's startup push + each load request it
+		     serves, so CI can see whether boot-time autoload actually fires.
+		     It must work with no manual poke (real-hardware shape). -->
+		<string>-v</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/overlays/usr/tests/nextbsd-iokit/run.sh
+++ b/overlays/usr/tests/nextbsd-iokit/run.sh
@@ -134,22 +134,19 @@ if [ ! -c /dev/iocatalogue ]; then
 	exit 0
 fi
 
-# Run kextd ourselves (it flushes then re-pushes, so it's idempotent). kextd is
-# NOT a boot-time launchd daemon yet — running a CF/OSKext-heavy job before the
-# system is up wedges launchd's boot dispatch; the launchd boot-push integration
-# lands with K3 (#216) when kextd becomes persistent and its ordering is
-# designed. Bound it with a watchdog so a hang surfaces as an empty catalogue
-# (-> IOCATALOGUE-FAIL) instead of stalling the whole boot test.
-if [ -x /usr/libexec/kextd ]; then
-	/usr/libexec/kextd -v &
-	kpid=$!
-	( sleep 90; kill "$kpid" 2>/dev/null ) &
-	wpid=$!
-	wait "$kpid" || echo "WARN: kextd exited nonzero or was killed (watchdog)"
-	kill "$wpid" 2>/dev/null
-else
-	echo "WARN: /usr/libexec/kextd missing"
-fi
+# kextd is now a boot-time launchd daemon (com.apple.kextd.plist, RunAtLoad,
+# K3b/#217) that registers HOST_KEXTD_PORT, pushes the repo personalities, and
+# serves load requests. We DO NOT push again here: a manual one-shot `kextd`
+# push used to run at this point and masked a real bug — the *boot daemon's own*
+# push does not result in boot-time autoload (the manual push only worked because
+# it ran against the already-serving daemon). This test now verifies the PURE
+# boot-daemon state — catalogue populated AND devices autoloaded by the boot
+# daemon ALONE, no manual poke — exactly how real hardware behaves.
+echo "=== /var/log/kextd.log (boot daemon, verbose) ==="
+cat /var/log/kextd.log 2>/dev/null
+echo "=== kextstat (what the boot daemon autoloaded) ==="
+kextstat 2>/dev/null
+echo "==="
 
 count=$(sysctl -n hw.iokit.catalogue_count 2>/dev/null || echo 0)
 dump=$(sysctl -n hw.iokit.catalogue 2>/dev/null || echo "")
@@ -158,7 +155,7 @@ echo "hw.iokit.catalogue:"
 echo "${dump}"
 
 if [ "${count}" -lt 1 ] 2>/dev/null; then
-	echo "IOCATALOGUE-FAIL: catalogue is empty after kextd push"
+	echo "IOCATALOGUE-FAIL: catalogue empty — the boot kextd daemon did not push personalities"
 	exit 1
 fi
 
@@ -238,19 +235,26 @@ fi
 # separate loaded file, so the kext-loaded signal cleanly distinguishes the two.
 # em0's address is read with `ipconfig` (Apple IPConfiguration); FreeBSD's
 # ifconfig(8) is NOT on the stripped image, so it must not be used here. Emits:
-#   EM-AUTOLOAD-OK    — IntelEthernet auto-loaded AND em0 has an address
-#   EM-AUTOLOAD-SKIP  — IntelEthernet not loaded -> em is built in (pre-#219)
-#   EM-AUTOLOAD-FAIL  — IntelEthernet loaded but em0 has no address (bind/DHCP failed)
+#
+# No manual kextd poke ran above, so this is the PURE boot-autoload result —
+# em0 must have been brought up by the boot daemon alone (real-hardware shape).
+#   EM-AUTOLOAD-OK    — IntelEthernet auto-loaded by the boot daemon AND em0 has an address
+#   EM-AUTOLOAD-SKIP  — IntelEthernet not loaded but em0 IS up -> em is built into this kernel
+#   EM-AUTOLOAD-FAIL  — IntelEthernet loaded but em0 has no address (bind/DHCP failed), OR
+#                       IntelEthernet not loaded AND em0 has no address (boot autoload did NOT happen)
 em_addr=$(ipconfig getifaddr em0 2>/dev/null || true)
-if kextstat 2>/dev/null | grep -qi intelethernet || \
-   kldstat 2>/dev/null | grep -qi intelethernet; then
+if kextstat 2>/dev/null | grep -qi intelethernet; then
 	if [ -n "$em_addr" ]; then
-		echo "EM-AUTOLOAD-OK: em0 ($em_addr) up via kextd auto-load of IntelEthernet.kext"
+		echo "EM-AUTOLOAD-OK: em0 ($em_addr) up via boot-daemon auto-load of IntelEthernet.kext"
 	else
 		echo "EM-AUTOLOAD-FAIL: IntelEthernet.kext loaded but em0 has no address (bind/DHCP failed)"
 	fi
+elif [ -n "$em_addr" ]; then
+	echo "EM-AUTOLOAD-SKIP: IntelEthernet not loaded but em0 is up — em is built into this kernel"
 else
-	echo "EM-AUTOLOAD-SKIP: IntelEthernet not loaded — em is built into the kernel (pre-#219 nodevice em)"
+	# em is nodevice in the continuous kernel (#219), so "not loaded + no address"
+	# means the boot daemon never autoloaded the NIC — the real-hardware bug.
+	echo "EM-AUTOLOAD-FAIL: boot daemon did NOT autoload IntelEthernet — em0 absent (real-hardware autoload failure)"
 fi
 
 exit 0

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -87,7 +87,7 @@ eval spawn qemu-system-x86_64 \
     -bios $env(OVMF) \
     $accel_flags \
     -drive file=$img,format=raw,if=virtio \
-    -nic user,model=e1000 \
+    -nic user,model=e1000e \
     -display none -serial stdio \
     -no-reboot
 


### PR DESCRIPTION
Experiment (do not merge): swap the qemu NIC from e1000 (82540EM 0x100e) to e1000e (82574L 0x10d3), a different in-IntelEthernet-list PCIe NIC — a closer proxy to the T460s PCH-integrated I219-LM (0x156f, present+unmatched, never autoloaded on real hardware while qemu's default e1000 autoloads fine).

If EM-AUTOLOAD-FAIL → the kernel boot-nomatch→autoload trigger is reproduced in CI (debuggable without hardware). If it autoloads → the failure is specific to real-PCH topology/timing.

Built on #265 (pure boot-autoload test, no manual kextd poke, verbose kextd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)