### PR TITLE
build: bootstrap pkg and configure pkg repos in img + ISO

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -141,9 +141,15 @@ pwd_mkdb -p -d "$RF/etc" "$RF/etc/master.passwd"
 env DESTDIR="$RF" certctl rehash 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
-# 5. FreeBSD ports repo in the SHIPPED image (arch-dynamic) so a user on the
-#    installed system can `pkg install <port>` out of the box. NextBSD rebrands
-#    the ABI, so pin FreeBSD:15:<arch> + ignore the osversion gate (#357).
+# 5. pkg repos in the SHIPPED image (arch-dynamic) so a user on the installed
+#    system can `pkg install` out of the box. Exactly TWO repos, deliberately:
+#      - FreeBSD: pkg.FreeBSD.org/latest  (FreeBSD *packages* — ports)
+#      - NextBSD: the nextbsd-pkg continuous flat repo (the NextBSD base/world)
+#    NOT the FreeBSD pkgbase base/kmods repos — NextBSD supplies its own base,
+#    and we never want FreeBSD-base/FreeBSD-kernel packages on the image. Those
+#    are only ever on the build VM (in its own /etc/pkg) and are never written
+#    into $RF. NextBSD rebrands the ABI, so pin FreeBSD:15:<arch> + ignore the
+#    osversion gate (#357). The NextBSD flat repo is unsigned (GitHub assets).
 # ---------------------------------------------------------------------------
 mkdir -p "$RF/usr/local/etc/pkg/repos"
 cat > "$RF/usr/local/etc/pkg/repos/FreeBSD.conf" <<CONF
@@ -151,6 +157,13 @@ FreeBSD: {
   url: "pkg+https://pkg.FreeBSD.org/FreeBSD:15:${ABIARCH}/latest",
   mirror_type: "srv",
   enabled: yes
+}
+CONF
+cat > "$RF/usr/local/etc/pkg/repos/NextBSD.conf" <<CONF
+NextBSD: {
+  url: "${PKG_REPO_URL}",
+  enabled: yes,
+  signature_type: none,
 }
 CONF
 cat > "$RF/usr/local/etc/pkg.conf" <<CONF

--- a/build.sh
+++ b/build.sh
@@ -193,36 +193,6 @@ if [ -f "$ROOT/pkglist.txt" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 5c. Clone gershwin-developer into /Developer so the shipped img + ISO carry
-#     the developer toolkit out of the box (the four-domain layout's /Developer
-#     root). Uses the build VM's git (installed in the workflow prepare step),
-#     not the freshly-installed image git. The repo is small; keep a full clone
-#     (incl. .git) so it can be updated with `git pull` on the booted system.
-# ---------------------------------------------------------------------------
-GERSHWIN_DEV_URL="https://github.com/gershwin-desktop/gershwin-developer.git"
-echo "==> cloning gershwin-developer into $RF/Developer"
-rm -rf "$RF/Developer"
-git clone "$GERSHWIN_DEV_URL" "$RF/Developer"
-
-# ---------------------------------------------------------------------------
-# 5d. Bake gershwin's build dependencies into the image — the effect of
-#     gershwin-developer's Bootstrap.sh nextbsd path (which just `pkg install`s
-#     Library/OSSupport/nextbsd.txt), done HOST-DRIVEN so it uses the build
-#     host's network/certs (no chroot / devfs / resolv.conf) and cross-installs
-#     for aarch64 later. Reading the toolkit's own list keeps it in sync. With
-#     these + the xlibre packages above, the img + ISO carry everything needed
-#     to build and run gershwin (the user then runs Install-System-Domain.sh).
-# ---------------------------------------------------------------------------
-GERSHWIN_REQ="$RF/Developer/Library/OSSupport/nextbsd.txt"
-if [ -f "$GERSHWIN_REQ" ]; then
-    GERSHWIN_DEPS=$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "$GERSHWIN_REQ" | tr '\n' ' ')
-    if [ -n "$GERSHWIN_DEPS" ]; then
-        echo "==> installing gershwin build deps (nextbsd.txt) into $RF: $GERSHWIN_DEPS"
-        pkg -r "$RF" -o REPOS_DIR="$RF/usr/local/etc/pkg/repos" install -y $GERSHWIN_DEPS
-    fi
-fi
-
-# ---------------------------------------------------------------------------
 # 6. Version identity (single source of truth = $IMG_DATE).
 # ---------------------------------------------------------------------------
 cat > "$RF/etc/os-release" <<OSREL

