### PR TITLE
arm64: fix the ISO's UEFI boot path, boot-test aarch64 in CI, re-enable the arm64 lane

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,21 +89,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # `freebsd` is the vmactions/freebsd-vm release (bare "15.1"). The image
-        # is assembled host-driven (pkg -r install, host pwd_mkdb/cap_mkdb,
-        # arch-agnostic makefs/mkuzip/mkimg) in the x86 FreeBSD 15.1 VM, so an
-        # aarch64 image needs no qemu-user to BUILD.
+        # `freebsd` is the vmactions/freebsd-vm release (bare "15.1"). Both
+        # arches build in the SAME x86 FreeBSD 15.1 VM: the image is assembled
+        # host-driven (pkg -r install, host pwd_mkdb/cap_mkdb, arch-agnostic
+        # makefs/mkuzip/mkimg), so aarch64 needs no qemu-user to BUILD. The two
+        # entries run as independent parallel matrix legs.
         #
-        # arm64 is TEMPORARILY DISABLED: the aarch64 ISO builds+publishes fine
-        # but does not boot, and CI never caught it because the disk `img-test` and
-        # live `iso-test` jobs are amd64-only (they run qemu-system-x86; booting
-        # aarch64 needs qemu-system-aarch64 + AAVMF firmware). Re-added in a
-        # follow-up together with an aarch64 boot test, and only once it boots
-        # green. build.sh keeps its arch-aware paths (ABIARCH, BOOTAA64.EFI,
-        # UEFI-only mkimg) so re-enabling is just restoring the matrix leg.
+        # arm64 was disabled in #360 because the aarch64 ISO built and published
+        # but did not boot, and CI could not see it (both boot jobs were
+        # amd64-only). Both halves are fixed here: build.sh now exports
+        # TARGET=arm64 to mkisoimages.sh — without it the ISO's El Torito ESP got
+        # this amd64 VM's BOOTX64.EFI instead of BOOTAA64.EFI, so no arm64
+        # firmware would boot it — and the img-test/iso-test jobs below have an
+        # arm64 leg on a native-ARM runner.
         include:
           - freebsd: '15.1'
             arch: 'amd64'
+          - freebsd: '15.1'
+            arch: 'arm64'
     steps:
       - uses: actions/checkout@v4
 
@@ -201,7 +204,11 @@ jobs:
     # the flaky qemu-serial loader handshake. We still boot-test on pull_request
     # (the gate) and on repository_dispatch (the base-updated cascade has no PR).
     if: "!cancelled() && needs.changes.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped') && github.event_name != 'push'"
-    runs-on: ubuntu-latest
+    # Each leg boots its own arch natively so qemu can use KVM: amd64 on the x86
+    # runner, arm64 on GitHub's ubuntu-24.04-arm (free for public repos). Under
+    # TCG the aarch64 boot takes tens of minutes; with KVM it is ~1 min, the same
+    # shape nextbsd-userland's ci-image-boot has run since #355.
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -210,6 +217,11 @@ jobs:
           - freebsd: '15.1'
             variant: '15.1-RELEASE'
             arch: 'amd64'
+            runner: 'ubuntu-24.04'
+          - freebsd: '15.1'
+            variant: '15.1-RELEASE'
+            arch: 'arm64'
+            runner: 'ubuntu-24.04-arm'
     steps:
       - uses: actions/checkout@v4
 
@@ -241,12 +253,20 @@ jobs:
             --dir out/ --clobber
           ls -lh out/
 
+      # qemu-system-arm carries qemu-system-aarch64; qemu-efi-aarch64 supplies
+      # /usr/share/qemu-efi-aarch64/QEMU_EFI.fd (the arm64 counterpart of ovmf).
       - name: install qemu + expect
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends qemu-system-x86 expect ovmf
+          if [ "${{ matrix.arch }}" = arm64 ]; then
+            sudo apt-get install -y --no-install-recommends qemu-system-arm qemu-efi-aarch64 expect
+          else
+            sudo apt-get install -y --no-install-recommends qemu-system-x86 ovmf expect
+          fi
 
       - name: boot test
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           chmod +x tests/img-boot-test.sh
           IMG=$(ls out/NextBSD-${{ matrix.arch }}-*.img.zip)
@@ -271,13 +291,17 @@ jobs:
     # publishing; it exists as the iteration feedback loop + a regression signal.
     # Skipped on push-to-main (same flaky-serial rationale as the disk `img-test`).
     if: "!cancelled() && needs.build.result == 'success' && needs.changes.outputs.build_needed == 'true' && github.event_name != 'push'"
-    runs-on: ubuntu-latest
+    # Native-arch runners, same rationale as img-test.
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
           - arch: 'amd64'
+            runner: 'ubuntu-24.04'
+          - arch: 'arm64'
+            runner: 'ubuntu-24.04-arm'
     steps:
       - uses: actions/checkout@v4
 
@@ -291,9 +315,15 @@ jobs:
       - name: install qemu + expect
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends qemu-system-x86 expect ovmf
+          if [ "${{ matrix.arch }}" = arm64 ]; then
+            sudo apt-get install -y --no-install-recommends qemu-system-arm qemu-efi-aarch64 expect
+          else
+            sudo apt-get install -y --no-install-recommends qemu-system-x86 ovmf expect
+          fi
 
       - name: iso boot test
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           chmod +x tests/iso-boot-test.sh
           ISO=$(ls out/NextBSD-${{ matrix.arch }}-*.iso.zip)
@@ -309,7 +339,7 @@ jobs:
           fi
 
   release:
-    name: release (${{ matrix.arch }})
+    name: release
     needs: [build, img-test]
     # Publish on main from a push to this repo, an upstream cascade
     # (repository_dispatch: base-updated), or a manual run (workflow_dispatch:
