### PR TITLE
mDNSResponder: route daemon log to its own file, off /dev/console

### DIFF
--- a/overlays/System/Library/LaunchDaemons/com.apple.mDNSResponder.plist
+++ b/overlays/System/Library/LaunchDaemons/com.apple.mDNSResponder.plist
@@ -25,14 +25,29 @@
     <array>
         <string>/usr/sbin/mDNSResponder</string>
         <!--
-          -foreground: tell PosixDaemon.c's ParseCmdLineArgs to skip
-          daemon(0, 0). Without this, daemon() closes stdin/stdout/
-          stderr and we lose all fprintf-to-stderr output (including
-          the iter-2 MDNS-ENGINE-OK marker). launchd already manages
-          the daemon's lifecycle via KeepAlive, so the self-
-          backgrounding is redundant anyway.
+          -debug: tell PosixDaemon.c's ParseCmdLineArgs to set
+          mDNS_DebugMode. This does two things:
+
+          (1) skips daemon(0, 0) just like -foreground did — without
+              that, daemon() closes stdin/stdout/stderr and we lose all
+              fprintf-to-stderr output (including the iter-2
+              MDNS-ENGINE-OK marker). launchd already manages the
+              daemon's lifecycle via KeepAlive, so self-backgrounding is
+              redundant anyway.
+
+          (2) routes mDNSPlatformWriteLogMsg through fprintf(stderr)
+              instead of syslog(). The engine logs at NOTICE volume
+              (mDNS_LoggingEnabled is on), and feeding that into the
+              shared asl/syslog pipeline leaks the chatter onto
+              /dev/console at boot, papering over the getty login
+              prompt. With -debug it goes straight to StandardErrorPath
+              (/var/log/mDNSResponder.stderr) — mDNS keeps its full log
+              in its own file, off the console and off syslogd.
+
+          Note: PosixDaemon.c only inspects argv[1], so -debug must be
+          the sole argument (it supersedes -foreground).
         -->
-        <string>-foreground</string>
+        <string>-debug</string>
     </array>
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
## Problem

On a non-verbose boot, mDNSResponder smears its internal engine trace across `/dev/console`, papering over the getty login prompt (interleaved with the kernel's `iokit:` / `iwlwifi0:` / `em0:` driver-attach printfs):

```
... mDNSResponder 29 - - mDNS: [Q0] mDNS_StartQuery_internal START -- qname: ...
... mDNSResponder 29 - - Default: RR Auth now using 1 objects
... mDNSResponder 29 - - Default: Lock failure: Check Lock ...
```

mDNS is uniquely loud because it's built with `mDNS_LoggingEnabled` on (`PosixDaemon.c:212`), so all the `LogInfo`/`LogOperation`/`LogRedact` calls fire at NOTICE level.

## Why it's not a syslogd-config fix

The console leak is **not** driven by any syslogd config — I traced the whole pipeline:
- `asl.conf` (the `asl_action` module) routes `≤notice` to `system.log` + the ASL store — **no `/dev/console` rule**.
- There is **no `/etc/syslog.conf`**, so the `bsd_out` module creates zero rules and is inert.
- There is **no `/etc/asl/*.conf`** to merge in.

So pulling in Apple's `syslog.conf` would only *add* a `*.err;kern.* /dev/console` rule (more console output, not less) and risk the parser SIGSEGV the `asl.conf` header already documents. The right fix is to take mDNS's firehose **out of the shared asl/syslog bus**, not to patch the bus.

## Change

Swap `-foreground` → `-debug` in `ProgramArguments`. `-debug` sets `mDNS_DebugMode`, which:

1. **Skips `daemon(0,0)`** exactly like `-foreground` did (`PosixDaemon.c:117`), so stderr stays attached and the `MDNS-ENGINE-OK` marker still prints.
2. **Routes `mDNSPlatformWriteLogMsg` through `fprintf(stderr)`** instead of `syslog()` (`PlatformCommon.c:287-291`). With the plist's existing `StandardErrorPath`, the full log lands in `/var/log/mDNSResponder.stderr` — its own file, off the console and off syslogd.

`PosixDaemon.c` only inspects `argv[1]`, so `-debug` is the sole argument (it supersedes `-foreground`).

## Test impact

None. The boot-test markers (`MDNS-BOOT-OK`, `MDNS-ENGINE-OK`, `MDNS-IFWATCH-OK`, `MDNS-DNSSD-OK`) are all `fprintf(stderr)`/`printf` — they already land in `/var/log/mDNSResponder.stderr`, which `run.sh` greps. None flow through the `mDNS_LoggingEnabled`/syslog path this change touches.

## Out of scope

The kernel `iokit:` / `iwlwifi0:` / `em0:` lines on the console are a **separate** issue — kernel `printf()` straight to `/dev/console` from the kextd present-scan + driver attach. That's the `bootverbose`-gating + getty/kextd ordering work, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)