### PR TITLE
hostnamed: actually fire mDNS hostname recompute (#156 follow-up)

### DIFF
--- a/overlays/usr/tests/freebsd-launchd-mach/run.sh
+++ b/overlays/usr/tests/freebsd-launchd-mach/run.sh
@@ -1678,10 +1678,13 @@ if [ -x /usr/tests/freebsd-launchd-mach/hostnamedbonjourset ] && \
         # same name; its probe will collide and mDNSCore will rename it.
         /usr/tests/freebsd-launchd-mach/hostnameprefset \
             "$HOSTNAMED_BONJOUR_FIXTURE"
-        # Poll up to 15s for the full round-trip (probe + conflict-rename +
-        # State: publish + observer persist + prefs republish + sethostname)
-        # to converge on the -2 suffix, rather than a fixed sleep.
-        for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+        # Poll up to 30s for the full round-trip to converge on the -2
+        # suffix, rather than a fixed sleep. Each hop (mDNS adopt+probe ->
+        # conflict-rename -> State: publish -> observer persist -> prefs
+        # republish -> sethostname) is gated on the periodic IPv4 churn that
+        # drives the recompute (Setup: change-notify is unreliable in our
+        # configd), so allow several churn cycles.
+        for i in $(seq 1 30); do
             if [ "$(hostname 2>/dev/null)" = \
                 "$HOSTNAMED_BONJOUR_RESOLVED" ]; then
                 break

--- a/src/mDNSResponder/mDNSPosix/mDNSConfigStore.c
+++ b/src/mDNSResponder/mDNSPosix/mDNSConfigStore.c
@@ -472,17 +472,26 @@ mDNSConfigStoreWake(int fd, void *context)
 	(void)mDNSPlatformPosixRefreshInterfaceList(&mDNSStorage);
 }
 
-/* SCDS callback — every registered key + pattern routes here. We log
- * the change(s) and dispatch: HostNames changes arm the debounced
- * hostname recompute (mDNS_SetFQDN); interface / service IPv4 changes
- * wake the main thread to re-walk the interface list. A single callback
- * can carry both kinds, so we track them independently. */
+/* SCDS callback — every registered key + pattern routes here. We log the
+ * change(s), ALWAYS arm the debounced hostname recompute, and wake the main
+ * thread to re-walk the interface list when an interface / service IPv4 key
+ * changed.
+ *
+ * The recompute is armed unconditionally rather than only on the exact
+ * HostNames key because in our configd the Setup:/Network/HostNames
+ * change-notification is not reliably delivered to this subscriber, while
+ * the frequent State:/Network/.../IPv4 churn (DHCP renewals) is. Gating the
+ * recompute on the HostNames key therefore left it dormant and
+ * mDNSResponder never re-adopted a changed LocalHostName (#156). The
+ * recompute is idempotent — the g_desired_host guard makes it a no-op
+ * unless the desired name actually changed — so riding the IPv4 churn is
+ * cheap and mirrors how the vendored set-hostname.c engine already relies
+ * on the same churn to re-read its inputs. */
 static void
 mDNSConfigStoreCallback(SCDynamicStoreRef store, CFArrayRef changedKeys,
     void *info)
 {
 	CFIndex i, count;
-	Boolean hostname_changed = FALSE;
 	Boolean interface_changed = FALSE;
 
 	(void)store;
@@ -497,21 +506,21 @@ mDNSConfigStoreCallback(SCDynamicStoreRef store, CFArrayRef changedKeys,
 		(void)fprintf(stderr, "mDNSResponder mDNSConfigStore: "
 		    "key changed -> %s\n", kk);
 
-		/* Classify: the exact HostNames key drives the hostname
-		 * recompute; everything else we subscribe to is interface /
-		 * service IPv4 (State:/Network/Global/IPv4 or the
+		/* Anything that is not the exact HostNames key is an interface /
+		 * service IPv4 change (State:/Network/Global/IPv4 or the
 		 * State:/Network/Service/.+/IPv4 pattern) and drives the
-		 * interface re-walk. */
-		if (g_hostnames_key[0] != '\0' &&
-		    strcmp(kk, g_hostnames_key) == 0)
-			hostname_changed = TRUE;
-		else
+		 * interface re-walk. The hostname recompute is armed
+		 * unconditionally below, so no separate hostname flag is kept. */
+		if (!(g_hostnames_key[0] != '\0' &&
+		    strcmp(kk, g_hostnames_key) == 0))
 			interface_changed = TRUE;
 	}
 	(void)fflush(stderr);
 
-	if (hostname_changed)
-		mDNSConfigStoreDebounce();
+	/* Always arm the hostname recompute (see the function comment): the
+	 * Setup: HostNames notify is unreliable here, so we ride the IPv4
+	 * churn; the recompute is idempotent under the g_desired_host guard. */
+	mDNSConfigStoreDebounce();
 	if (interface_changed)
 		mDNSConfigStorePostInterfaceRefresh();
 }


### PR DESCRIPTION
Follow-up to #314. That PR landed the Bonjour conflict-rename feedback path and merged green, but its ROUND 5 check is a non-gating WARN — and inspecting the CI run showed the conflict-rename **never actually fired**: the kernel hostname stayed `hostnamed-iter5-fixture` with no `-2` suffix.

## Root cause

`mDNSConfigStore` armed the hostname recompute (`mDNS_SetFQDN`) only when the exact `Setup:/Network/HostNames` key appeared in an SCDS change callback. But **in our configd the `Setup:` domain change-notification is not reliably delivered to this subscriber** — the callback fires constantly for `State:/Network/.../IPv4` (DHCP renewals) but never once for the `Setup:` HostNames key (confirmed across the whole boot log). So the recompute stayed dormant, mDNSResponder never re-adopted/re-probed the configured LocalHostName, no collision occurred, and there was nothing to rename.

The vendored `set-hostname.c` engine works in the same environment precisely because it rides that same IPv4 churn to re-read its inputs.

## Fix

- Arm the debounced recompute on **every** SCDS callback, not only on the HostNames key. The recompute is idempotent (the `g_desired_host` guard makes it a no-op unless the desired name changed), so riding the IPv4 churn is cheap and matches `set-hostname.c`'s model. The interface re-walk still fires only on interface/service IPv4 changes.
- Widen ROUND 5's convergence poll 15s → 30s: each hop (adopt+probe → conflict-rename → `State:` publish → observer persist → prefs republish → `sethostname`) is gated on a churn cycle.

## Verification

CI ROUND 5 should now reach `HOSTNAMED-BONJOUR-RENAME-OK` (all four surfaces converge on `hostnamed-iter5-fixture-2`). I'll watch the run.

## Separate follow-up worth tracking
configd does not deliver `Setup:`-domain change-notifications to SCDynamicStore subscribers (`State:` works). Both this path and `set-hostname.c` depend on IPv4 churn instead of a direct prefs notification — fixing configd would let the whole hostname subsystem react promptly instead of on the next churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)