### PR TITLE
tests/boot-test.sh: brand-agnostic getty boot banner (NextBSD)

### DIFF
--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -153,7 +153,10 @@ send "boot\r"
 
 # Stage 1a: capture getty's boot banner. PAM port iter 4 (issue #99)
 # restored RunAtLoad on com.apple.hostnamed.plist so hostnamed runs
-# at boot. Banner format: "FreeBSD/amd64 (HOSTNAME) (console)".
+# at boot. Banner format: "<ostype>/<arch> (HOSTNAME) (console)", from getty's
+# \s/\m -- ostype is NextBSD after the kernel rebrand (FreeBSD upstream) and
+# arch follows the target (amd64/arm64/powerpc/...). Matched brand- AND
+# arch-agnostically so neither a rebrand nor a new arch breaks this check.
 #
 # This check is INFORMATIONAL, not gating. Both daemons (hostnamed
 # + getty) have RunAtLoad=true and launchd dispatches them in
@@ -177,10 +180,10 @@ expect {
         puts "\nFAIL: boot banner not seen within 8 minutes"
         exit 1
     }
-    -re "FreeBSD/amd64 \\(Amnesiac\\) \\(console\\)" {
+    -re "\[A-Za-z\]*BSD/\[A-Za-z0-9_\]+ \\(Amnesiac\\) \\(console\\)" {
         puts "\nWARN: BOOT-BANNER — first-boot banner shows 'Amnesiac' (getty/hostnamed race; cosmetic only)"
     }
-    -re "FreeBSD/amd64 \\(\(\[A-Za-z0-9._-\]+\)\\) \\(console\\)" {
+    -re "\[A-Za-z\]*BSD/\[A-Za-z0-9_\]+ \\(\(\[A-Za-z0-9._-\]+\)\\) \\(console\\)" {
         puts "\nOK: BOOT-BANNER-OK — synthesized hostname '$expect_out(1,string)' visible to getty (hostnamed won the race this run)"
     }
 }


### PR DESCRIPTION
## What

The boot smoke-test's getty-banner matcher is hardcoded to `FreeBSD/amd64`. After the kernel rebrand (nextbsd-kernel#43) sets `ostype=NextBSD`, getty prints `NextBSD/amd64 (HOSTNAME) (console)`, so the matcher times out — `FAIL: boot banner not seen within 8 minutes` — **even though the kernel boots fine and reaches `login:`**.

Observed in nextbsd-kernel#43's smoke-test (the kernel booted and printed):
```
NextBSD 20260613-211748 #0 fef97a6889f9-dirty: Sat Jun 13 21:17:48 UTC 2026
login: ...
```

## Change

Match the brand with char class `[A-Za-z]*BSD` (accepts both `FreeBSD` and `NextBSD`) instead of the literal `FreeBSD`. Two notes:
- Kept it a **char class, not an alternation group**, so the `$expect_out(1,string)` hostname capture in the second pattern keeps group index 1. (Verified with `tclsh`: matches `NextBSD/amd64 (myhost) (console)` → host=`myhost`.)
- The **EFI loader** banner match (`"FreeBSD/amd64 EFI"`) is intentionally left unchanged — the boot loader is not rebranded.

## Why this matters cross-repo

nextbsd-kernel's PR smoke-test `curl`s this script from `nextbsd` **main**, so this needs to merge here before nextbsd-kernel#43's smoke-test can go green.

Refs nextbsd#300, nextbsd-kernel#43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)