### PR TITLE
build: produce + publish a live ISO (compressed uzip root + overlay) — #70

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,8 +231,9 @@ jobs:
         run: |
           ls -lh out/
           IMG="NextBSD-${{ matrix.arch }}-${{ steps.meta.outputs.date }}.img.zip"
-          ( cd out && sha256sum "$IMG" > "$IMG.sha256" )
-          cat "out/$IMG.sha256"
+          ISO="NextBSD-${{ matrix.arch }}-${{ steps.meta.outputs.date }}.iso.zip"
+          ( cd out && sha256sum "$IMG" > "$IMG.sha256" && sha256sum "$ISO" > "$ISO.sha256" )
+          cat "out/$IMG.sha256" "out/$ISO.sha256"
 
       # compression-level: 0 — the .img.zip is already DEFLATE-9; the outer
       # artifact wrapper just stores it (no recompression). GitHub always
@@ -245,6 +246,8 @@ jobs:
           path: |
             out/NextBSD-${{ matrix.arch }}-${{ steps.meta.outputs.date }}.img.zip
             out/NextBSD-${{ matrix.arch }}-${{ steps.meta.outputs.date }}.img.zip.sha256
+            out/NextBSD-${{ matrix.arch }}-${{ steps.meta.outputs.date }}.iso.zip
+            out/NextBSD-${{ matrix.arch }}-${{ steps.meta.outputs.date }}.iso.zip.sha256
           compression-level: 0
           retention-days: 14
           if-no-files-found: error
@@ -356,7 +359,7 @@ jobs:
           merge-multiple: true
 
       - name: list release assets
-        run: ls -lh out/NextBSD-*.img.zip out/NextBSD-*.img.zip.sha256
+        run: ls -lh out/NextBSD-*.img.zip out/NextBSD-*.img.zip.sha256 out/NextBSD-*.iso.zip out/NextBSD-*.iso.zip.sha256
 
       # `gh release create` wedges silently on big ISO uploads (single PUT,
       # no chunking, no retry). softprops/action-gh-release uses Octokit's
@@ -391,3 +394,5 @@ jobs:
           files: |
             out/NextBSD-*.img.zip
             out/NextBSD-*.img.zip.sha256
+            out/NextBSD-*.iso.zip
+            out/NextBSD-*.iso.zip.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ repos/
 *.iso
 *.iso.sha256
 SHA256SUMS
+
+.claude/

--- a/build.sh
+++ b/build.sh
@@ -2987,6 +2987,11 @@ cp -R "$WORK/rootfs/boot/." "$ISOROOT/boot/"
 for f in cdboot loader.efi; do
     [ -f "$ISOROOT/boot/$f" ] || { echo "ERROR: live ISO needs rootfs/boot/$f" >&2; exit 1; }
 done
+# mkisoimages.sh runs `makefs -N $ISOROOT/etc` to map owner names -> uid/gid, so
+# the bits dir's etc needs passwd + group (it writes etc/fstab itself).
+for f in passwd group master.passwd; do
+    [ -f "$WORK/rootfs/etc/$f" ] && cp "$WORK/rootfs/etc/$f" "$ISOROOT/etc/$f"
+done
 # Live loader config (zz- => read last, wins). Preload the uzip as md0, mount it
 # through geom_uzip, and set the vfs.root.overlay kenv the kernel hook gates on.
 # vfs.root.mountfrom overrides the kernel's baked ROOTDEVNAME (ufs:/dev/ufs/

--- a/build.sh
+++ b/build.sh
@@ -2950,6 +2950,71 @@ echo "==> zip disk image"
 ls -lh "$OUT/${IMG_NAME}.zip"
 sha256 "$OUT/${IMG_NAME}.zip" 2>/dev/null || sha256sum "$OUT/${IMG_NAME}.zip"
 
