### PR TITLE
ssh-bonjour: advertise _sftp-ssh._tcp so SSH shows in Workspace (#291)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2801,13 +2801,15 @@ test -x "$WORK/rootfs/usr/bin/ssh-keygen" \
 echo "==> OpenSSH built + installed (sshd, ssh, ssh-keygen)"
 
 # sshd-mdns-register — tiny libdns_sd co-process that advertises
-# _ssh._tcp so mDNSResponder publishes the host's <name>.local record
-# (mDNSCore only advertises host records when an AutoTarget service is
-# registered; a headless box otherwise advertises nothing). Started by
-# sshd-keygen-wrapper just before `exec sshd -D` and tied to sshd's
-# lifetime via getppid(). Depends on libdns_sd + dns_sd.h built in
-# Phase K (above). Same link shape as dnssdtest.
-echo "==> building sshd-mdns-register (src/ssh-bonjour, _ssh._tcp advertiser)"
+# _ssh._tcp + _sftp-ssh._tcp so mDNSResponder publishes the host's
+# <name>.local record (mDNSCore only advertises host records when an
+# AutoTarget service is registered; a headless box otherwise advertises
+# nothing) and the box surfaces in both Network Browser (_ssh) and
+# Workspace (_sftp-ssh). Started by sshd-keygen-wrapper just before
+# `exec sshd -D` and tied to sshd's lifetime via getppid(). Depends on
+# libdns_sd + dns_sd.h built in Phase K (above). Same link shape as
+# dnssdtest.
+echo "==> building sshd-mdns-register (src/ssh-bonjour, _ssh + _sftp-ssh advertiser)"
 cc -I"$WORK/rootfs/usr/include" \
    -L"$WORK/rootfs/usr/lib/system" \
    -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \

--- a/src/ssh-bonjour/sshd-mdns-register.c
+++ b/src/ssh-bonjour/sshd-mdns-register.c
@@ -1,5 +1,6 @@
 /*
- * sshd-mdns-register — advertise this host's sshd over Bonjour (_ssh._tcp).
+ * sshd-mdns-register — advertise this host's sshd over Bonjour, as both
+ * _ssh._tcp and _sftp-ssh._tcp.
  *
  * Why this exists: mDNSResponder publishes the host's <name>.local
  * address record only once at least one service that targets the local
@@ -7,11 +8,29 @@
  * the per-interface A/PTR records on m->AutoTargetServices > 0. A
  * headless box with no registered services advertises nothing, so it
  * can't be reached by <name>.local at all (its Auth Records list is
- * empty). Registering _ssh._tcp here bumps AutoTargetServices, which
+ * empty). Registering an _ssh._tcp service here bumps AutoTargetServices,
+ * which
  *   (a) makes mDNSResponder advertise the host A/PTR records, so
  *       <name>.local resolves, and
  *   (b) makes the box discoverable as an SSH service in Bonjour
  *       browsers (alongside other _ssh._tcp hosts on the LAN).
+ *
+ * Why _sftp-ssh._tcp too: Network Browser.app finds hosts via _ssh._tcp,
+ * but Workspace only surfaces (and connects to) SSH hosts advertised as
+ * _sftp-ssh._tcp. Apple gets both types from launchd's native Bonjour
+ * socket key (ssh.plist lists <array>ssh sftp-ssh</array>); this image's
+ * launchd doesn't implement that key and our sshd plist isn't socket-
+ * activated, so we register both types here instead. Same port (22),
+ * same AutoTarget host — _sftp-ssh is the same sshd, just the service
+ * name Workspace looks for.
+ *
+ * NOT handled here: _device-info._tcp (the model= TXT richer browsers
+ * read). On Apple that is a host-level record owned by mDNSResponder
+ * itself (m->DeviceInfo / UpdateDeviceInfoRecord), present whenever the
+ * host advertises at all — independent of sshd. Bolting it onto this
+ * sshd co-process would make it blink in/out with Remote Login, which is
+ * wrong. It belongs in mDNSResponder's stubbed UpdateDeviceInfoRecord();
+ * tracked separately. See nextbsd-redux/nextbsd#291.
  *
  * Lifecycle: sshd-keygen-wrapper starts this in the background right
  * before exec'ing `sshd -D`, so our parent becomes the sshd process.
@@ -39,7 +58,8 @@
 #include <unistd.h>
 
 #define SSH_SVC_TYPE	"_ssh._tcp"
-#define SSH_SVC_PORT	22
+#define SFTP_SVC_TYPE	"_sftp-ssh._tcp"
+#define SSH_SVC_PORT	22		/* both types front the same sshd */
 #define PARENT_POLL_SEC	2
 
 static volatile sig_atomic_t g_stop;
@@ -66,10 +86,34 @@ register_cb(DNSServiceRef sdRef, DNSServiceFlags flags,
 	(void)fflush(stderr);
 }
 
+/*
+ * Register one AutoTarget service on the shared connection. name=NULL ->
+ * mDNSResponder uses the host's .local name; host=NULL -> the service
+ * targets the daemon's own hostname (AutoTarget). That AutoTarget SRV is
+ * what bumps AutoTargetServices and triggers host-record advertisement.
+ * op is a *copy* of the shared ref; the ShareConnection flag tells the
+ * library to reuse the shared connection's socket rather than open a new
+ * one. Deallocating the shared ref later tears down every op with it.
+ */
+static DNSServiceErrorType
+register_svc(DNSServiceRef shared, DNSServiceRef *op, const char *type)
+{
+	*op = shared;
+	return DNSServiceRegister(op, kDNSServiceFlagsShareConnection, 0,
+	    NULL,		/* name = host's .local name */
+	    type,
+	    NULL,		/* domain = ".local." */
+	    NULL,		/* host = this host (AutoTarget) */
+	    htons(SSH_SVC_PORT),
+	    0, NULL,		/* txt record */
+	    register_cb, NULL);
+}
+
 int
 main(void)
 {
-	DNSServiceRef ref = NULL;
+	DNSServiceRef shared = NULL;	/* shared connection; owns both ops */
+	DNSServiceRef ssh_op, sftp_op;	/* copies — do not deallocate */
 	DNSServiceErrorType err;
 	int fd;
 
@@ -77,52 +121,53 @@ main(void)
 	(void)signal(SIGINT, on_term);
 
 	/*
-	 * name=NULL -> mDNSResponder uses the host's .local name; host=NULL
-	 * -> the service targets the daemon's own hostname (AutoTarget).
-	 * That AutoTarget SRV is what bumps AutoTargetServices and triggers
-	 * host-record advertisement.
+	 * Open one shared connection and register both _ssh._tcp and
+	 * _sftp-ssh._tcp on it, so a single socket fd drives both (and a
+	 * single deallocate drops both, keeping the deregister atomic).
 	 *
-	 * Retry until it succeeds: mDNSResponder and sshd are both
-	 * RunAtLoad, and if sshd wins the boot race the daemon's
-	 * /var/run/mDNSResponder socket may not exist yet, so the register
-	 * (or the implicit connection) fails. We are not launchd-managed —
+	 * Retry the whole bundle until it succeeds: mDNSResponder and sshd
+	 * are both RunAtLoad, and if sshd wins the boot race the daemon's
+	 * /var/run/mDNSResponder socket may not exist yet, so the connect
+	 * or either register fails. We are not launchd-managed —
 	 * sshd-keygen-wrapper backgrounded us — so nothing would restart us
 	 * until sshd itself respawned. Loop instead, giving up only if sshd
-	 * (our parent) goes away (getppid()==1) or we are signalled. */
+	 * (our parent) goes away (getppid()==1) or we are signalled. On any
+	 * partial failure tear the connection down and start over, so we
+	 * never end up advertising only one of the two types. */
 	for (;;) {
-		err = DNSServiceRegister(&ref, 0, 0,
-		    NULL,		/* name = host's .local name */
-		    SSH_SVC_TYPE,
-		    NULL,		/* domain = ".local." */
-		    NULL,		/* host = this host (AutoTarget) */
-		    htons(SSH_SVC_PORT),
-		    0, NULL,		/* txt record */
-		    register_cb, NULL);
+		err = DNSServiceCreateConnection(&shared);
+		if (err == kDNSServiceErr_NoError)
+			err = register_svc(shared, &ssh_op, SSH_SVC_TYPE);
+		if (err == kDNSServiceErr_NoError)
+			err = register_svc(shared, &sftp_op, SFTP_SVC_TYPE);
 		if (err == kDNSServiceErr_NoError)
 			break;
+		if (shared != NULL) {
+			DNSServiceRefDeallocate(shared);
+			shared = NULL;
+		}
 		if (g_stop || getppid() == 1) {
 			(void)fprintf(stderr, "sshd-mdns-register: giving up "
 			    "(register err=%d, sshd gone/stopped)\n", (int)err);
 			return (1);
 		}
-		(void)fprintf(stderr, "sshd-mdns-register: DNSServiceRegister "
-		    "failed (err=%d) — mDNSResponder not up yet? retrying\n",
-		    (int)err);
+		(void)fprintf(stderr, "sshd-mdns-register: register failed "
+		    "(err=%d) — mDNSResponder not up yet? retrying\n", (int)err);
 		(void)fflush(stderr);
 		(void)sleep(PARENT_POLL_SEC);
 	}
 
-	fd = DNSServiceRefSockFD(ref);
+	fd = DNSServiceRefSockFD(shared);
 	if (fd < 0) {
 		(void)fprintf(stderr, "sshd-mdns-register: DNSServiceRefSockFD "
 		    "failed\n");
-		DNSServiceRefDeallocate(ref);
+		DNSServiceRefDeallocate(shared);
 		return (1);
 	}
 
 	(void)fprintf(stderr, "sshd-mdns-register: advertising " SSH_SVC_TYPE
-	    " on port %d (tied to sshd pid %ld)\n", SSH_SVC_PORT,
-	    (long)getppid());
+	    " + " SFTP_SVC_TYPE " on port %d (tied to sshd pid %ld)\n",
+	    SSH_SVC_PORT, (long)getppid());
 	(void)fflush(stderr);
 
 	/*
@@ -130,8 +175,8 @@ main(void)
 	 * backgrounded by sshd-keygen-wrapper just before it exec'd sshd,
 	 * so getppid() is the sshd pid. When sshd exits we are reparented
 	 * to launchd (PID 1); getppid() == 1 is the signal to deregister
-	 * and exit so the _ssh._tcp advertisement (and the host .local
-	 * record it carries) goes away with sshd.
+	 * and exit so the SSH advertisements (and the host .local record
+	 * they carry) go away with sshd.
 	 */
 	while (!g_stop && getppid() != 1) {
 		fd_set rfds;
@@ -144,12 +189,18 @@ main(void)
 		tv.tv_usec = 0;
 		r = select(fd + 1, &rfds, NULL, NULL, &tv);
 		if (r > 0 && FD_ISSET(fd, &rfds))
-			(void)DNSServiceProcessResult(ref);
+			(void)DNSServiceProcessResult(shared);
 	}
 
 	(void)fprintf(stderr, "sshd-mdns-register: sshd gone (getppid=%ld) — "
-	    "deregistering " SSH_SVC_TYPE "\n", (long)getppid());
+	    "deregistering " SSH_SVC_TYPE " + " SFTP_SVC_TYPE "\n",
+	    (long)getppid());
 	(void)fflush(stderr);
