### PR TITLE
nextbsd-version: make -k robust to kernel banner wording

### DIFF
--- a/src/nextbsd-version/nextbsd-version.sh.in
+++ b/src/nextbsd-version/nextbsd-version.sh.in
@@ -30,8 +30,10 @@
 #     UTC build timestamp (YYYYMMDD-HHMMSS) baked in at build time from the
 #     one IMG_DATE value the nextbsd build also uses for the ISO/img names and
 #     /etc/os-release -- so all of them share the exact same value.
-#   - The kernel-banner type token is pinned to "NextBSD" (the rebranded
-#     ostype) so -k parses /boot/kernel/kernel correctly.
+#   - -k extracts the YYYYMMDD-HHMMSS build-timestamp pattern from the kernel
+#     banner (not a positional token after a fixed prefix), so it's robust to
+#     the banner wording -- matches both "NextBSD <ts> #N ..." and the newer
+#     "NextBSD Kernel Version <ts>; ...".
 # -u (userland) reflects the world/ISO build time; -k/-r (installed/running
 # kernel) reflect the kernel build time. These legitimately differ -- the
 # kernel is built in a separate repo at a different time -- and exposing that
@@ -47,7 +49,7 @@ USERLAND_VERSION="@@VERSION@@"
 : ${LOADER_CONF_FILES:=$LOADER_DIR/defaults/loader.conf $LOADER_DIR/loader.conf $LOADER_DIR/loader.conf.local}
 LOADER_RE1='^\([A-Z_a-z][0-9A-Z_a-z]*=[-./0-9A-Z_a-z]\{1,\}\).*$'
 LOADER_RE2='^\([A-Z_a-z][0-9A-Z_a-z]*="[-./0-9A-Z_a-z]\{1,\}"\).*$'
-KERNEL_RE='^NextBSD \([-.0-9A-Za-z]\{1,\}\) .*$'
+KERNEL_RE='^[^0-9]*\([0-9]\{8\}-[0-9]\{6\}\).*$'
 
 progname=${0##*/}
 


### PR DESCRIPTION
## What
`nextbsd-version -k` parsed the banner positionally (`^NextBSD \(token\) …`, expecting a space after the token). The kernel banner reformat in **nextbsd-kernel#44** (`NextBSD Kernel Version <ts>; …`) would break that — it'd extract `Kernel`.

Switch `KERNEL_RE` to extract the **`YYYYMMDD-HHMMSS` timestamp pattern** directly:
```sh
KERNEL_RE='^[^0-9]*\([0-9]\{8\}-[0-9]\{6\}\).*$'
```

## Verified
Extracts `20260613-220051` from **both** banners (old `NextBSD <ts> #0 <hash>-dirty: …` and new `NextBSD Kernel Version <ts>; …`); baked tool is `sh -n` clean; `-u` unchanged.

Order-independent with nextbsd-kernel#44 (works with whichever kernel is installed).

Refs nextbsd-redux/nextbsd#300

🤖 Generated with [Claude Code](https://claude.com/claude-code)