### PR TITLE
build: certctl rehash to bake the CA trust store into the image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -243,6 +243,18 @@ if [ -n "$RUNTIME_PKGS" ] || [ -n "$DRIVER_PKGS" ] || [ -n "$BUILD_PKGS" ]; then
     }
     trap cleanup_chroot EXIT INT TERM
 
+    # CA trust store: build the hashed /etc/ssl/certs dir (+ the canonical
+    # cert.pem and untrusted/) with certctl(8). That hashed dir is the CApath
+    # the PORTS OpenSSL/curl read — the bare cert.pem bundle made above is NOT
+    # enough on its own, so without certs/ a pkg-installed git/curl fails TLS
+    # verify ("unable to get local issuer certificate (20)") even though the
+    # bundle is present and valid. Do it before pkg bootstrap so the in-chroot
+    # pkg phase gets a proper trust store too. certctl now ships in the base
+    # (nextbsd-freebsd-compat usr.sbin/certctl); it's a C program needing only
+    # libcrypto + /usr/share/certs, no shell.
+    chroot "$WORK/rootfs" certctl rehash
+    echo "    certs/: $(ls "$WORK/rootfs/etc/ssl/certs" 2>/dev/null | wc -l | tr -d ' ') hashed CA entries"
+
     # Bootstrap the real pkg(8) ON our from-source base: our /usr/sbin/pkg
     # (the base pkg(7) bootstrap) reads /etc/pkg/FreeBSD.conf (PORTS repo) and
     # fetches+verifies pkg(8) against our /usr/share/keys/pkg fingerprints.


### PR DESCRIPTION
Fixes pkg-installed `git clone https://` failing `SSL certificate ... unable to get local issuer certificate (20)` — even though `/etc/ssl/cert.pem` exists and is valid.

**Root cause:** the build generates the `cert.pem` *bundle* but never the hashed `/etc/ssl/certs/` dir. The ports OpenSSL/curl (libssl 3.5.6, what the pkg `git`/`curl` link) read `/etc/ssl/certs` as their compiled-in **CApath** — not the bundle. With no hashed dir, verification finds no roots.

Verified on `root@1-2`: `certctl rehash` creates `/etc/ssl/certs` (150 hashed entries) → `curl https://github.com` returns HTTP/2 200 and `git clone https://` succeeds, with no `--cacert`.

**Fix:** `chroot "$WORK/rootfs" certctl rehash` at build time (before pkg bootstrap, so the in-chroot pkg phase also gets a real trust store). On the live union root a runtime rehash is ephemeral (tmpfs upper), so it must be baked into the image.

Pairs with nextbsd-freebsd-compat#20 (ships `certctl` in the base deliberately; it was leaking in untracked from the build VM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)