### PR TITLE
mDNSResponder: advertise _device-info._tcp (model=) from the daemon (#311)

### DIFF
--- a/src/mDNSResponder/mDNSPosix/mDNSPosix.c
+++ b/src/mDNSResponder/mDNSPosix/mDNSPosix.c
@@ -58,6 +58,9 @@
 #include <sys/ioctl.h>
 #include <linux/sockios.h>
 #endif
+#if defined(__FreeBSD__)
+#include <kenv.h>                   // SMBIOS system-product name -> _device-info "model="
+#endif
 
 #include "mDNSUNP.h"
 #include "GenLinkedList.h"
@@ -1924,6 +1927,41 @@ mDNSlocal mDNSBool mDNSPlatformInit_CanReceiveUnicast(void)
     return(err == 0);
 }
 
+// Fill in m->HIHardware with the machine model, used by mDNSResponder to
+// build the host's _device-info "model=" TXT (this mirrors Apple's macOS
+// platform layer, which populates HIHardware from the hardware model).
+// On NextBSD the model comes from the SMBIOS system-product name (kenv
+// smbios.system.product) — the Mac model identifier on real Apple hardware
+// (e.g. "MacBookPro15,1"), the hypervisor product in a VM. When SMBIOS is
+// empty or unavailable we fall back to "NextBSD". HIHardware is a
+// length-prefixed string (c[0] = length); clamp it so "model=" + model
+// fits an inline-storage TXT record (see UpdateDeviceInfoRecord).
+mDNSlocal void SetupDeviceModel(mDNS *const m)
+{
+    // 6 bytes for "model=" plus the model, all inside one TXT string that
+    // must fit InlineCacheRDSize bytes of inline rdata (1 length byte too).
+    enum { kMaxModelLen = InlineCacheRDSize - 1 - 6 };
+    char model[256];
+    int len = 0;
+
+#if defined(__FreeBSD__)
+    if (kenv(KENV_GET, "smbios.system.product", model, (int)sizeof(model)) > 0)
+        for (len = 0; len < (int)sizeof(model) && model[len] != '\0'; len++)
+            continue;
+#endif
+
+    if (len <= 0)
+    {
+        static const char fallback[] = "NextBSD";
+        len = (int)(sizeof(fallback) - 1);
+        mDNSPlatformMemCopy(model, fallback, (mDNSu32)len);
+    }
+    if (len > kMaxModelLen) len = kMaxModelLen;
+
+    m->HIHardware.c[0] = (mDNSu8)len;
+    mDNSPlatformMemCopy(&m->HIHardware.c[1], model, (mDNSu32)len);
+}
+
 // mDNS core calls this routine to initialise the platform-specific data.
 mDNSexport mStatus mDNSPlatformInit(mDNS *const m)
 {
@@ -1944,6 +1982,9 @@ mDNSexport mStatus mDNSPlatformInit(mDNS *const m)
     m->hostlabel.c[0] = 0;
     GetUserSpecifiedRFC1034ComputerName(&m->hostlabel);
     if (m->hostlabel.c[0] == 0) MakeDomainLabelFromLiteralString(&m->hostlabel, "Computer");
+
+    // Machine model for the _device-info "model=" TXT record.
+    SetupDeviceModel(m);
 
     mDNS_SetFQDN(m);
 

--- a/src/mDNSResponder/mDNSShared/uds_daemon.c
+++ b/src/mDNSResponder/mDNSShared/uds_daemon.c
@@ -3142,9 +3142,67 @@ mDNSlocal void SetPrefsBrowseDomains(mDNS *m, DNameListElem *browseDomains, mDNS
     }
 }
 
