### PR TITLE
mDNSResponder: don't SIGABRT on fd >= FD_SETSIZE; refuse the source instead

### DIFF
--- a/src/mDNSResponder/mDNSPosix/mDNSPosix.c
+++ b/src/mDNSResponder/mDNSPosix/mDNSPosix.c
@@ -93,10 +93,10 @@ static int num_pkts_rejected = 0;
 
 // ***************************************************************************
 // Locals
-mDNSlocal void requestReadEvents(PosixEventSource *eventSource,
+mDNSlocal mStatus requestReadEvents(PosixEventSource *eventSource,
                                     const char *taskName, mDNSPosixEventCallback callback, void *context);
 mDNSlocal mStatus stopReadOrWriteEvents(int fd, mDNSBool freeSource, mDNSBool removeSource, int flags);
-mDNSlocal void requestWriteEvents(PosixEventSource *eventSource,
+mDNSlocal mStatus requestWriteEvents(PosixEventSource *eventSource,
                                      const char *taskName, mDNSPosixEventCallback callback, void *context);
 mDNSlocal void UDPReadCallback(int fd, void *context);
 mDNSlocal int SetupIPv4Socket(int fd);
@@ -2452,20 +2452,23 @@ mDNSexport void mDNSPosixProcessFDSet(mDNS *const m, fd_set *readfds, fd_set *wr
 
 mDNSu32 mDNSPlatformEventContextSize = sizeof (PosixEventSource);
 
-mDNSlocal void requestIOEvents(PosixEventSource *newSource, const char *taskName,
+mDNSlocal mStatus requestIOEvents(PosixEventSource *newSource, const char *taskName,
                                   mDNSPosixEventCallback callback, void *context, int flag)
 {
     PosixEventSource **epp = &gEventSources;
 
     if (newSource->fd >= (int) FD_SETSIZE || newSource->fd < 0)
     {
-        LogMsg("requestIOEvents called with fd %d > FD_SETSIZE %d.", newSource->fd, FD_SETSIZE);
-        assert(0);
+        // The select()-based event loop can't represent an fd >= FD_SETSIZE.
+        // Refuse the source and let the caller clean up rather than aborting
+        // the whole daemon (which an fd leak elsewhere could otherwise trigger).
+        LogMsg("requestIOEvents called with fd %d >= FD_SETSIZE %d -- refusing source.", newSource->fd, FD_SETSIZE);
+        return mStatus_NoMemoryErr;
     }
     if (callback == NULL)
     {
-        LogMsg("requestIOEvents called no callback.", newSource->fd, FD_SETSIZE);
-        assert(0);
+        LogMsg("requestIOEvents called with no callback (fd %d).", newSource->fd);
+        return mStatus_BadParamErr;
     }
 
     // See if this event context is already on the list; if it is, no need to scan the list.
@@ -2503,18 +2506,19 @@ mDNSlocal void requestIOEvents(PosixEventSource *newSource, const char *taskName
         newSource->flags |= PosixEventFlag_Write;
         newSource->writeTaskName = taskName;
     }
+    return mStatus_NoError;
 }
 
-mDNSlocal void requestReadEvents(PosixEventSource *eventSource,
+mDNSlocal mStatus requestReadEvents(PosixEventSource *eventSource,
                                     const char *taskName, mDNSPosixEventCallback callback, void *context)
 {
-    requestIOEvents(eventSource, taskName, callback, context, PosixEventFlag_Read);
+    return requestIOEvents(eventSource, taskName, callback, context, PosixEventFlag_Read);
 }
 
-mDNSlocal void requestWriteEvents(PosixEventSource *eventSource,
+mDNSlocal mStatus requestWriteEvents(PosixEventSource *eventSource,
                                      const char *taskName, mDNSPosixEventCallback callback, void *context)
 {
-    requestIOEvents(eventSource, taskName, callback, context, PosixEventFlag_Write);
+    return requestIOEvents(eventSource, taskName, callback, context, PosixEventFlag_Write);
 }
 
 // Remove a file descriptor from the set that mDNSPosixRunEventLoopOnce() listens to.
@@ -2557,6 +2561,7 @@ mDNSlocal mStatus stopReadOrWriteEvents(int fd, mDNSBool freeContext, mDNSBool r
 mStatus mDNSPosixAddFDToEventLoop(int fd, mDNSPosixEventCallback callback, void *context)
 {
     PosixEventSource *newSource;
+    mStatus err;
 
     newSource = (PosixEventSource*) mdns_malloc(sizeof *newSource);
     if (NULL == newSource)
@@ -2564,8 +2569,11 @@ mStatus mDNSPosixAddFDToEventLoop(int fd, mDNSPosixEventCallback callback, void 
     memset(newSource, 0, sizeof *newSource);
     newSource->fd = fd;
 
-    requestReadEvents(newSource, "mDNSPosixAddFDToEventLoop", callback, context);
-    return mStatus_NoError;
+    // If the source can't be registered (e.g. fd >= FD_SETSIZE), don't leak it.
+    err = requestReadEvents(newSource, "mDNSPosixAddFDToEventLoop", callback, context);
+    if (err != mStatus_NoError)
+        mdns_free(newSource);
+    return err;
 }
 
 mStatus mDNSPosixRemoveFDFromEventLoop(int fd)

--- a/src/mDNSResponder/mDNSShared/uds_daemon.c
+++ b/src/mDNSResponder/mDNSShared/uds_daemon.c
@@ -5049,7 +5049,14 @@ mDNSlocal void connect_callback(int fd, void *info)
         request->last_full_log_time_secs = 0;
         set_peer_pid(request);
         LogRedact(MDNS_LOG_CATEGORY_DEFAULT, MDNS_LOG_DEBUG, "%3d: connect_callback: Adding FD for uid %u", request->sd, request->uid);
-        udsSupportAddFDToEventLoop(sd, request_callback, request, &request->platform_data);
+        if (udsSupportAddFDToEventLoop(sd, request_callback, request, &request->platform_data) != mStatus_NoError)
+        {
+            // Couldn't register the client fd (e.g. fd >= FD_SETSIZE). Drop the
+            // connection instead of leaking it; AbortUnlinkAndFree closes sd
+            // (via udsSupportRemoveFDFromEventLoop) and frees the request_state.
+            LogRedact(MDNS_LOG_CATEGORY_DEFAULT, MDNS_LOG_DEFAULT, "%3d: connect_callback: failed to add client FD to event loop -- dropping connection", sd);
+            AbortUnlinkAndFree(request);
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

mDNSPosix's event loop is `select()`-based, and `requestIOEvents()` did `assert(0)` whenever a source's fd was `>= FD_SETSIZE` (1024). So the instant a leaked fd elsewhere pushed an accepted UDS client fd past 1024, the **whole daemon aborted (SIGABRT)** at `mDNSPosix.c:2463` — and the dead service port then drove the COMPAT_MACH `ipc_right.c:1645` dead-name console flood. This is the visible crash that started #342.

## Fix (defense-in-depth)

- `requestIOEvents()` returns `mStatus` and **refuses** an out-of-range fd (or NULL callback) with an error instead of `assert(0)`; `requestReadEvents`/`requestWriteEvents` propagate it.
- `mDNSPosixAddFDToEventLoop()` frees the `PosixEventSource` it just allocated when registration is refused (no leak on the error path).
- `connect_callback()` (uds_daemon.c) checks `udsSupportAddFDToEventLoop` and, on failure, `AbortUnlinkAndFree()`s the request — which closes the client fd (`udsSupportRemoveFDFromEventLoop` always `close()`s) and frees the `request_state`. Only the one out-of-range client is dropped; the daemon keeps serving everything else.

The existing socket-setup callers of `requestRead/WriteEvents` (UDP/TCP, small fds) ignore the new return value, which is fine.

## Why

The underlying fd leak is fixed in libmach/configd (#343, #344, #345), but a `select()`-based daemon should never abort on a high fd. Converting the loop to `kqueue`/`poll` is the proper long-term fix and is left as a follow-up; this stops the crash now.

## Validation

Mechanical return-type threading + a teardown path that mirrors the daemon's existing `AbortUnlinkAndFree` usage (verified `udsSupportRemoveFDFromEventLoop` unconditionally `close()`s the fd, so no double-close/leak). CI build + boot-test covers integration.

Refs #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)