### PR TITLE
build: chown overlayed /etc to root so login.conf passes secure_path (#293)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2835,6 +2835,13 @@ if [ -d "$ROOT/overlays" ]; then
     cp -aR "$ROOT/overlays/." "$WORK/rootfs/"
 fi
 
+# Force root:wheel on the overlayed /etc. cp -aR preserves the build user's
+# uid (the freebsd-vm overlay files inherit it — same mechanism as the / chown
+# in step 6a). A non-root-owned /etc/login.conf makes login(1)'s _secure_path()
+# reject it, which breaks login_getclass() -> "unknown class root" (nextbsd#293).
+# Do this BEFORE pwd_mkdb/cap_mkdb so the regenerated .db indices inherit it too.
+chown -R 0:0 "$WORK/rootfs/etc"
+
 # rc.local needs to be executable
 [ -f "$WORK/rootfs/etc/rc.local" ] && chmod +x "$WORK/rootfs/etc/rc.local"
 


### PR DESCRIPTION
Fixes #293.

`cp -aR "$ROOT/overlays/." "$WORK/rootfs/"` preserves the freebsd-vm build user's uid, so `/etc/login.conf` baked into the image **non-root-owned**. `login`'s `_secure_path()` rejects any `login.conf` with `st_uid != 0`, after which `login_getclass()` can't resolve root's class:

```
_secure_path: /etc/login.conf is not owned by root
login_getclass: unknown class "root"
```

The existing step-6a `chown 0:0` only covers `/` and `System/Library/Extensions`, never `/etc`. This adds `chown -R 0:0 "$WORK/rootfs/etc"` right after the overlay copy and **before** `pwd_mkdb`/`cap_mkdb`, so the source config and the regenerated `.db` indices are all root:wheel.

`cap_mkdb` already emitted `login.conf.db`, but `secure_path` checks the plaintext file's owner, not the `.db` — so the db regen alone never fixed it.

Latent since `login.conf` was first overlaid (9b48bb8); not a regression from #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)