-	DNSServiceRefDeallocate(ref);
+	/*
+	 * Deallocating the shared ref terminates the connection and both
+	 * subordinate ops at once; per dns_sd.h we must NOT also deallocate
+	 * ssh_op / sftp_op (their memory is freed with the parent).
+	 */
+	DNSServiceRefDeallocate(shared);
 	return (0);
 }


### PR DESCRIPTION
## What

`sshd-mdns-register` advertised only `_ssh._tcp`. **Network Browser.app** finds hosts that way, but **Workspace** only surfaces (and connects to) SSH hosts advertised as **`_sftp-ssh._tcp`**. This registers both types so the box shows up in both.

## Why a co-process (and not launchd)

On macOS sshd's Bonjour advertisement comes from launchd's native `Bonjour` socket key — Apple's `ssh.plist` lists `<array>ssh sftp-ssh</array>` and launchd registers both with mDNSResponder. This image's launchd doesn't implement that key, and our `com.openssh.sshd.plist` isn't socket-activated (runs standalone `sshd -D` as a rescue daemon), so we register from the existing tiny libdns_sd co-process instead. Same observable result Apple gives, same port (22), same AutoTarget host — `_sftp-ssh` is the same sshd under the service name Workspace looks for.

## How

- Switch from a single `DNSServiceRegister` to a **shared connection**: `DNSServiceCreateConnection` + two `kDNSServiceFlagsShareConnection` registrations (via a small `register_svc` helper).
- A single socket fd still drives the existing select/parent-watch loop, and a single `DNSServiceRefDeallocate(shared)` drops both ops — so the deregister stays **atomic** and the host `.local` record stays tied to sshd's lifetime exactly as before.
- The boot-race retry now retries the **whole bundle** and tears the connection down on partial failure, so it never ends up advertising only one of the two types.
- Header + `build.sh` comments/echo updated.

## Out of scope — `_device-info._tcp`

The other half of #291. On Apple that's a **host-level** record owned by mDNSResponder itself (`UpdateDeviceInfoRecord`, currently a no-op stub here), present whenever the host advertises at all — independent of sshd. Bolting it onto this co-process would make `model=` blink in/out with Remote Login, which is wrong. Split out to **#311**.

## Testing

- Compiles clean with `cc -fsyntax-only -Wall -Wextra` against the in-tree `dns_sd.h`.
- Not yet verified on a booted image — needs a full build, then confirming the host appears in **Workspace** (via `_sftp-ssh._tcp`) and still in **Network Browser** (via `_ssh._tcp`), and that both records go away when sshd stops.

Closes #291 (the `_sftp-ssh` half). `_device-info` continues in #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)