### PR TITLE
live ISO: drop orphaned /rofs + /cow cruft from the pivoted root (#283)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3036,10 +3036,13 @@ rm -f "$WORK/$IMG_NAME" "$WORK/rootfs.ufs" "$WORK/esp.img"
 #
 echo "==> live ISO: building on-demand compressed root + mfsroot"
 
-# 7a. Overlay mountpoints must exist (empty) in the read-only uzip root so the
-#     post-pivot union has valid /rofs + /cow paths (the kernel can't mkdir on a
-#     RO fs). Added only now, after the disk image's makefs.
-mkdir -p "$WORK/rootfs/rofs" "$WORK/rootfs/cow"
+# 7a. Do NOT bake /rofs + /cow mountpoints into the uzip root. The live init
+#     mounts the components on the MFSROOT's own /rofs + /cow (created below),
+#     and `sysctl vfs.pivot` only repoints rootvnode to the union -- it never
+#     relocates those component mounts into the new root (see nextbsd-kernel
+#     sys/kern/vfs_pivot.c). Baking them here would just leave empty, orphaned
+#     /rofs + /cow dirs in the pivoted / (nextbsd#283); omit them so the live
+#     root is clean.
 
 # 7b. Compact UFS image of rootfs (no rw headroom — it is read-only), then
 #     mkuzip (zlib; geom_uzip reads it on demand). Separate from the disk


### PR DESCRIPTION
## Problem (#283)
After `vfs.pivot`, the live root shows empty **`/cow`** and **`/rofs`** dirs — the placeholders baked into the uzip root (`build.sh` step 7a). The actual tmpfs/uzip/unionfs mounts are made on the **mfsroot's** paths, so these uzip copies are just orphaned cruft in the pivoted `/`.

## Why the bake is unnecessary
Verified against `nextbsd-kernel sys/kern/vfs_pivot.c`: `sysctl vfs.pivot` only repoints `rootvnode` to the union root and moves it to the head of the mountlist (+ cache purge). It does **not** relocate the component mounts into the new root, so the uzip never needs `/rofs` or `/cow` to exist. The live `/init` mounts everything on the **mfsroot's own** `/rofs` + `/cow` (kept, step 7c).

## Change
Remove `mkdir -p "$WORK/rootfs/rofs" "$WORK/rootfs/cow"` (step 7a). The mount/pivot flow is unchanged; the pivoted `/` no longer carries the two empty dirs.

- `/libexec` is **kept** — it's a real system dir (`ld-elf.so.1`, `getty`), as #283 notes.
- Live-ISO only (the bake ran after the disk-image makefs).
- Addresses #283's "no leftover empty `/cow` + `/rofs`" goal. The separate mount-table tidy (orphaned component mounts) is a kernel-side follow-up.

CI `iso-test` boots the live ISO, so it validates the pivot still works without the bake.

Refs nextbsd-redux/nextbsd#283

🤖 Generated with [Claude Code](https://claude.com/claude-code)