--- a/build.sh
+++ b/build.sh
@@ -180,6 +180,18 @@ if [ -f "$ROOT/pkglist.txt" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# 5c. Clone gershwin-developer into /Developer so the shipped img + ISO carry
+#     the developer toolkit out of the box (the four-domain layout's /Developer
+#     root). Uses the build VM's git (installed in the workflow prepare step),
+#     not the freshly-installed image git. The repo is small; keep a full clone
+#     (incl. .git) so it can be updated with `git pull` on the booted system.
+# ---------------------------------------------------------------------------
+GERSHWIN_DEV_URL="https://github.com/gershwin-desktop/gershwin-developer.git"
+echo "==> cloning gershwin-developer into $RF/Developer"
+rm -rf "$RF/Developer"
+git clone "$GERSHWIN_DEV_URL" "$RF/Developer"
+
+# ---------------------------------------------------------------------------
 # 6. Version identity (single source of truth = $IMG_DATE).
 # ---------------------------------------------------------------------------
 cat > "$RF/etc/os-release" <<OSREL

--- a/build.sh
+++ b/build.sh
@@ -159,6 +159,27 @@ IGNORE_OSVERSION = yes;
 CONF
 
 # ---------------------------------------------------------------------------
+# 5b. Bake pkglist.txt packages into the shipped rootfs from the FreeBSD ports
+#     repo, so BOTH the published .img and .iso (same rootfs) ship them out of
+#     the box (pkg + git). Uses the FreeBSD.conf written just above via a
+#     REPOS_DIR override so pkg ignores the build VM's own signed repos (which
+#     jam the SAT solver). pkg resolves each package's full dependency closure
+#     automatically — no manual runtime-lib audit (unlike the base srclist); the
+#     libscan step below then re-verifies the closure over the whole rootfs.
+#     ABI / OSVERSION / IGNORE_OSVERSION / ASSUME_ALWAYS_YES are still exported
+#     from the NextBSD-everything install above.
+# ---------------------------------------------------------------------------
+if [ -f "$ROOT/pkglist.txt" ]; then
+    EXTRA_PKGS=$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "$ROOT/pkglist.txt" | tr '\n' ' ')
+    if [ -n "$EXTRA_PKGS" ]; then
+        echo "==> installing pkglist.txt packages from FreeBSD repo: $EXTRA_PKGS"
+        FBSD_REPOS="$RF/usr/local/etc/pkg/repos"
+        pkg -r "$RF" -o REPOS_DIR="$FBSD_REPOS" update -f
+        pkg -r "$RF" -o REPOS_DIR="$FBSD_REPOS" install -y $EXTRA_PKGS
+    fi
+fi
+
+# ---------------------------------------------------------------------------
 # 6. Version identity (single source of truth = $IMG_DATE).
 # ---------------------------------------------------------------------------
 cat > "$RF/etc/os-release" <<OSREL

--- a/build.sh
+++ b/build.sh
@@ -205,6 +205,24 @@ rm -rf "$RF/Developer"
 git clone "$GERSHWIN_DEV_URL" "$RF/Developer"
 
 # ---------------------------------------------------------------------------
+# 5d. Bake gershwin's build dependencies into the image — the effect of
+#     gershwin-developer's Bootstrap.sh nextbsd path (which just `pkg install`s
+#     Library/OSSupport/nextbsd.txt), done HOST-DRIVEN so it uses the build
+#     host's network/certs (no chroot / devfs / resolv.conf) and cross-installs
+#     for aarch64 later. Reading the toolkit's own list keeps it in sync. With
+#     these + the xlibre packages above, the img + ISO carry everything needed
+#     to build and run gershwin (the user then runs Install-System-Domain.sh).
+# ---------------------------------------------------------------------------
+GERSHWIN_REQ="$RF/Developer/Library/OSSupport/nextbsd.txt"
+if [ -f "$GERSHWIN_REQ" ]; then
+    GERSHWIN_DEPS=$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "$GERSHWIN_REQ" | tr '\n' ' ')
+    if [ -n "$GERSHWIN_DEPS" ]; then
+        echo "==> installing gershwin build deps (nextbsd.txt) into $RF: $GERSHWIN_DEPS"
+        pkg -r "$RF" -o REPOS_DIR="$RF/usr/local/etc/pkg/repos" install -y $GERSHWIN_DEPS
+    fi
+fi
+
+# ---------------------------------------------------------------------------
 # 6. Version identity (single source of truth = $IMG_DATE).
 # ---------------------------------------------------------------------------
 cat > "$RF/etc/os-release" <<OSREL