+// Build the _device-info TXT rdata ("model=<HIHardware>") into ptr and
+// return its length. The TXT holds a single length-prefixed key/value
+// string. Returns 0 (advertise nothing) when no model string is set.
+mDNSexport mDNSu32 initializeDeviceInfoTXT(mDNS *m, mDNSu8 *ptr)
+{
+    static const char key[] = "model=";       // 6 bytes, no NUL
+    const mDNSu8 modellen = m->HIHardware.c[0];
+    mDNSu8 *const start = ptr;
+
+    if (modellen == 0) return 0;
+
+    *ptr++ = (mDNSu8)((sizeof(key) - 1) + modellen);   // TXT string length
+    mDNSPlatformMemCopy(ptr, key, sizeof(key) - 1);
+    ptr += sizeof(key) - 1;
+    mDNSPlatformMemCopy(ptr, &m->HIHardware.c[1], modellen);
+    ptr += modellen;
+    return (mDNSu32)(ptr - start);
+}
+
+// Register/refresh (or tear down) the host's _device-info._tcp TXT record,
+// which carries "model=" for Bonjour browsers. Apple ties this record to
+// the presence of autoname services: it is advertised whenever at least
+// one service is registered under the host's default (nice) name, and is
+// renamed/removed in lockstep with that name. We mirror that here rather
+// than advertising _device-info from any single daemon. Called from the
+// service register/deregister paths.
 mDNSlocal void UpdateDeviceInfoRecord(mDNS *const m)
 {
-    (void)m; // unused
+    int num_autoname = 0;
+    request_state *req;
+
+    for (req = all_requests; req; req = req->next)
+        if (req->terminate == regservice_termination_callback &&
+            req->servicereg && req->servicereg->autoname)
+            num_autoname++;
+
+    // Deregister if we have it but no longer should, or the host name changed.
+    if (m->DeviceInfo.resrec.RecordType != kDNSRecordTypeUnregistered)
+        if (num_autoname == 0 ||
+            !SameDomainLabelCS(m->DeviceInfo.resrec.name->c, m->nicelabel.c))
+        {
+            LogOperation("UpdateDeviceInfoRecord Deregister %##s", m->DeviceInfo.resrec.name->c);
+            mDNS_Deregister(m, &m->DeviceInfo);
+        }
+
+    // Register if we should have it but don't.
+    if (m->DeviceInfo.resrec.RecordType == kDNSRecordTypeUnregistered && num_autoname > 0)
+    {
+        mDNSu8 txt[256];
+        mDNSu32 len = initializeDeviceInfoTXT(m, txt);
+        if (len == 0) return;                  // no model -> nothing to advertise
+
+        mDNS_SetupResourceRecord(&m->DeviceInfo, mDNSNULL, mDNSInterface_Any, kDNSType_TXT,
+            kStandardTTL, kDNSRecordTypeAdvisory, AuthRecordAny, mDNSNULL, mDNSNULL);
+        ConstructServiceName(&m->DeviceInfo.namestorage, &m->nicelabel, &DeviceInfoName, &localdomain);
+        if (len > m->DeviceInfo.resrec.rdata->MaxRDLength) return;   // paranoia: never overrun inline rdata
+        m->DeviceInfo.resrec.rdlength = len;
+        mDNSPlatformMemCopy(m->DeviceInfo.resrec.rdata->u.txt.c, txt, len);
+        LogOperation("UpdateDeviceInfoRecord   Register %##s", m->DeviceInfo.resrec.name->c);
+        mDNS_Register(m, &m->DeviceInfo);
+    }
 }
 
 mDNSexport void udsserver_handle_configchange(mDNS *const m)


### PR DESCRIPTION
## What

Implements `_device-info._tcp` (the `model=...` TXT richer Bonjour browsers read) **in mDNSResponder**, where it belongs — the other half of #291, split out per #311. This is the host-level record macOS uses to give a node an icon/identity in browsers.

## Is this how Apple does it?

Yes — the scaffolding was already in the tree; it had just been stubbed/stripped:

- `m->DeviceInfo` (`AuthRecord`) — declared
- `DeviceInfoName` / `LocalDeviceInfoName` (`_device-info._tcp[.local]`) — defined
- `m->HIHardware` — the HINFO hardware string Apple builds `model=` from — present, zeroed at init
- the response/goodbye code that attaches the DeviceInfo TXT to service-PTR answers — present (`mDNS.c`)
- `initializeDeviceInfoTXT()` — **declared but never defined**
- `UpdateDeviceInfoRecord()` — a **no-op stub**

This PR restores the two missing functions and feeds `m->HIHardware`, so the daemon owns the record and gets rename/conflict/goodbye integration for free.

## How

- **`initializeDeviceInfoTXT()`** — build the `model=<HIHardware>` TXT (single length-prefixed key/value; returns 0 → advertise nothing when no model).
- **`UpdateDeviceInfoRecord()`** — register/refresh/deregister `<nicelabel>._device-info._tcp.local`, **keyed on the count of active autoname service registrations** (exactly Apple's gating — the in-tree comment at `uds_daemon.c:1799` already describes this count). So it rides along with whatever is advertised under the host's default name and is renamed/removed in lockstep. Copy is guarded against overrunning the inline rdata.
- **`mDNSPosix`** — populate `m->HIHardware` from the **SMBIOS system-product name** (`kenv smbios.system.product`): the Mac model id on real Apple hardware (e.g. `MacBookPro15,1`), the hypervisor product in a VM, falling back to `NextBSD` when SMBIOS is empty/unavailable. This mirrors Apple's macOS platform layer, which fills `HIHardware` from the hardware model. (`hw.model` was deliberately **not** used — on FreeBSD that's the CPU brand string, not a machine model.)

The service register/deregister paths were **already** calling `UpdateDeviceInfoRecord()`; this just makes those calls do something.

## Lifetime note (correcting #311's wording)

Apple does **not** advertise `_device-info` "even with every service off." It's gated on autoname-service presence. With the sshd co-process registering `_ssh`/`_sftp-ssh` as autoname services (#291 / #312), `_device-info` appears alongside them and goes away with them — but via mDNSResponder's integrated path, not a hand-rolled registration. The point of doing it here (vs. the co-process) is **ownership + integration**, not decoupling from sshd.

## Testing

- Both translation units compile clean (`cc -fsyntax-only -fwrapv -W -Wall` with the project includes); no new warnings on the added code. The `kenv` path is `#if defined(__FreeBSD__)`-guarded, so non-FreeBSD hosts take the `NextBSD` fallback.
- Not yet verified on a booted image — needs a full build, then confirming `_device-info._tcp` resolves with a `model=` TXT while an autoname service (sshd) is up, that the value matches `kenv smbios.system.product`, and that it renames/deregisters with the host name / last autoname service.

Closes #311. Pairs with #312 (the `_sftp-ssh` half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)