### PR TITLE
overlay: ship base /etc files + /etc/rc.d/ldconfig workaround (#280)

### DIFF
--- a/overlays/etc/ld-elf.so.conf
+++ b/overlays/etc/ld-elf.so.conf
@@ -1,0 +1,5 @@
+# Extra directories ldconfig(8) folds into /var/run/ld-elf.so.hints, beyond
+# rtld's compiled-in default search path (which already includes /usr/local/lib
+# via Lever B, nextbsd #278). Kept for the ports `service ldconfig restart`
+# path and tooling that reads this file.
+/usr/local/lib

--- a/overlays/etc/man.conf
+++ b/overlays/etc/man.conf
@@ -1,0 +1,4 @@
+# mandoc man.conf(5) - manual page search paths.
+MANPATH /usr/share/man
+MANPATH /usr/local/share/man
+MANPATH /usr/local/man

--- a/overlays/etc/profile
+++ b/overlays/etc/profile
@@ -1,0 +1,10 @@
+# /etc/profile - system-wide setup sourced by sh(1) login shells.
+#
+# PATH for login shells currently comes from login.conf. It is slated to move
+# to Apple-style path_helper + /etc/paths (nextbsd #277); when that lands, this
+# file gains:
+#   if [ -x /usr/libexec/path_helper ]; then
+#       eval "$(/usr/libexec/path_helper -s)"
+#   fi
+# Until then this is an intentionally minimal stub so login shells have a
+# system-wide profile to source.

--- a/overlays/etc/rc.d/ldconfig
+++ b/overlays/etc/rc.d/ldconfig
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# WORKAROUND (nextbsd #280; to be removed by #281). NextBSD has no rc.d boot
+# sequence -- launchd is PID 1 and nothing runs /etc/rc.d at boot. This script
+# exists ONLY so the FreeBSD ports tree's shared-library post-installs (which
+# hardcode `service ldconfig restart`) SUCCEED, and so the linker hints refresh
+# on package install. It is invoked solely on-demand by service(8) from a pkg
+# post-install -- never at boot. #281 replaces service(8) with a launchd-native
+# shim and drops this file.
+#
+# PROVIDE: ldconfig
+
+. /etc/rc.subr
+
+name=ldconfig
+start_cmd=ldconfig_start
+stop_cmd=:
+restart_cmd=ldconfig_start
+status_cmd=:
+
+ldconfig_start()
+{
+	/sbin/ldconfig -elf /lib /usr/lib /usr/lib/system /usr/local/lib \
+	    $(cat /usr/local/libdata/ldconfig/* 2>/dev/null)
+}
+
+load_rc_config $name 2>/dev/null
+run_rc_command "$1"

--- a/overlays/etc/shells
+++ b/overlays/etc/shells
@@ -1,0 +1,7 @@
+# List of acceptable shells for chpass(1).
+# ftpd(8) will not allow users to connect who are not using
+# one of these shells.
+
+/bin/sh
+/bin/csh
+/bin/tcsh


### PR DESCRIPTION
Fixes the `pkg: POST-INSTALL script failed` flood — two base-system gaps, neither the linker (Lever B / nextbsd-freebsd-compat#16 handles resolution):

**1. lua post-installs need base `/etc` files.** Proven on a live box: git's post-install dies on missing `/etc/shells`.
**2. shared-lib post-installs run `service ldconfig restart`**, which fails because there's no `/etc/rc.d/ldconfig` (NextBSD dropped rc.d).

## Ships in `overlays/etc/`
- `shells` (FreeBSD base) — fixes git-shell registration (the proven one)
- `profile` — minimal sh login stub (path_helper hook lands with #277)
- `ld-elf.so.conf` — lists `/usr/local/lib` (rtld's compiled default already has it via Lever B #278; this is for the service-ldconfig path + tooling)
- `man.conf` — mandoc manual search paths
- `rc.d/ldconfig` — **WORKAROUND**: makes `service ldconfig restart` succeed (and refreshes hints on install). **Never run at boot** — NextBSD has no rc.d boot sequence; only invoked on-demand by `service(8)` from pkg post-installs. **#281 removes this** (replaces `service(8)` with a launchd-native shim).

## Not shipped
`manpath.config` is the GNU man-db mechanism, not used by FreeBSD's mandoc `man(1)` — intentionally omitted.

## Verify
Proven piecemeal on `1-2.local`: creating `/etc/shells` made git's post-install pass; adding `/etc/rc.d/ldconfig` made `service ldconfig restart` → rc=0 and libxcb/xcb-util-errors post-installs pass. This bakes both into the image.

Refs #278, #281; pairs with nextbsd-freebsd-compat#16 (Lever B, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)