@@ -324,22 +354,22 @@ jobs:
     # tests-only push (build skipped) yields build.result!='success' -> no
     # republish, which is correct.
     if: ${{ always() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch') && needs.build.result == 'success' && (needs['img-test'].result == 'success' || needs['img-test'].result == 'skipped') }}
+    #
+    # Deliberately NOT a matrix: one job publishes EVERY arch's artifacts in a
+    # single `continuous` release. A per-arch matrix would run the delete-then-
+    # publish sequence once per cell, and the second cell's delete would drop the
+    # first cell's freshly-uploaded assets (the race the old comment here
+    # predicted for exactly this moment — the arm64 leg landing).
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - freebsd: '15.1'
-            variant: '15.1-RELEASE'
-            arch: 'amd64'
     steps:
       - uses: actions/checkout@v4
 
-      # Pull the dated diskimg artifact as-built — its NextBSD-<arch>-<date>.img.zip
-      # is already the final published name, so there is nothing to rename
-      # or recompute here; publish it straight to `continuous`.
+      # Pull EVERY arch's dated artifact (no `pattern`) — each
+      # NextBSD-<arch>-<date>.img.zip is already the final published name, so
+      # there is nothing to rename or recompute here; publish them straight to
+      # `continuous`.
       - uses: actions/download-artifact@v4
         with:
           path: out/
@@ -351,12 +381,8 @@ jobs:
       # `gh release create` wedges silently on big ISO uploads (single PUT,
       # no chunking, no retry). softprops/action-gh-release uses Octokit's
       # chunked upload with retries -- canonical path for big release assets.
-      # Delete previous continuous release first so old assets don't pile up.
-      #
-      # NOTE: when matrix grows to multiple cells (e.g. adding aarch64 or a
-      # zlib variant), this delete will race across cells. At that point
-      # refactor to a single non-matrix release job that downloads all
-      # artifacts and publishes them together.
+      # Delete previous continuous release first so old assets don't pile up
+      # (safe here: this job is a single cell, so nothing else is uploading).
       - name: delete previous continuous release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,10 +204,14 @@ jobs:
     # the flaky qemu-serial loader handshake. We still boot-test on pull_request
     # (the gate) and on repository_dispatch (the base-updated cascade has no PR).
     if: "!cancelled() && needs.changes.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped') && github.event_name != 'push'"
-    # Each leg boots its own arch natively so qemu can use KVM: amd64 on the x86
-    # runner, arm64 on GitHub's ubuntu-24.04-arm (free for public repos). Under
-    # TCG the aarch64 boot takes tens of minutes; with KVM it is ~1 min, the same
-    # shape nextbsd-userland's ci-image-boot has run since #355.
+    # Each leg boots on a runner of its OWN arch: amd64 on the x86 runner, arm64
+    # on GitHub's ubuntu-24.04-arm (free for public repos), the same shape
+    # nextbsd-userland's ci-image-boot has used since #355. That keeps the guest
+    # off cross-arch emulation, which is where qemu gets genuinely slow. The x86
+    # runner also has /dev/kvm; the arm64 one does NOT, so its guest runs on
+    # same-arch TCG — measured at ~1m50s per boot job, comparable to the
+    # KVM-accelerated amd64 leg. tests/qemu-arch.sh picks KVM whenever /dev/kvm
+    # shows up, so these legs get faster for free if that changes.
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     strategy:

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ entirely differently than those original solutions.
 ## Try it in 5 minutes
 
 1. Grab the latest [continuous release][release]. Download
-   `NextBSD-amd64-<STAMP>.img.zip` (the raw disk image; there's also an
-   `.iso.zip`).
+   `NextBSD-<ARCH>-<STAMP>.img.zip` (the raw disk image; there's also an
+   `.iso.zip`). `<ARCH>` is `amd64` (x86-64) or `arm64` (AArch64) — both
+   are built, boot-tested and published on every merge.
 2. Unzip it (any platform's native tools work — macOS Finder,
    Windows Explorer, `unzip` on Linux/BSD):
 
@@ -61,6 +62,23 @@ entirely differently than those original solutions.
      -nic user,model=e1000 \
      -nographic
    ```
+
+   On arm64 the machine is `virt`, the firmware is AAVMF/`QEMU_EFI.fd`,
+   and virtio-net needs its PXE option ROM turned off (`romfile=`)
+   because the arm64 QEMU packages don't ship one:
+
+   ```sh
+   img=$(echo NextBSD-arm64-*.img)
+   qemu-system-aarch64 \
+     -accel kvm -cpu host -m 2048 -machine virt \
+     -bios /usr/share/qemu-efi-aarch64/QEMU_EFI.fd \
+     -drive file="$img",format=raw,if=virtio \
+     -netdev user,id=net0 -device virtio-net-pci,netdev=net0,romfile= \
+     -nographic
+   ```
+
+   (`-accel kvm -cpu host` only works when the host is the same
+   architecture as the image; drop it for emulation, which is slow.)
 
 4. Wait ~10 seconds. You'll see launchd start its daemons, DHCP fire
    on `em0`, syslog come up, and the `login:` prompt land. Log in

--- a/build.sh
+++ b/build.sh
@@ -31,8 +31,14 @@ ARCH=${ARCH:-amd64}
 # IMG_DATE so the artifact name, image, nextbsd-version and os-release all match.
 : "${IMG_DATE:=$(date -u +%Y%m%d-%H%M%S)}"
 
-# pkg uses `aarch64` for 64-bit ARM; release tags / artifact names use `arm64`.
-case "$ARCH" in arm64|aarch64) ABIARCH=aarch64 ;; *) ABIARCH="$ARCH" ;; esac
+# Two names for 64-bit ARM, and they are NOT interchangeable:
+#   ARCH=arm64      FreeBSD MACHINE. The download mirror path, the src tree's
+#                   release/<arch>/ scripts, the nextbsd-pkg release tag
+#                   (continuous-<arch>) and our artifact names all use this.
+#   ABIARCH=aarch64 MACHINE_ARCH — what pkg(8) puts in the ABI string.
+# Normalize an `aarch64` ARCH to `arm64` so a hand-run `ARCH=aarch64 sh build.sh`
+# still finds the mirror, the pkg repo tag and mkisoimages.sh.
+case "$ARCH" in arm64|aarch64) ARCH=arm64; ABIARCH=aarch64 ;; *) ABIARCH="$ARCH" ;; esac
 PKG_ABI="FreeBSD:15:${ABIARCH}"
 
 ROOT=$(cd "$(dirname "$0")" && pwd)
@@ -463,6 +469,19 @@ done
 # Transitive .so closure: BFS over readelf NEEDED, pulling each soname from the
 # rootfs lib dirs into the flat mfsroot /lib.
 needed() { readelf -d "$1" 2>/dev/null | sed -n 's/.*(NEEDED).*\[\(.*\)\].*/\1/p'; }
+# Fallback search path for a soname the shipped rootfs doesn't provide. The build
+# VM's own base is only a legitimate donor on the NATIVE lane: on the cross
+# (aarch64-in-an-amd64-VM) lane those are x86-64 objects, and dropping one into
+# the aarch64 mfsroot yields a tool that dies in ld-elf.so.1 with "unsupported
+# file layout" at live-boot time — a much worse failure to read than the plain
+# "shared object not found" the missing lib gives. So the cross lane searches
+# only the target rootfs and WARNs if a soname is genuinely absent.
+if [ "$ABIARCH" = "$(uname -p)" ]; then
+    HOST_LIBDIRS="/lib /usr/lib"
+else
+    HOST_LIBDIRS=""
+    echo "    (cross lane: NOT cribbing libs from the amd64 build VM)"
+fi
 seen=" "
 work=$(for t in $MFS_TOOLS; do [ -f "$MFS/$t" ] && needed "$MFS/$t"; done | sort -u)
 while [ -n "$work" ]; do
@@ -471,9 +490,10 @@ while [ -n "$work" ]; do
         case "$seen" in *" $so "*) continue ;; esac
         seen="$seen$so "
         # Prefer the shipped rootfs libs; fall back to the build VM's base libs
-        # for anything the curated from-source base omits (e.g. libkiconv.so.4,
-        # which mount_cd9660 hard-NEEDs but the base srclist doesn't build).
-        src=$(find "$RF/lib" "$RF/usr/lib" /lib /usr/lib -name "$so" 2>/dev/null | head -1)
+        # (native lane only — see HOST_LIBDIRS above) for anything the curated
+        # base omits (e.g. libkiconv.so.4, which mount_cd9660 hard-NEEDs but the
+        # base srclist historically didn't build).
+        src=$(find "$RF/lib" "$RF/usr/lib" $HOST_LIBDIRS -name "$so" 2>/dev/null | head -1)
         if [ -n "$src" ]; then
             cp -p "$src" "$MFS/lib/$so"
             nextwork="$nextwork $(needed "$src")"
@@ -623,7 +643,15 @@ ISO_NAME="NextBSD-${ARCH}-${IMG_DATE}.iso"
 echo "==> mkisoimages.sh: bootable cd9660 (BIOS + UEFI)"
 MKISO=$(find "$WORK/freebsd-src" -path "*/release/${ARCH}/mkisoimages.sh" 2>/dev/null | head -1)
 [ -n "$MKISO" ] || { echo "ERROR: mkisoimages.sh not found under $WORK/freebsd-src" >&2; exit 1; }
-sh "$MKISO" -b NEXTBSD "$WORK/$ISO_NAME" "$ISOROOT"
+# TARGET=$ARCH is REQUIRED for the cross (arm64) lane. release/arm64/mkisoimages.sh
+# builds the El Torito ESP with make_esp_file() and lets it derive the UEFI
+# fallback loader name from tools/boot/install-boot.sh's get_uefi_bootname(),
+# which resolves the target as ${TARGET:-$(uname -m)}. Unset, that is this amd64
+# VM -> the aarch64 ISO ships /EFI/BOOT/bootx64.efi, arm64 firmware finds no
+# BOOTAA64.EFI, and the ISO does not boot — the exact failure that got the arm64
+# lane disabled in #360. (release/amd64/mkisoimages.sh passes `bootx64`
+# explicitly, so this is a no-op on the native lane.)
+env TARGET="$ARCH" sh "$MKISO" -b NEXTBSD "$WORK/$ISO_NAME" "$ISOROOT"
 ls -lh "$WORK/$ISO_NAME"
 echo "==> zip live ISO"
 (cd "$WORK" && zip -9 "$OUT/${ISO_NAME}.zip" "$ISO_NAME")

--- a/build.sh
+++ b/build.sh
@@ -640,7 +640,9 @@ cp "$WORK/rootfs.uzip" "$ISOROOT/rootfs.uzip"
 # 7e. Build the bootable cd9660 (BIOS cdboot + UEFI ESP) via the release script
 #     (extracted from src.txz at step 3a; lands under usr/src/ — locate by glob).
 ISO_NAME="NextBSD-${ARCH}-${IMG_DATE}.iso"
-echo "==> mkisoimages.sh: bootable cd9660 (BIOS + UEFI)"
+# amd64 gets BIOS (El Torito cdboot) + UEFI; arm64 is UEFI-only, same split as
+# the GPT disk image above.
+echo "==> mkisoimages.sh: bootable cd9660 ($([ -f "$ISOROOT/boot/cdboot" ] && echo 'BIOS + UEFI' || echo 'UEFI-only'))"
 MKISO=$(find "$WORK/freebsd-src" -path "*/release/${ARCH}/mkisoimages.sh" 2>/dev/null | head -1)
 [ -n "$MKISO" ] || { echo "ERROR: mkisoimages.sh not found under $WORK/freebsd-src" >&2; exit 1; }
 # TARGET=$ARCH is REQUIRED for the cross (arm64) lane. release/arm64/mkisoimages.sh

--- a/tests/img-boot-test.sh
+++ b/tests/img-boot-test.sh
@@ -14,11 +14,19 @@
 # direct-UFS disk image and the live ISO (iso-boot-test.sh).
 #
 # Success = "login:" prompt reached (launchd PID 1 got getty up).
+#
+# Arch-agnostic: the qemu shape (binary, machine, UEFI firmware, NIC, accel)
+# comes from tests/qemu-arch.sh, which takes ARCH from the environment or infers
+# it from the NextBSD-<arch>-<date> image name. amd64 boots on q35+OVMF, arm64 on
+# virt+AAVMF.
 
 set -eu
 
-IMG=${1:?usage: img-boot-test.sh path/to/NextBSD-*.img[.zip]}
+IMG=${1:?usage: [ARCH=amd64|arm64] img-boot-test.sh path/to/NextBSD-*.img[.zip]}
 [ -f "$IMG" ] || { echo "ERROR: $IMG not found"; exit 1; }
+# The as-published name (NextBSD-<arch>-<date>.img.zip) is what carries the arch;
+# $IMG is rewritten to the extracted scratch copy below.
+ARTIFACT=$IMG
 
 mkdir -p tests
 LOG=tests/img-boot.log
@@ -36,70 +44,45 @@ case "$IMG" in
     ;;
 esac
 
-echo "==> img boot test: $IMG"
+. "$(dirname "$0")/qemu-arch.sh"
+qemu_arch_setup "$IMG" "$ARTIFACT"
+
+echo "==> img boot test: $IMG (arch=$ARCH)"
 ls -lh "$IMG"
-
-if [ -e /dev/kvm ]; then
-    sudo chmod 666 /dev/kvm 2>/dev/null || true
-fi
-if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
-    ACCEL_FLAGS="-accel kvm -cpu host"
-    echo "==> using KVM acceleration"
-else
-    ACCEL_FLAGS="-accel tcg,thread=single -cpu qemu64"
-    echo "==> using TCG (single-thread)"
-fi
-
-OVMF=""
-for f in /usr/share/OVMF/OVMF_CODE.fd /usr/share/ovmf/OVMF.fd /usr/share/qemu/OVMF.fd; do
-    [ -f "$f" ] && { OVMF="$f"; break; }
-done
-[ -n "$OVMF" ] || { echo "ERROR: no OVMF firmware found"; exit 1; }
-echo "==> using UEFI firmware: $OVMF"
-
-export ACCEL_FLAGS OVMF
 
 cat > "$EXP" <<'EOF'
 set timeout 600
 log_file -a tests/img-boot.log
 log_user 1
 
-set img [lindex $argv 0]
 set accel_flags [split $env(ACCEL_FLAGS) " "]
+set net_args    [split $env(NET_ARGS) " "]
+set disk_args   [split $env(DISK_ARGS) " "]
 
-eval spawn qemu-system-x86_64 \
+eval spawn $env(QEMU) \
     -m 4G \
-    -machine q35 \
-    -bios $env(OVMF) \
+    -machine $env(MACHINE) \
+    -bios $env(FW) \
     $accel_flags \
-    -drive file=$img,format=raw,if=virtio \
-    -nic user,model=e1000 \
+    $disk_args \
+    $net_args \
     -display none -serial stdio \
     -no-reboot
 
+source tests/loader.exp.inc
+
 # Stage 0: drop into the loader OK prompt and enable the serial console for
 # the kernel (/boot/loader.conf leaves console unset for a clean console on
-# real hardware). Kept minimal — every extra `set` round-trip risks the loader
-# eating serial chars. Match the echoed command before "OK " to avoid racing a
-# stale OK from the prior `set`.
-expect {
-    timeout { puts "\nFAIL: didn't see loader autoboot prompt within 60s"; exit 1 }
-    -re "Hit \\\[Enter\\\]" { send " " }
-    "Booting"                { send " " }
-    "FreeBSD/amd64 EFI"      { send " " }
-}
-expect {
-    timeout { puts "\nFAIL: didn't reach loader OK prompt within 30s"; exit 1 }
-    "OK " { puts "\n==> at loader prompt; setting serial console vars" }
-}
-send "set console=comconsole\r"; expect "set console=comconsole"; expect "OK "
-send "set boot_serial=YES\r";    expect "set boot_serial=YES";    expect "OK "
-send "set comconsole_speed=115200\r"; expect "set comconsole_speed=115200"; expect "OK "
-send "set boot_multicons=YES\r"; expect "set boot_multicons=YES"; expect "OK "
+# real hardware).
+loader_prompt 60
+loader_set "set console=comconsole"
+loader_set "set boot_serial=YES"
+loader_set "set comconsole_speed=115200"
+loader_set "set boot_multicons=YES"
 # boot VERBOSE: the shipped image sets boot_mutemsgs="YES" (nextbsd#363), which
 # mutes kernel console output. RB_VERBOSE (boot -v) bypasses the mute so CI sees
 # full boot output; shipped images (booted normally) stay quiet.
-send "boot -v\r"
+loader_boot "boot -v"
 
 # Stage 1: launchd PID 1 comes up and getty reaches a login prompt.
 expect {
@@ -129,7 +112,7 @@ puts "\nIMG-BOOT-DONE"
 EOF
 
 set +e
-expect -f "$EXP" "$IMG"
+expect -f "$EXP"
 rc=$?
 set -e
 
@@ -138,8 +121,8 @@ echo "==> verdict"
 # Assert against the getty login prompt in the transcript (launchd PID 1 reached
 # getty on the installed image).
 if grep -q "login:" "$LOG"; then
-    echo "PASS: disk image booted — launchd reached the login prompt on a UFS root"
+    echo "PASS: $ARCH disk image booted — launchd reached the login prompt on a UFS root"
     exit 0
 fi
-echo "FAIL: disk image did not reach the login prompt (rc=$rc)"
+echo "FAIL: $ARCH disk image did not reach the login prompt (rc=$rc)"
 exit 1

--- a/tests/img-boot-test.sh
+++ b/tests/img-boot-test.sh
@@ -57,6 +57,7 @@ log_user 1
 
 set accel_flags [split $env(ACCEL_FLAGS) " "]
 set net_args    [split $env(NET_ARGS) " "]
+set video_args  [split $env(VIDEO_ARGS) " "]
 set disk_args   [split $env(DISK_ARGS) " "]
 
 eval spawn $env(QEMU) \
@@ -66,6 +67,7 @@ eval spawn $env(QEMU) \
     $accel_flags \
     $disk_args \
     $net_args \
+    $video_args \
     -display none -serial stdio \
     -no-reboot
 

--- a/tests/iso-boot-test.sh
+++ b/tests/iso-boot-test.sh
@@ -50,6 +50,7 @@ log_user 1
 
 set accel_flags [split $env(ACCEL_FLAGS) " "]
 set net_args    [split $env(NET_ARGS) " "]
+set video_args  [split $env(VIDEO_ARGS) " "]
 set cd_args     [split $env(CD_ARGS) " "]
 
 eval spawn $env(QEMU) \
@@ -59,6 +60,7 @@ eval spawn $env(QEMU) \
     $accel_flags \
     $cd_args \
     $net_args \
+    $video_args \
     -display none -serial stdio \
     -no-reboot
 

--- a/tests/iso-boot-test.sh
+++ b/tests/iso-boot-test.sh
@@ -8,11 +8,18 @@
 # Success = we see the pivot marker ("vfs.pivot: / is now unionfs") AND the
 # login prompt. The full serial log is always dumped for diagnosis — this is
 # the feedback loop for iterating the live-root pipeline.
+#
+# Arch-agnostic: the qemu shape (binary, machine, UEFI firmware, NIC, CD
+# attachment, accel) comes from tests/qemu-arch.sh, which takes ARCH from the
+# environment or infers it from the NextBSD-<arch>-<date> ISO name.
 
 set -eu
 
-ISO=${1:?usage: iso-boot-test.sh path/to/NextBSD-*.iso[.zip]}
+ISO=${1:?usage: [ARCH=amd64|arm64] iso-boot-test.sh path/to/NextBSD-*.iso[.zip]}
 [ -f "$ISO" ] || { echo "ERROR: $ISO not found"; exit 1; }
+# The as-published name (NextBSD-<arch>-<date>.iso.zip) is what carries the arch;
+# $ISO is rewritten to the extracted scratch copy below.
+ARTIFACT=$ISO
 
 mkdir -p tests
 LOG=tests/iso-boot.log
@@ -30,69 +37,44 @@ case "$ISO" in
     ;;
 esac
 
-echo "==> iso boot test: $ISO"
+. "$(dirname "$0")/qemu-arch.sh"
+qemu_arch_setup "$ISO" "$ARTIFACT"
+
+echo "==> iso boot test: $ISO (arch=$ARCH)"
 ls -lh "$ISO"
-
-if [ -e /dev/kvm ]; then
-    sudo chmod 666 /dev/kvm 2>/dev/null || true
-fi
-if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
-    ACCEL_FLAGS="-accel kvm -cpu host"
-    echo "==> using KVM acceleration"
-else
-    ACCEL_FLAGS="-accel tcg,thread=single -cpu qemu64"
-    echo "==> using TCG (single-thread)"
-fi
-
-OVMF=""
-for f in /usr/share/OVMF/OVMF_CODE.fd /usr/share/ovmf/OVMF.fd /usr/share/qemu/OVMF.fd; do
-    [ -f "$f" ] && { OVMF="$f"; break; }
-done
-[ -n "$OVMF" ] || { echo "ERROR: no OVMF firmware found"; exit 1; }
-echo "==> using UEFI firmware: $OVMF"
-
-export ACCEL_FLAGS OVMF
 
 cat > "$EXP" <<'EOF'
 set timeout 600
 log_file -a tests/iso-boot.log
 log_user 1
 
-set iso [lindex $argv 0]
 set accel_flags [split $env(ACCEL_FLAGS) " "]
+set net_args    [split $env(NET_ARGS) " "]
+set cd_args     [split $env(CD_ARGS) " "]
 
-eval spawn qemu-system-x86_64 \
+eval spawn $env(QEMU) \
     -m 4G \
-    -machine q35 \
-    -bios $env(OVMF) \
+    -machine $env(MACHINE) \
+    -bios $env(FW) \
     $accel_flags \
-    -cdrom $iso \
-    -boot d \
-    -nic user,model=e1000 \
+    $cd_args \
+    $net_args \
     -display none -serial stdio \
     -no-reboot
 
+source tests/loader.exp.inc
+
 # Stage 0: loader autoboot -> OK prompt; enable serial console.
-expect {
-    timeout { puts "\nFAIL: didn't see loader autoboot prompt within 90s"; exit 1 }
-    -re "Hit \\\[Enter\\\]" { send " " }
-    "Booting"                { send " " }
-    "FreeBSD/amd64 EFI"      { send " " }
-    "Loading /boot/loader"   { send " " }
-}
-expect {
-    timeout { puts "\nFAIL: didn't reach loader OK prompt within 30s"; exit 1 }
-    "OK " { puts "\n==> at loader prompt; setting serial console vars" }
-}
-send "set console=comconsole\r"; expect "set console=comconsole"; expect "OK "
-send "set boot_serial=YES\r";    expect "set boot_serial=YES";    expect "OK "
-send "set comconsole_speed=115200\r"; expect "set comconsole_speed=115200"; expect "OK "
-send "set boot_multicons=YES\r"; expect "set boot_multicons=YES"; expect "OK "
+loader_prompt 90
+loader_set "set console=comconsole"
+loader_set "set boot_serial=YES"
+loader_set "set comconsole_speed=115200"
+loader_set "set boot_multicons=YES"
 # boot VERBOSE: the shipped image sets boot_mutemsgs="YES" (nextbsd#363) which
 # mutes kernel console output — including the "vfs.pivot: / is now unionfs"
 # marker this harness sequences on. RB_VERBOSE (boot -v) bypasses the mute in
 # the kernel, so CI sees all markers while shipped images stay quiet.
-send "boot -v\r"
+loader_boot "boot -v"
 
 # Stage 1: the live-root assembly markers from /rescue/init + vfs.pivot.
 set saw_init 0
@@ -139,7 +121,7 @@ puts "\nISO-BOOT-DONE"
 EOF
 
 set +e
-expect -f "$EXP" "$ISO"
+expect -f "$EXP"
 rc=$?
 set -e
 
@@ -149,8 +131,8 @@ echo "==> verdict"
 # transcript: the kernel's vfs.pivot adoption + the getty login prompt (launchd
 # PID 1 reached getty on the union).
 if grep -q "vfs.pivot: / is now unionfs" "$LOG" && grep -q "login:" "$LOG"; then
-    echo "PASS: live ISO booted — vfs.pivot to writable union + launchd reached the login prompt"
+    echo "PASS: $ARCH live ISO booted — vfs.pivot to writable union + launchd reached the login prompt"
     exit 0
 fi
-echo "FAIL: live ISO did not complete the pivot+login sequence (rc=$rc)"
+echo "FAIL: $ARCH live ISO did not complete the pivot+login sequence (rc=$rc)"
 exit 1

--- a/tests/loader.exp.inc
+++ b/tests/loader.exp.inc
@@ -1,0 +1,92 @@
+# loader.exp.inc — the FreeBSD loader serial handshake, shared by the generated
+# img/ISO expect scripts. `source tests/loader.exp.inc` immediately after the
+# qemu spawn, then: loader_prompt <secs> ; loader_set ... ; loader_boot "boot -v".
+#
+# Lifted from nextbsd-userland's tests/boot-test.sh, which hardened it over
+# several flaky runs. The emulated UART (16550 on q35, pl011 on virt) drops the
+# odd character in BOTH directions, so:
+#   - input is paced at ~25 cps (send -s) rather than dumped at once;
+#   - each command syncs on the loader's next "OK " prompt, never on the echo of
+#     what we typed (run 26070245676 showed `boot_multicons` echoed back as
+#     `boo_multicons` on a command the loader had in fact accepted);
+#   - the final `boot` is re-sent if the loader rejects it, because a garbled
+#     boot never self-recovers — it just sits at the prompt (run 28754808354).
+
+# ~25 cps: brisk-typist cadence, slow enough for the UART to keep up.
+set send_slow {1 .04}
+
+# loader_prompt <secs> — catch the autoboot countdown and stop at the OK prompt.
+# Under -display none the loader's default `efi` console routes to serial on both
+# arches, so the banner and the prompt come to us over -serial stdio.
+proc loader_prompt {secs} {
+    global timeout
+    set saved $timeout
+    set timeout $secs
+    expect {
+        timeout { puts "\nFAIL: didn't see the loader autoboot prompt within ${secs}s"; exit 1 }
+        -re "Hit \\\[Enter\\\]"      { send " " }
+        "Booting"                    { send " " }
+        -re "FreeBSD/\[a-z0-9\]+ EFI" { send " " }
+        "Loading /boot/loader"       { send " " }
+    }
+    set timeout 30
+    expect {
+        timeout { puts "\nFAIL: didn't reach the loader OK prompt within 30s"; exit 1 }
+        "OK " { puts "\n==> at loader prompt" }
+    }
+    set timeout $saved
+}
+
+# loader_set <cmd> — set one loader variable, robustly.
+#   1. settle at the prompt (the loader is still printing when it first appears)
+#   2. drain, so we can't latch the PREVIOUS command's OK
+#   3. send paced
+#   4. sync on the fresh OK
+proc loader_set {cmd} {
+    global timeout
+    set saved $timeout
+    set timeout 20
+    sleep 0.3
+    expect *
+    send -s -- "$cmd\r"
+    expect {
+        timeout { puts "\nFAIL: no OK prompt after '$cmd' within 20s"; exit 1 }
+        "OK "
+    }
+    set timeout $saved
+}
+
+# loader_boot <cmd> — issue the final boot command, retrying a garbled send.
+# Success = the loader leaves the prompt to load the kernel: no "unknown
+# command" and no fresh "OK " inside the settle window.
+proc loader_boot {cmd} {
+    global timeout
+    set saved $timeout
+    set timeout 10
+    for {set try 1} {$try <= 5} {incr try} {
+        sleep 0.3
+        expect *
+        send -s -- "$cmd\r"
+        expect {
+            "unknown command" {
+                puts "\n==> loader garbled '$cmd' (try $try/5); resending"
+                continue
+            }
+            -re "Booting|/boot/kernel/kernel|Loading kernel|---<<" {
+                set timeout $saved
+                return
+            }
+            "OK " {
+                puts "\n==> loader still at prompt after '$cmd' (try $try/5); resending"
+                continue
+            }
+            timeout {
+                # No reject and no fresh prompt => the kernel is loading.
+                set timeout $saved
+                return
+            }
+        }
+    }
+    puts "\nFAIL: loader never accepted '$cmd' after 5 tries (UART input drop)"
+    exit 1
+}

--- a/tests/qemu-arch.sh
+++ b/tests/qemu-arch.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# qemu-arch.sh — the per-arch qemu shape shared by the two boot harnesses
+# (img-boot-test.sh, iso-boot-test.sh). SOURCED, never executed.
+#
+# Both harnesses boot the same NextBSD rootfs, just wrapped differently (a UFS
+# disk image vs. the live ISO), so the only thing that differs between the amd64
+# and arm64 lanes is the machine they are booted on:
+#
+#            amd64                          arm64
+#   qemu     qemu-system-x86_64             qemu-system-aarch64
+#   machine  q35                            virt
+#   firmware OVMF                           AAVMF / QEMU_EFI
+#   NIC      e1000 (ROM ships with qemu)    virtio-net-pci, romfile= (see below)
+#   TCG cpu  qemu64                         max
+#   CD       -cdrom (SATA/ATAPI on q35)     virtio-scsi + scsi-cd (virt has no IDE)
+#
+# The same split is already proven in nextbsd-userland's tests/boot-test.sh,
+# which has been booting the aarch64 CI image under KVM on GitHub's
+# ubuntu-24.04-arm runners since #355.
+#
+# Usage:  . tests/qemu-arch.sh ; qemu_arch_setup <media-path> [<name-hint>]
+# Exports (consumed by the generated expect scripts via env):
+#   ARCH QEMU MACHINE FW ACCEL_FLAGS NET_ARGS DISK_ARGS CD_ARGS
+
+# qemu_arch_setup <media> [<name-hint>] — resolve the arch and export the qemu
+# flags for it. ARCH may be set in the environment (CI passes the matrix arch);
+# otherwise it is inferred from the NextBSD-<arch>-<date> name, defaulting to
+# amd64 for a hand-named image. <name-hint> is the ORIGINAL artifact name when
+# <media> is a decompressed scratch copy (tests/disk.img, tests/live.iso) whose
+# name no longer carries the arch.
+qemu_arch_setup() {
+    _media=$1
+    _hint=${2:-$1}
+
+    if [ -z "${ARCH:-}" ]; then
+        case "$_hint" in
+        *-arm64-*|*-aarch64-*) ARCH=arm64 ;;
+        *)                     ARCH=amd64 ;;
+        esac
+        echo "==> ARCH not set; inferred $ARCH from $(basename "$_hint")"
+    fi
+
+    case "$ARCH" in
+    amd64)
+        QEMU=qemu-system-x86_64
+        MACHINE=q35
+        NET_ARGS="-nic user,model=e1000"
+        _tcg_cpu=qemu64
+        _fw_candidates="/usr/share/OVMF/OVMF_CODE.fd /usr/share/ovmf/OVMF.fd /usr/share/qemu/OVMF.fd"
+        # q35 has an AHCI controller, so plain -cdrom gets a real ATAPI cd0.
+        CD_ARGS="-cdrom $_media -boot d"
+        ;;
+    arm64|aarch64)
+        ARCH=arm64
+        QEMU=qemu-system-aarch64
+        MACHINE=virt
+        # virtio-net-pci defaults to loading a PXE option ROM (efi-virtio.rom)
+        # that the arm64 qemu package doesn't ship -> qemu exits "failed to find
+        # romfile". We never netboot, so disable it with romfile= (empty); -nic
+        # can't express that, hence the -netdev/-device pair.
+        NET_ARGS="-netdev user,id=net0 -device virtio-net-pci,netdev=net0,romfile="
+        _tcg_cpu=max
+        _fw_candidates="/usr/share/qemu-efi-aarch64/QEMU_EFI.fd /usr/share/AAVMF/AAVMF_CODE.fd /usr/share/edk2/aarch64/QEMU_EFI.fd"
+        # `virt` has no IDE/AHCI, so -cdrom would land the ISO on a read-only
+        # virtio-blk (a vtbd, not a cd). Attach a real SCSI CD instead: EDK2's
+        # VirtioScsiDxe boots the El Torito ESP off it, and the guest gets the
+        # /dev/cd0 the live init looks for. bootindex pins it as boot device 0
+        # (there is no -boot d equivalent for a UEFI machine).
+        CD_ARGS="-drive file=$_media,format=raw,if=none,id=cd0,media=cdrom -device virtio-scsi-pci -device scsi-cd,drive=cd0,bootindex=0"
+        ;;
+    *)
+        echo "ERROR: unsupported ARCH=$ARCH (expected amd64 or arm64)" >&2
+        return 1
+        ;;
+    esac
+
+    # virtio-blk is available on both machines and needs no option ROM.
+    DISK_ARGS="-drive file=$_media,format=raw,if=virtio"
+
+    # KVM when the runner is the same arch as the guest (ubuntu-24.04 for amd64,
+    # ubuntu-24.04-arm for arm64); single-threaded TCG otherwise.
+    if [ -e /dev/kvm ]; then
+        sudo chmod 666 /dev/kvm 2>/dev/null || true
+    fi
+    if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+        ACCEL_FLAGS="-accel kvm -cpu host"
+        echo "==> using KVM acceleration"
+    else
+        ACCEL_FLAGS="-accel tcg,thread=single -cpu $_tcg_cpu"
+        echo "==> using TCG (single-thread, cpu=$_tcg_cpu)"
+    fi
+
+    FW=""
+    for _f in $_fw_candidates; do
+        [ -f "$_f" ] && { FW="$_f"; break; }
+    done
+    if [ -z "$FW" ]; then
+        echo "ERROR: no UEFI firmware for $ARCH (looked in: $_fw_candidates)" >&2
+        return 1
+    fi
+
+    echo "==> $ARCH: $QEMU -machine $MACHINE | firmware $FW"
+    export ARCH QEMU MACHINE FW ACCEL_FLAGS NET_ARGS DISK_ARGS CD_ARGS
+}

--- a/tests/qemu-arch.sh
+++ b/tests/qemu-arch.sh
@@ -13,6 +13,7 @@
 #   NIC      e1000 (ROM ships with qemu)    virtio-net-pci, romfile= (see below)
 #   TCG cpu  qemu64                         max
 #   CD       -cdrom (SATA/ATAPI on q35)     virtio-scsi + scsi-cd (virt has no IDE)
+#   video    default VGA (q35 has one)      virtio-gpu-pci (virt has NONE)
 #
 # The same split is already proven in nextbsd-userland's tests/boot-test.sh,
 # which has been booting the aarch64 CI image under KVM on GitHub's
@@ -20,7 +21,7 @@
 #
 # Usage:  . tests/qemu-arch.sh ; qemu_arch_setup <media-path> [<name-hint>]
 # Exports (consumed by the generated expect scripts via env):
-#   ARCH QEMU MACHINE FW ACCEL_FLAGS NET_ARGS DISK_ARGS CD_ARGS
+#   ARCH QEMU MACHINE FW ACCEL_FLAGS NET_ARGS DISK_ARGS CD_ARGS VIDEO_ARGS
 
 # qemu_arch_setup <media> [<name-hint>] — resolve the arch and export the qemu
 # flags for it. ARCH may be set in the environment (CI passes the matrix arch);
@@ -49,6 +50,10 @@ qemu_arch_setup() {
         _fw_candidates="/usr/share/OVMF/OVMF_CODE.fd /usr/share/ovmf/OVMF.fd /usr/share/qemu/OVMF.fd"
         # q35 has an AHCI controller, so plain -cdrom gets a real ATAPI cd0.
         CD_ARGS="-cdrom $_media -boot d"
+        # q35 always instantiates a VGA adapter (-display none only suppresses
+        # the HOST window, not the emulated device), so the guest already gets a
+        # framebuffer, efifb, vt(4) and /dev/ttyv0. Nothing to add.
+        VIDEO_ARGS=""
         ;;
     arm64|aarch64)
         ARCH=arm64
@@ -67,6 +72,16 @@ qemu_arch_setup() {
         # /dev/cd0 the live init looks for. bootindex pins it as boot device 0
         # (there is no -boot d equivalent for a UEFI machine).
         CD_ARGS="-drive file=$_media,format=raw,if=none,id=cd0,media=cdrom -device virtio-scsi-pci -device scsi-cd,drive=cd0,bootindex=0"
+        # `virt` instantiates NO display adapter at all, unlike q35. Without one
+        # the firmware exposes no GOP, the loader hands the kernel no
+        # framebuffer, vt(4) never attaches, and /dev/ttyv0 does not exist — so
+        # every console-on-screen path goes untested on this arch, which is
+        # exactly how nextbsd-userland#55 (no login on the arm64 framebuffer)
+        # reached a release. Give the guest a GPU so the tested machine has the
+        # same shape as the machines users actually run (UTM/qemu desktop VMs
+        # ship virtio-gpu-pci). Costs nothing under -display none: the device is
+        # emulated, only the host-side window is suppressed.
+        VIDEO_ARGS="-device virtio-gpu-pci"
         ;;
     *)
         echo "ERROR: unsupported ARCH=$ARCH (expected amd64 or arm64)" >&2
@@ -100,5 +115,5 @@ qemu_arch_setup() {
     fi
 
     echo "==> $ARCH: $QEMU -machine $MACHINE | firmware $FW"
-    export ARCH QEMU MACHINE FW ACCEL_FLAGS NET_ARGS DISK_ARGS CD_ARGS
+    export ARCH QEMU MACHINE FW ACCEL_FLAGS NET_ARGS DISK_ARGS CD_ARGS VIDEO_ARGS
 }


### PR DESCRIPTION
Restores arm64 as a first-class, boot-tested, published architecture — the follow-up #360 asked for ("re-added in a follow-up together with an aarch64 boot test, and only once it boots green").

## The bug that broke the arm64 ISO

`release/arm64/mkisoimages.sh` builds the ISO's El Torito ESP with `make_esp_file()` and lets it derive the UEFI fallback loader name from `tools/boot/install-boot.sh`:

```sh
get_uefi_bootname() {
    case ${TARGET:-$(uname -m)} in
        amd64) echo bootx64 ;;
        arm64) echo bootaa64 ;;
```

We cross-assemble the aarch64 image in an **amd64** FreeBSD VM, so with `TARGET` unset that resolved to `amd64`: the aarch64 ISO shipped `/EFI/BOOT/bootx64.efi` and no `BOOTAA64.EFI`, which arm64 firmware never looks for. Hence "builds and publishes fine but does not boot".

`build.sh` now passes `TARGET=$ARCH` to the release script. `release/amd64/mkisoimages.sh` passes `bootx64` explicitly, so this is a no-op on the native lane, and the `.img` path was never affected (build.sh names that ESP itself, and already picks `BOOTAA64.EFI`).

Two smaller arch fixes ride along:

* `ARCH=aarch64` is normalized to `arm64` up front. `arm64` is FreeBSD's `MACHINE` and is what the download mirror, `release/<arch>/`, the `continuous-<arch>` pkg tag and our artifact names use; `aarch64` is `MACHINE_ARCH` and belongs only in the pkg ABI (`ABIARCH`).
* The mfsroot lib closure no longer falls back to the build VM's `/lib`:`/usr/lib` on the cross lane. Those are x86-64 objects, and one copied into an aarch64 mfsroot produces a tool that dies in `ld-elf.so.1` with "unsupported file layout" at live-boot time — worse to debug than the missing soname it was covering. (Nothing hits it today: the arm64 rootfs does ship `libkiconv.so.4`.) Native lane keeps the fallback.

## CI can now see an aarch64 boot

The other half of #360: both boot jobs ran `qemu-system-x86` on an x86 runner, so an arm64 regression was invisible.

* **`tests/qemu-arch.sh`** (new, sourced by both harnesses) holds the per-arch qemu shape — binary, machine, firmware, NIC, TCG cpu, CD attachment, KVM detection. amd64 = q35 + OVMF + e1000 + `-cdrom`; arm64 = virt + AAVMF/`QEMU_EFI.fd` + virtio-net with `romfile=` (the arm64 qemu packages ship no `efi-virtio.rom`) + a virtio-scsi CD, because `virt` has no IDE and a plain `-cdrom` there lands the ISO on a virtio-blk rather than a `cd0`. `ARCH` comes from the environment or is inferred from the `NextBSD-<arch>-<date>` artifact name.
* **`tests/loader.exp.inc`** (new) is the loader serial handshake, lifted from `nextbsd-userland`'s `tests/boot-test.sh` where it was hardened against exactly this flake class: input paced at ~25 cps, each command synced on the loader's next `OK ` prompt instead of on the echo of what we typed (the emulated UART drops characters both ways), and a garbled final `boot` re-sent because that one never self-recovers. Both harnesses used the echo-matching version, so this also fixes a known amd64 flake.
* `img-test` and `iso-test` each run their arch on its own native runner. `ubuntu-24.04-arm` is free for public repos, the same shape `nextbsd-userland`'s `ci-image-boot` has used since #355. That keeps the guest off cross-arch emulation, which is where qemu gets genuinely slow — the ARM runner has no `/dev/kvm`, and same-arch TCG still boots it in ~1m50s, faster than the KVM-accelerated amd64 legs (2m49s img, 11m32s iso). `qemu-arch.sh` picks KVM whenever `/dev/kvm` appears, so the legs get faster for free if that changes (whose getty `3wire.9600` fix, in the current arm64 packages, is what lets the arm64 console reach a shell at all).
* The `release` job drops its matrix: one job publishes every arch's artifacts into the single `continuous` release. As the comment there predicted, a second matrix cell's delete-then-publish would have dropped the first cell's freshly uploaded assets.

## Verification

CI on this PR is the test: the arm64 legs of `build`, `img-test` and `iso-test` all have to go green, and they are gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Result

Green on the first run ([31831562114](https://github.com/nextbsd-redux/nextbsd/actions/runs/31831562114)):

| job | amd64 | arm64 |
|---|---|---|
| build | 10m46s | 6m02s |
| img-test | 2m49s | 1m51s |
| iso-test | 11m32s | 1m47s |

The arm64 evidence, from the serial transcripts:

* **disk image** — `NextBSD/arm64 (virt-8-2) (console)` getty banner, `login:`, `ROOT-IS-UFS`.
* **live ISO** — `vfs.pivot: / is now unionfs (mounted from /rofs)`, `login:`, `ROOT-IS-UNION`. This is the ISO that could not boot before; the ESP now carries `BOOTAA64.EFI`.
* the cross-lane guard fired (`(cross lane: NOT cribbing libs from the amd64 build VM)`) and the mfsroot still resolved its full library closure, so nothing was relying on the x86 fallback.