### PR TITLE
build: prebuilt /var/run/ld-elf.so.hints at image-build (minimal #278 step)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2894,6 +2894,27 @@ echo "==> [libscan] ELF shared-library closure over rootfs"
 )
 echo "==> [libscan] end"
 
+# 5y. Prebuilt linker hints — the "shipped cache" (the analog of Apple's
+#     prebuilt dyld shared cache baked into the OS image). The builder has no
+#     launchd, so this is the ONE place the hints are generated for the shipped
+#     image: run ONCE, after every pkg + Apple lib is in place, writing rtld's
+#     compiled-in default /var/run/ld-elf.so.hints. rtld (the per-exec program
+#     interpreter, not a service) reads that path automatically on every exec,
+#     so there is no boot step and no env var. Hints are DIRECTORY-based, so
+#     baking /usr/local/lib here means any port-installed lib that later lands
+#     there is found at runtime with no rebuild; the libdata/ldconfig drop-in
+#     dirs (perl5 CORE, gccNN, pkg compat) are folded in too. mkdir guarantees
+#     /usr/local/lib is listed even if empty in the base image.
+#     EXPERIMENT (issue #278): does this prebuilt baseline alone suffice for the
+#     common case? Tail dirs added by post-boot pkg installs still need a refresh
+#     (the planned org.freebsd.ldconfig WatchPaths daemon); this PR tests the floor.
+echo "==> generating /var/run/ld-elf.so.hints (prebuilt linker cache)"
+mkdir -p "$WORK/rootfs/usr/local/lib"
+chroot "$WORK/rootfs" /bin/sh -c \
+    '/sbin/ldconfig /lib /usr/lib /usr/lib/system /usr/local/lib $(cat /usr/local/libdata/ldconfig/* 2>/dev/null)'
+ls -l "$WORK/rootfs/var/run/ld-elf.so.hints"
+chroot "$WORK/rootfs" ldconfig -r 2>/dev/null | grep -i 'search director' || true
+
 # 6a. root UFS — content plus ~1.5 GB read-write headroom. UFS label
 #     "ROOTFS" matches loader.conf.d's vfs.root.mountfrom and the
 #     overlays/etc/fstab entry. softupdates for crash resilience.


### PR DESCRIPTION
Minimal first step of the #278 plan — **does a prebuilt linker hints baseline alone fix pkg/ports?**

pkg binaries link bare sonames and need the runtime linker to know `/usr/local/lib`, but NextBSD builds no `ld-elf.so.hints` (it dropped rc.d and never replaced it), so `git` dies at exec: `libpcre2-8.so.0 not found` (the lib *is* in `/usr/local/lib`).

This generates the hints **once, at the end of the build**, after every pkg + Apple lib is in place, into rtld's **compiled-in default path** `/var/run/ld-elf.so.hints`:
```sh
chroot rootfs ldconfig /lib /usr/lib /usr/lib/system /usr/local/lib $(cat /usr/local/libdata/ldconfig/*)
```

Why this should be enough for the common case:
- **rtld reads `/var/run/ld-elf.so.hints` on its own** (it's the per-exec program interpreter the kernel loads, not a service) — no boot step, no env var, no daemon.
- **Hints are directory-based**, so baking `/usr/local/lib` means any lib a user `pkg install`s there *later* is found at runtime with no rebuild.
- The `libdata/ldconfig` drop-in dirs present at build (pkg compat, etc.) are folded in.

**The test:** boot the resulting ISO, `pkg install git`, run `git --version` — should work with **no manual `ldconfig`**.

Known gap this does NOT cover (by design, for now): subdir lib dirs added by *post-boot* installs (e.g. `gcc14` → `/usr/local/lib/gcc14`, perl `CORE`) — their dirs aren't in the baked hints. Those need the planned `org.freebsd.ldconfig` `WatchPaths` daemon to refresh the file, and/or Lever B (compiled rtld default) as a floor. This PR deliberately tests the baseline first. Design doc: pkgdemon.github.io/nextbsd-library-resolution-plan.html. Refs #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)