### PR TITLE
rpi5: enable the v3d and full-KMS device-tree overlays

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -635,6 +635,37 @@ hdmi_force_hotplug=1
 # Costs nothing on a board without the node -- an overlay whose target is
 # absent is a no-op.
 dtoverlay=nextbsd-fkms
+
+# nextbsd-v3d enables v3d@2000000, which also ships disabled. Measured on a Pi
+# 500+: the node comes up with the "disabled" gone and IRQs 70/71 resolved, and
+# enabling it disturbs neither the firmware framebuffer nor firmware KMS -- fb0
+# still comes up and vc4_fkms0 still attaches with /dev/dri/card0.
+#
+# It does NOT by itself give you 3D. Nothing in tree binds "brcm,2712-v3d", so
+# /dev/dri stays card0 with no renderD128. GL additionally needs a v3d DRM
+# driver, the drm_gpu_scheduler it depends on, and mesa-libs built with vc4 and
+# v3d in GALLIUM_DRIVERS (nextbsd#427). Enabled now because the node has to be
+# up before any of that can be developed against it.
+dtoverlay=nextbsd-v3d
+
+# nextbsd-vc4-kms enables the seven nodes the full KMS port needs: the vc6
+# master, hvs, both pixelvalves, both HDMI controllers and ddc0. Measured on a
+# Pi 500+: all seven come up with their IRQs assigned -- HVS with exactly 3
+# (ch0/1/2-eof) and each HDMI with exactly 5 -- and firmware KMS still attached
+# alongside them.
+#
+# Enabled, deliberately, even though vc4_kms.ko is not packaged yet: the driver
+# is under active development on this hardware
+# (nextbsd-kernel-extensions#51) and the nodes have to be enabled for it to
+# bind at all. Shipping it disabled would mean hand-editing this file on the
+# FAT32 partition after every image rebuild.
+#
+# It is harmless while nothing binds those nodes. It becomes MUTUALLY EXCLUSIVE
+# with nextbsd-fkms the moment vc4_kms.ko is installed, because both drive the
+# same display -- at which point exactly one of vc4_fkms and vc4_kms may be
+# loaded. That is a driver/packaging decision, not a device-tree one, and this
+# comment is where to start when it has to be made.
+dtoverlay=nextbsd-vc4-kms
 CFG
 
     # FreeBSD's FDT bootargs parser takes the "FreeBSD:" prefix and reads what


### PR DESCRIPTION
nextbsd/nextbsd-kernel-extensions#61 ships two more overlays in `rpi5-overlays.tar.gz`. **Shipping an overlay does not enable it** — the firmware applies only what `config.txt` names — so without these lines both files land on the FAT32 partition and are never read.

Adds two `dtoverlay=` lines to the `config.txt` heredoc in `build.sh`.

## `nextbsd-v3d`

Enables `v3d@2000000`, which ships disabled. Measured on a Pi 500+: the node comes up with `disabled` gone and IRQs 70/71 resolved, and enabling it disturbs neither the firmware framebuffer nor firmware KMS — `fb0` still comes up and `vc4_fkms0` still attaches with `/dev/dri/card0`.

It does **not** by itself give 3D. Nothing in tree binds `brcm,2712-v3d`, so `/dev/dri` stays `card0` with no `renderD128`. GL additionally needs a v3d DRM driver, the `drm_gpu_scheduler` it depends on, and `mesa-libs` built with `vc4`/`v3d` in `GALLIUM_DRIVERS` (#427).

## `nextbsd-vc4-kms`

Enables the seven nodes the full KMS port needs: the vc6 master, `hvs`, both pixelvalves, both HDMI controllers, and `ddc0`. Measured on the same board: all seven come up with IRQs assigned — **HVS with exactly 3** (`ch0/1/2-eof`) and **each HDMI with exactly 5**, which is what the multi-IRQ work in that port was built for — and firmware KMS still attached alongside them.

## Why both are enabled rather than commented out

The driver is under active development on this hardware, and the nodes have to be up for it to bind at all. Shipping them disabled would mean hand-editing `config.txt` on the FAT32 partition after every image rebuild — which is precisely the workflow this exists to support.

The KMS overlay is harmless while nothing binds those nodes. It becomes **mutually exclusive with `nextbsd-fkms`** the moment `vc4_kms.ko` is installed, because both drive the same display — a driver and packaging decision, not a device-tree one, and the comment in `build.sh` says so.

## Testing

All three overlays validated on a Pi 500+ by hand-staging them on the FAT32 partition and rebooting, before either PR was written. This change only moves that into the image build.

Refs #429, nextbsd/nextbsd-kernel-extensions#51, nextbsd/nextbsd-kernel-extensions#61