+#
+# 7. live ISO (nextbsd #70 + the live-root overlay). A bootable cd9660 the
+#    loader reads /boot from; it md-preloads rootfs.uzip, and geom_uzip + the
+#    kernel's vfs.root.overlay hook (nextbsd-kernel #39) stack a writable
+#    tmpfs/unionfs over the read-only uzip root BEFORE launchd -- so the live /
+#    is read-write, while the installed rw-UFS disk image above never unions.
+#    First proof: md-preloaded (RAM-resident) uzip; on-demand/isohybrid + the
+#    tarfs bake-off are follow-ons. launchd needs no change: its
+#    launchd_root_make_writable() already skips the remount when / is not
+#    MNT_RDONLY (the live union is already writable).
+#
+echo "==> live ISO: building compressed read-only root"
+
+# 7a. The kernel overlay hook mounts the writable tmpfs at /.overlay, which must
+#     already exist (empty) in the read-only root -- the kernel can't mkdir on a
+#     RO fs. Added only to the ISO's root image (after the disk image's makefs).
+mkdir -p "$WORK/rootfs/.overlay"
+
+# 7b. Compact UFS image of rootfs (no rw headroom -- it is read-only), then
+#     mkuzip (zlib; geom_uzip reads it). Separate from the disk image's padded
+#     rootfs.ufs.
+echo "==> makefs ffs (compact) + mkuzip"
+makefs -t ffs -B little -o version=2,label=NBROOT \
+    "$WORK/rootfs.iso.ufs" "$WORK/rootfs"
+mkuzip -o "$WORK/rootfs.uzip" "$WORK/rootfs.iso.ufs"
+ls -lh "$WORK/rootfs.uzip"
+
+# 7c. ISO bits dir: /boot (loader + kernel, copied from rootfs) + a live loader
+#     config + the uzip. mkisoimages.sh needs boot/cdboot (BIOS El Torito) and
+#     boot/loader.efi (UEFI; it builds the El Torito ESP from it).
+ISOROOT="$WORK/isoroot"
+rm -rf "$ISOROOT"
+mkdir -p "$ISOROOT/boot/loader.conf.d" "$ISOROOT/etc"
+cp -R "$WORK/rootfs/boot/." "$ISOROOT/boot/"
+for f in cdboot loader.efi; do
+    [ -f "$ISOROOT/boot/$f" ] || { echo "ERROR: live ISO needs rootfs/boot/$f" >&2; exit 1; }
+done
+# Live loader config (zz- => read last, wins). Preload the uzip as md0, mount it
+# through geom_uzip, and set the vfs.root.overlay kenv the kernel hook gates on.
+# vfs.root.mountfrom overrides the kernel's baked ROOTDEVNAME (ufs:/dev/ufs/
+# ROOTFS); the installed disk image has no such file, so it boots plain rw-UFS.
+cat > "$ISOROOT/boot/loader.conf.d/zz-live.conf" <<'LIVEEOF'
+# NextBSD live ISO: compressed read-only root + writable overlay.
+mdroot_load="YES"
+mdroot_type="md_image"
+mdroot_name="/rootfs.uzip"
+vfs.root.mountfrom="ufs:/dev/md0.uzip"
+vfs.root.overlay="tmpfs"
+LIVEEOF
+cp "$WORK/rootfs.uzip" "$ISOROOT/rootfs.uzip"
+
+# 7d. Build the bootable cd9660 (BIOS cdboot + UEFI ESP) via the release script
+#     (extracted from src.txz at step 3a).
+ISO_NAME="NextBSD-${ARCH}-${IMG_DATE}.iso"
+echo "==> mkisoimages.sh: bootable cd9660 (BIOS + UEFI)"
+sh "$WORK/freebsd-src/release/${ARCH}/mkisoimages.sh" -b NEXTBSD \
+    "$WORK/$ISO_NAME" "$ISOROOT"
+ls -lh "$WORK/$ISO_NAME"
+echo "==> zip live ISO"
+(cd "$WORK" && zip -9 "$OUT/${ISO_NAME}.zip" "$ISO_NAME")
+ls -lh "$OUT/${ISO_NAME}.zip"
+sha256 "$OUT/${ISO_NAME}.zip" 2>/dev/null || sha256sum "$OUT/${ISO_NAME}.zip"
+rm -rf "$ISOROOT"
+rm -f "$WORK/rootfs.iso.ufs" "$WORK/rootfs.uzip" "$WORK/$ISO_NAME"
+
 # trim the multi-GB image intermediates — only out/ needs to survive
 # the post-build copyback.
 rm -f "$WORK/$IMG_NAME" "$WORK/rootfs.ufs" "$WORK/esp.img"

