### PR TITLE
build: give the rpi500 image a working display

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -490,6 +490,35 @@ arm_64bit=1
 # partway through boot.
 enable_uart=1
 
+# Video. Without these the firmware sets up no display and allocates no
+# framebuffer, vt(4) comes up as "init without driver", and the machine boots
+# to a black screen -- which on this board is indistinguishable from a kernel
+# that never started.
+#
+# max_framebuffers is what makes the firmware allocate one at all.
+# display_auto_detect lets it probe and configure whatever is attached.
+#
+# hdmi_force_hotplug is the interesting one, and it is here deliberately.
+# Measured on a Pi 500+: the firmware reported "hotplug 0" with a monitor
+# attached and its EDID perfectly readable -- DDC works (pins 15/16), hotplug
+# detect (pin 19) does not, which is what a micro-HDMI adapter that skips that
+# pin looks like. Raspberry Pi OS has the same workaround in its own
+# cmdline.txt as the "D" in video=HDMI-A-1:1280x720@60D, so the fault is
+# common enough that their default image carries a fix for it.
+#
+# The cost is a few MB of framebuffer allocated on a headless machine. The
+# alternative failure is a black screen with no message, on hardware whose
+# only other console is a cable inside the case. Worth the trade here; it is
+# also the first thing to remove if a display misbehaves.
+max_framebuffers=2
+display_auto_detect=1
+hdmi_force_hotplug=1
+
+# Deliberately NO hardcoded resolution. Forcing hdmi_group/hdmi_mode or
+# framebuffer_width/height was measured to be ignored anyway, and letting the
+# firmware read EDID gave 1920x1080 where a hardcoded mode would have pinned
+# the machine to 720p. The display knows better than this file does.
+
 # Deliberately no dtoverlay= or dtparam= lines. Every overlay in the vendor
 # tree is written against Linux driver bindings; NextBSD reads the same device
 # tree with its own drivers, and an overlay that renames or reparents a node


### PR DESCRIPTION
Adds three firmware settings to the image's `config.txt`. **Proven on the board.**

## Before

```
VT: init without driver.
fb0: bcm2835_mbox_fb_init failed, err=5
device_attach: fb0 attach returned 6
```

Black screen — and on this board that is indistinguishable from a kernel that never started.

## After

```
fb0: keeping existing fb bpp of 32
fbd0 on fb0
VT: initialize with new VT driver "fb".
fb0: 1920x1080(1920x1080@0,0) 32bpp
fb0: fbswap: 1, pitch 7680, base 0x3f400000, screen_size 8294400
```

## What was added, and why each

```
max_framebuffers=2
display_auto_detect=1
hdmi_force_hotplug=1
```

`max_framebuffers` is what makes the firmware allocate a framebuffer at all. `display_auto_detect` lets it probe and configure whatever is attached.

**`hdmi_force_hotplug=1` is the interesting one.** Measured on a Pi 500+: the firmware reported `hotplug 0` with a monitor attached *and its EDID perfectly readable*:

```
Select resolution HDMI0/2 hotplug 0 max_mode 2     <- HPD low
HDMI0 edid block 0 offset 0                        <- but DDC fine
HDMI0 edid block 1 offset 128
HDMI0: best-mode 2 (limit 2) 1920x1080 60 Hz
```

DDC works (pins 15/16), hotplug detect (pin 19) does not — the signature of a micro-HDMI adapter that skips that pin. Raspberry Pi OS ships the same workaround as the `D` in `video=HDMI-A-1:1280x720@60D`, so the fault is common enough that the vendor image carries a fix for it.

The cost is a few MB of framebuffer on a headless machine. The alternative failure is a black screen with no message, on hardware whose only other console is a cable inside the case. Worth the trade — and it is the first thing to remove if a display misbehaves.

## Deliberately NOT included: a hardcoded resolution

Forcing `hdmi_group`/`hdmi_mode` and `framebuffer_width`/`framebuffer_height` was **measured to be ignored** — the firmware chose 1920×1080 regardless. Letting it read EDID is strictly better than pinning the machine to the 720p I had asked for, and it is what makes the image work on someone else's monitor.

## Honest caveat

Eight settings were changed at once during the experiment; these three are the ones I believe did the work, but only `hdmi_force_hotplug` is individually proven necessary (HPD was measurably low). `max_framebuffers` and `display_auto_detect` are reasoned. A bisect via `/dev/vcio` from Linux can narrow it further without costing board reboots, and is worth doing before this hardens into folklore.

Refs nextbsd-kernel#96, #416.