### PR TITLE
ci: bump build matrix 15.0-RELEASE → 15.1-RELEASE + drop version from job labels (#336)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           echo "==> build_needed=$need"
 
   build:
-    name: build (FreeBSD ${{ matrix.variant }} ${{ matrix.arch }})
+    name: build (${{ matrix.arch }})
     needs: changes
     if: needs.changes.outputs.build_needed == 'true'
     runs-on: ubuntu-latest
@@ -90,15 +90,17 @@ jobs:
       fail-fast: false
       matrix:
         # `freebsd` is what vmactions/freebsd-vm expects as its release
-        # tag (a bare "15.0" — it doesn't accept "-RELEASE" / "-STABLE"
-        # suffixes). `variant` distinguishes release trains (15.0-RELEASE
-        # vs. 15-STABLE vs. 16.0-CURRENT); build.sh reports it and the
-        # distfiles cache key below is keyed on it. The matrix entries below
-        # pair them; add a new include block when vmactions gains support
-        # for snapshot builds or when CI gains a non-vmactions runner.
+        # tag (a bare "15.1" — it doesn't accept "-RELEASE" / "-STABLE"
+        # suffixes) AND the FreeBSD release the rootfs gap-fillers (the
+        # VM's /bin /sbin /usr/bin copied no-clobber in build.sh, e.g.
+        # init/uname) come from -- so it must track the base releng train,
+        # not lag it. `variant` distinguishes release trains; build.sh
+        # reports it and the distfiles cache key below is keyed on it.
+        # The matrix entries below pair them; add a new include block when
+        # vmactions gains snapshot support or CI gains a non-vmactions runner.
         include:
-          - freebsd: '15.0'
-            variant: '15.0-RELEASE'
+          - freebsd: '15.1'
+            variant: '15.1-RELEASE'
             arch: 'amd64'
     steps:
       - uses: actions/checkout@v4
@@ -258,7 +260,7 @@ jobs:
           if-no-files-found: error
 
   test:
-    name: test (FreeBSD ${{ matrix.variant }} ${{ matrix.arch }})
+    name: test (${{ matrix.arch }})
     needs: [changes, build]
     # Run after a real build, OR when the build was skipped for a tests-only
     # change (then we boot the latest published continuous ISO). Do NOT run if
@@ -277,8 +279,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - freebsd: '15.0'
-            variant: '15.0-RELEASE'
+          - freebsd: '15.1'
+            variant: '15.1-RELEASE'
             arch: 'amd64'
     steps:
       - uses: actions/checkout@v4
@@ -375,7 +377,7 @@ jobs:
           fi
 
   release:
-    name: release (FreeBSD ${{ matrix.variant }} ${{ matrix.arch }})
+    name: release (${{ matrix.arch }})
     needs: [build, test]
     # Publish on main from a push to this repo or an upstream cascade
     # (repository_dispatch: base-updated). PRs and other branches never publish.
@@ -395,8 +397,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - freebsd: '15.0'
-            variant: '15.0-RELEASE'
+          - freebsd: '15.1'
+            variant: '15.1-RELEASE'
             arch: 'amd64'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What
- Bump the ISO build matrix: `freebsd: '15.0' → '15.1'`, `variant: '15.0-RELEASE' → '15.1-RELEASE'` (all three matrix blocks: build/test/release).
- Make the job `name:` labels version-agnostic: `build (FreeBSD ${{ matrix.variant }} …)` → `build (${{ matrix.arch }})` (and test/release), so they stop drifting on every releng bump.

## Why — this is the last 15.0 pin, and it's a real bug, not just a label
`matrix.freebsd` drives **both** the vmactions VM `release:` and the release `MIRROR` in `build.sh`. `build.sh` then gap-fills the rootfs from the **VM's** `/bin /sbin /usr/bin` no-clobber (`build.sh:202`) for anything the curated from-source base omits. So binaries the base doesn't ship — `init`, `uname`, and `freebsd-version` (the last removed from the base in #300) — were being back-filled from **FreeBSD 15.0-RELEASE-p10**.

Result on a freshly-booted latest image:
```
uname -K  = 1501000   # kernel  -> 15.1  ✅ (nextbsd-kernel #47)
uname -U  = 1500068   # userland-> 15.0  ❌ (VM-copied 15.0 binaries)
freebsd-version -u = 15.0-RELEASE-p10    ❌ (stale VM binary, dated when 15.0-p10 shipped)
```
The from-source base (libc, fbsdglue, …) and kernel are already 15.1; only the VM/mirror gap-fillers lagged. **This is not a cache problem** — those binaries carry their `__FreeBSD_version` baked in at FreeBSD-release time; ccache/distfiles can't produce or hold them. Only bumping the VM/mirror fixes it.

Bumping to 15.1 makes the gap-fillers come from **15.1-RELEASE** (confirmed present on the mirror — `base.txz` returns HTTP 200), so `uname -U` → 1501000 and `freebsd-version` (where still present) reports 15.1.

## Scope / safety
- `variant` still drives the `distfiles` cache key (auto-invalidates to the 15.1 key) and the `FREEBSD_VARIANT` export — only the value changed, not the wiring.
- Labels are cosmetic; dropping the version string is the "don't chase a moving target" cleanup discussed for the job names.

Closes the final `nextbsd-freebsd-compat`-adjacent 15.0 pin tracked in #336 (kernel #47, modules, compat #27 already on 15.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)