### PR TITLE
configd: dispose undelivered request/reply ports in configd_serve (per-RPC Mach-port leak)

### DIFF
--- a/src/configd/configd.c
+++ b/src/configd/configd.c
@@ -712,14 +712,35 @@ configd_serve(mach_port_t port_set)
 		memset(&rep, 0, sizeof(rep));
 		if (!config_server(&req.hdr, &rep.hdr)) {
 			clog("unhandled message id=%d", req.hdr.msgh_id);
+			/*
+			 * Demux didn't claim the message: its reply send-once
+			 * right (and any moved-in rights) are still ours to
+			 * dispose, otherwise they leak one Mach port per
+			 * undemuxable RPC. See #342.
+			 */
+			mach_msg_destroy(&req.hdr);
 			continue;
 		}
 		if (rep.hdr.msgh_remote_port != MACH_PORT_NULL) {
 			mr = mach_msg(&rep.hdr, MACH_SEND_MSG | MACH_SEND_TIMEOUT,
 			    rep.hdr.msgh_size, 0, MACH_PORT_NULL, 1000,
 			    MACH_PORT_NULL);
-			if (mr != MACH_MSG_SUCCESS)
+			if (mr != MACH_MSG_SUCCESS) {
 				clog("reply send failed: 0x%x", (unsigned)mr);
+				/*
+				 * A failed/timed-out send does not consume the
+				 * reply send-once right or any reply-carried
+				 * ports — drop them rather than leak.
+				 */
+				mach_msg_destroy(&rep.hdr);
+			}
+		} else {
+			/*
+			 * MIG produced no reply (simpleroutine, or a routine
+			 * that errored before building one): the request's
+			 * reply send-once right is still ours to dispose.
+			 */
+			mach_msg_destroy(&req.hdr);
 		}
 	}
 }


### PR DESCRIPTION
## Problem

`configd_serve()` hand-rolls the `mach_msg` receive/dispatch loop and only disposed the request's reply send-once right on the **successful-reply** path. Three other paths dropped the message without disposing it, leaking the reply port (fd-backed here → the type-`?` Mach-port fd growth seen on configd, ~523 fds):

- `config_server()` demux returns false (unhandled id) → `continue`
- reply `mach_msg` send fails / times out (`MACH_SEND_TIMED_OUT` does **not** consume the send-once right)
- MIG produced no reply (`msgh_remote_port == MACH_PORT_NULL`)

## Fix

Call `mach_msg_destroy()` on the appropriate header on each of those paths — the standard MIG cleanup for an undelivered message. The per-session / per-notification lifecycle in `config_session.c` is already balanced; this is purely the serve loop's request disposition.

## Dependency

Relies on `mach_msg_destroy()` being implemented rather than a no-op — see the companion libmach PR #344. `mach_msg_destroy` is prototyped in `<mach/message.h>`, so this compiles against either, but only frees the ports once #344 lands. Best merged after #344.

Refs #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)