--- a/build.sh
+++ b/build.sh
@@ -3005,8 +3005,13 @@ cp "$WORK/rootfs.uzip" "$ISOROOT/rootfs.uzip"
 #     (extracted from src.txz at step 3a).
 ISO_NAME="NextBSD-${ARCH}-${IMG_DATE}.iso"
 echo "==> mkisoimages.sh: bootable cd9660 (BIOS + UEFI)"
-sh "$WORK/freebsd-src/release/${ARCH}/mkisoimages.sh" -b NEXTBSD \
-    "$WORK/$ISO_NAME" "$ISOROOT"
+# src.txz extracts under usr/src/, so the release script lands at
+# $WORK/freebsd-src/usr/src/release/$ARCH/mkisoimages.sh -- locate it by glob
+# rather than hardcoding the nesting. It sources ../../tools/boot/install-boot.sh
+# (also in the extracted tree).
+MKISO=$(find "$WORK/freebsd-src" -path "*/release/${ARCH}/mkisoimages.sh" 2>/dev/null | head -1)
+[ -n "$MKISO" ] || { echo "ERROR: mkisoimages.sh not found under $WORK/freebsd-src" >&2; exit 1; }
+sh "$MKISO" -b NEXTBSD "$WORK/$ISO_NAME" "$ISOROOT"
 ls -lh "$WORK/$ISO_NAME"
 echo "==> zip live ISO"
 (cd "$WORK" && zip -9 "$OUT/${ISO_NAME}.zip" "$ISO_NAME")


### PR DESCRIPTION
**PR3 of the live-root series** (nextbsd-kernel #38 baked the filesystems, #39 added the `vfs_mountroot` overlay hook). `build.sh` now also produces a bootable cd9660 **live ISO** alongside the rw-UFS GPT disk image.

## What
- add an empty **`/.overlay`** dir to the ISO's root image (the tmpfs mountpoint the kernel hook mounts — kernel can't `mkdir` on a RO fs)
- `makefs` a compact UFS of `rootfs` → **`mkuzip`** → `rootfs.uzip`
- stage an ISO bits dir (`/boot` from `rootfs` + a live `loader.conf` + the uzip)
- **`mkisoimages.sh -b`** → a BIOS+UEFI bootable cd9660
- publish **`NextBSD-<arch>-<date>.iso.zip`** next to the `.img.zip` (closes #70's ask)

## The live `loader.conf` (the whole live/installed switch)
```
mdroot_load="YES"  mdroot_type="md_image"  mdroot_name="/rootfs.uzip"
vfs.root.mountfrom="ufs:/dev/md0.uzip"      # geom_uzip; overrides baked ROOTDEVNAME
vfs.root.overlay="tmpfs"                     # → the kernel overlay hook fires
```
The loader reads `/boot` from the cd9660 (which it understands), preloads the uzip as `md0`, and `geom_uzip` mounts it. The installed disk image has **no** such loader.conf, so it boots plain rw-UFS and never unions. **launchd needs no change** — `launchd_root_make_writable()` already skips its `mount -uw /` when `/` isn't `MNT_RDONLY` (the live union is already writable).

## Scope of THIS PR
Gets the ISO **building + publishing** — which validates the real unknowns (`mkuzip`, `mkisoimages.sh`, that `boot/cdboot` + `boot/loader.efi` are present). The disk-image boot-test is unchanged (no regression); the ISO is built + published but **not yet boot-tested**.

## Next (PR4)
The **`qemu -cdrom` boot-test** that actually exercises the overlay end-to-end — asserting `vfs.root.overlay: / is now read-write`, `unionfs on /`, a write to `/`, and one clean `df`. It needs `boot-test.sh` adapted for `-cdrom`, so it's isolated here.

> Bonus: once this lands, the published `.iso.zip` is bootable in a VM / on hardware — you can *see* the overlay come up before PR4's automated test exists.

First proof uses a RAM-preloaded (md) uzip; on-demand/isohybrid + the tarfs bake-off are follow-ons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)