### PR TITLE
build: one image for the Pi 5 family, and publish it on merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,8 +199,8 @@ jobs:
   # an emulator would fake. So the artifact is built on every PR and downloaded
   # by a human with the board in front of them; it reaches `continuous` only
   # once it has booted real hardware (nextbsd-kernel#85).
-  build-rpi500:
-    name: build (rpi500 arm64)
+  build-rpi5:
+    name: build (rpi5 arm64)
     needs: changes
     if: needs.changes.outputs.build_needed == 'true'
     runs-on: ubuntu-latest
@@ -242,7 +242,7 @@ jobs:
           fi
           echo "Image header ok"
 
-      - name: build the rpi500 image inside FreeBSD VM
+      - name: build the rpi5 image inside FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         with:
           release: '15.1'
@@ -266,7 +266,7 @@ jobs:
       - name: checksum + summary
         run: |
           ls -lh out/
-          IMG="NextBSD-rpi500-arm64-${{ steps.meta.outputs.date }}.img.zip"
+          IMG="NextBSD-arm64-rpi5-${{ steps.meta.outputs.date }}.img.zip"
           ( cd out && sha256sum "$IMG" > "$IMG.sha256" )
           cat "out/$IMG.sha256"
           {
@@ -280,10 +280,10 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: NextBSD-rpi500-arm64-${{ steps.meta.outputs.date }}
+          name: NextBSD-arm64-rpi5-${{ steps.meta.outputs.date }}
           path: |
-            out/NextBSD-rpi500-arm64-${{ steps.meta.outputs.date }}.img.zip
-            out/NextBSD-rpi500-arm64-${{ steps.meta.outputs.date }}.img.zip.sha256
+            out/NextBSD-arm64-rpi5-${{ steps.meta.outputs.date }}.img.zip
+            out/NextBSD-arm64-rpi5-${{ steps.meta.outputs.date }}.img.zip.sha256
           compression-level: 0
           retention-days: 14
           if-no-files-found: error
@@ -346,7 +346,9 @@ jobs:
         with:
           # Only THIS arch's artifact — the matrix builds both, and a bare glob
           # would otherwise match both arches' images.
-          pattern: NextBSD-${{ matrix.arch }}-*
+          # [0-9]* anchors on the datestamp: NextBSD-arm64-rpi5-... must not
+          # be swallowed by the glob for the generic NextBSD-arm64-... image.
+          pattern: NextBSD-${{ matrix.arch }}-[0-9]*
           path: out/
           merge-multiple: true
 
@@ -358,7 +360,7 @@ jobs:
           mkdir -p out
           gh release download continuous \
             --repo "$GITHUB_REPOSITORY" \
-            --pattern 'NextBSD-${{ matrix.arch }}-*.img.zip' \
+            --pattern 'NextBSD-${{ matrix.arch }}-[0-9]*.img.zip' \
             --dir out/ --clobber
           ls -lh out/
 
@@ -378,7 +380,9 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           chmod +x tests/img-boot-test.sh
-          IMG=$(ls out/NextBSD-${{ matrix.arch }}-*.img.zip)
+          # A bare glob would match the board image too and put two paths
+          # into a scalar. Anchor on the datestamp.
+          IMG=$(ls out/NextBSD-${{ matrix.arch }}-[0-9]*.img.zip)
           ./tests/img-boot-test.sh "$IMG"
 
       - name: dump img boot serial log
@@ -417,7 +421,9 @@ jobs:
       - name: download built ISO (artifact)
         uses: actions/download-artifact@v4
         with:
-          pattern: NextBSD-${{ matrix.arch }}-*
+          # [0-9]* anchors on the datestamp: NextBSD-arm64-rpi5-... must not
+          # be swallowed by the glob for the generic NextBSD-arm64-... image.
+          pattern: NextBSD-${{ matrix.arch }}-[0-9]*
           path: out/
           merge-multiple: true
 
@@ -484,16 +490,12 @@ jobs:
           path: out/
           merge-multiple: true
 
-      # Drop the board images before the glob below sees them. download-artifact
-      # above takes EVERY artifact, and `out/NextBSD-*.img.zip` matches
-      # NextBSD-rpi500-arm64-<date>.img.zip just as happily as the generic
-      # ones -- so without this the Pi 500+ image would publish to `continuous`
-      # having never booted on hardware, which is the one thing that lane is
-      # not allowed to do (nextbsd-kernel#85). Board images ship only once a
-      # human has booted them on the real board.
-      - name: hold board images back from continuous
-        run: |
-          rm -fv out/NextBSD-rpi500-* || true
+      # No hold-back step here any more. The release job cannot run on a pull
+      # request -- its guard requires refs/heads/main plus a push/dispatch
+      # event -- so a PR builds a downloadable artifact and publishes nothing.
+      # Merging is therefore the deliberate act of publishing, which is a
+      # clearer contract than deleting files on the way past, and easier to get
+      # right than remembering to re-enable a deletion.
 
       - name: list release assets
         run: ls -lh out/NextBSD-*.img.zip out/NextBSD-*.img.zip.sha256 out/NextBSD-*.iso.zip out/NextBSD-*.iso.zip.sha256

--- a/build.sh
+++ b/build.sh
@@ -442,33 +442,47 @@ if [ "$BOARD" = rpi500 ]; then
     # /proc/device-tree/compatible reads "raspberrypi,500 brcm,bcm2712" and the
     # firmware selects bcm2712-rpi-500.dtb, which is the 500+ too.
     : "${RPI_FIRMWARE_TAG:=1.20250430}"
-    : "${RPI_DTB:=bcm2712-rpi-500.dtb}"
+
+    # Ship EVERY BCM2712 device tree and let the firmware pick.
+    #
+    # The firmware selects a DTB by board revision code, which is the mechanism
+    # designed for exactly this -- "This selection is automatic, and allows the
+    # same SD card image to be used in a variety of devices". Pinning
+    # device_tree= to one file is what made this image Pi 500/500+ only: any
+    # other board would have been handed a device tree for hardware it is not.
+    #
+    # Note there are three separate Pi 5 B blobs, because the firmware
+    # distinguishes silicon steppings. That is also the reason this is not a
+    # guarantee for untested boards -- see the coverage note below.
+    RPI_DTBS="bcm2712-rpi-5-b bcm2712d0-rpi-5-b bcm2712-d-rpi-5-b \
+              bcm2712-rpi-500 \
+              bcm2712-rpi-cm5-cm4io bcm2712-rpi-cm5-cm5io \
+              bcm2712-rpi-cm5l-cm4io bcm2712-rpi-cm5l-cm5io"
     if [ -n "${DTB:-}" ]; then
         echo "==> rpi500: using DTB override $DTB"
-        cp "$DTB" "$BOOTSTAGE/$RPI_DTB"
+        cp "$DTB" "$BOOTSTAGE/$(basename "$DTB")"
     else
-        _dtb="$DIST/${RPI_FIRMWARE_TAG}-${RPI_DTB}"
-        if [ ! -f "$_dtb" ]; then
-            echo "==> fetching $RPI_DTB from raspberrypi/firmware $RPI_FIRMWARE_TAG"
-            fetch -o "$_dtb" \
-                "https://raw.githubusercontent.com/raspberrypi/firmware/${RPI_FIRMWARE_TAG}/boot/${RPI_DTB}"
-        fi
-        cp "$_dtb" "$BOOTSTAGE/$RPI_DTB"
-        # Ship the licence the blob is redistributed under, from the same
-        # pinned tag, as Raspberry Pi OS does.
+        for d in $RPI_DTBS; do
+            _dtb="$DIST/${RPI_FIRMWARE_TAG}-${d}.dtb"
+            if [ ! -f "$_dtb" ]; then
+                echo "==> fetching ${d}.dtb from raspberrypi/firmware $RPI_FIRMWARE_TAG"
+                fetch -o "$_dtb" \
+                    "https://raw.githubusercontent.com/raspberrypi/firmware/${RPI_FIRMWARE_TAG}/boot/${d}.dtb"
+            fi
+            cp "$_dtb" "$BOOTSTAGE/${d}.dtb"
+            # A flattened device tree opens with magic 0xd00dfeed, big-endian.
+            MAGIC=$(dd if="$BOOTSTAGE/${d}.dtb" bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')
+            if [ "$MAGIC" != "d00dfeed" ]; then
+                echo "ERROR: ${d}.dtb is not a flattened device tree (magic=$MAGIC)." >&2
+                exit 1
+            fi
+        done
         _lic="$DIST/${RPI_FIRMWARE_TAG}-LICENCE.broadcom"
         [ -f "$_lic" ] || fetch -o "$_lic" \
             "https://raw.githubusercontent.com/raspberrypi/firmware/${RPI_FIRMWARE_TAG}/boot/LICENCE.broadcom"
         cp "$_lic" "$BOOTSTAGE/LICENCE.broadcom"
     fi
-    # A flattened device tree opens with magic 0xd00dfeed, big-endian.
-    DTBMAGIC=$(dd if="$BOOTSTAGE/$RPI_DTB" bs=1 count=4 2>/dev/null |
-        od -An -tx1 | tr -d ' \n')
-    if [ "$DTBMAGIC" != "d00dfeed" ]; then
-        echo "ERROR: $RPI_DTB is not a flattened device tree (magic=$DTBMAGIC)." >&2
-        exit 1
-    fi
-    echo "    $RPI_DTB $(ls -l "$BOOTSTAGE/$RPI_DTB" | awk '{print $5}') bytes, FDT magic ok"
+    echo "    $(ls "$BOOTSTAGE"/*.dtb | wc -l | tr -d ' ') device trees, FDT magic ok"
 
     cat > "$BOOTSTAGE/config.txt" <<CFG
 # NextBSD on the Raspberry Pi 500+ (BCM2712).
@@ -478,9 +492,13 @@ if [ "$BOARD" = rpi500 ]; then
 # loader(8) anywhere in that path, so anything the kernel needs in order to
 # boot is compiled into it rather than loaded here.
 kernel=kernel8.img
-device_tree=$RPI_DTB
 cmdline=cmdline.txt
 arm_64bit=1
+
+# Deliberately NO device_tree= line. The firmware selects the right blob for
+# the board it is running on, from the ones shipped alongside this file --
+# which is what lets one image serve the whole Pi 5 family. Pinning it here
+# would hand every board but one a device tree for hardware it is not.
 
 # The kernel's console is UART10 inside the BCM2712 at 0x10_7d00_1000 -- the
 # 3-pin JST-SH debug header on the board, not the 40-pin GPIO header. Which
@@ -573,7 +591,10 @@ CFG
     # NVMe (dos label, p1 type 0x0c FAT32-LBA, p2 the OS). fat32lba is that
     # 0x0c; a plain fat32 (0x0b) is CHS-addressed and the wrong type here.
     echo "==> mkimg: MBR disk image (FAT32 boot + freebsd root)"
-    IMG_NAME="NextBSD-rpi500-${ARCH}-${IMG_DATE}.img"
+    # Arch first, board second: NextBSD-arm64-rpi5-<date>.img. Sorts with the
+    # other arm64 images, and the globs that consume these are anchored on the
+    # datestamp ([0-9]*) so a board token can never be mistaken for one.
+    IMG_NAME="NextBSD-${ARCH}-rpi5-${IMG_DATE}.img"
     mkimg -s mbr -f raw \
         -p fat32lba:="$WORK/rpiboot.img" \
         -p freebsd:="$WORK/rootfs.ufs" \


### PR DESCRIPTION
Three changes that belong together.

## 1. Ship every BCM2712 device tree, and stop pinning one

`build.sh` fetched exactly one DTB and wrote `device_tree=bcm2712-rpi-500.dtb` into `config.txt`. That is what made the image **Pi 500/500+ only** — any other board would have been handed a device tree for hardware it is not.

The firmware selects a DTB by board revision code, which is the mechanism designed for this. Raspberry Pi's own documentation: *"This selection is automatic, and allows the same SD card image to be used in a variety of devices."*

So: ship all eight, drop `device_tree=`.

```
bcm2712-rpi-5-b      bcm2712d0-rpi-5-b     bcm2712-d-rpi-5-b
bcm2712-rpi-500
bcm2712-rpi-cm5-cm4io   bcm2712-rpi-cm5-cm5io
bcm2712-rpi-cm5l-cm4io  bcm2712-rpi-cm5l-cm5io
```

627 KB against a 100 MB boot partition. Each is checked for FDT magic before shipping.

This is what Raspberry Pi OS and Ubuntu both do — Ubuntu ships a *single* `+raspi` image covering Pi 3, 4, 5, CM4 and Zero 2 W. Neither has ever shipped a per-board image.

## 2. Rename to `NextBSD-arm64-rpi5-<date>.img.zip`

Arch first, so it sorts with the other arm64 images.

That ordering was previously unavailable, and the reason is worth recording. Four globs did `NextBSD-${ARCH}-*`, which would match **both** images:

```
NextBSD-arm64-*.img.zip  ->  NextBSD-arm64-20260825-014146.img.zip
                             NextBSD-arm64-rpi5-20260825-014146.img.zip
```

One of them is `IMG=$(ls out/NextBSD-${ARCH}-*.img.zip)` — a bare `ls` into a scalar — so the existing arm64 `img-test` lane would have broken with two paths in one variable.

All four are now anchored on the datestamp, which a board token can never satisfy:

```
NextBSD-${ARCH}-[0-9]*.img.zip  ->  1 match
```

That is a better glob regardless of naming, and it is what makes a second board lane possible later without another collision.

## 3. Remove the hold-back; merging is now the publish

The `rm -fv out/NextBSD-rpi500-*` step deleted board images before the release glob saw them. It was redundant: the `release` job's guard already requires `refs/heads/main` **plus** a push/dispatch event, so it cannot run on a pull request at all — confirmed on the last PR run, where `release` reported `skipped`.

So a PR builds a downloadable artifact and publishes nothing, and **merging becomes the deliberate act of publishing**. That is a clearer contract than deleting files on the way past, and easier to get right than remembering to re-enable a deletion.

## Coverage

**Only the Pi 500+ has been booted.** The rest of the family is claimed on shared silicon — same BCM2712, same RP1, so video, Ethernet and USB are the same drivers on the same hardware — plus firmware DTB selection. That is a good reason to expect it to work and **not the same thing as having seen it**.

Worth noting there are three separate Pi 5 B device trees, because the firmware distinguishes silicon steppings. Every board tested so far has been D0; the early C1 Pi 5 Bs are unexercised.

## Why `rpi5` and not `+raspi`

The limit is the kernel, not the image. `NEXTBSD-RPI5` sets `SOCDEV_PA=0x107d001000` (UART10, BCM2712 only) and `nooptions SOC_BRCM_BCM2837/BCM2838`, because those drivers match this board by accident. A universal image needs runtime console selection, which is real work on the most safety-critical path there is.

A Pi 4 lane is the cheaper future option — `if_genet.c`, `bcm2838_xhci.c` and `bcm2838_pci.c` are all in tree already, and `bcm2838_pci` covers both SoCs — and it needs no console rework, since each kernel keeps its own compile-time `SOCDEV_PA`. Per-board images are also what FreeBSD, Armbian and Fedora all do. The glob fix above is what leaves room for it.