### PR TITLE
rpi5: stop enabling the firmware-KMS overlay

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -622,19 +622,22 @@ hdmi_force_hotplug=1
 # it out from under the FreeBSD driver's compatible string. Add them one at a
 # time, each with a boot that proves it.
 #
-# nextbsd-fkms is ours, and meets that bar (nextbsd#429). It does not rename or
-# reparent anything -- it flips one node's status from "disabled" to "okay":
+# nextbsd-fkms is deliberately NOT enabled. It brings up the firmware-KMS node,
+# which VideoCoreKMS.kext binds -- and firmware KMS cannot program a plane on
+# 2712, because the firmware does not service SET_PLANE
+# (nextbsd-kernel-extensions#48, measured). No planes means no hardware cursor.
 #
-#   ofwbus0: <firmwarekms> irq 12 disabled compat raspberrypi,rpi-firmware-kms-2712 (no driver attached)
+# VideoCore6KMS.kext drives the same display directly and does not need that
+# node. The two must never both be loaded, since they drive the same hardware,
+# so leaving the node disabled removes the way to get that wrong.
 #
-# is what a Pi 5 reports without it, with VideoCoreKMS.kext installed and
-# loadable but unable to bind. Proven by a boot on a Pi 500+: with the overlay
-# staged, the node comes up enabled, the kext attaches, /dev/dri/card0 appears
-# and vblank is delivered.
+# Verified on a Pi 500+ with this overlay disabled: VideoCore6KMS binds, EDID
+# reads over the firmware mailbox, the connector reports the attached panel by
+# name, and a modeset at its native 2560x1440@60 puts an image on screen with
+# no errors.
 #
-# Costs nothing on a board without the node -- an overlay whose target is
-# absent is a no-op.
-dtoverlay=nextbsd-fkms
+# The overlay file still ships, so re-enabling it is a one-line change for
+# anyone who wants to compare the two drivers.
 
 # nextbsd-v3d enables v3d@2000000, which also ships disabled. Measured on a Pi
 # 500+: the node comes up with the "disabled" gone and IRQs 70/71 resolved, and


### PR DESCRIPTION
Removes `dtoverlay=nextbsd-fkms` from the generated `config.txt`. One line, plus
the comment above it rewritten to say why.

## Why

`nextbsd-fkms` enables the firmware-KMS node, which `VideoCoreKMS.kext` binds.
Firmware KMS cannot program a plane on 2712 -- the firmware does not service
`SET_PLANE` (nextbsd/nextbsd-kernel-extensions#48, measured) -- so it has no
hardware cursor and no route to one.

`VideoCore6KMS.kext` programs the HVS, pixelvalves and HDMI PHY directly and
does not need that node. The two must never both be loaded, since they drive the
same display, so leaving the node disabled removes the way to get that wrong.

## Verified on hardware

On a Pi 500+ with this overlay disabled:

- `VideoCore6KMS` binds, `/dev/dri/card0` appears
- EDID reads over the firmware mailbox with no DDC adapter; the connector
  reports the attached panel by name (ViewSonic XG2705-2K)
- a modeset at its native 2560x1440@60 puts an image on screen, no errors
- `CRTC ACTIVE=1`, HSM clock 365872500 Hz, pixel-bvb 300000000 Hz

Confirmed twice, once observed directly on the panel.

## What is deliberately NOT changed

`hdmi_force_hotplug=1` stays. Removing it was tested and breaks the display
outright -- `bcm2835_mbox_fb_init failed, err=5`, no framebuffer, and the EDID
mailbox returns errors -- with the cable in HDMI0 and again in HDMI1. It is
load-bearing. See nextbsd/nextbsd-kernel-extensions#63.

## The overlay no longer exists

When this PR was opened the overlay file still shipped, so this line was merely
inert. That is no longer true: nextbsd/nextbsd-kernel-extensions#67 retires
`VideoCoreKMS.kext` and deletes `nextbsd-fkms.dtbo` along with it. Once #67
lands, `config.txt` names an overlay the image does not contain, so dropping the
line stops being a tidy-up and becomes required.

Epic: #440
Depends on: nextbsd/nextbsd-kernel-extensions#51 (the driver this hands over to, merged in nextbsd/nextbsd-kernel-extensions#62)
Related: nextbsd/nextbsd-kernel-extensions#67 (removes the overlay this line references)
