### PR TITLE
hostnamed: persist mDNSResponder Bonjour conflict-rename (#156)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2624,7 +2624,28 @@ cc -fblocks \
    -ldns_sd -lsystem_kernel -lpthread
 test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnamedmdnsset" \
     || { echo "FAIL: hostnamedmdnsset not built"; exit 1; }
-echo "==> hostnamed + hostnametest + hostnameprefset + hostnamedhcpset + hostnamedmdnsset built"
+
+# hostnamedbonjourset — iter 5 (#156) CI fixture. Registers an
+# authoritative, UNIQUE A record for <fixture>.local (192.0.2.1, an
+# RFC 5737 TEST-NET address that won't match a real interface, so the
+# records conflict rather than coalesce), holds it open, and lets the
+# daemon's later probe for the same name collide -> mDNSCore renames the
+# daemon host label to <fixture>-2. Same -fblocks + CF/SC + -ldns_sd
+# linkage as the iter 3b fixture.
+echo "==> building hostnamedbonjourset"
+cc -fblocks \
+   -I"$WORK/rootfs/usr/include" \
+   -I"$ROOT/src/launchd/liblaunch" \
+   -I"$ROOT/src/launchd/freebsd-shims" \
+   -L"$WORK/rootfs/usr/lib/system" \
+   -Wl,-rpath,/usr/lib/system -Wl,--allow-shlib-undefined \
+   -o "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnamedbonjourset" \
+   "$ROOT/src/hostnamed/hostnamedbonjourset.c" \
+   -lSystemConfiguration -lCoreFoundation -ldispatch -lBlocksRuntime \
+   -ldns_sd -lsystem_kernel -lpthread
+test -x "$WORK/rootfs/usr/tests/freebsd-launchd-mach/hostnamedbonjourset" \
+    || { echo "FAIL: hostnamedbonjourset not built"; exit 1; }
+echo "==> hostnamed + hostnametest + hostnameprefset + hostnamedhcpset + hostnamedmdnsset + hostnamedbonjourset built"
 
 #
 # 3y2. PAM port iter 1 — vendor Apple OpenPAM (issue #93). Builds

--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -1639,6 +1639,71 @@ else
     echo "HOSTNAMED-MDNS-FAIL: hostnamedmdnsset binary not installed"
 fi
 
+# ROUND 5: Bonjour conflict-rename feedback (#156). Background
+# hostnamedbonjourset to claim <fixture>.local (authoritative UNIQUE A
+# record). Then set SCPrefs ComputerName=<fixture>: prefs_monitor
+# republishes Setup:/Network/HostNames, mDNSConfigStore (iter-5 watch on
+# the Setup: key) re-adopts <fixture> and re-probes <fixture>.local, which
+# the fixture already owns -> mDNSCore renames the daemon host label to
+# <fixture>-2 and PosixDaemon.c publishes it to State:/Network/HostNames.
+# hostnamed's observer persists <fixture>-2 to SCPrefs ComputerName, which
+# flows back through prefs_monitor + set-hostname.c to the kernel hostname.
+echo "==> hostnamed ROUND 5 (Bonjour conflict-rename)"
+HOSTNAMED_BONJOUR_FIXTURE="hostnamed-iter5-fixture"
+HOSTNAMED_BONJOUR_RESOLVED="${HOSTNAMED_BONJOUR_FIXTURE}-2"
+if [ -x /usr/tests/freebsd-launchd-mach/hostnamedhcpset ]; then
+    /usr/tests/freebsd-launchd-mach/hostnamedhcpset --clear || true
+fi
+if [ -x /usr/tests/freebsd-launchd-mach/hostnamedbonjourset ] && \
+   [ -x /usr/tests/freebsd-launchd-mach/hostnameprefset ]; then
+    /usr/tests/freebsd-launchd-mach/hostnamedbonjourset \
+        "$HOSTNAMED_BONJOUR_FIXTURE" > /var/log/hostnamedbonjourset.stdout \
+        2> /var/log/hostnamedbonjourset.stderr &
+    HOSTNAMED_BONJOURSET_PID=$!
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        if grep -q "BONJOURSET-READY" \
+            /var/log/hostnamedbonjourset.stdout 2>/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+    echo "--- /var/log/hostnamedbonjourset.stdout ---"
+    cat /var/log/hostnamedbonjourset.stdout 2>/dev/null
+    echo "--- /var/log/hostnamedbonjourset.stderr ---"
+    cat /var/log/hostnamedbonjourset.stderr 2>/dev/null
+    echo "--- end hostnamedbonjourset logs ---"
+    if grep -q "BONJOURSET-READY" \
+        /var/log/hostnamedbonjourset.stdout 2>/dev/null; then
+        # The fixture owns <fixture>.local. Now make the daemon want that
+        # same name; its probe will collide and mDNSCore will rename it.
+        /usr/tests/freebsd-launchd-mach/hostnameprefset \
+            "$HOSTNAMED_BONJOUR_FIXTURE"
+        # Poll up to 15s for the full round-trip (probe + conflict-rename +
+        # State: publish + observer persist + prefs republish + sethostname)
+        # to converge on the -2 suffix, rather than a fixed sleep.
+        for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+            if [ "$(hostname 2>/dev/null)" = \
+                "$HOSTNAMED_BONJOUR_RESOLVED" ]; then
+                break
+            fi
+            sleep 1
+        done
+        hostnamed_dump_log "ROUND 5"
+        echo "    kernel hostname = '$(hostname 2>/dev/null)' " \
+            "(expected '$HOSTNAMED_BONJOUR_RESOLVED')"
+        /usr/tests/freebsd-launchd-mach/hostnametest \
+            "$HOSTNAMED_BONJOUR_RESOLVED" BONJOUR-RENAME
+    else
+        echo "HOSTNAMED-BONJOUR-RENAME-FAIL: hostnamedbonjourset never" \
+            "reached READY (could not claim <fixture>.local)"
+    fi
+    kill "$HOSTNAMED_BONJOURSET_PID" 2>/dev/null || true
+    wait "$HOSTNAMED_BONJOURSET_PID" 2>/dev/null || true
+else
+    echo "HOSTNAMED-BONJOUR-RENAME-FAIL: hostnamedbonjourset or" \
+        "hostnameprefset binary not installed"
+fi
+
 echo "==> hostnamed: persistent daemon liveness POST-rounds check"
 echo "    pgrep -x hostnamed -> $(pgrep -x hostnamed 2>/dev/null || echo MISSING)"
 echo "--- /var/log/hostnamed.stderr (last 40 lines, post-rounds) ---"

--- a/src/hostnamed/Makefile
+++ b/src/hostnamed/Makefile
@@ -4,6 +4,10 @@
 # Sources:
 #   hostnamed.c            — main(), event loop, signal handling, xlog.
 #   prefs_monitor.c        — SCPrefs → SCDS Setup: keys bridge.
+#   hostname_observer.c    — watches State:/Network/HostNames for
+#                            mDNSResponder's Bonjour conflict-rename
+#                            feedback; persists the resolved name to
+#                            SCPrefs ComputerName (#156).
 #   freebsd-shim/shim.c    — ip_plugin.h externs, SCPrivate SPI subset,
 #                            freebsd_synthesize_hostname, synthesis
 #                            machinery.
@@ -22,7 +26,7 @@ PROG=		hostnamed
 # NO_MAN=yes alone is insufficient. Same suppression hwregd / configd /
 # ipconfigd use.
 MAN=
-SRCS=		hostnamed.c prefs_monitor.c shim.c set-hostname.c
+SRCS=		hostnamed.c prefs_monitor.c hostname_observer.c shim.c set-hostname.c
 
 # WARNS=0: hostnamed.c pulls the CoreFoundation + SystemConfiguration
 # public header tree. At WARNS>0 FreeBSD adds -Wsystem-headers -Werror

--- a/src/hostnamed/hostname_observer.c
+++ b/src/hostnamed/hostname_observer.c
@@ -1,0 +1,270 @@
+/*
+ * hostname_observer.c — Bonjour conflict-rename feedback for hostnamed.
+ * freebsd-launchd-mach iter 5, issue #156.
+ *
+ * THE LOOP THIS CLOSES
+ *
+ * mDNSResponder owns the dot-local host name on the link. When it probes
+ * <name>.local and finds a collision, mDNSCore's conflict-rename
+ * (mDNS_HostNameCallback -> IncrementLabelSuffix) bumps the label to
+ * "<name>-2", "<name>-3", ... Through iter 4 that resolved name lived only
+ * in mDNSResponder's memory; nothing persisted it, so the next boot would
+ * collide again. (Apple's PosixDaemon.c left exactly this as an empty stub
+ * with a comment: "On Mac OS X we store the current dot-local mDNS host
+ * name in the SCPreferences store.")
+ *
+ * iter 5 fills that stub: mDNSResponder now writes the resolved label to
+ * State:/Network/HostNames (the SCDynamicStore "actual name in use"
+ * surface — see src/mDNSResponder/mDNSPosix/mDNSConfigStore.c
+ * mDNSConfigStorePublishResolvedHostName). This observer subscribes to that
+ * State: key and, on a resolved-name change, persists it into SCPreferences
+ * /System/System ComputerName + commits — the same write the hostnameprefset
+ * CI fixture performs. prefs_monitor's SCPrefs callback then republishes
+ * Setup:/System + Setup:/Network/HostNames, and the vendored set-hostname.c
+ * decision engine sets the kernel hostname. Convergence:
+ *
+ *   mDNS conflict -> State:/Network/HostNames = "foo-2"
+ *     -> [this observer] SCPrefs ComputerName = "foo-2" + commit
+ *     -> prefs_monitor republishes Setup:/{System,Network/HostNames} = "foo-2"
+ *     -> mDNSConfigStore re-adopts desired "foo-2", re-probes foo-2.local
+ *        (now unique) -> no further rename -> no further State: write.
+ *
+ * NO-LOOP. We watch only State:/Network/HostNames. prefs_monitor writes
+ * Setup: (not State:), and mDNSResponder rewrites State: only on an actual
+ * conflict — which won't recur once the unique "-2" name is adopted. The
+ * compare-before-write guard (resolved == current ComputerName -> skip) is
+ * a belt-and-suspenders second line of defence.
+ *
+ * Apple-divergence note: #156 specifies persisting into ComputerName. Real
+ * macOS only suffixes LocalHostName and leaves the user's ComputerName
+ * untouched. Targeting ComputerName here is a deliberate choice for the
+ * headless server port (ComputerName is the single name source the rest of
+ * the chain keys off); flip the path string below to a LocalHostName pref
+ * if Apple-exact semantics are wanted later.
+ */
+
+#include <SystemConfiguration/SCDynamicStore.h>
+#include <SystemConfiguration/SCPreferences.h>
+#include <SystemConfiguration/SCSchemaDefinitions.h>
+
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <dispatch/dispatch.h>
+
+#include <stdio.h>
+#include <string.h>
+
+/* hostnamed.c's logger. */
+extern void	xlog(const char *fmt, ...);
+
+/* Internal state — singleton per process. */
+struct observer_state {
+	SCDynamicStoreRef	store;
+	dispatch_queue_t	queue;
+};
+static struct observer_state g_state;
+
+/* Read the conflict-resolved LocalHostName from State:/Network/HostNames —
+ * the key mDNSResponder writes after a Bonjour conflict-rename. NULL if the
+ * key/value is absent (the common case: no conflict has occurred). Caller
+ * releases. */
+static CFStringRef
+read_state_local_hostname(SCDynamicStoreRef store)
+{
+	CFStringRef key, name = NULL;
+	CFDictionaryRef dict;
+
+	if (store == NULL)
+		return (NULL);
+	key = SCDynamicStoreKeyCreateNetworkGlobalEntity(NULL,
+	    kSCDynamicStoreDomainState, CFSTR("HostNames"));
+	if (key == NULL)
+		return (NULL);
+	dict = (CFDictionaryRef)SCDynamicStoreCopyValue(store, key);
+	CFRelease(key);
+	if (dict == NULL)
+		return (NULL);
+	if (CFGetTypeID(dict) == CFDictionaryGetTypeID()) {
+		CFStringRef v = CFDictionaryGetValue(dict,
+		    kSCPropNetLocalHostName);
+		if (v != NULL && CFGetTypeID(v) == CFStringGetTypeID() &&
+		    CFStringGetLength(v) > 0)
+			name = CFStringCreateCopy(NULL, v);
+	}
+	CFRelease(dict);
+	return (name);
+}
+
+/* Read the current SCPrefs ComputerName from /System/System, so we only
+ * persist (and trigger the downstream republish chain) when the resolved
+ * name actually differs. NULL if absent. Caller releases. */
+static CFStringRef
+read_prefs_computer_name(void)
+{
+	SCPreferencesRef prefs;
+	CFStringRef path, name = NULL;
+	CFDictionaryRef sysdict;
+
+	prefs = SCPreferencesCreate(NULL,
+	    CFSTR("com.apple.hostnamed.observer.read"), NULL);
+	if (prefs == NULL)
+		return (NULL);
+	path = CFStringCreateWithCString(NULL, "/System/System",
+	    kCFStringEncodingUTF8);
+	if (path != NULL) {
+		sysdict = SCPreferencesPathGetValue(prefs, path);
+		CFRelease(path);
+		if (sysdict != NULL &&
+		    CFGetTypeID(sysdict) == CFDictionaryGetTypeID()) {
+			CFStringRef v = CFDictionaryGetValue(sysdict,
+			    CFSTR("ComputerName"));
+			if (v != NULL && CFGetTypeID(v) == CFStringGetTypeID())
+				name = CFStringCreateCopy(NULL, v);
+		}
+	}
+	CFRelease(prefs);
+	return (name);
+}
+
+/* Persist `name` into SCPreferences /System/System ComputerName + commit.
+ * Mirrors hostnameprefset.c. Returns 0 on success. The commit fires
+ * prefs_monitor's SCPrefs callback, which republishes the Setup: keys the
+ * set-hostname.c engine reads. */
+static int
+persist_computer_name(CFStringRef name)
+{
+	SCPreferencesRef prefs;
+	CFStringRef path, key;
+	CFMutableDictionaryRef dict;
+	int rc = -1;
+
+	prefs = SCPreferencesCreate(NULL,
+	    CFSTR("com.apple.hostnamed.observer"), NULL);
+	if (prefs == NULL) {
+		xlog("hostname_observer: SCPreferencesCreate failed: %s",
+		    SCErrorString(SCError()));
+		return (-1);
+	}
+	path = CFStringCreateWithCString(NULL, "/System/System",
+	    kCFStringEncodingUTF8);
+	key = CFStringCreateWithCString(NULL, "ComputerName",
+	    kCFStringEncodingUTF8);
+	dict = CFDictionaryCreateMutable(NULL, 0,
+	    &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	if (path != NULL && key != NULL && dict != NULL) {
+		CFDictionarySetValue(dict, key, name);
+		if (!SCPreferencesPathSetValue(prefs, path, dict))
+			xlog("hostname_observer: PathSetValue failed: %s",
+			    SCErrorString(SCError()));
+		else if (!SCPreferencesCommitChanges(prefs))
+			xlog("hostname_observer: CommitChanges failed: %s",
+			    SCErrorString(SCError()));
+		else
+			rc = 0;
+	}
+	if (dict != NULL) CFRelease(dict);
+	if (key != NULL) CFRelease(key);
+	if (path != NULL) CFRelease(path);
+	CFRelease(prefs);
+	return (rc);
+}
+
+/* Core action: read the resolved name from State:, and if it differs from
+ * the current SCPrefs ComputerName, persist it. Shared by the initial
+ * startup check and the SCDS change callback. */
+static void
+reconcile(SCDynamicStoreRef store)
+{
+	CFStringRef resolved, current;
+	char rbuf[256];
+
+	resolved = read_state_local_hostname(store);
+	if (resolved == NULL)
+		return;	/* no conflict-resolved name published (yet) */
+
+	if (!CFStringGetCString(resolved, rbuf, sizeof(rbuf),
+	    kCFStringEncodingUTF8))
+		rbuf[0] = '\0';
+
+	current = read_prefs_computer_name();
+	if (current != NULL && CFEqual(current, resolved)) {
+		/* Already persisted — nothing to do (loop guard). */
+		CFRelease(current);
+		CFRelease(resolved);
+		return;
+	}
+	if (current != NULL)
+		CFRelease(current);
+
+	if (persist_computer_name(resolved) == 0)
+		xlog("hostname_observer: persisted conflict-resolved hostname "
+		    "'%s' to SCPrefs ComputerName (State:/Network/HostNames -> "
+		    "SCPreferences); set-hostname.c will adopt it", rbuf);
+	CFRelease(resolved);
+}
+
+/* SCDS callback: State:/Network/HostNames changed (mDNSResponder published
+ * a conflict-resolved name). Reconcile into SCPrefs. */
+static void
+observer_cb(SCDynamicStoreRef store, CFArrayRef changedKeys, void *info)
+{
+	(void)changedKeys;
+	(void)info;
+	reconcile(store);
+}
+
+/* Entry: open SCDS, subscribe to State:/Network/HostNames on the supplied
+ * dispatch queue, do an initial reconcile (covers a conflict already
+ * published before we started). Returns 0 on success; non-zero on a
+ * failure that prevents observation. The caller (hostnamed's main) keeps
+ * `queue` alive for the daemon's lifetime. */
+int
+hostname_observer_start(dispatch_queue_t queue)
+{
+	CFMutableArrayRef keys;
+	CFStringRef key;
+	SCDynamicStoreContext sctx = {0, &g_state, NULL, NULL, NULL};
+
+	memset(&g_state, 0, sizeof(g_state));
+	g_state.queue = queue;
+	g_state.store = SCDynamicStoreCreate(NULL,
+	    CFSTR("com.apple.hostnamed.observer"), observer_cb, &sctx);
+	if (g_state.store == NULL) {
+		xlog("hostname_observer: SCDynamicStoreCreate failed");
+		return (-1);
+	}
+
+	key = SCDynamicStoreKeyCreateNetworkGlobalEntity(NULL,
+	    kSCDynamicStoreDomainState, CFSTR("HostNames"));
+	if (key == NULL) {
+		xlog("hostname_observer: key create failed");
+		return (-1);
+	}
+	keys = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+	if (keys == NULL) {
+		CFRelease(key);
+		return (-1);
+	}
+	CFArrayAppendValue(keys, key);
+	CFRelease(key);
+
+	if (!SCDynamicStoreSetNotificationKeys(g_state.store, keys, NULL)) {
+		xlog("hostname_observer: SetNotificationKeys failed");
+		CFRelease(keys);
+		return (-1);
+	}
+	CFRelease(keys);
+
+	if (!SCDynamicStoreSetDispatchQueue(g_state.store, queue)) {
+		xlog("hostname_observer: SetDispatchQueue failed");
+		return (-1);
+	}
+
+	/* Initial reconcile: if mDNSResponder already published a resolved
+	 * name before this observer subscribed, persist it now. */
+	reconcile(g_state.store);
+
+	xlog("hostname_observer: watching State:/Network/HostNames for "
+	    "Bonjour conflict-rename feedback (#156)");
+	return (0);
+}

--- a/src/hostnamed/hostnamed.c
+++ b/src/hostnamed/hostnamed.c
@@ -55,6 +55,11 @@ extern void	load_hostname(dispatch_queue_t S_queue);
 /* prefs_monitor entry — extern from src/hostnamed/prefs_monitor.c. */
 extern int	prefs_monitor_start(dispatch_queue_t queue);
 
+/* hostname_observer entry — extern from src/hostnamed/hostname_observer.c.
+ * Watches State:/Network/HostNames for mDNSResponder's Bonjour
+ * conflict-rename feedback and persists the resolved name to SCPrefs (#156). */
+extern int	hostname_observer_start(dispatch_queue_t queue);
+
 /* Shared logger used by every component in the daemon. Format-string
  * variadic via vfprintf; stderr → /var/log/hostnamed.stderr via the
  * launchd plist's StandardErrorPath. UTC timestamp per line. */
@@ -147,6 +152,14 @@ main(int argc, char **argv)
 	xlog("post-load_hostname");
 	xlog("HOSTNAMED-OK: load_hostname scheduled (Apple-shape engine "
 	    "subscribed to SCDS + notify_register_dispatch)");
+
+	/* Bonjour conflict-rename feedback (#156): watch State:/Network/HostNames
+	 * for the resolved name mDNSResponder publishes after a .local collision
+	 * and persist it to SCPrefs ComputerName. Non-fatal on failure — the
+	 * rest of the daemon still drives the kernel hostname. */
+	if (hostname_observer_start(queue) != 0)
+		xlog("hostname_observer_start failed (Bonjour rename feedback "
+		    "disabled); continuing");
 
 	/* Block + dispatch-source SIGTERM/INT for clean shutdown. Pattern
 	 * from src/Libnotify/notifyd/notifyd.c:1480-1503. */

--- a/src/hostnamed/hostnamedbonjourset.c
+++ b/src/hostnamed/hostnamedbonjourset.c
@@ -1,0 +1,202 @@
+/*
+ * hostnamedbonjourset — CI fixture helper for hostnamed iter 5 (#156).
+ *
+ * Usage:  hostnamedbonjourset <fixture-hostname>
+ *
+ * Forces a Bonjour host-name collision so the hostnamed iter-5
+ * conflict-rename feedback path can be exercised end to end.
+ *
+ *   Registers an AUTHORITATIVE, UNIQUE A record for <fixture>.local over
+ *   multicast via libdns_sd:
+ *
+ *       <fixture>.local.   A   192.0.2.1      (TEST-NET-1, RFC 5737)
+ *
+ *   The address is deliberately a documentation-range address that will
+ *   NOT match any real interface address mDNSResponder would announce, so
+ *   the records genuinely conflict (identical rdata would coalesce, not
+ *   conflict). The fixture wins its own probe first (nobody else owns the
+ *   name yet) and reaches the announced state.
+ *
+ *   The test then sets SCPrefs ComputerName=<fixture> (via hostnameprefset).
+ *   prefs_monitor republishes Setup:/Network/HostNames, mDNSConfigStore
+ *   re-adopts <fixture> and re-probes <fixture>.local — which this fixture
+ *   already owns — so mDNSCore renames the daemon's host label to
+ *   <fixture>-2 and PosixDaemon.c publishes it to State:/Network/HostNames.
+ *   hostnamed's observer then persists <fixture>-2 to SCPrefs ComputerName.
+ *
+ * Foreground — run.sh backgrounds with `&` and kills via the printed pid.
+ * Prints "BONJOURSET-READY:" once the register callback fires (the fixture
+ * owns the name) so run.sh can sequence without a fixed sleep.
+ *
+ * Not shipped to real images (CI-only); lives under
+ * /usr/tests/freebsd-launchd-mach/ alongside hostnametest /
+ * hostnameprefset / hostnamedhcpset / hostnamedmdnsset.
+ *
+ * Issue: hostnamed iter 5 — Bonjour conflict-rename feedback (#156).
+ */
+
+#include <dns_sd.h>
+
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define REGISTER_TIMEOUT	5	/* seconds to wait for register cb */
+
+static volatile sig_atomic_t got_register_cb;
+static volatile sig_atomic_t register_ok;
+
+static void
+on_term(int sig)
+{
+	(void)sig;
+	_exit(0);
+}
+
+static void DNSSD_API
+register_cb(DNSServiceRef sdRef, DNSRecordRef recRef, DNSServiceFlags flags,
+    DNSServiceErrorType err, void *context)
+{
+	(void)sdRef;
+	(void)recRef;
+	(void)flags;
+	(void)context;
+	got_register_cb = 1;
+	register_ok = (err == kDNSServiceErr_NoError);
+	if (err != kDNSServiceErr_NoError)
+		(void)fprintf(stderr,
+		    "hostnamedbonjourset: register callback err=%d\n",
+		    (int)err);
+}
+
+int
+main(int argc, char **argv)
+{
+	DNSServiceRef sd_ref = NULL;
+	DNSRecordRef rec_ref = NULL;
+	DNSServiceErrorType derr;
+	char fqdn[80];
+	struct in_addr addr;
+	int sock_fd;
+	time_t deadline;
+
+	if (argc != 2 || argv[1][0] == '\0' || strlen(argv[1]) > 63) {
+		(void)fprintf(stderr,
+		    "usage: %s <fixture-hostname>\n", argv[0]);
+		return (2);
+	}
+	(void)signal(SIGTERM, on_term);
+	(void)signal(SIGINT, on_term);
+
+	/* DNSServiceRegisterRecord takes the record name as a (dotted) C
+	 * string, not DNS wire format — the A record's rdata is the raw 4-byte
+	 * address. */
+	(void)snprintf(fqdn, sizeof(fqdn), "%s.local", argv[1]);
+
+	/* 192.0.2.1 (RFC 5737 TEST-NET-1) — guaranteed to differ from any
+	 * real interface address mDNSResponder announces, so the A records
+	 * conflict instead of coalescing. */
+	if (inet_pton(AF_INET, "192.0.2.1", &addr) != 1) {
+		(void)fprintf(stderr, "BONJOURSET-FAIL: inet_pton\n");
+		return (1);
+	}
+
+	derr = DNSServiceCreateConnection(&sd_ref);
+	if (derr != kDNSServiceErr_NoError) {
+		(void)fprintf(stderr,
+		    "BONJOURSET-FAIL: DNSServiceCreateConnection=%d\n",
+		    (int)derr);
+		return (1);
+	}
+
+	/* kDNSServiceFlagsUnique: claim sole ownership of <fixture>.local A —
+	 * this is what makes the daemon's later probe for the same name
+	 * conflict (and rename). Forced multicast keeps it on the .local
+	 * link even with a unicast resolver configured. */
+	derr = DNSServiceRegisterRecord(sd_ref, &rec_ref,
+	    kDNSServiceFlagsUnique | kDNSServiceFlagsForceMulticast,
+	    0 /* any interface */, fqdn,
+	    kDNSServiceType_A, kDNSServiceClass_IN,
+	    (uint16_t)sizeof(addr.s_addr), &addr.s_addr, 120 /* ttl */,
+	    register_cb, NULL);
+	if (derr != kDNSServiceErr_NoError) {
+		(void)fprintf(stderr,
+		    "BONJOURSET-FAIL: DNSServiceRegisterRecord=%d\n",
+		    (int)derr);
+		DNSServiceRefDeallocate(sd_ref);
+		return (1);
+	}
+	sock_fd = DNSServiceRefSockFD(sd_ref);
+	if (sock_fd < 0) {
+		(void)fprintf(stderr,
+		    "BONJOURSET-FAIL: DNSServiceRefSockFD=%d\n", sock_fd);
+		DNSServiceRefDeallocate(sd_ref);
+		return (1);
+	}
+
+	(void)fprintf(stderr,
+	    "hostnamedbonjourset: claiming %s.local A 192.0.2.1 "
+	    "(pid=%d)\n", argv[1], (int)getpid());
+
+	/* Drive the libdns_sd socket until the register callback fires — that
+	 * is when mDNSResponder has accepted (probed + announced) our unique
+	 * record and we own the name. */
+	deadline = time(NULL) + REGISTER_TIMEOUT;
+	while (!got_register_cb && time(NULL) < deadline) {
+		fd_set rfds;
+		struct timeval tv;
+		int r;
+
+		FD_ZERO(&rfds);
+		FD_SET(sock_fd, &rfds);
+		tv.tv_sec = 1;
+		tv.tv_usec = 0;
+		r = select(sock_fd + 1, &rfds, NULL, NULL, &tv);
+		if (r > 0 && FD_ISSET(sock_fd, &rfds))
+			(void)DNSServiceProcessResult(sd_ref);
+	}
+	if (!got_register_cb) {
+		(void)fprintf(stderr,
+		    "BONJOURSET-FAIL: register callback timeout (%ds)\n",
+		    REGISTER_TIMEOUT);
+		DNSServiceRefDeallocate(sd_ref);
+		return (1);
+	}
+	if (!register_ok) {
+		DNSServiceRefDeallocate(sd_ref);
+		return (1);
+	}
+
+	(void)printf("BONJOURSET-READY: own %s.local (pid=%d)\n",
+	    argv[1], (int)getpid());
+	(void)fflush(stdout);
+
+	/* Hold the registration alive so the daemon's probe collides with it.
+	 * SIGTERM from run.sh exits via on_term -> _exit(0). */
+	for (;;) {
+		fd_set rfds;
+		struct timeval tv;
+		int r;
+
+		FD_ZERO(&rfds);
+		FD_SET(sock_fd, &rfds);
+		tv.tv_sec = 60;
+		tv.tv_usec = 0;
+		r = select(sock_fd + 1, &rfds, NULL, NULL, &tv);
+		if (r > 0 && FD_ISSET(sock_fd, &rfds))
+			(void)DNSServiceProcessResult(sd_ref);
+	}
+	/* NOTREACHED */
+}

--- a/src/hostnamed/hostnametest.c
+++ b/src/hostnamed/hostnametest.c
@@ -176,8 +176,14 @@ main(int argc, char **argv)
 	 *     empty in these rounds by construction. Only assert kernel
 	 *     hostname equals expected. */
 	if (expected != NULL) {
+		/* BONJOUR-RENAME (iter 5 / #156): after mDNSResponder's
+		 * conflict-rename the observer persists the resolved name to
+		 * SCPrefs ComputerName, so prefs_monitor mirrors it into both
+		 * Setup: keys exactly like the PREFS path — assert all four
+		 * surfaces, not just the kernel. */
 		const Boolean uses_setup_mirror = (argc < 3 ||
-		    strcmp(argv[2], "PREFS") == 0);
+		    strcmp(argv[2], "PREFS") == 0 ||
+		    strcmp(argv[2], "BONJOUR-RENAME") == 0);
 
 		if (uses_setup_mirror) {
 			if (cn == NULL || hn == NULL || lhn == NULL) {

--- a/src/mDNSResponder/mDNSPosix/PosixDaemon.c
+++ b/src/mDNSResponder/mDNSPosix/PosixDaemon.c
@@ -61,6 +61,12 @@ static domainname DynDNSHostname;
 static CacheEntity gRRCache[RR_CACHE_SIZE];
 static mDNS_PlatformSupport PlatformStorage;
 
+// freebsd-launchd-mach #156: publish the conflict-resolved dot-local host
+// name to State:/Network/HostNames so hostnamed can persist it. No-op
+// unless mDNSCore's conflict-rename actually changed m->hostlabel. Declared
+// here (above mDNS_StatusCallback) since the callback calls it.
+extern void mDNSConfigStorePublishResolvedHostName(void);
+
 mDNSlocal void mDNS_StatusCallback(mDNS *const m, mStatus result)
 {
     (void)m; // Unused
@@ -71,6 +77,13 @@ mDNSlocal void mDNS_StatusCallback(mDNS *const m, mStatus result)
         // name in persistent storage for next time. It should also inform the user of the name change.
         // On Mac OS X we store the current dot-local mDNS host name in the SCPreferences store,
         // and notify the user with a CFUserNotification.
+        //
+        // freebsd-launchd-mach #156: mDNSCore's conflict-rename (mDNS_HostNameCallback ->
+        // IncrementLabelSuffix) may have bumped m->hostlabel to "<name>-2". Publish the resolved
+        // dot-local name to State:/Network/HostNames; hostnamed's observer persists it to
+        // SCPreferences. The publisher self-guards (no-op unless a rename actually changed the
+        // name and it has not already been published), so calling it on every NoError is cheap.
+        mDNSConfigStorePublishResolvedHostName();
     }
     else if (result == mStatus_ConfigChanged)
     {

--- a/src/mDNSResponder/mDNSPosix/mDNSConfigStore.c
+++ b/src/mDNSResponder/mDNSPosix/mDNSConfigStore.c
@@ -19,10 +19,13 @@
  *     re-walk its interface list, open / close mDNS sockets for the
  *     newly-bound / newly-gone interfaces.
  *
- *   - key State:/Network/HostNames — fires when prefs_monitor (in
- *     hostnamed) republishes Setup:/Network/HostNames after SCPrefs
- *     ComputerName changes; mDNSResponder should re-announce its
- *     Bonjour records under the new LocalHostName.
+ *   - key Setup:/Network/HostNames — fires when prefs_monitor (in
+ *     hostnamed) republishes it after an SCPrefs ComputerName change;
+ *     mDNSResponder re-adopts the new LocalHostName and re-announces its
+ *     Bonjour records under it. (Through iter 4 this watched
+ *     State:/Network/HostNames, which nothing ever writes, so the
+ *     recompute was dormant; iter 5 / #156 repoints it at the Setup:
+ *     key that prefs_monitor actually writes.)
  *
  *   - key State:/Network/Global/IPv4 — fires when ipconfigd selects a
  *     new primary service / interface. mDNSResponder should re-pick
@@ -46,6 +49,20 @@
  * (InterfaceChangeCallback in mDNSPosix.c) already drives. Both
  * triggers firing in parallel stays fine — the interface walk is
  * idempotent.
+ *
+ * iter 5 (#156): Bonjour conflict-rename feedback. Two changes. (1) The
+ * HostNames watch moves from State: to Setup:/Network/HostNames (the key
+ * prefs_monitor actually writes), so a ComputerName/LocalHostName change
+ * re-probes the new dot-local name. (2) When mDNSCore's conflict-rename
+ * (mDNS_HostNameCallback -> IncrementLabelSuffix) bumps m->hostlabel to
+ * "<name>-2", PosixDaemon.c's mDNS_StatusCallback calls
+ * mDNSConfigStorePublishResolvedHostName(), which writes the resolved
+ * label to State:/Network/HostNames. hostnamed's observer watches that
+ * State: key and persists the resolved name to SCPreferences. Setup: =
+ * desired, State: = actual-after-conflict — Apple's split. Because mDNS
+ * no longer watches State:, the write-back cannot re-trigger our own
+ * recompute, and a g_desired_host guard keeps a later recompute from
+ * clobbering the conflict suffix back to the un-suffixed desired name.
  *
  * THREADING. The mDNS core runs single-threaded on the daemon's MAIN
  * thread (PosixDaemon.c's mDNSPosixRunEventLoopOnce select loop). The
@@ -137,6 +154,18 @@ static int	g_wake_wr = -1;
  * interface path (pipe wake -> RefreshInterfaceList) when classifying a
  * changed key in the SCDS callback. Empty if it couldn't be cached. */
 static char	g_hostnames_key[256];
+
+/* Conflict-rename write-back state (#156). g_desired_host is the last
+ * LocalHostName we adopted from Setup: (the user/prefs "desired" name);
+ * mDNSConfigStoreRecompute compares against THIS, not m->hostlabel, so a
+ * conflict-incremented hostlabel ("foo-2") is not clobbered back to "foo"
+ * on the next unrelated recompute. Seeded in mDNSConfigStoreInit from the
+ * boot hostlabel mDNS_Init adopted via gethostname(3). g_published_host is
+ * the last resolved label we wrote to State:/Network/HostNames, making the
+ * StatusCallback publisher idempotent (it fires on every successful
+ * registration, not just hostname ones). */
+static domainlabel	g_desired_host;
+static domainlabel	g_published_host;
 
 static const char *
 key_kind(CFStringRef key)
@@ -273,7 +302,14 @@ mDNSConfigStoreRecompute(void *info)
 		return;	/* read succeeded but empty label — skip */
 
 	mDNS_Lock(m);
-	if (!SameDomainLabelCS(m->hostlabel.c, new_host.c)) {
+	/* Compare the new desired name against g_desired_host (the last
+	 * desired name we applied), NOT against m->hostlabel. After a
+	 * conflict-rename m->hostlabel is "foo-2" while the desired name is
+	 * still "foo"; comparing against m->hostlabel would reset it to "foo"
+	 * and re-trigger the same conflict forever. We only re-adopt + re-probe
+	 * when the DESIRED name actually changes (#156). */
+	if (!SameDomainLabelCS(g_desired_host.c, new_host.c)) {
+		g_desired_host = new_host;
 		m->hostlabel = new_host;
 		changed = TRUE;
 	}
@@ -289,6 +325,88 @@ mDNSConfigStoreRecompute(void *info)
 		mDNS_SetFQDN(m);
 	}
 	mDNS_Unlock(m);
+}
+
+/* Convert a domainlabel (length-prefixed, label->c[0] = length) to a
+ * NUL-terminated C string. */
+static void
+label_to_cstr(const domainlabel *label, char *out, size_t outsz)
+{
+	size_t n = label->c[0];
+
+	if (outsz == 0)
+		return;
+	if (n > outsz - 1)
+		n = outsz - 1;
+	(void)memcpy(out, &label->c[1], n);
+	out[n] = '\0';
+}
+
+/* Write the conflict-resolved LocalHostName to State:/Network/HostNames.
+ * Apple's Setup:/State: split: Setup: carries the user/prefs DESIRED name
+ * (owned by prefs_monitor); State: carries the ACTUAL name now in use after
+ * mDNSResponder's conflict-rename. hostnamed's observer watches the State:
+ * key and persists the resolved name back to SCPreferences (#156). */
+static void
+write_state_local_hostname(SCDynamicStoreRef store, const char *label)
+{
+	CFStringRef key, val;
+	CFMutableDictionaryRef dict;
+
+	if (store == NULL)
+		return;
+	key = SCDynamicStoreKeyCreateNetworkGlobalEntity(NULL,
+	    kSCDynamicStoreDomainState, CFSTR("HostNames"));
+	if (key == NULL)
+		return;
+	val = CFStringCreateWithCString(NULL, label, kCFStringEncodingUTF8);
+	dict = CFDictionaryCreateMutable(NULL, 0,
+	    &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	if (val != NULL && dict != NULL) {
+		CFDictionarySetValue(dict, kSCPropNetLocalHostName, val);
+		if (!SCDynamicStoreSetValue(store, key, dict))
+			(void)fprintf(stderr, "mDNSResponder mDNSConfigStore: "
+			    "SetValue(State:/Network/HostNames) failed\n");
+	}
+	if (dict != NULL) CFRelease(dict);
+	if (val != NULL) CFRelease(val);
+	CFRelease(key);
+}
+
+/* Publish mDNSResponder's conflict-resolved dot-local host name to the
+ * SCDynamicStore so hostnamed can persist it (#156). Called from
+ * PosixDaemon.c's mDNS_StatusCallback on every successful registration
+ * (mStatus_NoError); the guards below make it a no-op unless a real
+ * conflict-rename produced a hostlabel that differs from the desired name
+ * AND we have not already published that exact label.
+ *
+ * Runs on the mDNS-core MAIN thread (the StatusCallback caller). The only
+ * shared object it touches is g_store via SCDynamicStoreSetValue — a
+ * synchronous configd IPC independent of g_store's notification dispatch
+ * queue, so it is safe from this thread. */
+mDNSexport void
+mDNSConfigStorePublishResolvedHostName(void)
+{
+	mDNS *const m = &mDNSStorage;
+	char cur[MAX_DOMAIN_LABEL + 1];
+
+	if (g_store == NULL || m->hostlabel.c[0] == 0)
+		return;
+	/* No conflict-rename: hostlabel still equals the desired name we
+	 * adopted from Setup: (seeded from the boot hostlabel). Nothing to do. */
+	if (SameDomainLabelCS(m->hostlabel.c, g_desired_host.c))
+		return;
+	/* Already published this exact resolved label — idempotent across the
+	 * many NoError callbacks a single rename produces. */
+	if (SameDomainLabelCS(m->hostlabel.c, g_published_host.c))
+		return;
+	g_published_host = m->hostlabel;
+	label_to_cstr(&m->hostlabel, cur, sizeof(cur));
+	write_state_local_hostname(g_store, cur);
+	(void)fprintf(stderr, "mDNSResponder MDNS-RENAME-PUBLISHED: "
+	    "conflict-resolved LocalHostName='%s' -> State:/Network/HostNames "
+	    "(desired differed; hostnamed will persist)\n", cur);
+	(void)fflush(stderr);
 }
 
 /* Schedule (or re-schedule) the debounce-fire timer. Any SCDS
@@ -417,11 +535,13 @@ mDNSConfigStoreSubscribe(SCDynamicStoreRef store)
 		return (FALSE);
 	}
 
-	/* State:/Network/HostNames — Bonjour LocalHostName surface. Cache
-	 * its string form so the callback can tell the hostname path from
-	 * the interface path (see g_hostnames_key). */
-	key = SCDynamicStoreKeyCreateNetworkGlobalEntity(NULL,
-	    kSCDynamicStoreDomainState, CFSTR("HostNames"));
+	/* Setup:/Network/HostNames — the DESIRED Bonjour LocalHostName,
+	 * written by prefs_monitor and read by read_local_hostname. Watching
+	 * this (not the State: key, which nothing writes) is what makes a
+	 * ComputerName/LocalHostName change re-probe the new dot-local name
+	 * (#156). Cache its string form so the callback can tell the hostname
+	 * path from the interface path (see g_hostnames_key). */
+	key = SCDynamicStoreKeyCreateHostNames(NULL);
 	if (key != NULL) {
 		(void)CFStringGetCString(key, g_hostnames_key,
 		    sizeof(g_hostnames_key), kCFStringEncodingUTF8);
@@ -517,6 +637,14 @@ int
 mDNSConfigStoreInit(void)
 {
 	SCDynamicStoreContext	ctx = {0, NULL, NULL, NULL, NULL};
+
+	/* Seed the desired-name guard with the boot hostlabel mDNS_Init just
+	 * adopted from gethostname(3) (PosixDaemon.c calls us right after
+	 * mDNS_Init, before the event loop concludes the first probe). The
+	 * conflict-rename publisher compares m->hostlabel against this, so it
+	 * fires only when a real rename changes the name — never for the
+	 * un-conflicted boot name. */
+	g_desired_host = mDNSStorage.hostlabel;
 
 	g_queue = dispatch_queue_create("com.apple.mDNSResponder.scds",
 	    NULL);

--- a/tests/boot-test.sh
+++ b/tests/boot-test.sh
@@ -1193,6 +1193,33 @@ expect {
     }
 }
 
+# HOSTNAMED-BONJOUR-RENAME — iter 5 / #156 gate. ROUND 5 in run.sh:
+# hostnamedbonjourset claims <fixture>.local (authoritative UNIQUE A
+# record); the test then sets SCPrefs ComputerName=<fixture>, so the
+# daemon re-probes <fixture>.local, collides, and mDNSCore renames its
+# host label to <fixture>-2. mDNSResponder publishes the resolved name to
+# State:/Network/HostNames; hostnamed's observer persists it to SCPrefs,
+# which flows back to the kernel hostname. hostnametest verifies all four
+# surfaces (kernel + Setup:/System + Setup:/Network/HostNames) carry
+# <fixture>-2.
+#
+# Non-gating WARN for now: the conflict round-trip (mDNS probe timing +
+# the multi-hop State->SCPrefs->Setup->sethostname convergence) is
+# timing-sensitive under CI, and it builds on the mDNS tier that is itself
+# non-gating above. Promote to a hard gate (FAIL -> exit 1) once it has
+# proven stable across CI runs.
+expect {
+    timeout {
+        puts "\nWARN: HOSTNAMED-BONJOUR-RENAME marker not seen (conflict round-trip did not converge in the CI window)"
+    }
+    "HOSTNAMED-BONJOUR-RENAME-FAIL" {
+        puts "\nWARN: hostnamed Bonjour conflict-rename feedback did not persist the -2 suffix in the CI window (#156)"
+    }
+    "HOSTNAMED-BONJOUR-RENAME-OK" {
+        puts "\nOK: hostnamed persisted mDNSResponder's Bonjour conflict-rename (<fixture>.local collision -> <fixture>-2 in SCPrefs + kernel)"
+    }
+}
+
 # PAM-FRAMEWORK — issue #93 iter 1 gate. pamframeworktest exercises
 # /usr/lib/libpam.so.6 (our vendored Apple OpenPAM-35) by pam_start
 # against /etc/pam.d/test_iter1 (which references pam_deny.so) and


### PR DESCRIPTION
Closes #156 (hostnamed iter 4/5: Bonjour conflict-rename feedback).

## Background

When mDNSResponder probes `<hostname>.local` and finds a collision, mDNSCore's conflict-rename (`mDNS_HostNameCallback` → `IncrementLabelSuffix`) bumps the host label to `<hostname>-2`. Until now the resolved name lived **only in mDNSResponder's memory**: `PosixDaemon.c`'s `mDNS_StatusCallback` left the persistence path as an empty stub — Apple's shipped comment was *"On Mac OS X we store the current dot-local mDNS host name in the SCPreferences store"* — so the next boot collided again.

We investigated the alternatives (registering from hostnamed via `DNSServiceRegister`/`DNSServiceRegisterRecord`) and confirmed they re-detect a conflict mDNSCore already resolves internally. Since we own the mDNSResponder source, this implements the **Apple-shape Option D**: fill the stub and observe the result through the SCDynamicStore `Setup:`/`State:` split.

## Approach

```
mDNS conflict -> State:/Network/HostNames = "foo-2"
  -> [hostnamed observer] SCPrefs ComputerName = "foo-2" + commit
  -> prefs_monitor republishes Setup:/{System,Network/HostNames} = "foo-2"
  -> mDNSConfigStore re-adopts desired "foo-2", re-probes foo-2.local
     (now unique) -> no further rename -> no further State: write.
```

### mDNSResponder
- `mDNSConfigStorePublishResolvedHostName()` writes the conflict-resolved `m->hostlabel` to `State:/Network/HostNames`. Called from `mDNS_StatusCallback(mStatus_NoError)`; self-guards (`g_desired_host` / `g_published_host`) so it's a no-op unless a real rename changed the name.
- **Repointed the HostNames recompute watch from `State:` → `Setup:`** — a latent bugfix. Nothing writes the `State:` key, so the hostname recompute was dormant; watching the `Setup:` key prefs_monitor actually writes makes a name change re-probe. The `g_desired_host` guard prevents clobbering the conflict suffix, and since mDNS no longer watches `State:`, the write-back can't re-trigger our own recompute → no loop.

### hostnamed
- `hostname_observer.c` watches `State:/Network/HostNames` and persists the resolved name to SCPreferences `/System/System` ComputerName + commit; prefs_monitor + set-hostname.c carry it to the kernel hostname.

### CI
- `hostnamedbonjourset.c` claims `<fixture>.local` (authoritative UNIQUE A, `192.0.2.1` / RFC 5737 so rdata differs and the records conflict rather than coalesce).
- `run.sh` ROUND 5 + `hostnametest` `BONJOUR-RENAME` mode assert all four surfaces converge on `<fixture>-2`. `boot-test.sh` gates on `HOSTNAMED-BONJOUR-RENAME-OK`.

## Reviewer notes
- **Non-gating WARN** initially (like the mDNS tier it builds on) — the conflict round-trip is timing-sensitive under CI. Promote to a hard gate once stable.
- **Apple divergence:** #156 specifies persisting into ComputerName; real macOS only suffixes LocalHostName and leaves ComputerName untouched. Deliberate choice for the headless port (documented in `hostname_observer.c`); flip the pref path to revert.
- **Privilege:** mDNSResponder performs the `State:` write *after* dropping to `nobody` (`PosixDaemon.c:235`). Relies on configd allowing the unprivileged `SetValue` (thin store server); logs `SetValue(State:/Network/HostNames) failed` otherwise — worth watching on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)