### PR TITLE
ci: ingest the drm-kmod graphics kexts from the modules continuous release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,15 +184,19 @@ jobs:
           # Driver-kext tarballs, extracted + installed inside the VM by build.sh
           # (the build.sh loop installs every kext-dl/*.tar.gz it finds). Each is
           # non-fatal if absent (ISO just ships without that driver kext).
+          # Iterate over full asset stems: most are <driver>-kext, but the
+          # drm-kmod graphics stack ships as one graphics-kexts (plural — it is
+          # IOGraphics/DMABuf/TTM drm core + IntelGraphics/AMDGraphics/
+          # RadeonGraphics, each with its bundled vendor firmware).
           mkdir -p kext-dl
-          for k in intelwifi intelethernet; do
+          for asset in intelwifi-kext intelethernet-kext graphics-kexts; do
             if gh release download continuous \
                  -R nextbsd-redux/nextbsd-kernel-modules \
-                 --pattern "${k}-kext.tar.gz" \
-                 --output "kext-dl/${k}-kext.tar.gz" --clobber; then
-              echo "kext tarball: $(ls -lh kext-dl/${k}-kext.tar.gz | awk '{print $5}')"
+                 --pattern "${asset}.tar.gz" \
+                 --output "kext-dl/${asset}.tar.gz" --clobber; then
+              echo "kext tarball: $(ls -lh kext-dl/${asset}.tar.gz | awk '{print $5}')"
             else
-              echo "WARN: no ${k}-kext asset; ISO ships without ${k} kext"
+              echo "WARN: no ${asset}.tar.gz asset; ISO ships without it"
             fi
           done
 


### PR DESCRIPTION
## What

Pulls the new `graphics-kexts.tar.gz` from the nextbsd-kernel-modules `continuous` release into the ISO, so the drm-kmod graphics stack actually ships.

The kext-fetch loop was hardcoded to `intelwifi intelethernet` with a `<name>-kext.tar.gz` pattern — it neither included graphics nor matched its plural `graphics-kexts.tar.gz` asset name. Now iterates over full asset stems (`intelwifi-kext`, `intelethernet-kext`, `graphics-kexts`).

## Verified the asset first
Downloaded + inspected `graphics-kexts.tar.gz` from `continuous` — it's complete:
- 6 kexts: `IOGraphics`/`DMABuf`/`TTM` (drm core) + `IntelGraphics`/`AMDGraphics`/`RadeonGraphics`
- firmware bundled with the correct vendor subdirs: `firmware/i915` (127 files), `firmware/amdgpu` (676), `firmware/radeon` (182) + each `LICENSE.*`
- drm-core kexts correctly firmware-free; each kext carries its `.ko`

## Why nothing else changes
- `build.sh`'s install loop already extracts **every** `kext-dl/*.tar.gz` into `/System/Library/Extensions` (no per-kext logic).
- `firmware(9)` (kernel patch 0004) **auto-searches** each loaded kext's `Contents/Resources/firmware`, so no `firmware_path` config.
- No kernel change: there's **no built-in drm driver** to displace (unlike `em`, which needed `nodevice em`), so the GPU kexts bind on `device_nomatch` once a supported GPU is present.

## Note
The ISO grows by ~160 MB (extracted) for the graphics firmware — amdgpu dominates (per the bundle-in-kext model chosen).

After merge, a nextbsd build (dispatch or manual `workflow_dispatch`) produces an ISO with the graphics kexts installed.