--- a/pkglist.txt
+++ b/pkglist.txt
@@ -9,3 +9,16 @@
 # One package per line. Blank lines and #-comments are ignored.
 pkg
 git
+
+# X11 (Xlibre) — a minimal X server + input/video drivers so the desktop can
+# run on the ISO and installed system. gershwin's own build deps come from
+# gershwin-developer's Library/OSSupport/nextbsd.txt (installed separately).
+xlibre-minimal
+xlibre-xf86-input-evdev
+xlibre-xf86-input-joystick
+xlibre-xf86-input-keyboard
+xlibre-xf86-input-mouse
+xlibre-xf86-input-synaptics
+xlibre-xf86-input-vmmouse
+xlibre-xf86-video-scfb
+xlibre-xf86-video-vesa

--- a/pkglist.txt
+++ b/pkglist.txt
@@ -9,16 +9,3 @@
 # One package per line. Blank lines and #-comments are ignored.
 pkg
 git
-
-# X11 (Xlibre) — a minimal X server + input/video drivers so the desktop can
-# run on the ISO and installed system. gershwin's own build deps come from
-# gershwin-developer's Library/OSSupport/nextbsd.txt (installed separately).
-xlibre-minimal
-xlibre-xf86-input-evdev
-xlibre-xf86-input-joystick
-xlibre-xf86-input-keyboard
-xlibre-xf86-input-mouse
-xlibre-xf86-input-synaptics
-xlibre-xf86-input-vmmouse
-xlibre-xf86-video-scfb
-xlibre-xf86-video-vesa

--- a/pkglist.txt
+++ b/pkglist.txt
@@ -8,4 +8,3 @@
 #
 # One package per line. Blank lines and #-comments are ignored.
 pkg
-git

--- a/pkglist.txt
+++ b/pkglist.txt
@@ -1,0 +1,11 @@
+# Extra packages baked into the published NextBSD img + ISO from the FreeBSD
+# ports repo (pkg.FreeBSD.org). Both images are assembled from the same rootfs,
+# so everything listed here ships in BOTH the .img and the .iso.
+#
+# pkg resolves each package's full dependency closure automatically, so unlike
+# the curated base srclist there is no manual runtime-lib audit — the whole
+# .so closure is installed as packages.
+#
+# One package per line. Blank lines and #-comments are ignored.
+pkg
+git


### PR DESCRIPTION
Makes the published NextBSD `.img` and `.iso` (both built from the same rootfs) ready to install packages out of the box, kept lean.

### `pkglist.txt` — bootstrap pkg
Installs `pkg` into the rootfs during assembly from the FreeBSD ports repo, so the booted system can `pkg install` anything (including `git`) on demand. Extend the baked-in set by adding names to `pkglist.txt`.

### Shipped pkg repos (exactly two)
- **FreeBSD** — `pkg.FreeBSD.org/FreeBSD:15:<arch>/latest` (FreeBSD packages)
- **NextBSD** — the `nextbsd-pkg` continuous flat repo (`continuous-amd64`), unsigned GitHub-release assets

Deliberately **not** the FreeBSD pkgbase base/kmods repos — NextBSD supplies its own base; those live only on the build VM and are never written into the image.

The user can `pkg install git`, clone gershwin-developer to `/Developer`, and run its `Bootstrap.sh` on the booted system. Baking git, the gershwin build-dep closure, and xlibre into the ISO was dropped to keep build time and image size down.

amd64 only (arm64 deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)