### PR TITLE
test: boot CI verbose so boot_mutemsgs doesn't hide markers (#363)

### DIFF
--- a/tests/img-boot-test.sh
+++ b/tests/img-boot-test.sh
@@ -96,7 +96,10 @@ send "set console=comconsole\r"; expect "set console=comconsole"; expect "OK "
 send "set boot_serial=YES\r";    expect "set boot_serial=YES";    expect "OK "
 send "set comconsole_speed=115200\r"; expect "set comconsole_speed=115200"; expect "OK "
 send "set boot_multicons=YES\r"; expect "set boot_multicons=YES"; expect "OK "
-send "boot\r"
+# boot VERBOSE: the shipped image sets boot_mutemsgs="YES" (nextbsd#363), which
+# mutes kernel console output. RB_VERBOSE (boot -v) bypasses the mute so CI sees
+# full boot output; shipped images (booted normally) stay quiet.
+send "boot -v\r"
 
 # Stage 1: launchd PID 1 comes up and getty reaches a login prompt.
 expect {

--- a/tests/iso-boot-test.sh
+++ b/tests/iso-boot-test.sh
@@ -88,7 +88,11 @@ send "set console=comconsole\r"; expect "set console=comconsole"; expect "OK "
 send "set boot_serial=YES\r";    expect "set boot_serial=YES";    expect "OK "
 send "set comconsole_speed=115200\r"; expect "set comconsole_speed=115200"; expect "OK "
 send "set boot_multicons=YES\r"; expect "set boot_multicons=YES"; expect "OK "
-send "boot\r"
+# boot VERBOSE: the shipped image sets boot_mutemsgs="YES" (nextbsd#363) which
+# mutes kernel console output — including the "vfs.pivot: / is now unionfs"
+# marker this harness sequences on. RB_VERBOSE (boot -v) bypasses the mute in
+# the kernel, so CI sees all markers while shipped images stay quiet.
+send "boot -v\r"
 
 # Stage 1: the live-root assembly markers from /rescue/init + vfs.pivot.
 set saw_init 0


### PR DESCRIPTION
The shipped image sets `boot_mutemsgs="YES"` (nextbsd-overlays #363), muting kernel console output — including the `vfs.pivot: / is now unionfs` marker `iso-boot-test.sh` sequences on. That broke the live-ISO harness (it consumed `login:` in the wrong stage and timed out; the boot itself reached getty fine).

Boot the CI harnesses with `boot -v` — `RB_VERBOSE` bypasses the kernel mute so CI sees all markers, while shipped images stay quiet. Applied to `iso-boot-test.sh` + `img-boot-test.sh`.

Fixes the iso-test regression from nextbsd#363's `boot_mutemsgs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)